### PR TITLE
fixed the problem with libraries being repeated and not correctly inc…

### DIFF
--- a/cmake/modules/FindMKL.cmake
+++ b/cmake/modules/FindMKL.cmake
@@ -79,7 +79,7 @@ if(NOT MKL_FOUND)
     endif()
     if(MKL_${_lib}_LIBRARY)
       set(MKL_${_lib}_FOUND TRUE)
-      list(APPEND MKL_LIBRARIES ${MKL_${_lib}_LIBRARY})
+      list(APPEND MKL_LIBRARIESX ${MKL_${_lib}_LIBRARY})
     else()
       set(MKL_${_lib}_FOUND FALSE)
     endif()
@@ -89,10 +89,10 @@ if(NOT MKL_FOUND)
   if(MKL_mkl_core_FOUND)
     set(MKL_FOUND TRUE)
     if(UNIX AND BLA_STATIC)
-      set(MKL_LIBRARIES -Wl,--start-group ${MKL_LIBRARIES} -Wl,--end-group -lm -ldl
+      set(MKL_LIBRARIES -Wl,--start-group ${MKL_LIBRARIESX} -Wl,--end-group -lm -ldl
           CACHE STRING "The Intel MKL libraries")
     else()
-      set(MKL_LIBRARIES ${MKL_LIBRARIES} -lm -ldl
+      set(MKL_LIBRARIES ${MKL_LIBRARIESX} -lm -ldl
           CACHE STRING "The Intel MKL libraries")
     endif()
   endif()


### PR DESCRIPTION
…luded in start/end group

Apparently cmake does not like U setting a variable while using that variable to compute what is being assigned.  We now construct the list of libraries in MKL_LIBRARIESX and then process it into the final variable MKL_LIBRARIES.
