### PR TITLE
moved nonlinsol.h to mra, in absence of a generic solver lib, to enab…

### DIFF
--- a/src/apps/chem/CC2.h
+++ b/src/apps/chem/CC2.h
@@ -18,7 +18,7 @@
 #include <madness/mra/lbdeux.h>
 #include <madness/misc/ran.h>
 #include <chem/TDHF.h>
-#include <examples/nonlinsol.h>
+#include <madness/mra/nonlinsol.h>
 
 namespace madness {
 

--- a/src/apps/chem/CMakeLists.txt
+++ b/src/apps/chem/CMakeLists.txt
@@ -10,7 +10,7 @@ set(MADCHEM_HEADERS
     molecular_optimizer.h projector.h
     SCFOperators.h CCStructures.h CalculationParameters.h
     electronic_correlation_factor.h cheminfo.h vibanal.h molopt.h TDHF.h CC2.h CCPotentials.h
-    pcm.h)
+    pcm.h SCFProtocol.h)
 set(MADCHEM_SOURCES
     correlationfactor.cc molecule.cc molecularbasis.cc vibanal.cc
     corepotential.cc atomutil.cc lda.cc cheminfo.cc

--- a/src/apps/chem/mp2.cc
+++ b/src/apps/chem/mp2.cc
@@ -46,7 +46,7 @@
 #include <madness/mra/mra.h>
 #include <madness/mra/lbdeux.h>
 #include <chem/SCF.h>
-#include <examples/nonlinsol.h>
+#include <madness/mra/nonlinsol.h>
 #include <chem/projector.h>
 #include <chem/correlationfactor.h>
 #include <chem/nemo.h>

--- a/src/apps/chem/mp2.h
+++ b/src/apps/chem/mp2.h
@@ -43,7 +43,7 @@
 #include <madness/mra/mra.h>
 #include <madness/mra/lbdeux.h>
 #include <chem/SCF.h>
-#include <examples/nonlinsol.h>
+#include <madness/mra/nonlinsol.h>
 #include <chem/projector.h>
 #include <chem/correlationfactor.h>
 #include <chem/electronic_correlation_factor.h>

--- a/src/apps/chem/nemo.h
+++ b/src/apps/chem/nemo.h
@@ -52,7 +52,7 @@
 #include <chem/SCFProtocol.h>
 #include <chem/correlationfactor.h>
 #include <chem/molecular_optimizer.h>
-#include <examples/nonlinsol.h>
+#include <madness/mra/nonlinsol.h>
 #include <madness/mra/vmra.h>
 #include <chem/pcm.h>
 

--- a/src/examples/3dharmonic.cc
+++ b/src/examples/3dharmonic.cc
@@ -104,7 +104,7 @@
   to choose the size of the shift to optimize the rate of convergence
   (empirically \f$\Delta=7\f$ is best) rather than being forced to
   pick a large value.  We use the very easy to use solver in
-  examples/nonlinsol.h .
+  mra/nonlinsol.h .
 
   [Aside.  It is possible to apply the operator for positive energies,
   but efficient application requires separate treatment of the
@@ -116,7 +116,7 @@
 //#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/mra/funcplot.h>
-#include "nonlinsol.h"
+#include <madness/mra/nonlinsol.h>
 
 using namespace madness;
 

--- a/src/examples/Makefile.am
+++ b/src/examples/Makefile.am
@@ -19,7 +19,7 @@ noinst_PROGRAMS += hefxc
 endif
 
 thisincludedir = $(includedir)/examples
-thisinclude_HEADERS = molecularmask.h  nonlinsol.h spectralprop.h
+thisinclude_HEADERS = molecularmask.h  spectralprop.h
 
 AUTOMAKE_OPTIONS = subdir-objects
 

--- a/src/examples/colloid.cc
+++ b/src/examples/colloid.cc
@@ -31,7 +31,7 @@ This proram simulates the effect of surface solute interaction between a colloid
 //#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 //#include <madness/mra/operator.h>
 #include "molecularmask.h"
-#include "nonlinsol.h"
+#include <madness/mra/nonlinsol.h>
 #include <madness/mra/mra.h>
 #include <madness/mra/lbdeux.h>
 #include <madness/misc/ran.h>

--- a/src/examples/dielectric.cc
+++ b/src/examples/dielectric.cc
@@ -174,7 +174,7 @@
 #include <madness/mra/funcplot.h>
 #include <madness/tensor/solvers.h>
 #include "molecularmask.h"
-#include "nonlinsol.h"
+#include <madness/mra/nonlinsol.h>
 #include <madness/constants.h>
 #include <vector>
 

--- a/src/examples/dielectric_external_field.cc
+++ b/src/examples/dielectric_external_field.cc
@@ -98,7 +98,7 @@
 #include <madness/mra/funcplot.h>
 #include <madness/tensor/solvers.h>
 #include "molecularmask.h"
-#include "nonlinsol.h"
+#include <madness/mra/nonlinsol.h>
 #include <madness/constants.h>
 #include <vector>
 

--- a/src/examples/gygi_soltion.cc
+++ b/src/examples/gygi_soltion.cc
@@ -55,7 +55,7 @@ $Id$
 #include <ctime>
 #include <madness/tensor/solvers.h>
 #include <madness/mra/funcplot.h>
-#include "nonlinsol.h"
+#include <madness/mra/nonlinsol.h>
 using namespace madness;
 typedef real_function_3d realfunc;
 //define parameter

--- a/src/examples/h2dft.cc
+++ b/src/examples/h2dft.cc
@@ -1,7 +1,7 @@
 //#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/mra/operator.h>
-#include "nonlinsol.h"
+#include <madness/mra/nonlinsol.h>
 
 
 

--- a/src/examples/h2dynamic.cc
+++ b/src/examples/h2dynamic.cc
@@ -1,7 +1,7 @@
 //#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/mra/operator.h>
-#include "nonlinsol.h"
+#include <madness/mra/nonlinsol.h>
 
 using namespace madness;
 

--- a/src/examples/hedft.cc
+++ b/src/examples/hedft.cc
@@ -1,7 +1,7 @@
 //#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/mra/operator.h>
-#include "nonlinsol.h"
+#include <madness/mra/nonlinsol.h>
 
 
 

--- a/src/examples/hefxc.cc
+++ b/src/examples/hefxc.cc
@@ -1,7 +1,7 @@
 //#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/mra/operator.h>
-#include "nonlinsol.h"
+#include <madness/mra/nonlinsol.h>
 
 
 

--- a/src/examples/newsolver.cc
+++ b/src/examples/newsolver.cc
@@ -1,7 +1,7 @@
 //#define WORLD_INSTANTIATE_STATIC_TEMPLATES  
 #include <madness/mra/mra.h>
 #include <madness/mra/operator.h>
-#include "nonlinsol.h"
+#include <madness/mra/nonlinsol.h>
 
 using namespace madness;
 

--- a/src/examples/newsolver_lda.cc
+++ b/src/examples/newsolver_lda.cc
@@ -3,7 +3,7 @@
 #include <type_traits>
 #include <madness/mra/mra.h>
 #include <madness/mra/operator.h>
-#include "nonlinsol.h"
+#include <madness/mra/nonlinsol.h>
 
 #include <madness/mra/lbdeux.h>
 #include <madness/mra/qmprop.h>

--- a/src/examples/siam_example.cc
+++ b/src/examples/siam_example.cc
@@ -49,7 +49,7 @@
 
 #include <madness/mra/mra.h>
 #include <madness/constants.h>
-#include "nonlinsol.h"
+#include <madness/mra/nonlinsol.h>
 
 using namespace madness;
 using namespace std;

--- a/src/examples/svpe.cc
+++ b/src/examples/svpe.cc
@@ -37,7 +37,7 @@
 #include <madness/mra/funcplot.h>
 #include <madness/tensor/solvers.h>
 #include "molecularmask.h"
-#include "nonlinsol.h"
+#include <madness/mra/nonlinsol.h>
 #include <madness/constants.h>
 #include <vector>
 

--- a/src/examples/testsolver.cc
+++ b/src/examples/testsolver.cc
@@ -1,5 +1,5 @@
 #include <iostream>
-#include "nonlinsol.h"
+#include <madness/mra/nonlinsol.h>
 #include <cmath>
 
 using namespace madness;

--- a/src/madness/mra/CMakeLists.txt
+++ b/src/madness/mra/CMakeLists.txt
@@ -9,7 +9,7 @@ set(MADMRA_HEADERS
     mraimpl.h  funcplot.h  function_common_data.h function_factory.h
     function_interface.h gfit.h convolution1d.h simplecache.h derivative.h
     displacements.h functypedefs.h sdf_shape_3D.h sdf_domainmask.h vmra1.h
-    leafop.h)
+    leafop.h nonlinsol.h)
 set(MADMRA_SOURCES
     mra1.cc mra2.cc mra3.cc mra4.cc mra5.cc mra6.cc startup.cc legendre.cc 
     twoscale.cc qmprop.cc)

--- a/src/madness/mra/Makefile.am
+++ b/src/madness/mra/Makefile.am
@@ -44,7 +44,7 @@ thisinclude_HEADERS = adquad.h  funcimpl.h  indexit.h  legendre.h  operator.h  v
                       lbdeux.h  mraimpl.h  funcplot.h  function_common_data.h \
                       function_factory.h function_interface.h gfit.h convolution1d.h \
                       simplecache.h derivative.h displacements.h functypedefs.h \
-                      sdf_shape_3D.h sdf_domainmask.h vmra1.h
+                      sdf_shape_3D.h sdf_domainmask.h vmra1.h nonlinsol.h 
 
 
 LDADD = libMADmra.la $(LIBLINALG) $(LIBTENSOR) $(LIBMISC) $(LIBMUPARSER) $(LIBWORLD)

--- a/src/madness/mra/nonlinsol.h
+++ b/src/madness/mra/nonlinsol.h
@@ -35,10 +35,10 @@
 #define MADNESS_EXAMPLES_NONLINSOL_H__INCLUDED
 
 /*!
-  \file examples/nonlinsol.h
-  \brief Example implementation of Krylov-subspace nonlinear equation solver 
+  \file nonlinsol.h
+  \brief Implementation of Krylov-subspace nonlinear equation solver
   \defgroup nonlinearsolve Simple Krylov-subspace nonlinear equation solver 
-  \ingroup examples
+  \ingroup mra
 
   This class implements the solver described in 
   \verbatim


### PR DESCRIPTION
…le reuse by codes that depend e.g. on MADchem (contents in example/ are not reuable)