### PR TITLE
Futureptr as task args

### DIFF
--- a/src/madness/world/future.h
+++ b/src/madness/world/future.h
@@ -176,7 +176,7 @@ namespace madness {
     };
     template <typename T>
     struct future_to_ref<const Future<T>&> {
-      typedef const T& type;
+      typedef T& type;
     };
     template <typename T>
     using future_to_ref_t = typename future_to_ref< T >::type;

--- a/src/madness/world/future.h
+++ b/src/madness/world/future.h
@@ -167,6 +167,10 @@ namespace madness {
       typedef T& type;
     };
     template <typename T>
+    struct future_to_ref<Future<T>*> {
+      typedef T& type;
+    };
+    template <typename T>
     struct future_to_ref<Future<T>&> {
       typedef T& type;
     };

--- a/src/madness/world/test_world.cc
+++ b/src/madness/world/test_world.cc
@@ -193,6 +193,9 @@ void test5(World& world) {
     Future<string> kate2;
     Future<double> kate3;
     Future<string> kate = world.taskq.add(TTT::kate,&world,kate2,kate3);
+    Future<string> katy2;
+    Future<double> katy3;
+    Future<string> katy = world.taskq.add(TTT::kate,&world,&katy2,&katy3);
     Future<string> cute = world.taskq.add(right,TTT::kate,&world,string("Boo!"),-42.0);
     TTT ttt;
     Future<double> jody = world.taskq.add(ttt,&TTT::jody,1.0,2.0,3.0);
@@ -204,6 +207,8 @@ void test5(World& world) {
     sara2.set(double_complex(2.1,1.2));
     kate2.set(string("Who's your daddy?"));
     kate3.set(3.14);
+    katy2.set(string("Your momma"));
+    katy3.set(6.28);
 
     vector< Future<int> > futv = future_vector_factory<int>(7);
     Future<double> hugh = world.taskq.add(ttt,&TTT::hugh,futv);
@@ -222,6 +227,7 @@ void test5(World& world) {
     MADNESS_ASSERT(bert.probe());
     MADNESS_ASSERT(sara.probe());
     MADNESS_ASSERT(kate.probe());
+    MADNESS_ASSERT(katy.probe());
     MADNESS_ASSERT(cute.probe());
     MADNESS_ASSERT(jody.probe());
     MADNESS_ASSERT(hugh.probe());
@@ -235,6 +241,7 @@ void test5(World& world) {
     MADNESS_ASSERT(duh.get() == 21.0);
     print("Sara says",sara.get().real(),sara.get().imag());
     print("Kate says",kate.get());
+    print("Katy says",katy.get());
     print("Cute says",cute.get());
     print("Jody says",jody.get());
 

--- a/src/madness/world/world_task_queue.h
+++ b/src/madness/world/world_task_queue.h
@@ -605,7 +605,9 @@ namespace madness {
                   meta::taskattr_is_last_arg<argsT...>::value>>
         typename meta::drop_last_arg_and_apply_callable<detail::function_enabler, fnT, future_to_ref_t<argsT>...>::type::type
         add(fnT&& fn, argsT&&... args) {
-          using taskT = typename meta::drop_last_arg_and_apply<TaskFn, std::decay_t<fnT>, std::decay_t<argsT>...>::type;
+          using taskT = typename meta::drop_last_arg_and_apply<TaskFn,
+                                                               std::decay_t<fnT>,
+                                                               std::remove_const_t<std::remove_reference_t<argsT>>...>::type;
           return add(new taskT(typename taskT::futureT(), std::forward<fnT>(fn),
                                std::forward<argsT>(args)...));
         }
@@ -615,7 +617,7 @@ namespace madness {
                       !meta::taskattr_is_last_arg<argsT...>::value>>
         typename detail::function_enabler<fnT(future_to_ref_t<argsT>...)>::type add(
             fnT&& fn, argsT&&... args) {
-          using taskT = TaskFn<std::decay_t<fnT>, std::decay_t<argsT>...>;
+          using taskT = TaskFn<std::decay_t<fnT>, std::remove_const_t<std::remove_reference_t<argsT>>...>;
           return add(new taskT(typename taskT::futureT(), std::forward<fnT>(fn),
                                std::forward<argsT>(args)..., TaskAttributes()));
         }


### PR DESCRIPTION
Useful scenario: I want to use local futures (that refer to either for purely local data or refer to remote data but are cached locally), I manage their lifetime, and want to avoid unnecessary copying