### PR TITLE
conversion of taskq::add to accept callables

### DIFF
--- a/src/madness/mra/funcimpl.h
+++ b/src/madness/mra/funcimpl.h
@@ -4995,8 +4995,9 @@ namespace madness {
                                     const typename mapT::iterator lend,
                                     typename FunctionImpl<R,NDIM>::mapT* rmap_ptr,
                                     const bool sym,
-                                    Tensor< TENSOR_RESULT_TYPE(T,R) >& result,
+                                    Tensor< TENSOR_RESULT_TYPE(T,R) >* result_ptr,
                                     Mutex* mutex) {
+            Tensor< TENSOR_RESULT_TYPE(T,R) >& result = *result_ptr;
             Tensor< TENSOR_RESULT_TYPE(T,R) > r(result.dim(0),result.dim(1));
             for (typename mapT::iterator lit=lstart; lit!=lend; ++lit) {
                 const keyT& key = lit->first;
@@ -5073,7 +5074,7 @@ namespace madness {
             while (lstart != lmap.end()) {
                 typename mapT::iterator lend = lstart;
                 advance(lend,chunk);
-                left[0]->world.taskq.add(&FunctionImpl<T,NDIM>::do_inner_localX<R>, lstart, lend, rmap_ptr, sym, r, &mutex);
+                left[0]->world.taskq.add(&FunctionImpl<T,NDIM>::do_inner_localX<R>, lstart, lend, rmap_ptr, sym, &r, &mutex);
                 lstart = lend;
             }
             left[0]->world.taskq.fence();

--- a/src/madness/world/CMakeLists.txt
+++ b/src/madness/world/CMakeLists.txt
@@ -11,7 +11,7 @@ set(MADWORLD_HEADERS
     uniqueid.h worldprofile.h timers.h binary_fstream_archive.h mpi_archive.h 
     text_fstream_archive.h worlddc.h mem_func_wrapper.h taskfn.h group.h 
     dist_cache.h distributed_id.h type_traits.h function_traits.h stubmpi.h 
-    bgq_atomics.h binsorter.h parsec.h)
+    bgq_atomics.h binsorter.h parsec.h meta.h)
 set(MADWORLD_SOURCES
     madness_exception.cc world.cc timers.cc future.cc redirectio.cc
     archive_type_names.cc info.cc debug.cc print.cc worldmem.cc worldrmi.cc

--- a/src/madness/world/Makefile.am
+++ b/src/madness/world/Makefile.am
@@ -18,7 +18,7 @@ thisinclude_HEADERS = info.h archive.h print.h worldam.h future.h worldmpi.h \
 	timers.h binary_fstream_archive.h mpi_archive.h text_fstream_archive.h \
 	worlddc.h mem_func_wrapper.h taskfn.h group.h dist_cache.h \
 	distributed_id.h type_traits.h \
-	function_traits.h stubmpi.h bgq_atomics.h binsorter.h
+	function_traits.h stubmpi.h bgq_atomics.h binsorter.h meta.h
 
 
                       

--- a/src/madness/world/function_traits.h
+++ b/src/madness/world/function_traits.h
@@ -20,7 +20,7 @@ namespace madness {
         template <typename memfuncT>
         struct memfunc_traits : public std::false_type { };
 
-        /// Function traits in the spirit of boost function traits
+        /// Function trait specialization for a free function pointer
         template <typename resultT, typename... argTs>
         struct function_traits<resultT(*)(argTs...), void> {
           static const bool value = true;
@@ -28,7 +28,6 @@ namespace madness {
           using result_type = resultT;
         };
 
-        /// Function traits in the spirit of boost function traits
         /// Function trait specialization for a *reference* to a free function pointer
         template <typename resultT, typename... argTs>
         struct function_traits<resultT(*&)(argTs...), void> {
@@ -37,6 +36,7 @@ namespace madness {
           using result_type = resultT;
         };
 
+        /// Function trait specialization for a callable (can be a function, a (generic) lambda, etc.)
         template <typename fnT, typename... argTs>
         struct function_traits<fnT(argTs...), typename std::enable_if_t<is_type<std::result_of_t<fnT(argTs...)>>::value>> {
             static const bool value = true;

--- a/src/madness/world/function_traits.h
+++ b/src/madness/world/function_traits.h
@@ -29,6 +29,14 @@ namespace madness {
         };
 
         /// Function traits in the spirit of boost function traits
+        /// Function trait specialization for a *reference* to a free function pointer
+        template <typename resultT, typename... argTs>
+        struct function_traits<resultT(*&)(argTs...), void> {
+          static const bool value = true;
+          static const int arity = sizeof...(argTs);
+          using result_type = resultT;
+        };
+
         template <typename fnT, typename... argTs>
         struct function_traits<fnT(argTs...), typename std::enable_if_t<is_type<std::result_of_t<fnT(argTs...)>>::value>> {
             static const bool value = true;

--- a/src/madness/world/function_traits.h
+++ b/src/madness/world/function_traits.h
@@ -5,23 +5,46 @@
 
 namespace madness {
     namespace detail {
-        /// Function traits in the spirt of boost function traits
-        template <typename functionT>
+        // helps to implement other metafunctions
+        template<typename> struct is_type : public std::true_type { };
+
+        /// Function traits in the spirit of boost function traits
+        template <typename functionT, typename enablerT = void>
         struct function_traits : public std::false_type {};
 
-        /// Member function traits in the spirt of boost function traits
+        /// Function traits in the spirit of boost function traits
+        template <typename functionT, typename enablerT = void>
+        struct callable_traits : public std::false_type {};
+
+        /// Member function traits in the spirit of boost function traits
         template <typename memfuncT>
         struct memfunc_traits : public std::false_type { };
 
-        /// Function traits in the spirt of boost function traits
-        template <typename returnT, typename... argTs>
-        struct function_traits<returnT(*)(argTs...)> {
-            static const bool value = true;
-            static const int arity = sizeof...(argTs);
-            typedef returnT result_type;
+        /// Function traits in the spirit of boost function traits
+        template <typename resultT, typename... argTs>
+        struct function_traits<resultT(*)(argTs...), void> {
+          static const bool value = true;
+          static const int arity = sizeof...(argTs);
+          using result_type = resultT;
         };
 
-        /// Member function traits in the spirt of boost function traits
+        /// Function traits in the spirit of boost function traits
+        template <typename fnT, typename... argTs>
+        struct function_traits<fnT(argTs...), typename std::enable_if_t<is_type<std::result_of_t<fnT(argTs...)>>::value>> {
+            static const bool value = true;
+            static const int arity = sizeof...(argTs);
+            using result_type = std::result_of_t<fnT(argTs...)>;
+        };
+
+        /// Function traits in the spirit of boost function traits
+        template <typename fnT, typename... argTs>
+        struct callable_traits<fnT(argTs...), typename std::enable_if_t<is_type<std::result_of_t<fnT(argTs...)>>::value>> {
+            static const bool value = true;
+            static const int arity = sizeof...(argTs);
+            using result_type = std::result_of_t<fnT(argTs...)>;
+        };
+
+        /// Member function traits in the spirit of boost function traits
         template <typename objT, typename returnT, typename... argTs>
         struct memfunc_traits<returnT(objT::*)(argTs...)> {
             static const bool value = true;
@@ -31,7 +54,7 @@ namespace madness {
             typedef returnT result_type;
         };
 
-        /// Member function traits in the spirt of boost function traits
+        /// Member function traits in the spirit of boost function traits
         template <typename objT, typename returnT, typename... argTs>
         struct memfunc_traits<returnT(objT::*)(argTs...) const> {
             static const bool value = true;
@@ -40,11 +63,6 @@ namespace madness {
             typedef objT obj_type;
             typedef returnT result_type;
         };
-
-
-        // helps to implement other metafunctions
-        template<typename> struct is_type : public std::true_type { };
-
 
 
         template <typename fnT, typename Enabler = void>

--- a/src/madness/world/future.h
+++ b/src/madness/world/future.h
@@ -100,7 +100,11 @@ namespace madness {
         typedef T type;
     };
 
-    /// Boost-type-trait-like mapping of \c Future<T> to \c T.
+    /// This metafunction maps \c Future<T> to \c T.
+
+    /// \internal Future is a wrapper for T (it acts like an Identity monad), so this
+    /// unwraps T. It makes sense that the result should preserve the access traits
+    /// of the Future, i.e. const Future<T> should map to const T, etc.
 
     /// Specialization of \c remove_future for \c Future<T>
     /// \tparam T The type to have future removed.
@@ -108,6 +112,14 @@ namespace madness {
     struct remove_future< Future<T> > {
         /// Type with \c Future removed.
         typedef T type;
+    };
+
+    /// Specialization of \c remove_future for \c Future<T>
+    /// \tparam T The type to have future removed.
+    template <typename T>
+    struct remove_future< const Future<T> > {
+        /// Type with \c Future removed.
+        typedef const T type;
     };
 
     /// Specialization of \c remove_future for \c Future<T>&
@@ -648,7 +660,7 @@ namespace madness {
 
         /// Same as \c get().
 
-        /// \return The value.
+        /// \return An const lvalue reference to the value.
         inline operator T&() & {
             return get();
         }
@@ -656,14 +668,21 @@ namespace madness {
 
         /// Same as `get() const`.
 
-        /// \return The value.
+        /// \return An const lvalue reference to the value.
         inline operator const T&() const& {
             return get();
         }
 
-        /// Same as \c get().
+        /// An rvalue analog of \c get().
 
-        /// \return The value.
+        /// \return An rvalue reference to the value.
+        /// \internal Rationale: the conversion operators unwrap the
+        ///           Future object (see also \c remove_future
+        ///           metafunction), hence the result should maintain
+        ///           the traits of the Future object. The rvalue conversion
+        ///           is made explicit to avoid accidents (perhaps this should
+        ///           be revisited to make easier moving Future objects into
+        ///           functions).
         inline explicit operator T&&() && {
             return std::move(get());
         }

--- a/src/madness/world/future.h
+++ b/src/madness/world/future.h
@@ -102,7 +102,7 @@ namespace madness {
 
     /// Boost-type-trait-like mapping of \c Future<T> to \c T.
 
-    /// Specialization of \c remove_future.
+    /// Specialization of \c remove_future for \c Future<T>
     /// \tparam T The type to have future removed.
     template <typename T>
     struct remove_future< Future<T> > {
@@ -110,10 +110,38 @@ namespace madness {
         typedef T type;
     };
 
+    /// Specialization of \c remove_future for \c Future<T>&
+    /// \tparam T The type to have future removed.
+    template <typename T>
+    struct remove_future< Future<T>& > {
+        /// Type with \c Future removed.
+        typedef T& type;
+    };
+
+    /// Specialization of \c remove_future for \c Future<T>&&
+    /// \tparam T The type to have future removed.
+    template <typename T>
+    struct remove_future< Future<T>&& > {
+        /// Type with \c Future removed.
+        typedef T&& type;
+    };
+
+    /// Specialization of \c remove_future for \c const \c Future<T>&
+    /// \tparam T The type to have future removed.
+    template <typename T>
+    struct remove_future< const Future<T>& > {
+        /// Type with \c Future removed.
+        typedef const T& type;
+    };
+
     /// Macro to determine type of future (by removing wrapping \c Future template).
 
     /// \param T The type (possibly with \c Future).
 #define REMFUTURE(T) typename remove_future< T >::type
+
+    /// C++11 version of REMFUTURE
+    template <typename T>
+    using remove_future_t = typename remove_future< T >::type;
 
     /// Human readable printing of a \c Future to a stream.
 
@@ -621,7 +649,7 @@ namespace madness {
         /// Same as \c get().
 
         /// \return The value.
-        inline operator T&() {
+        inline operator T&() & {
             return get();
         }
 
@@ -629,14 +657,14 @@ namespace madness {
         /// Same as `get() const`.
 
         /// \return The value.
-        inline operator const T&() const {
+        inline operator const T&() const& {
             return get();
         }
 
         /// Same as \c get().
 
         /// \return The value.
-        inline explicit operator T&&() {
+        inline explicit operator T&&() && {
             return std::move(get());
         }
 

--- a/src/madness/world/meta.h
+++ b/src/madness/world/meta.h
@@ -31,54 +31,57 @@ struct last_type<T0, T1, Ts...> : last_type<T1, Ts...> {};
 
 ///////////////////////////////////////////////////////////////////////////////
 
-template <template <typename...> class MetaFn, typename T, typename... P>
-struct drop_last_param_and_apply_impl;
+template <template <typename...> class MetaFn, typename CurrentTypelist,
+          typename... RestOfTypes>
+struct drop_last_arg_and_apply_impl;
 
-template <template <typename...> class MetaFn, typename... P1, typename T,
-          typename... P2>
-struct drop_last_param_and_apply_impl<MetaFn, typelist<P1...>, T, P2...> {
+template <template <typename...> class MetaFn, typename... UpToT, typename T,
+          typename... Rest>
+struct drop_last_arg_and_apply_impl<MetaFn, typelist<UpToT...>, T, Rest...> {
   using type =
-      typename drop_last_param_and_apply_impl<MetaFn, typelist<P1..., T>,
-                                              P2...>::type;
+      typename drop_last_arg_and_apply_impl<MetaFn, typelist<UpToT..., T>,
+                                            Rest...>::type;
 };
 
-template <template <typename...> class MetaFn, typename... P1, typename T,
-          typename L>
-struct drop_last_param_and_apply_impl<MetaFn, typelist<P1...>, T, L> {
-  using type = MetaFn<P1..., T>;
+template <template <typename...> class MetaFn, typename... UpToLast,
+          typename Last>
+struct drop_last_arg_and_apply_impl<MetaFn, typelist<UpToLast...>, Last> {
+  using type = MetaFn<UpToLast...>;
 };
 
-template <template <typename...> class MetaFn, typename... P>
-struct drop_last_param_and_apply {
+template <template <typename...> class MetaFn, typename... Args>
+struct drop_last_arg_and_apply {
   using type =
-      typename drop_last_param_and_apply_impl<MetaFn, typelist<>, P...>::type;
+      typename drop_last_arg_and_apply_impl<MetaFn, typelist<>, Args...>::type;
 };
 
 ///////////////////////////////////////////////////////////////////////////////
 
-template <template <typename...> class MetaFn, typename T, typename... P>
-struct drop_last_param_and_apply_callable_impl;
+template <template <typename...> class MetaFn, typename Callable,
+          typename CurrentTypelist, typename... RestOfTypes>
+struct drop_last_arg_and_apply_callable_impl;
 
 template <template <typename...> class MetaFn, typename Callable,
-          typename... P1, typename T, typename... P2>
-struct drop_last_param_and_apply_callable_impl<MetaFn, Callable,
-                                               typelist<P1...>, T, P2...> {
-  using type = typename drop_last_param_and_apply_callable_impl<
-      MetaFn, Callable, typelist<P1..., T>, P2...>::type;
+          typename... UpToT, typename T, typename... Rest>
+struct drop_last_arg_and_apply_callable_impl<MetaFn, Callable,
+                                             typelist<UpToT...>, T, Rest...> {
+  using type = typename drop_last_arg_and_apply_callable_impl<
+      MetaFn, Callable, typelist<UpToT..., T>, Rest...>::type;
 };
 
 template <template <typename...> class MetaFn, typename Callable,
-          typename... P1, typename T, typename L>
-struct drop_last_param_and_apply_callable_impl<MetaFn, Callable,
-                                               typelist<P1...>, T, L> {
-  using type = MetaFn<Callable(P1..., T)>;
+          typename... UpToLast, typename Last>
+struct drop_last_arg_and_apply_callable_impl<MetaFn, Callable,
+                                             typelist<UpToLast...>, Last> {
+  using type = MetaFn<Callable(UpToLast...)>;
 };
 
-template <template <typename...> class MetaFn, typename Callable, typename... P>
-struct drop_last_param_and_apply_callable {
+template <template <typename...> class MetaFn, typename Callable,
+          typename... Args>
+struct drop_last_arg_and_apply_callable {
   using type =
-      typename drop_last_param_and_apply_callable_impl<MetaFn, Callable,
-                                                       typelist<>, P...>::type;
+      typename drop_last_arg_and_apply_callable_impl<MetaFn, Callable,
+                                                     typelist<>, Args...>::type;
 };
 
 }  // namespace meta

--- a/src/madness/world/meta.h
+++ b/src/madness/world/meta.h
@@ -1,0 +1,87 @@
+/*
+ * meta.h
+ *
+ *  Created on: Apr 15, 2017
+ *      Author: evaleev
+ */
+
+#ifndef SRC_MADNESS_WORLD_META_H_
+#define SRC_MADNESS_WORLD_META_H_
+
+namespace madness {
+namespace meta {  // to make it easier importing another MP library
+
+///////////////////////////////////////////////////////////////////////////////
+
+template <typename... P>
+struct typelist {};
+
+///////////////////////////////////////////////////////////////////////////////
+
+template <typename... Ts>
+struct last_type {};
+
+template <typename T0>
+struct last_type<T0> {
+  typedef T0 type;
+};
+
+template <typename T0, typename T1, typename... Ts>
+struct last_type<T0, T1, Ts...> : last_type<T1, Ts...> {};
+
+///////////////////////////////////////////////////////////////////////////////
+
+template <template <typename...> class MetaFn, typename T, typename... P>
+struct drop_last_param_and_apply_impl;
+
+template <template <typename...> class MetaFn, typename... P1, typename T,
+          typename... P2>
+struct drop_last_param_and_apply_impl<MetaFn, typelist<P1...>, T, P2...> {
+  using type =
+      typename drop_last_param_and_apply_impl<MetaFn, typelist<P1..., T>,
+                                              P2...>::type;
+};
+
+template <template <typename...> class MetaFn, typename... P1, typename T,
+          typename L>
+struct drop_last_param_and_apply_impl<MetaFn, typelist<P1...>, T, L> {
+  using type = MetaFn<P1..., T>;
+};
+
+template <template <typename...> class MetaFn, typename... P>
+struct drop_last_param_and_apply {
+  using type =
+      typename drop_last_param_and_apply_impl<MetaFn, typelist<>, P...>::type;
+};
+
+///////////////////////////////////////////////////////////////////////////////
+
+template <template <typename...> class MetaFn, typename T, typename... P>
+struct drop_last_param_and_apply_callable_impl;
+
+template <template <typename...> class MetaFn, typename Callable,
+          typename... P1, typename T, typename... P2>
+struct drop_last_param_and_apply_callable_impl<MetaFn, Callable,
+                                               typelist<P1...>, T, P2...> {
+  using type = typename drop_last_param_and_apply_callable_impl<
+      MetaFn, Callable, typelist<P1..., T>, P2...>::type;
+};
+
+template <template <typename...> class MetaFn, typename Callable,
+          typename... P1, typename T, typename L>
+struct drop_last_param_and_apply_callable_impl<MetaFn, Callable,
+                                               typelist<P1...>, T, L> {
+  using type = MetaFn<Callable(P1..., T)>;
+};
+
+template <template <typename...> class MetaFn, typename Callable, typename... P>
+struct drop_last_param_and_apply_callable {
+  using type =
+      typename drop_last_param_and_apply_callable_impl<MetaFn, Callable,
+                                                       typelist<>, P...>::type;
+};
+
+}  // namespace meta
+}  // namespace madness
+
+#endif /* SRC_MADNESS_WORLD_META_H_ */

--- a/src/madness/world/taskfn.h
+++ b/src/madness/world/taskfn.h
@@ -36,6 +36,9 @@
 #include <madness/world/dependency_interface.h>
 #include <madness/world/thread.h>
 #include <madness/world/future.h>
+#include <madness/world/meta.h>
+
+#define MADNESS_TASKQ_VARIADICS 1
 
 namespace madness {
 
@@ -172,7 +175,12 @@ namespace madness {
             Arg arg_;
         public:
 
-            ArgHolder(const Arg& arg) : arg_(arg) { }
+            template <typename Arg_ = Arg,
+            typename = std::enable_if_t<
+              !std::is_same<std::decay_t<Arg_>,
+                            archive::BufferInputArchive>::value
+            >>
+            ArgHolder(Arg_&& arg) : arg_(arg) { }
 
             ArgHolder(const archive::BufferInputArchive& input_arch) :
                 arg_()
@@ -180,9 +188,9 @@ namespace madness {
                 input_arch & arg_;
             }
 
-            operator Arg&() { return arg_; }
-            operator const Arg&() const { return arg_; }
-            explicit operator Arg&&() { return std::move(arg_); }
+            operator Arg&() & { return arg_; }
+            operator const Arg&() const& { return arg_; }
+            explicit operator Arg&&() && { return std::move(arg_); }
         }; // class ArgHolder
 
         template <typename T>
@@ -545,6 +553,132 @@ namespace madness {
 
     public:
 
+#if MADNESS_TASKQ_VARIADICS
+
+        // what this look like ... but need extra MP functionality
+//        template <typename ... argsT>
+//        TaskFn(const futureT& result, functionT func, argsT&& ... args) :
+//            TaskInterface(attr), result_(result), func_(func), arg1_(), arg2_(),
+//            arg3_(), arg4_(), arg5_(), arg6_(), arg7_(), arg8_(), arg9_()
+//            {
+//          MADNESS_ASSERT(arity == 0u);
+//          check_dependencies();
+//            }
+        TaskFn(const futureT& result, functionT func, const TaskAttributes& attr) :
+            TaskInterface(attr), result_(result), func_(func), arg1_(), arg2_(),
+            arg3_(), arg4_(), arg5_(), arg6_(), arg7_(), arg8_(), arg9_()
+        {
+            MADNESS_ASSERT(arity == 0u);
+            check_dependencies();
+        }
+
+        template <typename a1T>
+        TaskFn(const futureT& result, functionT func, a1T&& a1,
+                const TaskAttributes& attr) :
+            TaskInterface(attr), result_(result), func_(func), arg1_(std::forward<a1T>(a1)), arg2_(),
+            arg3_(), arg4_(), arg5_(), arg6_(), arg7_(), arg8_(), arg9_()
+        {
+            MADNESS_ASSERT(arity == 1u);
+            check_dependencies();
+        }
+
+        template <typename a1T, typename a2T>
+        TaskFn(const futureT& result, functionT func, a1T&& a1, a2T&& a2,
+                const TaskAttributes& attr) :
+            TaskInterface(attr), result_(result), func_(func), arg1_(std::forward<a1T>(a1)), arg2_(std::forward<a2T>(a2)),
+            arg3_(), arg4_(), arg5_(), arg6_(), arg7_(), arg8_(), arg9_()
+        {
+            MADNESS_ASSERT(arity == 2u);
+            check_dependencies();
+        }
+
+        template <typename a1T, typename a2T, typename a3T>
+        TaskFn(const futureT& result, functionT func, a1T&& a1, a2T&& a2,
+                a3T&& a3, const TaskAttributes& attr) :
+            TaskInterface(attr), result_(result), func_(func), arg1_(std::forward<a1T>(a1)), arg2_(std::forward<a2T>(a2)),
+            arg3_(std::forward<a3T>(a3)), arg4_(), arg5_(), arg6_(), arg7_(), arg8_(), arg9_()
+        {
+            MADNESS_ASSERT(arity == 3u);
+            check_dependencies();
+        }
+
+        template <typename a1T, typename a2T, typename a3T, typename a4T>
+        TaskFn(const futureT& result, functionT func, a1T&& a1, a2T&& a2,
+                a3T&& a3, a4T&& a4, const TaskAttributes& attr) :
+            TaskInterface(attr), result_(result), func_(func), arg1_(std::forward<a1T>(a1)), arg2_(std::forward<a2T>(a2)),
+            arg3_(std::forward<a3T>(a3)), arg4_(std::forward<a4T>(a4)), arg5_(), arg6_(), arg7_(), arg8_(), arg9_()
+        {
+            MADNESS_ASSERT(arity == 4u);
+            check_dependencies();
+        }
+
+        template <typename a1T, typename a2T, typename a3T, typename a4T, typename a5T>
+        TaskFn(const futureT& result, functionT func, a1T&& a1, a2T&& a2,
+                a3T&& a3, a4T&& a4, a5T&& a5, const TaskAttributes& attr) :
+            TaskInterface(attr), result_(result), func_(func), arg1_(std::forward<a1T>(a1)), arg2_(std::forward<a2T>(a2)),
+            arg3_(std::forward<a3T>(a3)), arg4_(std::forward<a4T>(a4)), arg5_(std::forward<a5T>(a5)), arg6_(), arg7_(), arg8_(), arg9_()
+        {
+            MADNESS_ASSERT(arity == 5u);
+            check_dependencies();
+        }
+
+        template <typename a1T, typename a2T, typename a3T, typename a4T, typename a5T,
+                typename a6T>
+        TaskFn(const futureT& result, functionT func, a1T&& a1, a2T&& a2,
+                a3T&& a3, a4T&& a4, a5T&& a5, a6T&& a6,
+                const TaskAttributes& attr) :
+            TaskInterface(attr), result_(result), func_(func), arg1_(std::forward<a1T>(a1)), arg2_(std::forward<a2T>(a2)),
+            arg3_(std::forward<a3T>(a3)), arg4_(std::forward<a4T>(a4)), arg5_(std::forward<a5T>(a5)), arg6_(std::forward<a6T>(a6)), arg7_(), arg8_(), arg9_()
+        {
+            MADNESS_ASSERT(arity == 6u);
+            check_dependencies();
+        }
+
+        template <typename a1T, typename a2T, typename a3T, typename a4T, typename a5T,
+                typename a6T, typename a7T>
+        TaskFn(const futureT& result, functionT func, a1T&& a1, a2T&& a2,
+                a3T&& a3, a4T&& a4, a5T&& a5, a6T&& a6,
+                a7T&& a7, const TaskAttributes& attr) :
+            TaskInterface(attr), result_(result), func_(func), arg1_(std::forward<a1T>(a1)), arg2_(std::forward<a2T>(a2)),
+            arg3_(std::forward<a3T>(a3)), arg4_(std::forward<a4T>(a4)), arg5_(std::forward<a5T>(a5)), arg6_(std::forward<a6T>(a6)), arg7_(std::forward<a7T>(a7)), arg8_(), arg9_()
+        {
+            MADNESS_ASSERT(arity == 7u);
+            check_dependencies();
+        }
+
+        template <typename a1T, typename a2T, typename a3T, typename a4T, typename a5T,
+                typename a6T, typename a7T, typename a8T>
+        TaskFn(const futureT& result, functionT func, a1T&& a1, a2T&& a2,
+                a3T&& a3, a4T&& a4, a5T&& a5, a6T&& a6, a7T&& a7,
+                a8T&& a8, const TaskAttributes& attr) :
+            TaskInterface(attr), result_(result), func_(func), arg1_(std::forward<a1T>(a1)), arg2_(std::forward<a2T>(a2)),
+            arg3_(std::forward<a3T>(a3)), arg4_(std::forward<a4T>(a4)), arg5_(std::forward<a5T>(a5)), arg6_(std::forward<a6T>(a6)), arg7_(std::forward<a7T>(a7)), arg8_(std::forward<a8T>(a8)), arg9_()
+        {
+            MADNESS_ASSERT(arity == 8u);
+            check_dependencies();
+        }
+
+        template <typename a1T, typename a2T, typename a3T, typename a4T, typename a5T,
+                typename a6T, typename a7T, typename a8T, typename a9T>
+        TaskFn(const futureT& result, functionT func, a1T&& a1, a2T&& a2,
+                a3T&& a3, a4T&& a4, a5T&& a5, a6T&& a6,
+                a7T&& a7, a8T&& a8, a9T&& a9, const TaskAttributes& attr) :
+            TaskInterface(attr), result_(result), func_(func), arg1_(std::forward<a1T>(a1)), arg2_(std::forward<a2T>(a2)),
+            arg3_(std::forward<a3T>(a3)), arg4_(std::forward<a4T>(a4)), arg5_(std::forward<a5T>(a5)), arg6_(std::forward<a6T>(a6)), arg7_(std::forward<a7T>(a7)), arg8_(std::forward<a8T>(a8)), arg9_(std::forward<a9T>(a9))
+        {
+            MADNESS_ASSERT(arity == 9u);
+            check_dependencies();
+        }
+
+        TaskFn(const futureT& result, functionT func, const TaskAttributes& attr,
+                archive::BufferInputArchive& input_arch) :
+            TaskInterface(attr), result_(result), func_(func), arg1_(input_arch),
+            arg2_(input_arch), arg3_(input_arch), arg4_(input_arch), arg5_(input_arch),
+            arg6_(input_arch), arg7_(input_arch), arg8_(input_arch), arg9_(input_arch)
+        {
+            // No need to check dependencies since the arguments are from an archive
+        }
+#else  // MADNESS_TASKQ_VARIADICS
         TaskFn(const futureT& result, functionT func, const TaskAttributes& attr) :
             TaskInterface(attr), result_(result), func_(func), arg1_(), arg2_(),
             arg3_(), arg4_(), arg5_(), arg6_(), arg7_(), arg8_(), arg9_()
@@ -659,6 +793,7 @@ namespace madness {
         {
             // No need to check dependencies since the arguments are from an archive
         }
+#endif  // MADNESS_TASKQ_VARIADICS
 
         virtual ~TaskFn() { }
 

--- a/src/madness/world/type_traits.h
+++ b/src/madness/world/type_traits.h
@@ -55,6 +55,8 @@ namespace madness {
         typedef typename remove_future<typename std::remove_cv<
                    typename std::remove_reference<T>::type>::type>::type type;
     };
+    template <typename T>
+    using remove_fcvr_t = typename remove_fcvr<T>::type;
 
     /// This defines stuff that is serialiable by default rules ... basically anything contiguous
     template <typename T>

--- a/src/madness/world/world_task_queue.h
+++ b/src/madness/world/world_task_queue.h
@@ -165,6 +165,17 @@ namespace madness {
         /// \todo Brief description needed.
 
         /// \todo Descriptions needed.
+        /// \tparam fnT Description needed.
+        template <typename callableT, typename Enabler = void>
+        struct callable_enabler;
+        template <typename callableT>
+        struct callable_enabler<callableT,
+        std::enable_if_t<callable_traits<callableT>::value>>
+        { using type = typename callable_traits<callableT>::result_type; };
+
+        /// \todo Brief description needed.
+
+        /// \todo Descriptions needed.
         /// \tparam objT Description needed.
         /// \tparam memfnT Description needed.
         /// \tparam enableT Description needed.
@@ -576,7 +587,7 @@ namespace madness {
         ///     type is \c void, a \c Future<void> object is returned that may
         ///     be ignored.
         template <typename fnT>
-        typename detail::function_enabler<fnT>::type
+        typename detail::function_enabler<fnT()>::type
         add(fnT fn, const TaskAttributes& attr=TaskAttributes()) {
             typedef TaskFn<fnT> taskT;
             return add(new taskT(typename taskT::futureT(),
@@ -596,7 +607,7 @@ namespace madness {
         ///     type is \c void, a \c Future<void> object is returned that may
         ///     be ignored.
         template <typename fnT, typename a1T>
-        typename detail::function_enabler<fnT>::type
+        typename detail::function_enabler<fnT(a1T)>::type
         add(fnT fn, const a1T& a1, const TaskAttributes& attr=TaskAttributes()) {
             typedef TaskFn<fnT, a1T> taskT;
             return add(new taskT(typename taskT::futureT(),
@@ -618,7 +629,7 @@ namespace madness {
         ///     type is \c void, a \c Future<void> object is returned that may
         ///     be ignored.
         template <typename fnT, typename a1T, typename a2T>
-        typename detail::function_enabler<fnT>::type
+        typename detail::function_enabler<fnT(a1T, a2T)>::type
         add(fnT fn, const a1T& a1, const a2T& a2, const TaskAttributes& attr=TaskAttributes()) {
             typedef TaskFn<fnT, a1T, a2T> taskT;
             return add(new taskT(typename taskT::futureT(),
@@ -642,7 +653,7 @@ namespace madness {
         ///     type is \c void, a \c Future<void> object is returned that may
         ///     be ignored.
         template <typename fnT, typename a1T, typename a2T, typename a3T>
-        typename detail::function_enabler<fnT>::type
+        typename detail::function_enabler<fnT(a1T, a2T, a3T)>::type
         add(fnT fn, const a1T& a1, const a2T& a2, const a3T& a3,
             const TaskAttributes& attr=TaskAttributes())
         {
@@ -670,7 +681,7 @@ namespace madness {
         ///     type is \c void, a \c Future<void> object is returned that may
         ///     be ignored.
         template <typename fnT, typename a1T, typename a2T, typename a3T, typename a4T>
-        typename detail::function_enabler<fnT>::type
+        typename detail::function_enabler<fnT(a1T, a2T, a3T, a4T)>::type
         add(fnT fn, const a1T& a1, const a2T& a2, const a3T& a3, const a4T& a4,
             const TaskAttributes& attr=TaskAttributes())
         {
@@ -701,7 +712,7 @@ namespace madness {
         ///     be ignored.
         template <typename fnT, typename a1T, typename a2T, typename a3T, typename a4T,
             typename a5T>
-        typename detail::function_enabler<fnT>::type
+        typename detail::function_enabler<fnT(a1T, a2T, a3T, a4T, a5T)>::type
         add(fnT fn, const a1T& a1, const a2T& a2, const a3T& a3, const a4T& a4,
             const a5T& a5, const TaskAttributes& attr=TaskAttributes())
         {
@@ -734,7 +745,7 @@ namespace madness {
         ///     be ignored.
         template <typename fnT, typename a1T, typename a2T, typename a3T, typename a4T,
             typename a5T, typename a6T>
-        typename detail::function_enabler<fnT>::type
+        typename detail::function_enabler<fnT(a1T, a2T, a3T, a4T, a5T, a6T)>::type
         add(fnT fn, const a1T& a1, const a2T& a2, const a3T& a3, const a4T& a4,
             const a5T& a5, const a6T& a6, const TaskAttributes& attr=TaskAttributes())
         {
@@ -769,7 +780,7 @@ namespace madness {
         ///     be ignored.
         template <typename fnT, typename a1T, typename a2T, typename a3T, typename a4T,
             typename a5T, typename a6T, typename a7T>
-        typename detail::function_enabler<fnT>::type
+        typename detail::function_enabler<fnT(a1T, a2T, a3T, a4T, a5T, a6T, a7T)>::type
         add(fnT fn, const a1T& a1, const a2T& a2, const a3T& a3, const a4T& a4,
             const a5T& a5, const a6T& a6, const a7T& a7,
             const TaskAttributes& attr=TaskAttributes())
@@ -807,7 +818,7 @@ namespace madness {
         ///     be ignored.
         template <typename fnT, typename a1T, typename a2T, typename a3T, typename a4T,
             typename a5T, typename a6T, typename a7T, typename a8T>
-        typename detail::function_enabler<fnT>::type
+        typename detail::function_enabler<fnT(a1T, a2T, a3T, a4T, a5T, a6T, a7T, a8T)>::type
         add(fnT fn, const a1T& a1, const a2T& a2, const a3T& a3, const a4T& a4,
             const a5T& a5, const a6T& a6, const a7T& a7, const a8T& a8,
             const TaskAttributes& attr=TaskAttributes())
@@ -847,7 +858,7 @@ namespace madness {
         ///     be ignored.
         template <typename fnT, typename a1T, typename a2T, typename a3T, typename a4T,
             typename a5T, typename a6T, typename a7T, typename a8T, typename a9T>
-        typename detail::function_enabler<fnT>::type
+        typename detail::function_enabler<fnT(a1T, a2T, a3T, a4T, a5T, a6T, a7T, a8T, a9T)>::type
         add(fnT fn, const a1T& a1, const a2T& a2, const a3T& a3, const a4T& a4,
             const a5T& a5, const a6T& a6, const a7T& a7, const a8T& a8, const a9T& a9,
             const TaskAttributes& attr=TaskAttributes())

--- a/src/madness/world/world_task_queue.h
+++ b/src/madness/world/world_task_queue.h
@@ -605,7 +605,7 @@ namespace madness {
                   meta::taskattr_is_last_arg<argsT...>::value>>
         typename meta::drop_last_arg_and_apply_callable<detail::function_enabler, fnT, remove_future_t<argsT>...>::type::type
         add(fnT&& fn, argsT&&... args) {
-          using taskT = typename meta::drop_last_arg_and_apply<TaskFn, std::decay_t<fnT>, remove_fcvr_t<argsT>...>::type;
+          using taskT = typename meta::drop_last_arg_and_apply<TaskFn, std::decay_t<fnT>, std::decay_t<argsT>...>::type;
           return add(new taskT(typename taskT::futureT(), std::forward<fnT>(fn),
                                std::forward<argsT>(args)...));
         }
@@ -615,7 +615,7 @@ namespace madness {
                       !meta::taskattr_is_last_arg<argsT...>::value>>
         typename detail::function_enabler<fnT(remove_future_t<argsT>...)>::type add(
             fnT&& fn, argsT&&... args) {
-          using taskT = TaskFn<std::decay_t<fnT>, remove_fcvr_t<argsT>...>;
+          using taskT = TaskFn<std::decay_t<fnT>, std::decay_t<argsT>...>;
           return add(new taskT(typename taskT::futureT(), std::forward<fnT>(fn),
                                std::forward<argsT>(args)..., TaskAttributes()));
         }


### PR DESCRIPTION
 e.g. this should work with polymorphic/generic lambdas, etc. when the interface is switched to universal refs.