### PR TITLE
Save/load

### DIFF
--- a/src/apps/chem/SCF.cc
+++ b/src/apps/chem/SCF.cc
@@ -249,10 +249,10 @@ namespace madness {
         
         /*
           File format:
-         
+
           unsigned int version;
           double current_energy;
-          bool spinrestricted --> if true only alpha orbitals are present         
+          bool spinrestricted --> if true only alpha orbitals are present
           unsigned int nmo_alpha;
           Tensor<double> aeps;
           Tensor<double> aocc;
@@ -276,7 +276,7 @@ namespace madness {
         unsigned int archive_version;
 
         ar & archive_version;
-      
+
         if(archive_version != version) {
            if(world.rank() == 0) print("Loading from a different version of archive. Archive version", archive_version, "MADNESS version", version);
            throw "Invalid archive";
@@ -293,11 +293,11 @@ namespace madness {
         // Some basic checks
         if(L != param.L) {
            if(world.rank() == 0) print("Warning: Box size mismatch between archive and input parameter. Archive value", L, "Param value:", param.L);
-           throw "Mismatch in box sizes"; 
+           throw "Mismatch in box sizes";
         }
         if(world.rank() == 0) print("Restarting from this molecular geometry");
         if(world.rank() == 0) molecule.print();
- 
+
         amo.resize(nmo);
         for (unsigned int i = 0; i < amo.size(); ++i)
             ar & amo[i];

--- a/src/apps/chem/SCF.h
+++ b/src/apps/chem/SCF.h
@@ -733,6 +733,7 @@ namespace madness {
             
             // read converged wave function from disk if there is one
             if (calc.param.no_compute) {
+                throw "Multiple things missing here. Please review.";
 		calc.load_mos(world);
 		calc.make_nuclear_potential(world);
 		calc.project_ao_basis(world);
@@ -814,7 +815,7 @@ namespace madness {
                         }
                         calc.project(world);
                     }
-                    
+
                     // If the basis for the inital guess was not sto-3g
                     // switch to sto-3g since this is needed for analysis
                     // of the MOs and orbital localization


### PR DESCRIPTION
Changing how moldft creates and loads archives used for restarting calculations.

Archive files will now contain (in order):
- unsigned int version;
- double current_energy;
- bool spinrestricted --> if true only alpha orbitals are present
- unsigned int nmo_alpha;
- Tensor<double> aeps;
- Tensor<double> aocc;
- vector<int> aset;
- double L;
- int k; 
- Molecule molecule;
- std::string xc_data;
- for i from 0 to nalpha-1:
          Function<double,3> amo[i]
- repeat for beta if !spinrestricted

*** NOTE: THIS CHANGE WILL CAUSE ALL OLD ARCHIVES TO NOT BE READABLE IN MOLDFT***