### PR TITLE
generalized redirectio

### DIFF
--- a/src/madness/world/print.h
+++ b/src/madness/world/print.h
@@ -194,6 +194,21 @@ namespace madness {
         print_helper(std::cout, ts...) << ENDL;
     }
 
+    /// \brief Print items to \c std::cerr (items separated by spaces) and
+    ///    terminate with a new line
+
+    /// The first item is printed here so that it isn't preceded by a space.
+    /// \tparam T Type of the first item to be printed.
+    /// \tparam Ts Argument pack type for the items to be printed.
+    /// \param[in] t The first item to be printed.
+    /// \param[in] ts The remaining items to be printed in the argument pack.
+    template<typename T, typename... Ts>
+    void print_error(const T& t, const Ts&... ts) {
+        ScopedMutex<Mutex> safe(detail::printmutex);
+        std::cerr << t;
+        print_helper(std::cerr, ts...) << ENDL;
+    }
+
     /// @}
 
 }

--- a/src/madness/world/redirectio.cc
+++ b/src/madness/world/redirectio.cc
@@ -39,14 +39,15 @@ using std::endl;
 
 static std::ofstream fout;
 namespace madness {
-    void redirectio(World& world) {
+    void redirectio(const World& world, bool split) {
         char filename[256];
         std::sprintf(filename,"log.%5.5d",world.mpi.rank());
-        
-        if (!freopen(filename, "w", stdout)) MADNESS_EXCEPTION("reopening stdout failed", 0);
-        if (!freopen(filename, "w", stderr)) MADNESS_EXCEPTION("reopening stderr failed", 0);
-	std::cout.sync_with_stdio(true);
-	std::cerr.sync_with_stdio(true);
+        char errfilename[256];
+        std::sprintf(errfilename,"%s.%5.5d", (split ? "err" : "log"), world.mpi.rank());
+        if (!freopen(   filename, "w", stdout)) MADNESS_EXCEPTION("reopening stdout failed", 0);
+        if (!freopen(errfilename, "w", stderr)) MADNESS_EXCEPTION("reopening stderr failed", 0);
+	      std::cout.sync_with_stdio(true);
+	      std::cerr.sync_with_stdio(true);
     }
 }
 

--- a/src/madness/world/world.h
+++ b/src/madness/world/world.h
@@ -82,11 +82,12 @@ namespace madness {
     class WorldAmInterface;
     class WorldGopInterface;
 
-    /// \todo Brief description needed.
+    /// redirects standard output and error to rank-specific files
 
-    /// \todo Description needed.
-    /// \param[in,out] world Description needed.
-    void redirectio(World& world);
+    /// @param[in] world the World object that determines rank of this process
+    /// @param[in] split if true, write standard output to log.<rank> and standard error to err.<rank>,
+    ///            otherwise write both standard output and error to log.<rank>. The default is false.
+    void redirectio(const World& world, bool split = false);
 
     /// Initialize the MADNESS runtime.
 


### PR DESCRIPTION
to split stdout and stderr (not split by default), also added madness::print_error to print to cerr