### PR TITLE
allow RUN_TEST=mra to fail since it can time out

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,8 @@ matrix:
       env: GCC_VERSION=4.9 RUN_TEST=tensor
     - compiler: clang
       env: GCC_VERSION=4.9 RUN_TEST=mra
+  allow_failures:
+    - env: RUN_TEST=mra
 #notifications:
 #  email:
 #    recipients:


### PR DESCRIPTION
This is my proposed solution to the problem of `mra` generating false-positives for bugs due to timing out in Travis most of the time.