### PR TITLE
Do not use -ansi with ICC

### DIFF
--- a/config/acx_enable_optimal.m4
+++ b/config/acx_enable_optimal.m4
@@ -92,7 +92,7 @@ AC_DEFUN([ACX_ENABLE_OPTIMAL], [
       ;;
 
       Intel)
-        acx_enable_optimal_flags="$acx_enable_optimal_flags -ip -no-prec-div -mkl=sequential -ansi -xHOST"
+        acx_enable_optimal_flags="$acx_enable_optimal_flags -ip -no-prec-div -mkl=sequential -xHOST"
         if test $enable_cpp0x = "yes"; then
           acx_enable_optimal_flags="$acx_enable_optimal_flags -std=c++0x"
         fi


### PR DESCRIPTION
ICC documents that -ansi behaves the same way as in GCC. GCC [documents](https://gcc.gnu.org/onlinedocs/gcc/Standards.html)  that `-ansi` implies C++98/C++03.  Clearly, if we are using C++11 or later, `-ansi` does not make sense.