### PR TITLE
Add install instructions for OS X 10.8.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -201,5 +201,19 @@ export CPPFLAGS="-I/bgsys/drivers/ppcfloor/arch/include"
 
        ./configure MPICC=/usr/bin/mpicc MPICXX=/usr/bin/mpicxx
 
+
+  o  Macintosh Darwin 10.8, mountain lion
+     Tested with Apple LLVM version 5.1 (clang-503.0.40) (based on LLVM 3.4svn)
+     
+       Set the following system variables
+       export OMPI_CC=/usr/bin/clang
+       export OMPI_CXX=/usr/bin/clang++
+
+       ./configure  MPICC=/usr/bin/mpicc MPICXX=/usr/bin/mpicxx \
+       LIBS="/System/Library/Frameworks/vecLib.framework/vecLib" \
+       CPPFLAGS="-I/System/Library/Frameworks/vecLib.framework/Headers" \
+       CXXFLAGS="-std=c++11 -stdlib=libc++"
+
+
   o On x86 without SSE3 -- configure with the option CPPFLAGS="-DDISABLE_SSE3", requires autoconf-2.65+, automake-1.11+
     


### PR DESCRIPTION
Add install instructions for OS X 10.8. The 10.6 instructions did not
work for me; `configure` indicated it did not detect a C++11 compiler,
which is nonsense, because Clang 3.4svn is C++11 compliant.

The problem appears to be in linking. If the "-stdlib=libc++" is not
specified, then Clang links with libstdc++. Since 10.8-vintage XCode
ships with a gcc 4.2-vintage version of libstdc++ that is not C++11
compliant, configure does not detect a C++11 compliant compiler.
Forcing Clang to link with libc++, which is C++11 compliant,
resolves the issue.