### PR TITLE
World::get_default() can be disabled via a macro

### DIFF
--- a/src/madness/world/world.h
+++ b/src/madness/world/world.h
@@ -267,6 +267,9 @@ namespace madness {
         /// \c madness::initialize().
         /// \return A reference to the default \c World.
         static World& get_default() {
+#ifdef MADNESS_DISABLE_WORLD_GET_DEFAULT
+            MADNESS_EXCEPTION("World::get_default() was called while disabled", 0);
+#endif
             MADNESS_ASSERT(default_world);
             return *default_world;
         }


### PR DESCRIPTION
rationale: useful to disable access to global World if want to write code that properly manages execution context (e.g. for writing reusable pieces that live in a subworld)