### PR TITLE
small fix in SCFOperators

### DIFF
--- a/src/apps/chem/SCFOperators.cc
+++ b/src/apps/chem/SCFOperators.cc
@@ -735,13 +735,21 @@ void XCOperator::prep_xc_args_response(const real_function_3d& dens_pt,
 
 
 Fock::Fock(World& world, const SCF* calc,
-           std::shared_ptr<NuclearCorrelationFactor> ncf,
            double scale_K)
     : world(world),
       J(world,calc),
       K(world,calc,0),
       T(world),
-      V(world,ncf),
+      V(world,calc),
+      scale_K(scale_K) {
+}
+Fock::Fock(World& world, const Nemo* nemo,
+           double scale_K)
+    : world(world),
+      J(world,nemo),
+      K(world,nemo,0),
+      T(world),
+      V(world,nemo),
       scale_K(scale_K) {
 }
 

--- a/src/apps/chem/SCFOperators.h
+++ b/src/apps/chem/SCFOperators.h
@@ -562,7 +562,9 @@ class Fock {
 public:
     /// \param[in] scale_K scaling factor for the Hartree-Fock exchange operator (the default is 1, i.e. include
     ///            the full exchange; setting scale_K to 0 excludes the exchange operator, and its computation is skipped)
-    Fock(World& world, const SCF* calc, std::shared_ptr<NuclearCorrelationFactor> ncf,
+    Fock(World& world, const SCF* calc,
+         double scale_K = 1);
+    Fock(World& world, const Nemo* nemo,
          double scale_K = 1);
 
     real_function_3d operator()(const real_function_3d& ket) const {

--- a/src/apps/chem/TDHF.cc
+++ b/src/apps/chem/TDHF.cc
@@ -135,7 +135,7 @@ TDHF::TDHF(World &world, const CCParameters & param, const Nemo & nemo_):
 
 	}
 	if(nemo.get_calc()->param.localize){
-		Fock F(world, nemo.get_calc().get(), nemo.nuclear_correlation);
+		Fock F(world, &nemo);
 		F_occ = F(get_active_mo_bra(),get_active_mo_ket());
 		for(size_t i=0;i<get_active_mo_ket().size();++i){
 			std::cout << std::scientific << std::setprecision(10);


### PR DESCRIPTION
fock operator (exchange) was not initialized correctly with a nontrivial nuclear-correlation factor