### PR TITLE
Libxc logderivatives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ cmake/cmake-*
 cmake/bin
 cmake/doc
 cmake/share
+Makefile-prog.in

--- a/doc/libraries/chemistry.dox
+++ b/doc/libraries/chemistry.dox
@@ -1,0 +1,138 @@
+/*
+  This file is part of MADNESS.
+
+  Copyright (C) 2015 Stony Brook University
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+  For more information please contact:
+
+  Robert J. Harrison
+  Oak Ridge National Laboratory
+  One Bethel Valley Road
+  P.O. Box 2008, MS-6367
+
+  email: harrisonrj@ornl.gov
+  tel:   865-241-3937
+  fax:   865-572-0680
+*/
+
+/**
+ \file chemistry.dox
+ \brief Overview over quantum chemistry implementations in the MADNESS framework.
+ \addtogroup chemistry
+
+\par Background
+
+MADNESS does quantum chemistry
+
+\par DFT functionals for the user
+
+A molecular wave function may be determined using the ground state density only. 
+For all but the simplest local density approximation functionals we use the density functional library <a href=http://www.tddft.org/programs/octopus/wiki/index.php/Libxc>libxc</a>.
+The user may request a functional according to the general syntax
+\code
+ xc  FUNC1 weight1 FUNC2 weight2 ..
+\endcode
+where FUNC1 etc are the name of a libxc functional, and the weight describes the admixture coefficient
+
+or use the following predefined functionals (not case sensitive)
+\code
+ xc hf
+ xc lda
+ xc bp
+ xc pbe
+ xc pbe0
+ xc b3lyp
+\endcode
+
+As an example, the PBE0 functional would be expressed in the general syntax as
+\code
+ xc  GGA_X_PBE 0.75 GGA_C_PBE 1.0 HF 0.25
+\endcode
+
+Expert parameters are RHOTOL, RHOMIN, and GGATOL, which determine at which density value threshold (RHOTOL) the density will be set to RHOMIN inside libxc, and at which density the gga potential will be munged, since it might not be bound.
+
+
+\par DFT functionals for the developer
+
+A DFT functional is most easily constructed through the use of the madness::XCOperator class in SCFOperators.h
+\code
+ #include "SCFOperators.h"
+ XCOperator xc_operator(world,&calc,ispin);
+\endcode
+
+where the arguments to the constructor are the world and a pointer to a madness::SCF or madness::Nemo calculation. 
+The constructor will create the necessary density and density gradients (in XCOperator::prep_xc_args() ).
+Note that the ispin argument (0 for alpha, 1 for beta) is only important for the computation of the xc potential, and may be changed later on to avoid re-creation of the density (gradients).
+The functional information is passed to the constructor through the calculation parameters.
+
+A DFT energy and potential can be constructed as
+\code
+double ex_energy=xc_operator.compute_xc_energy();
+real_function_3d xc_potential=xc_operator.make_xc_potential();
+\endcode
+
+Direct application of the XC functional to a vector of orbitals mo may be accomplished as
+\code 
+std::vector<real_function_3d> vmo = xc_operator(mo);
+\endcode
+
+If a response kernel is requested (e.g. in CPHF equations, or in linear response), the kernel itself is numerically unstable. 
+To some extent this instability is circumvented by performing as many operations as possible on a fixed grid, so that only the result of the kernel application is available
+\code
+real_function_3d result=xc_operator.apply_xc_kernel(perturbed_density);
+\endcode
+
+
+\par Internal implementation details
+
+For LDA functionals the density is processed as-is, only very small and negative densities  are set to zero (through the RHOTOL and RHOMIN arguments).
+
+For GGA functionals the reduced density gradients \f$ \sigma\f$ are necessary, which decay very fast and cause numerical instabilites. 
+To avoid these instabilities we express the density gradients as
+\f{align}{
+\rho &= exp(\zeta) \\
+\nabla \rho &= \rho \nabla \zeta \\
+\sigma &= |\nabla\rho|^2 = |\nabla \zeta|^2 \rho^2 = \chi \rho^2
+\f}
+which defines the quantities \f$ \zeta\f$ and \f$ \chi \f$.
+The functional form of \f$\zeta\f$ is a superposition of cones located at the nuclei with asymptotic slope of the HOMO orbital energy, its derivative is numerically more stable than that of the density itself.
+In this way the density gradients and the density may be munged in a consistent manner.
+In fact, often the ratio \f$ \sigma/\rho^2 =\chi\f$ is used in DFT functionals.
+All functions are passed to libxc through the madness::XCfunctional interface class. 
+A vector of functions named xc_arg is passed to the multiop method, with the various functions being on enumerated vector positions, described in madness::XCfunctional::xc_arg.
+
+Response kernels for GGA are even more numerically unstable than the XC potential. 
+We use the same log-derivative trick as before, which fixes the long-range noise. 
+However the intermediate potentials have to be multiplied with the gradients of the (perturbed) density, followed by taking the divergence, which is equivalent to applying the Laplacian to the (perturbed) density. 
+Numerical noise is amplified and convergence during the SCF or CPHF iterations might not be achieved.
+Furthermore, the perturbed density is not strictly positive, so its logarithm is not defined.
+We can pull an unperturbed density out of the perturbed density gradient to regain some stability
+\f{align}{
+\sigma_\mathrm{pt}	&=\nabla\rho\cdot\nabla\rho_\mathrm{pt} = \rho\left(\nabla\zeta\cdot\nabla\rho_\mathrm{pt}\right)
+\f}
+
+
+The code in XCOperator works as follows
+ - compute \f$\zeta\f$, density gradients, etc through madness::XCOperator::prep_xc_args and put them on a vector of functions. So far these are spin densities.
+ - call xc_potential or xc_kernel_apply
+   - call \c madness::XCfunctional::make_libxc_args to munge the density and density gradients -- convert spin density to full density if spin-restricted
+   - call libxc functions to compute the functional derivatives of the density functional
+   - multiply intermediate quantities to the functional derivatives
+   - return scalar intermediates, for the exact description see in madness::XCfunctional::vxc and madness::XCfunctional::fxc_apply
+ - multiply the semilocal intermediates with the density gradients, take div operator
+
+*/

--- a/doc/mainpage.dox
+++ b/doc/mainpage.dox
@@ -39,6 +39,9 @@
 ///    \defgroup parallel_runtime Parallel programming environment
 ///    \ingroup libraries
 
+///    \defgroup chemistry Chemistry
+///    \ingroup libraries
+
 ///       \defgroup world Distributed computing environment (World and its relations)
 ///       \ingroup parallel_runtime
 

--- a/src/apps/chem/SCF.cc
+++ b/src/apps/chem/SCF.cc
@@ -3424,17 +3424,17 @@ namespace madness {
 
                 world.gop.fence(); // NECESSARY
 
-                vf[XCfunctional::enum_saa] = copy(   delrho[0] * delrho[0] 
+                vf[XCfunctional::enum_saa] = copy(   delrho[0] * delrho[0]
                                                    + delrho[1] * delrho[1]
                                                    + delrho[2] * delrho[2]);   // sigma_aa
 
                 if (!param.spin_restricted && param.nbeta != 0)
                 {
-                       vf[XCfunctional::enum_sab] = copy(  delrho[0] * delrho[3] 
+                       vf[XCfunctional::enum_sab] = copy(  delrho[0] * delrho[3]
                                                          + delrho[1] * delrho[4]
                                                          + delrho[2] * delrho[5]); // sigma_ab
 
-                       vf[XCfunctional::enum_sbb] = copy(  delrho[3] * delrho[3] 
+                       vf[XCfunctional::enum_sbb] = copy(  delrho[3] * delrho[3]
                                                          + delrho[4] * delrho[4]
                                                          + delrho[5] * delrho[5]); // sigma_bb
                  }

--- a/src/apps/chem/SCF.cc
+++ b/src/apps/chem/SCF.cc
@@ -2868,44 +2868,43 @@ namespace madness {
         by = by_new;
     }
 
-    vecfuncT SCF::apply_potential_response(World & world, const tensorT & occ, const vecfuncT & dmo,
-                             const vecfuncT& vf, const vecfuncT& delrho,  const functionT & vlocal,
-                             double & exc, 
-                             int ispin)
+    vecfuncT SCF::apply_potential_response(World & world, const vecfuncT & dmo,
+            const XCOperator& xcop,  const functionT & vlocal, int ispin)
     {
         functionT vloc = copy(vlocal);
-        exc = 0.0;
 
         if (xc.is_dft() && !(xc.hf_exchange_coefficient()==1.0)) {
             START_TIMER(world);
 
-            XCOperator xcoperator(world,this,ispin);
-            if (ispin==0) exc=xcoperator.compute_xc_energy();
-            vloc += xcoperator.make_xc_potential();
+//            XCOperator xcoperator(world,this,ispin);
+//            if (ispin==0) exc=xcoperator.compute_xc_energy();
+            xcop.set_ispin(ispin);
+            vloc += xcop.make_xc_potential();
 
-
-#ifdef MADNESS_HAS_LIBXC
-            if (xc.is_gga() ) {
-                
-                functionT vsigaa = xcoperator.make_xc_potential();
-                functionT vsigab;
-		if (xc.is_spin_polarized() && param.nbeta != 0)// V_ab
-                    vsigab = xcoperator.make_xc_potential();                
-
-                for (int axis=0; axis<3; axis++) {
-                    functionT gradn = delrho[axis + 3*ispin];
-                    functionT ddel = vsigaa*gradn;
-	            if (xc.is_spin_polarized() && param.nbeta != 0) {
-                        functionT vsab = vsigab*delrho[axis + 3*(1-ispin)];
-                        ddel = ddel + vsab;
-                    }
-                    ddel.scale(xc.is_spin_polarized() ? 2.0 : 4.0);
-                    Derivative<double,3> D = free_space_derivative<double,3>(world, axis);
-                    functionT vxc2=D(ddel);
-                    vloc = vloc - vxc2;//.truncate();
-                }
-            }
-#endif
+// TODO: fbischoff thinks this is double-counting the gga potential part
+//
+//#ifdef MADNESS_HAS_LIBXC
+//            if (xc.is_gga() ) {
+//
+//                functionT vsigaa = xcoperator.make_xc_potential();
+//                functionT vsigab;
+//                if (xc.is_spin_polarized() && param.nbeta != 0)// V_ab
+//                    vsigab = xcoperator.make_xc_potential();
+//
+//                for (int axis=0; axis<3; axis++) {
+//                    functionT gradn = delrho[axis + 3*ispin];
+//                    functionT ddel = vsigaa*gradn;
+//                    if (xc.is_spin_polarized() && param.nbeta != 0) {
+//                        functionT vsab = vsigab*delrho[axis + 3*(1-ispin)];
+//                        ddel = ddel + vsab;
+//                    }
+//                    ddel.scale(xc.is_spin_polarized() ? 2.0 : 4.0);
+//                    Derivative<double,3> D = free_space_derivative<double,3>(world, axis);
+//                    functionT vxc2=D(ddel);
+//                    vloc = vloc - vxc2;//.truncate();
+//                }
+//            }
+//#endif
             END_TIMER(world, "DFT potential");
         }
 
@@ -2914,17 +2913,16 @@ namespace madness {
         START_TIMER(world);
         vecfuncT Vdmo = mul_sparse(world, vloc, dmo, vtol);
         END_TIMER(world, "V*dmo");
-	print_meminfo(world.rank(), "V*dmo");
+        print_meminfo(world.rank(), "V*dmo");
         if(xc.hf_exchange_coefficient()){
             START_TIMER(world);
             vecfuncT Kdmo;
             Exchange K=Exchange(world,this,ispin).small_memory(false).same(false);
-            vecfuncT Kamo=K(amo);
-             if(ispin == 0)
+            if(ispin == 0)
                 Kdmo=K(amo); 
             if(ispin == 1)
                 Kdmo=K(bmo); 
-             //tensorT excv = inner(world, Kdmo, dmo);
+            //tensorT excv = inner(world, Kdmo, dmo);
             //double exchf = 0.0;
             //for(unsigned long i = 0;i < dmo.size();++i){
             //    exchf -= 0.5 * excv[i] * occ[i];
@@ -2940,7 +2938,7 @@ namespace madness {
 
         truncate(world, Vdmo);
 
-	print_meminfo(world.rank(), "Truncate Vdmo");
+        print_meminfo(world.rank(), "Truncate Vdmo");
         world.gop.fence();
         return Vdmo;
     }
@@ -3087,8 +3085,9 @@ namespace madness {
     }
 
 
-    vecfuncT SCF::calc_xc_function(World & world, 
-             const vecfuncT & mo,  const vecfuncT & vf,  const functionT & drho, int & spin)
+    /// param[in]   drho    the perturbed density
+    vecfuncT SCF::calc_xc_function(World & world, XCOperator& xc_alda,
+             const vecfuncT & mo,  const functionT & drho)
     {
         START_TIMER(world);
         reconstruct(world, mo);
@@ -3097,38 +3096,23 @@ namespace madness {
         dJ.truncate();
 
         functionT vloc = dJ;
-        //if (xc.is_dft() && !(xc.hf_exchange_coefficient()==1.0)) {
+
+        // TODO openshell ?
         if (xc.is_dft() && xc.hf_exchange_coefficient() !=1.0) {
-            // ALDA approximation only
-            // use kernel of ground state
-            std::string xc_alda= "LDA";
-            xc.initialize(xc_alda, !param.spin_restricted, world);
-
-            real_function_3d fxc = multiop_values <double, xc_kernel_apply, 3> (xc_kernel_apply(xc, spin, XCfunctional::potential_rho), vf);
-
-            // return to original xc
-            xc.initialize(param.xc_data, !param.spin_restricted, world);
-     
-            vloc =  dJ +  fxc * drho;
-            //vloc = dJ + fxc;     
-     
-            // TODO openshell ?
+            vloc =  dJ +  xc_alda.apply_xc_kernel(drho);
         }
-        else { 
-            vloc =  dJ;
-        } 
+
         vecfuncT Vxcmo = mul_sparse(world, vloc, mo, vtol);
         truncate(world, Vxcmo);
-
 
         END_TIMER(world, "Calc calc_xc_function ");
         print_meminfo(world.rank(), "Calc calc_xc_function");
         return Vxcmo;
     }
     
-    vecfuncT SCF::calc_djkmo(World & world, const vecfuncT & dmo1, 
+    /// @param[in]  drho    the perturbed density
+    vecfuncT SCF::calc_djkmo(World & world, XCOperator& xc_alda, const vecfuncT & dmo1,
                         const vecfuncT & dmo2,  const functionT & drho, const vecfuncT & mo,  
-                        const vecfuncT & vf,
                         const functionT & drhos,
                         int  spin)
     {
@@ -3137,7 +3121,7 @@ namespace madness {
         // TODO becareful with drhos , drho
         // open shell drhoa !=drhob
 
-        vecfuncT dkxcmo = calc_xc_function(world, mo, vf, drho, spin);
+        vecfuncT dkxcmo = calc_xc_function(world, xc_alda, mo, drho);
          //TODO hybrdid functs: not sure if should i have to apply 
         if(xc.hf_exchange_coefficient() == 1.0){
         //if(xc.hf_exchange_coefficient()){
@@ -3223,7 +3207,6 @@ namespace madness {
             int & axis,
             tensorT & Dpolar_total, tensorT & Dpolar_alpha, tensorT & Dpolar_beta)
     {
-        int fflag = 0;
         double Dpolar_average = 0.0;
         double Dpolar_iso = 0.0;
 
@@ -3376,75 +3359,6 @@ namespace madness {
         functionT brho ; 
         functionT rho = make_density_ground(world, arho, brho);
 
-
-        // In order to integrate with Florian's rewrite, need vf to follow this formatting:
-        // 
-        // the ordering of the intermediates is fixed, but the code can handle
-        // non-initialized functions, so if e.g. no GGA is requested, all the
-        // corresponding vector components may be left empty.
-        //  enum xc_arg {
-        //      enum_rhoa=0,            ///< alpha density \f$ \rho_\alpha \f$
-        //      enum_rhob=1,            ///< \f$ \rho_\beta \f$
-        //      enum_rho_pt=2,          ///< perturbed density (CPHF, TDKS) \f$ \rho_{pt} \f$
-        //      enum_drhoa_x=4,         ///< \f$ \partial/{\partial x} \rho_{\alpha} \f$
-        //      enum_drhoa_y=5,         ///< \f$ \partial/{\partial y} \rho_{\alpha} \f$
-        //      enum_drhoa_z=6,         ///< \f$ \partial/{\partial z} \rho_{\alpha} \f$
-        //      enum_drhob_x=7,         ///< \f$ \partial/{\partial x} \rho_{\beta} \f$
-        //      enum_drhob_y=8,         ///< \f$ \partial/{\partial y} \rho_{\beta} \f$
-        //      enum_drhob_z=9,         ///< \f$ \partial/{\partial z} \rho_{\beta} \f$
-        //      enum_saa=10,            ///< \f$ \sigma_{aa} = \nabla \rho_{\alpha}.\nabla \rho_{\alpha} \f$
-        //      enum_sab=11,            ///< \f$ \sigma_{ab} = \nabla \rho_{\alpha}.\nabla \rho_{\beta} \f$
-        //      enum_sbb=12,            ///< \f$ \sigma_{bb} = \nabla \rho_{\beta}.\nabla \rho_{\beta} \f$
-        //      enum_sigtot=13,         ///< \f$ \sigma = \nabla \rho.\nabla \rho \f$
-        //      enum_sigma_pta=14,      ///< \f$ \nabla\rho_{\alpha}.\nabla\rho_{pt} \f$
-        //      enum_sigma_ptb=15       ///< \f$ \nabla\rho_{\beta}.\nabla\rho_{pt} \f$
-        //
-        //      const static int number_xc_args=16 ///< max number of intermediates
-
-        vecfuncT vf(XCfunctional::number_xc_args);
-        vecfuncT delrho;
-
-        if (xc.is_dft()) {
-            START_TIMER(world);
-            arho.reconstruct();
-            vf[XCfunctional::enum_rhoa] = copy(arho);
-            if(!param.spin_restricted && param.nbeta != 0) {
-                brho.reconstruct();
-                vf[XCfunctional::enum_rhob] = copy(brho);                
-            }
-
-#ifdef MADNESS_HAS_LIBXC
-            if (xc.is_gga()) {
-                for (int axis = 0; axis < 3; ++axis)
-                          delrho.push_back((*gradop[axis])(arho, false)); // delrho
-                if (!param.spin_restricted && param.nbeta != 0)
-                //TODO if (xc.is_spin_polarized() && param.nbeta != 0)
-                          for (int axis = 0; axis < 3; ++axis)
-                                  delrho.push_back((*gradop[axis])(brho, false));
-
-                world.gop.fence(); // NECESSARY
-
-                vf[XCfunctional::enum_saa] = copy(   delrho[0] * delrho[0]
-                                                   + delrho[1] * delrho[1]
-                                                   + delrho[2] * delrho[2]);   // sigma_aa
-
-                if (!param.spin_restricted && param.nbeta != 0)
-                {
-                       vf[XCfunctional::enum_sab] = copy(  delrho[0] * delrho[3]
-                                                         + delrho[1] * delrho[4]
-                                                         + delrho[2] * delrho[5]); // sigma_ab
-
-                       vf[XCfunctional::enum_sbb] = copy(  delrho[3] * delrho[3]
-                                                         + delrho[4] * delrho[4]
-                                                         + delrho[5] * delrho[5]); // sigma_bb
-                 }
-                 world.gop.fence(); // NECESSARY
-            }
-#endif
-        } 
-
-        print_meminfo(world.rank(), "Make delrho");
-
         // vlocal = vnuc + 2*J  
         functionT vlocal;
         {
@@ -3548,37 +3462,45 @@ namespace madness {
             } 
             functionT drho = drhoa + drhob; 
 
+            // construct xc operator only once since the ground state density
+            // will not change during the iterations.
+            XCOperator xcop(world,this,arho,brho);
+
+            // construct xc operator for acting on the perturbed density --
+            // use only the LDA approximation
+            XCOperator xc_alda(world, "LDA", not param.spin_restricted, arho, brho);
+
             for(int iter = 0; iter < param.maxiter; ++iter) {
                 if(world.rank() == 0)
                     printf("\nIteration %d at time %.1fs\n\n", iter, wall_time());
                 
                 double residual = 0.0;
-                double exca = 0.0, excb = 0.0;
             
                 if (iter > 0 && update_residual < 0.1) {
                     //do_this_iter = false;
                     param.maxsub = maxsub_save;
                 }
                 
+
                 if(iter == 0) {
                     // iter = 0 initial_guess
-                    aVx = apply_potential_response(world, aocc, dipoleamo, vf, delrho, vlocal, exca,  0);
-                    djkamox = calc_djkmo(world, dipoleamo, dipoleamo, drho, amo, vf, drhoa,  0);
+                    aVx = apply_potential_response(world, dipoleamo, xcop, vlocal,  0);
+                    djkamox = calc_djkmo(world, xc_alda, dipoleamo, dipoleamo, drho, amo, drhoa,  0);
                     axrhs = calc_rhs(world, amo,  aVx, dipoleamo, djkamox);
 
                     if(!param.spin_restricted && param.nbeta != 0) { 
-                        bVx = apply_potential_response(world, bocc, dipolebmo, vf, delrho, vlocal, excb, 0);
-                        djkbmox = calc_djkmo(world, dipolebmo, dipolebmo, drho, bmo, vf, drhob,  0);
+                        bVx = apply_potential_response(world, dipolebmo, xcop, vlocal, 0);
+                        djkbmox = calc_djkmo(world, xc_alda, dipolebmo, dipolebmo, drho, bmo, drhob,  0);
                         bxrhs = calc_rhs(world, bmo,  bVx, dipolebmo, djkbmox);
                     } 
  
                     if(omega != 0.0) {
-                        aVy = apply_potential_response(world, aocc, dipoleamo, vf, delrho, vlocal, exca, 0);
-                        djkamoy = calc_djkmo(world, dipoleamo, dipoleamo, drho, amo, vf, drhoa,  0);
+                        aVy = apply_potential_response(world, dipoleamo, xcop, vlocal, 0);
+                        djkamoy = calc_djkmo(world, xc_alda, dipoleamo, dipoleamo, drho, amo, drhoa,  0);
                         ayrhs = calc_rhs(world, amo,  aVy, dipoleamo, djkamoy);
                         if(!param.spin_restricted && param.nbeta != 0) 
-                            bVy = apply_potential_response(world, bocc, dipolebmo, vf, delrho, vlocal, excb,  0);
-                            djkbmoy = calc_djkmo(world, dipolebmo, dipolebmo, drho, bmo, vf, drhob,  0);
+                            bVy = apply_potential_response(world, dipolebmo, xcop, vlocal,  0);
+                            djkbmoy = calc_djkmo(world, xc_alda, dipolebmo, dipolebmo, drho, bmo, drhob,  0);
                             byrhs = calc_rhs(world, bmo,  bVy, dipolebmo, djkbmoy);
                     } 
                 }
@@ -3595,27 +3517,27 @@ namespace madness {
                     drho = drhoa + drhob; 
 
                     // calculate (dJ-dK)*2*mo
-                    aVx = apply_potential_response(world, aocc, ax_old, vf, delrho, vlocal, exca, 0);
+                    aVx = apply_potential_response(world, ax_old, xcop, vlocal, 0);
                     // make potential * wave function
-                    djkamox = calc_djkmo(world, ax_old, ay_old, drho, amo, vf, drhoa,  0);
+                    djkamox = calc_djkmo(world, xc_alda, ax_old, ay_old, drho, amo, drhoa,  0);
                     // axrhs = -2.0 * (aVx + dipoleamo + duamo)
                     axrhs = calc_rhs(world, amo,  aVx, dipoleamo, djkamox);
 
                     if(!param.spin_restricted && param.nbeta != 0) {
-                        bVx = apply_potential_response(world, bocc, bx_old, vf, delrho, vlocal, excb,  1);
-                        djkbmox = calc_djkmo(world, bx_old, by_old, drho, bmo, vf, drhob , 1);
+                        bVx = apply_potential_response(world, bx_old, xcop, vlocal,  1);
+                        djkbmox = calc_djkmo(world, xc_alda, bx_old, by_old, drho, bmo, drhob , 1);
                         bxrhs = calc_rhs(world, bmo, bVx, dipolebmo, djkbmox);
                     }
 
                     if(omega != 0.0) {
-                        aVy = apply_potential_response(world, aocc, ay_old, vf,  delrho, vlocal, exca, 0);
-                        djkamoy = calc_djkmo(world, ay_old, ax_old,  drho, amo, vf,  drhoa, 0);
+                        aVy = apply_potential_response(world, ay_old, xcop,  vlocal, 0);
+                        djkamoy = calc_djkmo(world, xc_alda, ay_old, ax_old,  drho, amo, drhoa, 0);
                         // bxrhs = -2.0 * (bVx + dipolebmo + dubmo)
                         ayrhs = calc_rhs(world, amo, aVy, dipoleamo, djkamoy);
 
                         if(!param.spin_restricted && param.nbeta != 0) {
-                            bVy = apply_potential_response(world, bocc, by_old, vf,  delrho, vlocal, excb, 1);
-                            djkbmoy = calc_djkmo(world, by_old, bx_old, drho, amo, vf, drhob, 1);
+                            bVy = apply_potential_response(world, by_old, xcop,  vlocal, 1);
+                            djkbmoy = calc_djkmo(world, xc_alda, by_old, bx_old, drho, amo, drhob, 1);
                             byrhs = calc_rhs(world, bmo, bVy, dipolebmo, djkbmoy);
                         }
                     }

--- a/src/apps/chem/SCF.h
+++ b/src/apps/chem/SCF.h
@@ -50,7 +50,7 @@
 #include <chem/xcfunctional.h>
 #include <chem/potentialmanager.h>
 #include <chem/gth_pseudopotential.h> 
-
+#include <chem/SCFOperators.h>
 #include <madness/tensor/solvers.h>
 #include <madness/tensor/distributed_matrix.h>
 
@@ -1052,10 +1052,8 @@ namespace madness {
                                       subspaceT & subspace, tensorT & Q, double & update_residual);
         
         
-        vecfuncT apply_potential_response(World & world, const tensorT & occ, const vecfuncT & dmo,
-                                          const vecfuncT& vf, const vecfuncT& delrho,  const functionT & vlocal,
-                                          double & exc,
-                                          int ispin);
+        vecfuncT apply_potential_response(World & world, const vecfuncT & dmo,
+                                          const XCOperator& xc,  const functionT & vlocal, int ispin);
         void this_axis(World & world, int & axis);
         vecfuncT calc_dipole_mo(World & world,  vecfuncT & mo, int & axis);
         void calc_freq(World & world, double & omega, tensorT & ak, tensorT & bk, int sign);
@@ -1069,11 +1067,10 @@ namespace madness {
         functionT calc_exchange_function(World & world,  const int & p,
                                          const vecfuncT & dmo1,  const vecfuncT & dmo2,
                                          const vecfuncT & mo, int & spin);
-        vecfuncT calc_xc_function(World & world,
-                                  const vecfuncT & mo,  const vecfuncT & vf,  const functionT & drho, int & spin)     ;
-        vecfuncT calc_djkmo(World & world, const vecfuncT & dmo1,
+        vecfuncT calc_xc_function(World & world, XCOperator& xc_alda,
+                                  const vecfuncT & mo,  const functionT & drho);
+        vecfuncT calc_djkmo(World & world, XCOperator& xc_alda, const vecfuncT & dmo1,
                             const vecfuncT & dmo2,  const functionT & drho, const vecfuncT & mo,     
-                            const vecfuncT & vf,
                             const functionT & drhos,
                             int  spin);
         vecfuncT calc_rhs(World & world, const vecfuncT & mo ,

--- a/src/apps/chem/SCFOperators.cc
+++ b/src/apps/chem/SCFOperators.cc
@@ -659,7 +659,7 @@ real_function_3d XCOperator::make_xc_potential() const {
 ///        + 2\frac{\partial^2 f_{xc}}{\partial \rho_\alpha\sigma_{\alpha\alpha}}
 ///            \left(\vec\nabla \rho_a\cdot \vec \nabla\tilde\rho\right)
 /// \f]
-//  the second partial derivatives that need to be multiplied with the density gradients
+///  the second partial derivatives that need to be multiplied with the density gradients
 /// \f[
 ///      second_{semilocal} = -\vec\nabla\cdot\left((\vec\nabla\rho)
 ///             \left[2\frac{\partial^2 f_{xc}}{\partial\rho_\alpha\partial\sigma_{\alpha\alpha}}\tilde\rho
@@ -686,48 +686,30 @@ real_function_3d XCOperator::apply_xc_kernel(const real_function_3d& dens_pt) co
 
     // compute the various terms from the xc kernel
 
-    // compute the local terms: second_{local}
+    // compute the local terms: second_{local} * rho
     real_function_3d result=multiop_values<double, xc_kernel_apply, 3>
             (xc_kernel_apply(*xc, ispin, XCfunctional::kernel_second_local), xc_args);
-//    save(result,"local_apply");
 
     if (xc->is_gga()) {
+
+        const real_function_3d& arho=xc_args[XCfunctional::enum_rhoa];
+        vecfuncT zeta(3);
+        zeta[0]=xc_args[XCfunctional::enum_zetaa_x];
+        zeta[1]=xc_args[XCfunctional::enum_zetaa_y];
+        zeta[2]=xc_args[XCfunctional::enum_zetaa_z];
+
         // compute the semilocal terms, second partial derivatives
         real_function_3d semilocal2a=multiop_values<double, xc_kernel_apply, 3>
                 (xc_kernel_apply(*xc, ispin, XCfunctional::kernel_second_semilocal), xc_args);
-        save(semilocal2a,"semilocal2a");
-
-        const real_function_3d& rho=xc_args[XCfunctional::enum_rhoa];
         double tol=xc->get_ggatol();
-        real_function_3d semilocal2=binary_op(semilocal2a,rho,binary_munging(tol));
-//        real_function_3d semilocal2=semilocal2a;
-        save(semilocal2,"semilocal2_ddel");
-
-        for (int idim=0; idim<3; ++idim) {
-            real_function_3d ddens = xc_args[XCfunctional::enum_drhoa_x+idim];
-            real_function_3d ddel = 2.0*semilocal2*ddens;
-            save(ddel,"ddel"+stringify(idim));
-            Derivative<double,3> D = free_space_derivative<double,3>(world, idim);
-            real_function_3d vxc2=D(ddel);
-            save(vxc2,"vxc2"+stringify(idim));
-            result-=vxc2;
-        }
+        real_function_3d semilocal2=binary_op(semilocal2a,arho,binary_munging(tol));
+        result-=2.0* div(zeta * (arho*semilocal2)); // factor 2 missing in arho
 
         // compute the semilocal terms, first partial derivative
         real_function_3d semilocal1a=multiop_values<double, xc_kernel_apply, 3>
                 (xc_kernel_apply(*xc, ispin, XCfunctional::kernel_first_semilocal), xc_args);
-        real_function_3d semilocal1=binary_op(semilocal1a,rho,binary_munging(tol));
-//        real_function_3d semilocal1=semilocal1a;
-//        save(semilocal1a,"semilocal1a");
-
-        for (int idim=0; idim<3; ++idim) {
-            real_function_3d ddel = semilocal1*ddens_pt[idim];
-            Derivative<double,3> D = free_space_derivative<double,3>(world, idim);
-            real_function_3d vxc2=D(ddel);
-            result-=vxc2;
-        }
-        real_function_3d result1=binary_op(result,rho,binary_munging(tol));
-        result=result1;
+        real_function_3d semilocal1=binary_op(semilocal1a,arho,binary_munging(tol));
+        result-=div(semilocal1*ddens_pt);
     }
 
     truncate(world,xc_args);
@@ -758,7 +740,6 @@ vecfuncT XCOperator::prep_xc_args(const real_function_3d& arho,
         xcargs[XCfunctional::enum_zetaa_x]=grada[0];
         xcargs[XCfunctional::enum_zetaa_y]=grada[1];
         xcargs[XCfunctional::enum_zetaa_z]=grada[2];
-//        save(xcargs[XCfunctional::enum_chi_aa],"chi");
 
         if (have_beta) {
             real_function_3d logdensb=unary_op(brho,logme());
@@ -771,10 +752,6 @@ vecfuncT XCOperator::prep_xc_args(const real_function_3d& arho,
             xcargs[XCfunctional::enum_chi_bb]=chib;
             xcargs[XCfunctional::enum_chi_ab]=chiab;
         }
-        //            // this is needed for proper munging of sigma_ab
-        //            xcargs[XCfunctional::enum_sigtot]= xcargs[XCfunctional::enum_saa]
-        //                           +2.0*xcargs[XCfunctional::enum_sab]+xcargs[XCfunctional::enum_sbb];
-
     }
 
     world.gop.fence();
@@ -789,45 +766,38 @@ void XCOperator::prep_xc_args_response(const real_function_3d& dens_pt,
     const bool have_beta=(xc->is_spin_polarized()) and (nbeta>0);
     World& world=dens_pt.world();
 
-    const real_function_3d& arho=xc_args[XCfunctional::enum_rhoa];
-    const real_function_3d& brho=xc_args[XCfunctional::enum_rhob];
-    ddens_pt=vecfuncT(3);
-
-    // assign the perturbed density (spin-free ??)
+    // assign the perturbed density (spin-free)
     xc_args[XCfunctional::enum_rho_pt]=dens_pt;
     world.gop.fence();
 
     // assign the reduced density gradients with the perturbed density for GGA
+    // \sigma_pt   = 2.0 * \nabla \rho_\alpha \cdot \nabla\tilde\rho
     // \sigma_pt_a = \nabla \rho_\alpha \cdot \nabla\tilde\rho
     // \sigma_pt_b = \nabla \rho_\beta \cdot \nabla\tilde\rho
+    //
+    // using the logarithmic derivatives for rho only we get (alpha and RHF)
+    // \sigma_pt = 2.0 * \rho_\alpha (\nabla\zeta_\alpha \cdot \nabla\tilde\rho)
+    // \sigma_pt_a = \rho_\alpha (\nabla\zeta_\alpha \cdot \nabla\tilde\rho)
+    // we save the functions without multiplying the ground state density rho
     if (xc->is_gga()) {
 
-        std::vector< std::shared_ptr<Derivative<double,3> > > gradop =
-                gradient_operator<double,3>(world);
-        arho.reconstruct(false);
-        brho.reconstruct(false);
-        dens_pt.reconstruct(false);
+        ddens_pt=grad(dens_pt);     // spin free
+
+        std::vector<real_function_3d> zeta(3);
+        zeta[0]=xc_args[XCfunctional::enum_zetaa_x];
+        zeta[1]=xc_args[XCfunctional::enum_zetaa_y];
+        zeta[2]=xc_args[XCfunctional::enum_zetaa_z];
+        xc_args[XCfunctional::enum_sigma_pta_div_rho]=dot(world,zeta,ddens_pt);    // sigma_a
+        // for RHF add factor 2 on rho; will be done in xcfunctional_libxc::make_libxc_args
+        // \sigma_pt = 2 * rho_a * sigma_pta_div_rho
         world.gop.fence();
 
-        std::vector<real_function_3d> ddensa(3),ddensb(3);
-        for (std::size_t i=0; i<3; ++i) {
-            ddensa[i]=(*gradop[i])(arho, false);
-            if (have_beta) ddensb[i]=(*gradop[i])(brho, false);
-            ddens_pt[i]=(*gradop[i])(dens_pt, false);
+        if (have_beta) {
+            zeta[0]=xc_args[XCfunctional::enum_zetab_x];
+            zeta[1]=xc_args[XCfunctional::enum_zetab_y];
+            zeta[2]=xc_args[XCfunctional::enum_zetab_z];
+            xc_args[XCfunctional::enum_sigma_ptb_div_rho]= dot(world,zeta,ddens_pt);  // sigma_b
         }
-        world.gop.fence();
-
-        // autorefine before squaring
-        for (std::size_t i=0; i<3; ++i) {
-            ddensa[i].refine(false);
-            if (have_beta) ddensb[i].refine(false);
-            ddens_pt[i].refine(false);
-        }
-        world.gop.fence();
-
-        xc_args[XCfunctional::enum_sigma_pta]=dot(world,ddensa,ddens_pt);    // sigma_a
-        if (have_beta) xc_args[XCfunctional::enum_sigma_ptb]= dot(world,ddensb,ddens_pt);
-//        save(xc_args[XCfunctional::enum_sigma_pta],"sigma_pt");
         world.gop.fence();
     }
     world.gop.fence();

--- a/src/apps/chem/SCFOperators.h
+++ b/src/apps/chem/SCFOperators.h
@@ -499,17 +499,10 @@ private:
     void prep_xc_args_response(const real_function_3d& dens_pt,
             vecfuncT& xc_args, vecfuncT& ddens_pt) const;
 
-    /// compute the intermediates for the XC functionals
-
-    /// @param[in]  arho    density of the alpha orbitals
-    /// @param[in]  brho    density of the beta orbitals (necessary only if spin-polarized)
-    /// @param[out] vf      vector of intermediates as described above
-    /// @param[out] delrho  vector of derivatives of the densities as described above
-    void prep_xc_args_old(const real_function_3d& arho,
-            const real_function_3d& brho, vecfuncT& delrho, vecfuncT& vf) const;
-
     /// check if the intermediates are initialized
-    bool is_initialized() const;
+    bool is_initialized() const {
+        return (xc_args.size()>0);
+    }
 
     /// simple structure to take the pointwise logarithm of a function, shifted by +14
     struct logme{

--- a/src/apps/chem/SCFOperators.h
+++ b/src/apps/chem/SCFOperators.h
@@ -439,6 +439,13 @@ public:
     /// apply the xc potential on a set of orbitals
     vecfuncT operator()(const vecfuncT& vket) const;
 
+    /// apply the xc potential on an orbitals
+    real_function_3d operator()(const real_function_3d& ket) const {
+        vecfuncT vket(1,ket);
+        vecfuncT vKket=this->operator()(vket);
+        return vKket[0];
+    }
+
     /// compute the xc energy using the precomputed intermediates vf and delrho
     double compute_xc_energy() const;
 

--- a/src/apps/chem/SCFOperators.h
+++ b/src/apps/chem/SCFOperators.h
@@ -433,6 +433,9 @@ public:
         return *this;
     }
 
+    /// set the spin state this operator is acting on
+    void set_ispin(const int i) const {ispin=i;}
+
     /// apply the xc potential on a set of orbitals
     vecfuncT operator()(const vecfuncT& vket) const;
 
@@ -464,7 +467,7 @@ private:
     int nbeta;
 
     /// the XC functionals depend on the spin of the orbitals they act on
-    int ispin;
+    mutable int ispin;
 
     /// functions that are need for the computation of the XC operator
 

--- a/src/apps/chem/xcfunctional_ldaonly.cc
+++ b/src/apps/chem/xcfunctional_ldaonly.cc
@@ -170,5 +170,14 @@ madness::Tensor<double> XCfunctional::fxc_apply(const std::vector<Tensor<double>
 	MADNESS_EXCEPTION("fxc_apply not implemented in xcfunctional_ldaonly.cc... use libxc",1);
 }
 
+void make_libxc_args(const std::vector< madness::Tensor<double> >& t,
+                        madness::Tensor<double>& rho,
+                        madness::Tensor<double>& sigma,
+                        madness::Tensor<double>& rho_pt,
+                        madness::Tensor<double>& sigma_pt,
+                        const bool need_response) const {
+    MADNESS_EXCEPTION("no make_libxc_args without libxc",1);
+}
+
 }
 #endif

--- a/src/apps/chem/xcfunctional_libxc.cc
+++ b/src/apps/chem/xcfunctional_libxc.cc
@@ -447,11 +447,6 @@ madness::Tensor<double> XCfunctional::vxc(const std::vector< madness::Tensor<dou
 }
 
 
-/// compute the derivative of the XC potential (2nd derivative of the XC energy)
-
-/// @param[in]  t   vector of Tensors holding rho and sigma
-/// @param[in]  ispin   the current spin (0=alpha, 1=beta)
-/// @param[in]  xc_contrib    which term to compute
 Tensor<double> XCfunctional::fxc_apply(const std::vector<Tensor<double> >& t,
         const int ispin, const xc_contribution xc_contrib) const {
 


### PR DESCRIPTION
Changed the interface to libxc to use the log-derivatives and added documentation and tests.

@alvarovm et al: I've adapted your response code to work again, and my tests worked, please check if I've missed something. Also, I think there was double-counting in the GGA potential part, see SCF.cc:2884, please double-check that too.
