### PR TITLE
Unintentional copying of WorldObject in CorrelationFactor::apply_U

### DIFF
--- a/src/apps/chem/electronic_correlation_factor.h
+++ b/src/apps/chem/electronic_correlation_factor.h
@@ -78,7 +78,7 @@ public:
 
     /// apply Kutzelnigg's regularized potential to an orbital product
     real_function_6d apply_U(const real_function_3d& phi_i, const real_function_3d& phi_j,
-            const real_convolution_6d op_mod, const bool symmetric=false) const {
+            const real_convolution_6d& op_mod, const bool symmetric=false) const {
 	  if(not op_mod.modified()) MADNESS_EXCEPTION("ElectronicCorrelationFactor::apply_U, op_mod must be in modified_NS form",1);
 	  const double thresh = FunctionDefaults<6>::get_thresh();
 	  const bool debug = false;


### PR DESCRIPTION
Small fix in electronic_correlation_factor.h. Screening operator is now passed as reference.