### PR TITLE
Travis ci container build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,9 @@ matrix:
   # these tests until the issue is resolved.
   allow_failures:
     - compiler: clang
-      env: GCC_VERSION=4.9 RUN_TEST=tensor
+      env: GCC_VERSION=5 RUN_TEST=tensor
     - compiler: clang
-      env: GCC_VERSION=4.9 RUN_TEST=mra
+      env: GCC_VERSION=5 RUN_TEST=mra
   exclude:
     - compiler: clang
       env: GCC_VERSION=4.7 RUN_TEST=buildonly

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,4 +82,8 @@ addons:
 
 before_install: ./ci/dep-$TRAVIS_OS_NAME.sh
 script: ./ci/build-$TRAVIS_OS_NAME.sh
-after_failure: find . -name config.log -exec cat {} ";"
+after_failure:
+  - echo "This is the beginning of the end"
+  - cat ./build/config.log
+  - find . -name config.log -exec cat {} ";"
+  - echo "This is the end of the end"

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,9 @@ addons:
       - gcc-4.9
       - g++-4.9
       - gfortran-4.9
+      - gcc-5
+      - g++-5
+      - gfortran-5
       - clang-3.6
       # BLAS/LAPACK libraries - use OpenBLAS or ATLAS if faster...
       - libblas-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,9 +81,6 @@ addons:
       #- cmake
 
 before_install: ./ci/dep-$TRAVIS_OS_NAME.sh
+before_script: find . -name config.log -exec cat {} ";"
 script: ./ci/build-$TRAVIS_OS_NAME.sh
-after_failure:
-  - echo "This is the beginning of the end"
-  - cat ./build/config.log
-  - find . -name config.log -exec cat {} ";"
-  - echo "This is the end of the end"
+after_failure: cat ./build/config.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,15 +49,19 @@ addons:
       - george-edison55-precise-backports
       - ubuntu-toolchain-r-test
     packages:
-      - gcc-$GCC_VERSION
-      - g++-$GCC_VERSION
+      - gcc-4.7
+      - g++-4.7
+      - gcc-4.8
+      - g++-4.8
+      - gcc-4.9
+      - g++-4.9
       - gfortran-$GCC_VERSION
       - libblas-dev
       - liblapack-dev
       - libgoogle-perftools-dev
-      - mpich2
+      #- mpich2 # disallowed - build from source
       - libtbb-dev
-      - cmake
+      #- cmake
 
 before_install: ./ci/dep-$TRAVIS_OS_NAME.sh
 script: ./ci/build-$TRAVIS_OS_NAME.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,15 @@ env:
   - GCC_VERSION=4.7 RUN_TEST=buildonly
   - GCC_VERSION=4.8 RUN_TEST=buildonly
   - GCC_VERSION=4.9 RUN_TEST=buildonly
-  - GCC_VERSION=4.7 RUN_TEST=world
-  - GCC_VERSION=4.8 RUN_TEST=world
-  - GCC_VERSION=4.9 RUN_TEST=world
-  - GCC_VERSION=4.7 RUN_TEST=tensor
-  - GCC_VERSION=4.8 RUN_TEST=tensor
-  - GCC_VERSION=4.9 RUN_TEST=tensor
-  - GCC_VERSION=4.7 RUN_TEST=mra
-  - GCC_VERSION=4.8 RUN_TEST=mra
-  - GCC_VERSION=4.9 RUN_TEST=mra
+#  - GCC_VERSION=4.7 RUN_TEST=world
+#  - GCC_VERSION=4.8 RUN_TEST=world
+#  - GCC_VERSION=4.9 RUN_TEST=world
+#  - GCC_VERSION=4.7 RUN_TEST=tensor
+#  - GCC_VERSION=4.8 RUN_TEST=tensor
+#  - GCC_VERSION=4.9 RUN_TEST=tensor
+#  - GCC_VERSION=4.7 RUN_TEST=mra
+#  - GCC_VERSION=4.8 RUN_TEST=mra
+#  - GCC_VERSION=4.9 RUN_TEST=mra
 matrix:
   # We will not count Mac failures until the issues with the
   # Travis build are resolved.

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,6 +83,4 @@ addons:
 before_install: ./ci/dep-$TRAVIS_OS_NAME.sh
 script: ./ci/build-$TRAVIS_OS_NAME.sh
 after_failure:
-  - cat ./libxc/config.log
-  - cat ./mpich/config.log
-  - cat ./build/config.log
+  - find config.log -exec cat {} ";"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: cpp
-os: linux
+os:
+  - linux
+  - mac
 compiler:
   - gcc
   - clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,19 @@ env:
   - GCC_VERSION=4.7 RUN_TEST=buildonly
   - GCC_VERSION=4.8 RUN_TEST=buildonly
   - GCC_VERSION=4.9 RUN_TEST=buildonly
+  - GCC_VERSION=5 RUN_TEST=buildonly
   - GCC_VERSION=4.7 RUN_TEST=world
   - GCC_VERSION=4.8 RUN_TEST=world
   - GCC_VERSION=4.9 RUN_TEST=world
+  - GCC_VERSION=5 RUN_TEST=world
   - GCC_VERSION=4.7 RUN_TEST=tensor
   - GCC_VERSION=4.8 RUN_TEST=tensor
   - GCC_VERSION=4.9 RUN_TEST=tensor
+  - GCC_VERSION=5 RUN_TEST=tensor
   - GCC_VERSION=4.7 RUN_TEST=mra
   - GCC_VERSION=4.8 RUN_TEST=mra
   - GCC_VERSION=4.9 RUN_TEST=mra
+  - GCC_VERSION=5 RUN_TEST=mra
 matrix:
   # Currently there is a segfault that occurs in the unit tests when
   # building with the clang compiler. Temporarily allow failures in
@@ -33,17 +37,25 @@ matrix:
     - compiler: clang
       env: GCC_VERSION=4.8 RUN_TEST=buildonly
     - compiler: clang
+      env: GCC_VERSION=4.9 RUN_TEST=buildonly
+    - compiler: clang
       env: GCC_VERSION=4.7 RUN_TEST=world
     - compiler: clang
       env: GCC_VERSION=4.8 RUN_TEST=world
+    - compiler: clang
+      env: GCC_VERSION=4.9 RUN_TEST=world
     - compiler: clang
       env: GCC_VERSION=4.7 RUN_TEST=tensor
     - compiler: clang
       env: GCC_VERSION=4.8 RUN_TEST=tensor
     - compiler: clang
+      env: GCC_VERSION=4.9 RUN_TEST=tensor
+    - compiler: clang
       env: GCC_VERSION=4.7 RUN_TEST=mra
     - compiler: clang
       env: GCC_VERSION=4.8 RUN_TEST=mra
+    - compiler: clang
+      env: GCC_VERSION=4.9 RUN_TEST=mra
     - os: osx
       compiler: gcc
 #notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: cpp
 os:
   - linux
-  - mac
+  - osx
 compiler:
   - gcc
   - clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,20 +9,22 @@ env:
   - GCC_VERSION=4.7 RUN_TEST=buildonly
   - GCC_VERSION=4.8 RUN_TEST=buildonly
   - GCC_VERSION=4.9 RUN_TEST=buildonly
-#  - GCC_VERSION=4.7 RUN_TEST=world
-#  - GCC_VERSION=4.8 RUN_TEST=world
-#  - GCC_VERSION=4.9 RUN_TEST=world
-#  - GCC_VERSION=4.7 RUN_TEST=tensor
-#  - GCC_VERSION=4.8 RUN_TEST=tensor
-#  - GCC_VERSION=4.9 RUN_TEST=tensor
-#  - GCC_VERSION=4.7 RUN_TEST=mra
-#  - GCC_VERSION=4.8 RUN_TEST=mra
-#  - GCC_VERSION=4.9 RUN_TEST=mra
+  - GCC_VERSION=4.7 RUN_TEST=world
+  - GCC_VERSION=4.8 RUN_TEST=world
+  - GCC_VERSION=4.9 RUN_TEST=world
+  - GCC_VERSION=4.7 RUN_TEST=tensor
+  - GCC_VERSION=4.8 RUN_TEST=tensor
+  - GCC_VERSION=4.9 RUN_TEST=tensor
+  - GCC_VERSION=4.7 RUN_TEST=mra
+  - GCC_VERSION=4.8 RUN_TEST=mra
+  - GCC_VERSION=4.9 RUN_TEST=mra
 matrix:
   # We will not count Mac failures until the issues with the
   # Travis build are resolved.
   allow_failures:
-    - os: osx
+    #- os: osx
+    - os: linux
+      compiler: clang
   exclude:
     - compiler: clang
       env: GCC_VERSION=4.7 RUN_TEST=buildonly
@@ -69,8 +71,9 @@ addons:
       - g++-5
       - gfortran-5
       - clang-3.6
-      - libc++-dev
-      - libc++1
+      # These do not lead to the desired result of libc++ >:-(
+      #- libc++-dev
+      #- libc++1
       # BLAS/LAPACK libraries - use OpenBLAS or ATLAS if faster...
       - libblas-dev
       - liblapack-dev
@@ -89,12 +92,4 @@ install:
 script:
   - ./ci/build-$TRAVIS_OS_NAME.sh
 after_failure:
-  - apt-cache search c++
-  - apt-cache show libc++1
-  - apt-cache show libc++-dev
-  - apt-cache showpkg libc++1
-  - apt-cache showpkg libc++-dev
-  - dpkg --print-avail libc++1
-  - dpkg --print-avail libc++-dev
-  - find /usr -name "libc*"
   - cat ./build/config.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,7 @@ addons:
       - g++-5
       - gfortran-5
       - clang-3.6
+      - libc++-dev
       # BLAS/LAPACK libraries - use OpenBLAS or ATLAS if faster...
       - libblas-dev
       - liblapack-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ addons:
     sources:
       - george-edison55-precise-backports
       - ubuntu-toolchain-r-test
-      - llvm-toolchain-precise-3.6
+      - llvm-toolchain-precise-3.7
     packages:
       - gcc-4.7
       - g++-4.7
@@ -73,7 +73,7 @@ addons:
       - gcc-5
       - g++-5
       - gfortran-5
-      - clang-3.6
+      - clang-3.7
       # These do not lead to the desired result of libc++ >:-(
       #- libc++-dev
       #- libc++1

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ addons:
       # BLAS/LAPACK libraries - use OpenBLAS or ATLAS if faster...
       - libblas-dev
       - liblapack-dev
-      - libopenblas-base
+      #- libopenblas-base # Do NOT use this library! it causes illegal instruction errors.
       #- libatlas3-base # "E: Unable to locate package libatlas3-base"
       # END
       - libgoogle-perftools-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,5 +89,12 @@ install:
 script:
   - ./ci/build-$TRAVIS_OS_NAME.sh
 after_failure:
+  - apt-cache search c++
+  - apt-cache show libc++1
+  - apt-cache show libc++-dev
+  - apt-cache showpkg libc++1
+  - apt-cache showpkg libc++-dev
+  - dpkg --print-avail libc++1
+  - dpkg --print-avail libc++-dev
   - find /usr -name "libc*"
   - cat ./build/config.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,8 +79,9 @@ addons:
       #- mpich2 # disallowed - build from source
       - libtbb-dev
       #- cmake
-
-before_install: ./ci/dep-$TRAVIS_OS_NAME.sh
-before_script: find . -name config.log -exec cat {} ";"
-script: ./ci/build-$TRAVIS_OS_NAME.sh
-after_failure: cat ./build/config.log
+script:
+  - ./ci/dep-$TRAVIS_OS_NAME.sh
+  - ./ci/build-$TRAVIS_OS_NAME.sh
+after_failure:
+  - find . -name config.log -exec cat {} ";"
+  - cat ./build/config.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,33 +7,33 @@ compiler:
   - clang
 env:
   - GCC_VERSION=4.7 RUN_TEST=buildonly
-  - GCC_VERSION=4.7 RUN_TEST=world
-  - GCC_VERSION=4.7 RUN_TEST=tensor
-  - GCC_VERSION=4.7 RUN_TEST=mra
   - GCC_VERSION=4.8 RUN_TEST=buildonly
-  - GCC_VERSION=4.8 RUN_TEST=world
-  - GCC_VERSION=4.8 RUN_TEST=tensor
-  - GCC_VERSION=4.8 RUN_TEST=mra
   - GCC_VERSION=4.9 RUN_TEST=buildonly
+  - GCC_VERSION=4.7 RUN_TEST=world
+  - GCC_VERSION=4.8 RUN_TEST=world
   - GCC_VERSION=4.9 RUN_TEST=world
+  - GCC_VERSION=4.7 RUN_TEST=tensor
+  - GCC_VERSION=4.8 RUN_TEST=tensor
   - GCC_VERSION=4.9 RUN_TEST=tensor
+  - GCC_VERSION=4.7 RUN_TEST=mra
+  - GCC_VERSION=4.8 RUN_TEST=mra
   - GCC_VERSION=4.9 RUN_TEST=mra
 matrix:
   exclude:
     - compiler: clang
       env: GCC_VERSION=4.7 RUN_TEST=buildonly
     - compiler: clang
-      env: GCC_VERSION=4.7 RUN_TEST=world
-    - compiler: clang
-      env: GCC_VERSION=4.7 RUN_TEST=tensor
-    - compiler: clang
-      env: GCC_VERSION=4.7 RUN_TEST=mra
-    - compiler: clang
       env: GCC_VERSION=4.8 RUN_TEST=buildonly
+    - compiler: clang
+      env: GCC_VERSION=4.7 RUN_TEST=world
     - compiler: clang
       env: GCC_VERSION=4.8 RUN_TEST=world
     - compiler: clang
+      env: GCC_VERSION=4.7 RUN_TEST=tensor
+    - compiler: clang
       env: GCC_VERSION=4.8 RUN_TEST=tensor
+    - compiler: clang
+      env: GCC_VERSION=4.7 RUN_TEST=mra
     - compiler: clang
       env: GCC_VERSION=4.8 RUN_TEST=mra
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,10 @@ matrix:
   # We will not count Mac failures until the issues with the
   # Travis build are resolved.
   allow_failures:
-    #- os: osx
+    - os: osx
+      env: GCC_VERSION=4.9 RUN_TEST=tensor
+    - os: osx
+      env: GCC_VERSION=4.9 RUN_TEST=mra
     - os: linux
       compiler: clang
   exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,4 +89,5 @@ install:
 script:
   - ./ci/build-$TRAVIS_OS_NAME.sh
 after_failure:
+  - find /usr -name "libc*"
   - cat ./build/config.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,7 @@ addons:
       - gfortran-5
       - clang-3.6
       - libc++-dev
+      - libc++1
       # BLAS/LAPACK libraries - use OpenBLAS or ATLAS if faster...
       - libblas-dev
       - liblapack-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,15 +19,14 @@ env:
   - GCC_VERSION=4.8 RUN_TEST=mra
   - GCC_VERSION=4.9 RUN_TEST=mra
 matrix:
-  # We will not count Mac failures until the issues with the
-  # Travis build are resolved.
+  # Currently there is a segfault that occurs in the unit tests when
+  # building with the clang compiler. Temporarily allow failures in
+  # these tests until the issue is resolved.
   allow_failures:
-    - os: osx
+    - compiler: clang
       env: GCC_VERSION=4.9 RUN_TEST=tensor
-    - os: osx
+    - compiler: clang
       env: GCC_VERSION=4.9 RUN_TEST=mra
-    - os: linux
-      compiler: clang
   exclude:
     - compiler: clang
       env: GCC_VERSION=4.7 RUN_TEST=buildonly

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,23 @@ matrix:
 #      - madness-developers@googlegroups.com
 #    on_success: change
 #    on_failure: always
+sudo: false
+addons:
+  apt:
+    sources:
+      - george-edison55-precise-backports
+      - ubuntu-toolchain-r-test
+    packages:
+      - gcc-$GCC_VERSION
+      - g++-$GCC_VERSION
+      - gfortran-$GCC_VERSION
+      - libblas-dev
+      - liblapack-dev
+      - libgoogle-perftools-dev
+      - mpich2
+      - libtbb-dev
+      - cmake
+
 before_install: ./ci/dep-$TRAVIS_OS_NAME.sh
 script: ./ci/build-$TRAVIS_OS_NAME.sh
 after_failure: cat ./config.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,9 +79,12 @@ addons:
       #- mpich2 # disallowed - build from source
       - libtbb-dev
       #- cmake
-script:
+# if necessary to debug the install step, move all lines into
+# script step and add appropriate debugging analysis to the
+# after_failure step e.g. find . -name config.log -exec cat {} ";"
+install:
   - ./ci/dep-$TRAVIS_OS_NAME.sh
+script:
   - ./ci/build-$TRAVIS_OS_NAME.sh
 after_failure:
-  - find . -name config.log -exec cat {} ";"
   - cat ./build/config.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,4 +82,7 @@ addons:
 
 before_install: ./ci/dep-$TRAVIS_OS_NAME.sh
 script: ./ci/build-$TRAVIS_OS_NAME.sh
-after_failure: cat ./build/config.log
+after_failure:
+  - cat ./libxc/config.log
+  - cat ./mpich/config.log
+  - cat ./build/config.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,11 +51,13 @@ addons:
     packages:
       - gcc-4.7
       - g++-4.7
+      - gfortran-4.7
       - gcc-4.8
       - g++-4.8
+      - gfortran-4.8
       - gcc-4.9
       - g++-4.9
-      - gfortran-$GCC_VERSION
+      - gfortran-4.9
       - libblas-dev
       - liblapack-dev
       - libgoogle-perftools-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,5 +82,4 @@ addons:
 
 before_install: ./ci/dep-$TRAVIS_OS_NAME.sh
 script: ./ci/build-$TRAVIS_OS_NAME.sh
-after_failure:
-  - find config.log -exec cat {} ";"
+after_failure: find . -name config.log -exec cat {} ";"

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,8 +66,12 @@ addons:
       - g++-4.9
       - gfortran-4.9
       - clang-3.6
+      # BLAS/LAPACK libraries - use OpenBLAS or ATLAS if faster...
       - libblas-dev
       - liblapack-dev
+      - libopenblas-base
+      - libatlas3-base
+      # END
       - libgoogle-perftools-dev
       #- mpich2 # disallowed - build from source
       - libtbb-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ addons:
       - libblas-dev
       - liblapack-dev
       - libopenblas-base
-      - libatlas3-base
+      #- libatlas3-base # "E: Unable to locate package libatlas3-base"
       # END
       - libgoogle-perftools-dev
       #- mpich2 # disallowed - build from source

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: cpp
 os:
-  - linux
   - osx
+  - linux
 compiler:
-  - gcc
   - clang
+  - gcc
 env:
   - GCC_VERSION=4.7 RUN_TEST=buildonly
   - GCC_VERSION=4.8 RUN_TEST=buildonly
@@ -19,6 +19,10 @@ env:
   - GCC_VERSION=4.8 RUN_TEST=mra
   - GCC_VERSION=4.9 RUN_TEST=mra
 matrix:
+  # We will not count Mac failures until the issues with the
+  # Travis build are resolved.
+  allow_failures:
+    - os: osx
   exclude:
     - compiler: clang
       env: GCC_VERSION=4.7 RUN_TEST=buildonly

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,13 +29,15 @@ matrix:
     - compiler: clang
       env: GCC_VERSION=4.7 RUN_TEST=mra
     - compiler: clang
-      env: GCC_VERSION=4.9 RUN_TEST=buildonly
+      env: GCC_VERSION=4.8 RUN_TEST=buildonly
     - compiler: clang
-      env: GCC_VERSION=4.9 RUN_TEST=world
+      env: GCC_VERSION=4.8 RUN_TEST=world
     - compiler: clang
-      env: GCC_VERSION=4.9 RUN_TEST=tensor
+      env: GCC_VERSION=4.8 RUN_TEST=tensor
     - compiler: clang
-      env: GCC_VERSION=4.9 RUN_TEST=mra
+      env: GCC_VERSION=4.8 RUN_TEST=mra
+    - os: osx
+      compiler: gcc
 #notifications:
 #  email:
 #    recipients:
@@ -48,6 +50,7 @@ addons:
     sources:
       - george-edison55-precise-backports
       - ubuntu-toolchain-r-test
+      - llvm-toolchain-precise-3.6
     packages:
       - gcc-4.7
       - g++-4.7
@@ -58,6 +61,7 @@ addons:
       - gcc-4.9
       - g++-4.9
       - gfortran-4.9
+      - clang-3.6
       - libblas-dev
       - liblapack-dev
       - libgoogle-perftools-dev
@@ -67,4 +71,4 @@ addons:
 
 before_install: ./ci/dep-$TRAVIS_OS_NAME.sh
 script: ./ci/build-$TRAVIS_OS_NAME.sh
-after_failure: cat ./config.log
+after_failure: cat ./build/config.log

--- a/ci/build-linux.sh
+++ b/ci/build-linux.sh
@@ -14,7 +14,9 @@ else
     export CC=/usr/bin/clang-3.6
     export CXX=/usr/bin/clang-3.6
     export CXXFLAGS="-stdlib=libc++"
-    export LDFLAGS="-fdefine-sized-deallocation"
+    #export LDFLAGS="-fdefine-sized-deallocation"
+    # clang-3.6 gives this error:
+    #       clang: error: unknown argument: '-fdefine-sized-deallocation'
 fi
 export F77=/usr/bin/gfortran-$GCC_VERSION
 # Jeff: these are unnecessary because MPICH has been compiler

--- a/ci/build-linux.sh
+++ b/ci/build-linux.sh
@@ -23,8 +23,8 @@ if [ "$CXX" = "g++" ]; then
     export CXX=/usr/bin/g++-$GCC_VERSION
 else
     # Assume CXX = clang
-    export CC=/usr/bin/clang-3.6
-    export CXX=/usr/bin/clang-3.6
+    export CC=/usr/bin/clang-3.7
+    export CXX=/usr/bin/clang++-3.7
     #export CXXFLAGS="-stdlib=libc++"
     #export LDFLAGS="-fdefine-sized-deallocation"
     # clang-3.6 gives this error:

--- a/ci/build-linux.sh
+++ b/ci/build-linux.sh
@@ -23,6 +23,7 @@ export LD_LIBRARY_PATH=/usr/lib/lapack:/usr/lib/openblas-base:$LD_LIBRARY_PATH
     --enable-debugging --disable-optimization --enable-warning --disable-optimal --disable-static \
     --with-google-test \
     --enable-never-spin \
+    --with-libxc=${HOME}/libxc \
     LIBS="-L/usr/lib/lapack -L/usr/lib/libblas -llapack -lblas -lpthread"
 
 if [ "$RUN_TEST" = "buildonly" ]; then

--- a/ci/build-linux.sh
+++ b/ci/build-linux.sh
@@ -9,6 +9,11 @@ export CPPFLAGS=-DDISABLE_SSE3
 if [ "$CXX" = "g++" ]; then
     export CC=/usr/bin/gcc-$GCC_VERSION
     export CXX=/usr/bin/g++-$GCC_VERSION
+else
+    # Assume CXX = clang
+    export CC=/usr/bin/clang-3.6
+    export CXX=/usr/bin/clang-3.6
+    export LDFLAGS="-fdefine-sized-deallocation"
 fi
 export F77=/usr/bin/gfortran-$GCC_VERSION
 # Jeff: these are unnecessary because MPICH has been compiler
@@ -21,8 +26,10 @@ export LD_LIBRARY_PATH=/usr/lib/lapack:/usr/lib/openblas-base:$LD_LIBRARY_PATH
 
 # Configure and build MADNESS
 ./autogen.sh 
-./configure \
-    --enable-debugging --disable-optimization --enable-warning --disable-optimal --disable-static \
+mkdir build
+cd build
+../configure \
+    --enable-debugging --enable-optimization --enable-warning --disable-optimal --disable-static \
     --with-google-test \
     --enable-never-spin \
     --with-libxc=${HOME}/libxc \

--- a/ci/build-linux.sh
+++ b/ci/build-linux.sh
@@ -37,7 +37,7 @@ export F77=/usr/bin/gfortran-$GCC_VERSION
 #export MPICH_CXX=$CXX
 export MPICC=$HOME/mpich/bin/mpicc
 export MPICXX=$HOME/mpich/bin/mpicxx
-export LD_LIBRARY_PATH=/usr/lib/lapack:/usr/lib/openblas-base:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=/usr/lib/lapack:/usr/lib/libblas:$LD_LIBRARY_PATH
 
 # Configure and build MADNESS
 ./autogen.sh 

--- a/ci/build-linux.sh
+++ b/ci/build-linux.sh
@@ -4,8 +4,20 @@
 set -ev
 
 # Environment variables
-export CXXFLAGS="-std=c++11 -mno-avx"
-export CPPFLAGS=-DDISABLE_SSE3
+MACHINE=`uname -m`
+case "$MACHINE" in
+    x86_64)
+        # assume all Intel hardware supports AVX,
+        # which was introduced in SNB (2011Q1)
+        export CXXFLAGS="-std=c++11"
+        ;;
+    *)
+        # probably not Intel, hence no SSE or AVX
+        export CXXFLAGS="-std=c++11 -mno-avx"
+        export CPPFLAGS=-DDISABLE_SSE3
+        ;;
+esac
+
 if [ "$CXX" = "g++" ]; then
     export CC=/usr/bin/gcc-$GCC_VERSION
     export CXX=/usr/bin/g++-$GCC_VERSION

--- a/ci/build-linux.sh
+++ b/ci/build-linux.sh
@@ -25,7 +25,7 @@ else
     # Assume CXX = clang
     export CC=/usr/bin/clang-3.6
     export CXX=/usr/bin/clang-3.6
-    export CXXFLAGS="-stdlib=libc++"
+    #export CXXFLAGS="-stdlib=libc++"
     #export LDFLAGS="-fdefine-sized-deallocation"
     # clang-3.6 gives this error:
     #       clang: error: unknown argument: '-fdefine-sized-deallocation'

--- a/ci/build-linux.sh
+++ b/ci/build-linux.sh
@@ -11,10 +11,12 @@ if [ "$CXX" = "g++" ]; then
     export CXX=/usr/bin/g++-$GCC_VERSION
 fi
 export F77=/usr/bin/gfortran-$GCC_VERSION
-export MPICH_CC=$CC
-export MPICH_CXX=$CXX
-export MPICC=/usr/bin/mpicc.mpich2
-export MPICXX=/usr/bin/mpicxx.mpich2
+# Jeff: these are unnecessary because MPICH has been compiler
+#       from source with these compilers.
+#export MPICH_CC=$CC
+#export MPICH_CXX=$CXX
+export MPICC=$HOME/mpich/bin/mpicc
+export MPICXX=$HOME/mpich/bin/mpicxx
 export LD_LIBRARY_PATH=/usr/lib/lapack:/usr/lib/openblas-base:$LD_LIBRARY_PATH
 
 # Configure and build MADNESS

--- a/ci/build-linux.sh
+++ b/ci/build-linux.sh
@@ -13,6 +13,7 @@ else
     # Assume CXX = clang
     export CC=/usr/bin/clang-3.6
     export CXX=/usr/bin/clang-3.6
+    export CXXFLAGS="-stdlib=libc++"
     export LDFLAGS="-fdefine-sized-deallocation"
 fi
 export F77=/usr/bin/gfortran-$GCC_VERSION

--- a/ci/build-osx.sh
+++ b/ci/build-osx.sh
@@ -1,12 +1,23 @@
 #! /bin/sh
 
 # Exit on error
-set -e
+set -ev
 
 # Configure MADNESS
-./autogen.sh 
-./configure --enable-never-spin
-make
+mkdir build
+cd build
+cmake \
+    -D CMAKE_BUILD_TYPE=RelWithDebInfo \
+    -D ENABLE_UNITTESTS=ON \
+    -D ENABLE_NEVER_SPIN=ON \
+    ..
 
-# Run unit tests
-make check
+if [ "$RUN_TEST" = "buildonly" ]; then
+    # Build all libraries, examples, and applications
+    make -j2 all
+else
+    # Run unit tests
+    export MAD_NUM_THREADS=2
+    export CTEST_OUTPUT_ON_FAILURE=1
+    make -C src/madness/$RUN_TEST -j2 test
+fi

--- a/ci/dep-linux.sh
+++ b/ci/dep-linux.sh
@@ -20,6 +20,10 @@ set -ev
 if [ "$CXX" = "g++" ]; then
     export CC=/usr/bin/gcc-$GCC_VERSION
     export CXX=/usr/bin/g++-$GCC_VERSION
+else
+    # Assume CXX = clang
+    export CC=/usr/bin/clang-3.6
+    export CXX=/usr/bin/clang-3.6
 fi
 export FC=/usr/bin/gfortran-$GCC_VERSION
 

--- a/ci/dep-linux.sh
+++ b/ci/dep-linux.sh
@@ -13,6 +13,7 @@ else
     export CC=/usr/bin/clang-3.6
     export CXX=/usr/bin/clang-3.6
     export CXXFLAGS="-std=c++11"
+    export LDFLAGS="-std=c++11"
 fi
 export FC=/usr/bin/gfortran-$GCC_VERSION
 
@@ -42,8 +43,12 @@ if [ ! -d "${HOME}/mpich" ]; then
     ../configure CC=$CC CXX=$CXX --disable-fortran --disable-romio --prefix=${HOME}/mpich
     make -j2
     make install
+    ${HOME}/mpich/bin/mpichversion
+    ${HOME}/mpich/bin/mpicc -show
+    ${HOME}/mpich/bin/mpicxx -show
 else
     echo "MPICH installed..."
     find ${HOME}/mpich -name mpiexec
     find ${HOME}/mpich -name mpicc
+    find ${HOME}/mpich -name mpicxx
 fi

--- a/ci/dep-linux.sh
+++ b/ci/dep-linux.sh
@@ -11,8 +11,8 @@ case "$CXX" in
         export CXX=/usr/bin/g++-$GCC_VERSION
         ;;
     clang++)
-        export CC=/usr/bin/clang-3.6
-        export CXX=/usr/bin/clang++-3.6
+        export CC=/usr/bin/clang-3.7
+        export CXX=/usr/bin/clang++-3.7
         export CXXFLAGS="-std=c++11"
         ;;
     *)

--- a/ci/dep-linux.sh
+++ b/ci/dep-linux.sh
@@ -3,20 +3,8 @@
 # Exit on error
 set -ev
 
-# Add repository for libxc
-#sudo add-apt-repository ppa:hogliux/misstep -y
-
-# Add PPA for a newer version GCC
-#sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-# Add PPA for newer cmake (3.2.3)
-#sudo add-apt-repository ppa:george-edison55/precise-backports -y
-
-# Update package list
-#sudo apt-get update -qq
-
 # Install packages
 
-#sudo apt-get install -qq -y gcc-$GCC_VERSION g++-$GCC_VERSION gfortran-$GCC_VERSION
 if [ "$CXX" = "g++" ]; then
     export CC=/usr/bin/gcc-$GCC_VERSION
     export CXX=/usr/bin/g++-$GCC_VERSION
@@ -43,12 +31,9 @@ make -j2
 make install
 
 # Install CMake 3
-#sudo apt-get -y -qq --no-install-suggests --no-install-recommends --force-yes install cmake cmake-data
 cmake --version
 
-# Install the rest
-#sudo apt-get install -qq -y libblas-dev liblapack-dev libgoogle-perftools-dev mpich2 libtbb-dev
-
+# Install MPICH
 if [ ! -d "${HOME}/mpich" ]; then
     wget --no-check-certificate -q http://www.mpich.org/static/downloads/3.2/mpich-3.2.tar.gz
     tar -xzf mpich-3.2.tar.gz

--- a/ci/dep-linux.sh
+++ b/ci/dep-linux.sh
@@ -24,6 +24,7 @@ else
     # Assume CXX = clang
     export CC=/usr/bin/clang-3.6
     export CXX=/usr/bin/clang-3.6
+    export CXXFLAGS="-std=c++11"
 fi
 export FC=/usr/bin/gfortran-$GCC_VERSION
 

--- a/ci/dep-linux.sh
+++ b/ci/dep-linux.sh
@@ -43,3 +43,17 @@ cmake --version
 
 # Install the rest
 #sudo apt-get install -qq -y libblas-dev liblapack-dev libgoogle-perftools-dev mpich2 libtbb-dev
+
+if [ ! -d "${HOME}/mpich" ]; then
+    wget --no-check-certificate -q http://www.mpich.org/static/downloads/3.2/mpich-3.2.tar.gz
+    tar -xzf mpich-3.2.tar.gz
+    cd mpich-3.2
+    mkdir build && cd build
+    ../configure CC=$CC CXX=$CXX --disable-fortran --disable-romio --prefix=${HOME}/mpich
+    make -j2
+    make install
+else
+    echo "MPICH installed..."
+    find ${HOME}/mpich -name mpiexec
+    find ${HOME}/mpich -name mpicc
+fi

--- a/ci/dep-linux.sh
+++ b/ci/dep-linux.sh
@@ -7,16 +7,16 @@ set -ev
 #sudo add-apt-repository ppa:hogliux/misstep -y
 
 # Add PPA for a newer version GCC
-sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+#sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
 # Add PPA for newer cmake (3.2.3)
-sudo add-apt-repository ppa:george-edison55/precise-backports -y
+#sudo add-apt-repository ppa:george-edison55/precise-backports -y
 
 # Update package list
-sudo apt-get update -qq
+#sudo apt-get update -qq
 
 # Install packages
 
-sudo apt-get install -qq -y gcc-$GCC_VERSION g++-$GCC_VERSION gfortran-$GCC_VERSION
+#sudo apt-get install -qq -y gcc-$GCC_VERSION g++-$GCC_VERSION gfortran-$GCC_VERSION
 if [ "$CXX" = "g++" ]; then
     export CC=/usr/bin/gcc-$GCC_VERSION
     export CXX=/usr/bin/g++-$GCC_VERSION
@@ -33,13 +33,13 @@ wget -O libxc-2.2.1.tar.gz "http://www.tddft.org/programs/octopus/down.php?file=
 tar -xzf libxc-2.2.1.tar.gz
 cd libxc-2.2.1
 autoreconf -i
-./configure --prefix=/usr/local --enable-shared --disable-static CFLAGS="-mno-avx" FCFLAGS="-mno-avx"
+./configure --prefix=${HOME}/libxc --enable-shared --disable-static CFLAGS="-mno-avx" FCFLAGS="-mno-avx"
 make -j2
-sudo make install
+make install
 
 # Install CMake 3
-sudo apt-get -y -qq --no-install-suggests --no-install-recommends --force-yes install cmake cmake-data
+#sudo apt-get -y -qq --no-install-suggests --no-install-recommends --force-yes install cmake cmake-data
 cmake --version
 
 # Install the rest
-sudo apt-get install -qq -y libblas-dev liblapack-dev libgoogle-perftools-dev mpich2 libtbb-dev
+#sudo apt-get install -qq -y libblas-dev liblapack-dev libgoogle-perftools-dev mpich2 libtbb-dev

--- a/ci/dep-linux.sh
+++ b/ci/dep-linux.sh
@@ -5,16 +5,22 @@ set -ev
 
 # Install packages
 
-if [ "$CXX" = "g++" ]; then
-    export CC=/usr/bin/gcc-$GCC_VERSION
-    export CXX=/usr/bin/g++-$GCC_VERSION
-else
-    # Assume CXX = clang
-    export CC=/usr/bin/clang-3.6
-    export CXX=/usr/bin/clang-3.6
-    export CXXFLAGS="-std=c++11"
-    export LDFLAGS="-std=c++11"
-fi
+case "$CXX" in
+    g++)
+        export CC=/usr/bin/gcc-$GCC_VERSION
+        export CXX=/usr/bin/g++-$GCC_VERSION
+        ;;
+    clang++)
+        export CC=/usr/bin/clang-3.6
+        export CXX=/usr/bin/clang++-3.6
+        export CXXFLAGS="-std=c++11"
+        ;;
+    *)
+        echo "Unknown C++ compiler:"
+        echo "$CXX"
+        exit 1
+        ;;
+esac
 export FC=/usr/bin/gfortran-$GCC_VERSION
 
 # Print compiler information

--- a/ci/dep-linux.sh
+++ b/ci/dep-linux.sh
@@ -23,13 +23,18 @@ $CXX --version
 $FC --version
 
 # Install libxc
-wget -O libxc-2.2.1.tar.gz "http://www.tddft.org/programs/octopus/down.php?file=libxc/libxc-2.2.1.tar.gz"
-tar -xzf libxc-2.2.1.tar.gz
-cd libxc-2.2.1
-autoreconf -i
-./configure --prefix=${HOME}/libxc --enable-shared --disable-static CFLAGS="-mno-avx" FCFLAGS="-mno-avx"
-make -j2
-make install
+if [ ! -d "${HOME}/libxc" ]; then
+    wget -O libxc-2.2.1.tar.gz "http://www.tddft.org/programs/octopus/down.php?file=libxc/libxc-2.2.1.tar.gz"
+    tar -xzf libxc-2.2.1.tar.gz
+    cd libxc-2.2.1
+    autoreconf -i
+    ./configure --prefix=${HOME}/libxc --enable-shared --disable-static CFLAGS="-mno-avx" FCFLAGS="-mno-avx"
+    make -j2
+    make install
+else
+    echo "LIBXC installed..."
+    ls -l ${HOME}/libxc
+fi
 
 # Install CMake 3
 cmake --version
@@ -39,8 +44,7 @@ if [ ! -d "${HOME}/mpich" ]; then
     wget --no-check-certificate -q http://www.mpich.org/static/downloads/3.2/mpich-3.2.tar.gz
     tar -xzf mpich-3.2.tar.gz
     cd mpich-3.2
-    mkdir build && cd build
-    ../configure CC=$CC CXX=$CXX --disable-fortran --disable-romio --prefix=${HOME}/mpich
+    ./configure CC=$CC CXX=$CXX --disable-fortran --disable-romio --prefix=${HOME}/mpich
     make -j2
     make install
     ${HOME}/mpich/bin/mpichversion

--- a/ci/dep-osx.sh
+++ b/ci/dep-osx.sh
@@ -4,4 +4,4 @@
 set -e
 
 brew update
-brew install autoconf automake libtool cmake libxc mpich2 tbb gperftools
+brew install autoconf automake libtool cmake libxc mpich tbb gperftools

--- a/ci/dep-osx.sh
+++ b/ci/dep-osx.sh
@@ -4,4 +4,4 @@
 set -e
 
 brew update
-brew install autoconf automake libtool cmake libxc mpich2
+brew install autoconf automake libtool cmake libxc mpich2 tbb gperftools

--- a/ci/dep-osx.sh
+++ b/ci/dep-osx.sh
@@ -4,4 +4,4 @@
 set -e
 
 brew update
-brew install autoconf automake libtool cmake libxc mpich tbb gperftools
+brew install libxc mpich tbb

--- a/cmake/toolchains/osx-clang-mkl-tbb.cmake
+++ b/cmake/toolchains/osx-clang-mkl-tbb.cmake
@@ -11,8 +11,6 @@
 #   * TBBROOT: the TBB root directory; if not set, will use /opt/intel/tbb
 #
 
-set(CMAKE_SYSTEM_NAME Darwin)
-
 # Compilers
 set(CMAKE_C_COMPILER clang)
 set(CMAKE_CXX_COMPILER clang++)

--- a/src/apps/chem/CMakeLists.txt
+++ b/src/apps/chem/CMakeLists.txt
@@ -8,11 +8,12 @@ set(MADCHEM_HEADERS
     SCF.h xcfunctional.h mp2.h nemo.h potentialmanager.h gth_pseudopotential.h
     molecular_optimizer.h projector.h TDA.h TDA_XC.h TDA_guess.h TDA_exops.h
     SCFOperators.h CCOperators.h CCStructures.h CC2.h CISOperators.h
-    electronic_correlation_factor.h)
+    electronic_correlation_factor.h cheminfo.h)
 set(MADCHEM_SOURCES
     correlationfactor.cc molecule.cc molecularbasis.cc corepotential.cc
-    atomutil.cc lda.cc distpm.cc SCF.cc gth_pseudopotential.cc nemo.cc mp2.cc
-    SCFOperators.cc TDA.cc TDA_XC.cc CC2.cc CCOperators.cc CISOperators.cc)
+    atomutil.cc lda.cc cheminfo.cc distpm.cc SCF.cc gth_pseudopotential.cc 
+    nemo.cc mp2.cc SCFOperators.cc TDA.cc TDA_XC.cc CC2.cc CCOperators.cc 
+    CISOperators.cc)
 if(LIBXC_FOUND)
   list(APPEND MADCHEM_SOURCES xcfunctional_libxc.cc)
 else()


### PR DESCRIPTION
At this point, all the CI scripts seem to be working correctly, but several of the unit tests are failing. At first I was thinking that it was just the OS X unit tests that were failing, but now the common element seems to be clang.

Current builds that are failing:
* Tensor tests on OS X with Apple Clang 6.0 (svn 3.5)
* MRA tests on OS X with Apple Clang 6.0 (svn 3.5)
* Tensor tests on Linux with Clang 3.7 (libstdc++ from gcc-5)
* MRA tests on Linux with Clang 3.7 (libstdc++ from gcc-5)
* MRA tests on Linux with GCC 4.9

I think we should merge these changes into the main repository. We should also create issues for the failing unit tests and try to reproduce the failures on other platforms.

