### PR TITLE
amended 37dd650079e7f3eecc09db9afd58a137be2ddc86 to relax decay rules…

### DIFF
--- a/src/madness/world/future.h
+++ b/src/madness/world/future.h
@@ -155,6 +155,28 @@ namespace madness {
     template <typename T>
     using remove_future_t = typename remove_future< T >::type;
 
+    /// Similar to remove_future , but future_to_ref<Future<T>> evaluates to T& ,whereas
+    /// remove_future<Future<T>> evaluates to T .
+    /// \tparam T The type to have future removed; in this case, do nothing.
+    template <typename T>
+    struct future_to_ref {
+        typedef T type;
+    };
+    template <typename T>
+    struct future_to_ref<Future<T>> {
+      typedef T& type;
+    };
+    template <typename T>
+    struct future_to_ref<Future<T>&> {
+      typedef T& type;
+    };
+    template <typename T>
+    struct future_to_ref<const Future<T>&> {
+      typedef const T& type;
+    };
+    template <typename T>
+    using future_to_ref_t = typename future_to_ref< T >::type;
+
     /// Human readable printing of a \c Future to a stream.
 
     /// \tparam T The type of future.

--- a/src/madness/world/world_task_queue.h
+++ b/src/madness/world/world_task_queue.h
@@ -603,7 +603,7 @@ namespace madness {
         template <typename fnT, typename... argsT,
                   typename = std::enable_if_t<
                   meta::taskattr_is_last_arg<argsT...>::value>>
-        typename meta::drop_last_arg_and_apply_callable<detail::function_enabler, fnT, remove_future_t<argsT>...>::type::type
+        typename meta::drop_last_arg_and_apply_callable<detail::function_enabler, fnT, future_to_ref_t<argsT>...>::type::type
         add(fnT&& fn, argsT&&... args) {
           using taskT = typename meta::drop_last_arg_and_apply<TaskFn, std::decay_t<fnT>, std::decay_t<argsT>...>::type;
           return add(new taskT(typename taskT::futureT(), std::forward<fnT>(fn),
@@ -613,7 +613,7 @@ namespace madness {
         template <typename fnT, typename... argsT,
                   typename = std::enable_if_t<
                       !meta::taskattr_is_last_arg<argsT...>::value>>
-        typename detail::function_enabler<fnT(remove_future_t<argsT>...)>::type add(
+        typename detail::function_enabler<fnT(future_to_ref_t<argsT>...)>::type add(
             fnT&& fn, argsT&&... args) {
           using taskT = TaskFn<std::decay_t<fnT>, std::decay_t<argsT>...>;
           return add(new taskT(typename taskT::futureT(), std::forward<fnT>(fn),


### PR DESCRIPTION
… for Future<T> as callable args