### PR TITLE
fix googleperf autotool m4.

### DIFF
--- a/config/acx_with_google_perf.m4
+++ b/config/acx_with_google_perf.m4
@@ -13,6 +13,7 @@ AC_DEFUN([ACX_WITH_GOOGLE_PERF], [
       ;;
       *)
         LIBS="$LIBS -L$withval/lib"
+	CPPFLAGS="-I$withval/include $CPPFLAGS"
         acx_with_google_perf="$withval"
       esac
     ],


### PR DESCRIPTION
This is a small fix so that world lib compiles properly with Google Perf Tools. 
