### PR TITLE
Fix implementation of inner_ext with a FunctionFunctorInterface

### DIFF
--- a/src/examples/test_inner.cc
+++ b/src/examples/test_inner.cc
@@ -5,20 +5,44 @@
 
 using namespace madness;
 
+typedef std::shared_ptr< FunctionFunctorInterface<double,3> > functorT;
+
 static const double R = 1.4;    // bond length
 static const double L = 5.0*R; // box size
 static const long k = 8;        // wavelet order
 static const double thresh = 1e-6; // precision
 
-static double easyfunc1(const coord_3d& r) {
+static double alpha_func(const coord_3d& r) {
     const double x=r[0], y=r[1], z=r[2];
     return (sin(x*x + y*y + z*z));
-}
+};
 
-static double easyfunc2(const coord_3d& r) {
+static double beta_func(const coord_3d& r) {
     const double x=r[0], y=r[1], z=r[2];
     return (exp(- x*x - y*y - z*z));
-}
+};
+
+class alpha_functor : public FunctionFunctorInterface<double,3> {
+private:
+    double coeff;
+public:
+    alpha_functor(double coeff=1.0) : coeff(coeff) {}
+
+    virtual double operator()(const coord_3d& r) const {
+        return (coeff * sin(r[0]*r[0] + r[1]*r[1] + r[2]*r[2]));
+    }
+};
+
+class beta_functor : public FunctionFunctorInterface<double,3> {
+private:
+    double coeff;
+public:
+    beta_functor(double coeff=1.0) : coeff(coeff) {}
+
+    virtual double operator()(const coord_3d& r) const {
+        return (coeff * exp(- r[0]*r[0] - r[1]*r[1] - r[2]*r[2]));
+    }
+};
 
 int main(int argc, char** argv) {
     initialize(argc, argv);
@@ -36,22 +60,52 @@ int main(int argc, char** argv) {
     FunctionDefaults<3>::set_truncate_mode(1);
     FunctionDefaults<3>::set_cubic_cell(-L/2, L/2);
 
-    real_function_3d beta = real_factory_3d(world).f(easyfunc1);
-    real_function_3d zeta = real_factory_3d(world).f(easyfunc2);
+    real_function_3d alpha = real_factory_3d(world).f(alpha_func);
+    real_function_3d beta = real_factory_3d(world).f(beta_func);
+    real_functor_3d alpha_ffi = real_functor_3d(new alpha_functor());
+    real_functor_3d beta_ffi = real_functor_3d(new beta_functor());
 
-    double norm = zeta.norm2();
-    zeta.compress();
-    double normc = zeta.norm2();
-    zeta.reconstruct();
-    double normr = zeta.norm2();
+    if (world.rank() == 0) print("Testing compression and reconstruction.");
+    double norm = beta.norm2();
+    beta.compress();
+    double normc = beta.norm2();
+    beta.reconstruct();
+    double normr = beta.norm2();
 
-    printf("%7.10f\n", zeta.inner_ext(easyfunc1));
-    printf("%7.10f\n", zeta.inner_ext(easyfunc2));
-    printf("%7.10f\n", beta.inner_ext(easyfunc1));
-    printf("%7.10f\n", beta.inner_ext(easyfunc2));
+    if (world.rank() == 0) print("Calculating inner product of two Functions.");
+    double aa = alpha.inner(alpha);
+    double ab = alpha.inner(beta);
+    double bb = beta.inner(beta);
+
+    if (world.rank() == 0) print("Calculating inner product of Function with external function.");
+    double aa_f = alpha.inner_ext(alpha_func);
+    double ab_f = alpha.inner_ext(beta_func);
+    double ba_f = beta.inner_ext(alpha_func);
+    double bb_f = beta.inner_ext(beta_func);
+
+    if (world.rank() == 0) print("Calculating inner product of Function with FunctionFunctorInterface.");
+    double aa_ffi = alpha.inner_ext(alpha_ffi);
+    double ab_ffi = alpha.inner_ext(beta_ffi);
+    double ba_ffi = beta.inner_ext(alpha_ffi);
+    double bb_ffi = beta.inner_ext(beta_ffi);
 
     if (world.rank() == 0) {
-    print("                    Norm is ", norm, normc, normr);
+        print("Norms are ", norm, normc, normr);
+        print("**********************************************************");
+        printf("<a|a> (using inner() with Function) =                      %7.10f\n", aa);
+        printf("<a|a> (using inner_ext() with external function) =         %7.10f\n", aa_f);
+        printf("<a|a> (using inner_ext() with FunctionFunctor Interface) = %7.10f\n", aa_ffi);
+        print("**********************************************************");
+        printf("<b|b> (using inner() with Function) =                      %7.10f\n", bb);
+        printf("<b|b> (using inner_ext() with external function) =         %7.10f\n", bb_f);
+        printf("<b|b> (using inner_ext() with FunctionFunctor Interface) = %7.10f\n", bb_ffi);
+        print("**********************************************************");
+        printf("<a|b> (using inner() with Function) =                      %7.10f\n", ab);
+        printf("<a|b> (using inner_ext() with external function) =         %7.10f\n", ab_f);
+        printf("<a|b> (using inner_ext() with FunctionFunctor Interface) = %7.10f\n", ab_ffi);
+        printf("<b|a> (using inner_ext() with external function) =         %7.10f\n", ba_f);
+        printf("<b|a> (using inner_ext() with FunctionFunctor Interface) = %7.10f\n", ba_ffi);
+        print("**********************************************************");
     }
 
     world.gop.fence();

--- a/src/madness/mra/mra.h
+++ b/src/madness/mra/mra.h
@@ -1177,6 +1177,7 @@ namespace madness {
         /// @return Returns local part of the inner product, i.e. over the domain of all function nodes on this compute node.
         T inner_ext_local(T (*f)(const coordT&)) const {
             PROFILE_MEMBER_FUNC(Function);
+            if (is_compressed()) reconstruct();
             return impl->inner_ext_local(f);
         }
 
@@ -1184,16 +1185,29 @@ namespace madness {
         /// @param[in] f Pointer to function of type T that take coordT arguments. This is the externally provided function
         /// @return Returns the inner product
         T inner_ext(T (*f)(const coordT&)) const {
+            PROFILE_MEMBER_FUNC(Function);
+            if (is_compressed()) reconstruct();
             T local = impl->inner_ext_local(f);
             impl->world.gop.sum(local);
             impl->world.gop.fence();
             return local;
         }
 
+        /// Return the local part of inner product with external function ... no communication.
+        /// @param[in] f Pointer to function of type T that take coordT arguments. This is the externally provided function
+        /// @return Returns local part of the inner product, i.e. over the domain of all function nodes on this compute node.
+        T inner_ext_local(const std::shared_ptr< FunctionFunctorInterface<T,NDIM> > f) const {
+            PROFILE_MEMBER_FUNC(Function);
+            if (is_compressed()) reconstruct();
+            return impl->inner_ext_local(f);
+        }
+
         /// Return the inner product with external function ... requires communication.
         /// @param[in] f Reference to FunctionFunctorInterface. This is the externally provided function
         /// @return Returns the inner product
-        T inner_ext(const FunctionFunctorInterface<T,NDIM>& f) const {
+        T inner_ext(const std::shared_ptr< FunctionFunctorInterface<T,NDIM> > f) const {
+            PROFILE_MEMBER_FUNC(Function);
+            if (is_compressed()) reconstruct();
             T local = impl->inner_ext_local(f);
             impl->world.gop.sum(local);
             impl->world.gop.fence();

--- a/src/madness/mra/mraimpl.h
+++ b/src/madness/mra/mraimpl.h
@@ -2061,7 +2061,6 @@ namespace madness {
         return fval;
     }
     
-    
     /// return the values of a Function on a grid
     
     /// @param[in]  key the key indicating where the quadrature points are located


### PR DESCRIPTION
This pull request fixes the implementation of inner_ext with a FunctionFunctorInterface. Following commit SHA: b5caabd401cd61b9a4538de5aa8a9223755544fa from @wsttiger, all of the inner_ext methods have been overloaded to accept a shared pointer to a FunctionFunctorInterface. This will help with issue #78.
