### PR TITLE
support for Cereal-based serialization [WIP]

### DIFF
--- a/ci/build-linux.sh
+++ b/ci/build-linux.sh
@@ -15,6 +15,11 @@ if [ "$CXX" = "clang++" ]; then
     export EXTRACXXFLAGS="-DMKL_DIRECT_CALL"
 fi
 
+# add cereal header files to include dirs
+if [ ! -f "${HOME}/cereal/include/cereal/cereal.hpp" ]; then
+    export EXTRACXXFLAGS="-DI${HOME}/cereal/include"
+fi
+
 # Set up paths to stuff we installed
 export MPIDIR=$HOME/mpich
 export LIBXCDIR=$HOME/libxc

--- a/ci/dep-linux.sh
+++ b/ci/dep-linux.sh
@@ -123,3 +123,13 @@ sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB
 sudo sh -c 'echo deb https://apt.repos.intel.com/mkl all main > /etc/apt/sources.list.d/intel-mkl.list'
 sudo apt-get update
 sudo apt-get install intel-mkl-2019.4-070
+
+# Install Cereal
+cd
+git clone https://github.com/USCiLab/cereal
+cd cereal
+mkdir build
+cd build
+cmake -DSKIP_PORTABILITY_TEST=ON ..
+make
+make install

--- a/ci/dep-linux.sh
+++ b/ci/dep-linux.sh
@@ -114,6 +114,21 @@ else
     find ${HOME}/mpich -name mpicxx
 fi
 
+# Install Cereal (headers only)
+if [ ! -f "${HOME}/cereal/include/cereal/cereal.hpp" ]; then
+    cd
+    git clone https://github.com/USCiLab/cereal cereal_repo
+    cd cereal_repo
+    git checkout a5a30953125e70b115a2
+    mkdir build
+    cd build
+    cmake -D JUST_INSTALL_CEREAL=ON -D CMAKE_INSTALL_PREFIX=${HOME}/cereal ..
+    make install
+else
+    echo "Cereal installed..."
+    find ${HOME}/cereal/include/cereal -name "cereal.hpp"
+fi
+
 # Do not exit on error because MKL is optional
 set +e
 
@@ -124,13 +139,3 @@ sudo sh -c 'echo deb https://apt.repos.intel.com/mkl all main > /etc/apt/sources
 sudo apt-get update
 sudo apt-get install intel-mkl-2019.4-070
 
-# Install Cereal
-cd
-git clone https://github.com/USCiLab/cereal
-cd cereal
-git checkout a5a30953125e70b115a2
-mkdir build
-cd build
-cmake -DSKIP_PORTABILITY_TEST=ON ..
-make
-sudo make install

--- a/ci/dep-linux.sh
+++ b/ci/dep-linux.sh
@@ -128,6 +128,7 @@ sudo apt-get install intel-mkl-2019.4-070
 cd
 git clone https://github.com/USCiLab/cereal
 cd cereal
+git checkout a5a30953125e70b115a2
 mkdir build
 cd build
 cmake -DSKIP_PORTABILITY_TEST=ON ..

--- a/ci/dep-linux.sh
+++ b/ci/dep-linux.sh
@@ -132,4 +132,4 @@ mkdir build
 cd build
 cmake -DSKIP_PORTABILITY_TEST=ON ..
 make
-make install
+sudo make install

--- a/ci/dep-osx.sh
+++ b/ci/dep-osx.sh
@@ -43,4 +43,4 @@ brew upgrade python@2 || brew install python@2 || true
 brew link --overwrite python@2 || true
 
 # Proceed assuming GCC is installed properly.
-brew install libxc mpich tbb
+brew install libxc mpich tbb cereal

--- a/src/madness/world/archive.h
+++ b/src/madness/world/archive.h
@@ -299,7 +299,7 @@ namespace madness {
         /// \param[in] t Pointer to the start of the array.
         /// \param[in] n Number of data items to be serialized.
         template <class Archive, class T>
-        typename std::enable_if< is_serializable<Archive,T>::value && is_output_archive<Archive>::value >::type
+        typename std::enable_if_t< is_serializable<Archive,T>::value && is_output_archive<Archive>::value, void>
         serialize(const Archive& ar, const T* t, unsigned int n) {
             MAD_ARCHIVE_DEBUG(std::cout << "serialize fund array" << std::endl);
             ar.store(t,n);
@@ -316,7 +316,7 @@ namespace madness {
         /// \param[in] t Pointer to the start of the array.
         /// \param[in] n Number of data items to be deserialized.
         template <class Archive, class T>
-        typename std::enable_if< is_serializable<Archive,T>::value && is_input_archive<Archive>::value >::type
+        typename std::enable_if_t< is_serializable<Archive,T>::value && is_input_archive<Archive>::value, void>
         serialize(const Archive& ar, const T* t, unsigned int n) {
             MAD_ARCHIVE_DEBUG(std::cout << "deserialize fund array" << std::endl);
             ar.load((T*) t,n);
@@ -333,7 +333,7 @@ namespace madness {
         /// \param[in] t Pointer to the start of the array.
         /// \param[in] n Number of data items to be serialized.
         template <class Archive, class T>
-        typename std::enable_if< ! is_serializable<Archive,T>::value && is_archive<Archive>::value >::type
+        typename std::enable_if_t< ! is_serializable<Archive,T>::value && is_archive<Archive>::value, void>
         serialize(const Archive& ar, const T* t, unsigned int n) {
             MAD_ARCHIVE_DEBUG(std::cout << "(de)serialize non-fund array" << std::endl);
             for (unsigned int i=0; i<n; ++i)
@@ -411,7 +411,7 @@ namespace madness {
         /// \param[in] t The data to be serialized.
         template <class Archive, class T>
         inline
-        typename std::enable_if< is_serializable<Archive,T>::value && is_archive<Archive>::value >::type
+        std::enable_if_t< is_serializable<Archive,T>::value && is_archive<Archive>::value, void>
         serialize(const Archive& ar, const T& t) {
             MAD_ARCHIVE_DEBUG(std::cout << "serialize(ar,t) -> serialize(ar,&t,1)" << std::endl);
             serialize(ar,&t,1);
@@ -428,7 +428,7 @@ namespace madness {
         /// \param[in] t The data to be serialized.
         template <class Archive, class T>
         inline
-        typename std::enable_if< !is_serializable<Archive,T>::value && is_archive<Archive>::value >::type
+        std::enable_if_t< !is_serializable<Archive,T>::value && is_archive<Archive>::value, void >
         serialize(const Archive& ar, const T& t) {
             MAD_ARCHIVE_DEBUG(std::cout << "serialize(ar,t) -> ArchiveSerializeImpl" << std::endl);
             ArchiveSerializeImpl<Archive,T>::serialize(ar,(T&) t);
@@ -515,7 +515,7 @@ namespace madness {
         /// \param[in] t The data.
         template <class Archive, class T>
         inline
-        typename std::enable_if<is_output_archive<Archive>::value, const Archive&>::type
+        std::enable_if_t<is_output_archive<Archive>::value, const Archive&>
         operator<<(const Archive& ar, const T& t) {
             //PROFILE_FUNC;
             return ArchiveImpl<Archive,T>::wrap_store(ar,t);
@@ -531,7 +531,7 @@ namespace madness {
         /// \param[in] t The data.
         template <class Archive, class T>
         inline
-        typename std::enable_if<is_input_archive<Archive>::value, const Archive&>::type
+        std::enable_if_t<is_input_archive<Archive>::value, const Archive&>
         operator>>(const Archive& ar, const T& t) {
             //PROFILE_FUNC;
             return ArchiveImpl<Archive,T>::wrap_load(ar,t);
@@ -547,7 +547,7 @@ namespace madness {
         /// \param[in] t The data.
         template <class Archive, class T>
         inline
-        typename std::enable_if<is_output_archive<Archive>::value, const Archive&>::type
+        std::enable_if_t<is_output_archive<Archive>::value, const Archive&>
         operator&(const Archive& ar, const T& t) {
             //PROFILE_FUNC;
             return ArchiveImpl<Archive,T>::wrap_store(ar,t);
@@ -563,7 +563,7 @@ namespace madness {
         /// \param[in] t The data.
         template <class Archive, class T>
         inline
-        typename std::enable_if<is_input_archive<Archive>::value, const Archive&>::type
+        std::enable_if_t<is_input_archive<Archive>::value, const Archive&>
         operator&(const Archive& ar, const T& t) {
             //PROFILE_FUNC;
             return ArchiveImpl<Archive,T>::wrap_load(ar,t);
@@ -1184,7 +1184,7 @@ namespace madness {
 
         /// @}
 
-    }
+}
 }
 
 #endif // MADNESS_WORLD_ARCHIVE_H__INCLUDED

--- a/src/madness/world/cereal_archive.h
+++ b/src/madness/world/cereal_archive.h
@@ -149,7 +149,7 @@ struct is_serializable<
     std::enable_if_t<
         (is_trivially_serializable<T>::value &&
             !cereal::traits::is_text_archive<Muesli>::value) ||
-            (cereal::traits::detail::count_output_serializers<T, Muesli>::value != 0 &&
+            (cereal::traits::detail::count_input_serializers<T, Muesli>::value != 0 &&
              cereal::traits::is_text_archive<Muesli>::value)>>
     : std::true_type {};
 

--- a/src/madness/world/cereal_archive.h
+++ b/src/madness/world/cereal_archive.h
@@ -72,10 +72,12 @@ public:
   }
 
   template <class T, class Cereal = Muesli>
-  inline std::enable_if_t<cereal::traits::is_text_archive<Cereal>::value,void>
+  inline std::enable_if_t<
+      !madness::is_trivially_serializable<T>::value ||
+          cereal::traits::is_text_archive<Cereal>::value,void>
   store(const T *t, long n) const {
     for (long i = 0; i != n; ++i)
-      *muesli << t[i];
+      *muesli & t[i];
   }
 
   void open(std::size_t hint) {}
@@ -136,14 +138,14 @@ struct is_text_archive<
 template <typename Muesli, typename T>
 struct is_serializable<
     archive::CerealOutputArchive<Muesli>, T,
-    std::enable_if_t<is_trivially_serializable<T>::value &&
-        !cereal::traits::is_text_archive<Muesli>::value>> : std::true_type {};
+    std::enable_if_t<(is_trivially_serializable<T>::value &&
+        !cereal::traits::is_text_archive<Muesli>::value) || cereal::traits::is_text_archive<Muesli>::value>> : std::true_type {};
 template <typename Muesli, typename T>
 struct is_serializable<
     archive::CerealInputArchive<Muesli>, T,
     std::enable_if_t<
-        is_trivially_serializable<T>::value &&
-            !cereal::traits::is_text_archive<Muesli>::value>>
+        (is_trivially_serializable<T>::value &&
+            !cereal::traits::is_text_archive<Muesli>::value) || cereal::traits::is_text_archive<Muesli>::value>>
     : std::true_type {};
 
 }  // namespace madness

--- a/src/madness/world/cereal_archive.h
+++ b/src/madness/world/cereal_archive.h
@@ -1,0 +1,118 @@
+/*
+  This file is part of MADNESS.
+
+  Copyright (C) 2007,2010 Oak Ridge National Laboratory
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+  For more information please contact:
+
+  Robert J. Harrison
+  Oak Ridge National Laboratory
+  One Bethel Valley Road
+  P.O. Box 2008, MS-6367
+
+  email: harrisonrj@ornl.gov
+  tel:   865-241-3937
+  fax:   865-572-0680
+*/
+
+#ifndef MADNESS_WORLD_CEREAL_ARCHIVE_H__INCLUDED
+#define MADNESS_WORLD_CEREAL_ARCHIVE_H__INCLUDED
+
+#if __has_include(<cereal/cereal.hpp>)
+
+#ifndef MADNESS_HAS_CEREAL
+#define MADNESS_HAS_CEREAL 1
+#endif
+
+#include <memory>
+#include <cereal/cereal.hpp>
+#include <cereal/archives/binary.hpp>
+#include <madness/world/archive.h>
+
+namespace madness {
+namespace archive {
+/// Wraps an output archive around a cereal archive
+template <typename Muesli>
+class MadnessCerealOutputArchive
+    : public ::madness::archive::BaseOutputArchive {
+  mutable std::shared_ptr<Muesli>
+      muesli; ///< The cereal archive being wrapped, deleter determines whether this is an owning ptr
+
+public:
+  MadnessCerealOutputArchive(Muesli &muesli)
+      : muesli(&muesli, [](Muesli *) {}) {}
+  template <typename Arg, typename... RestOfArgs,
+            typename = std::enable_if_t<
+                !std::is_same<Muesli, std::decay_t<Arg>>::value>>
+  MadnessCerealOutputArchive(Arg &&arg, RestOfArgs &&... rest_of_args)
+      : muesli(new Muesli(std::forward<Arg>(arg),
+                          std::forward<RestOfArgs>(rest_of_args)...),
+               std::default_delete<Muesli>{}) {}
+
+  template <class T>
+  inline typename std::enable_if<madness::is_trivially_serializable<T>::value,
+                                 void>::type
+  store(const T *t, long n) const {
+    const unsigned char *ptr = (unsigned char *)t;
+    (*muesli)(cereal::binary_data(ptr, sizeof(T) * n));
+  }
+  void open(std::size_t hint) {}
+  void close(){};
+  void flush(){};
+};
+
+/// Wraps an input archive around a cereal archive
+template <typename Muesli>
+class MadnessCerealInputArchive : public BaseInputArchive {
+  std::shared_ptr<Muesli> muesli; ///< The cereal archive being wrapped, deleter determines whether this is an owning ptr
+
+public:
+  MadnessCerealInputArchive(Muesli &muesli)
+      : muesli(&muesli, [](Muesli *) {}) {}
+  template <typename Arg, typename... RestOfArgs,
+      typename = std::enable_if_t<
+          !std::is_same<Muesli, std::decay_t<Arg>>::value>>
+  MadnessCerealInputArchive(Arg &&arg, RestOfArgs &&... rest_of_args)
+  : muesli(new Muesli(std::forward<Arg>(arg),
+                      std::forward<RestOfArgs>(rest_of_args)...),
+      std::default_delete<Muesli>{}) {}
+
+  template <class T>
+  inline typename std::enable_if<madness::is_trivially_serializable<T>::value,
+                                 void>::type
+  load(T *t, long n) const {
+    (*muesli)(cereal::binary_data(t, sizeof(T) * n));
+  }
+  void open(std::size_t hint) {}
+  void rewind() const {}
+  void close(){};
+};
+}
+
+template <typename Muesli, typename T>
+struct is_serializable<archive::MadnessCerealOutputArchive<Muesli>, T,
+                       std::enable_if_t<is_trivially_serializable<T>::value>>
+    : std::true_type {};
+template <typename Muesli, typename T>
+struct is_serializable<archive::MadnessCerealInputArchive<Muesli>, T,
+                       std::enable_if_t<is_trivially_serializable<T>::value>>
+    : std::true_type {};
+}
+
+#endif  // have cereal/cereal.hpp
+
+#endif  // MADNESS_WORLD_CEREAL_ARCHIVE_H__INCLUDED

--- a/src/madness/world/cereal_archive.h
+++ b/src/madness/world/cereal_archive.h
@@ -139,13 +139,18 @@ template <typename Muesli, typename T>
 struct is_serializable<
     archive::CerealOutputArchive<Muesli>, T,
     std::enable_if_t<(is_trivially_serializable<T>::value &&
-        !cereal::traits::is_text_archive<Muesli>::value) || cereal::traits::is_text_archive<Muesli>::value>> : std::true_type {};
+        !cereal::traits::is_text_archive<Muesli>::value) ||
+        (cereal::traits::detail::count_output_serializers<T, Muesli>::value != 0 &&
+         cereal::traits::is_text_archive<Muesli>::value)>>
+    : std::true_type {};
 template <typename Muesli, typename T>
 struct is_serializable<
     archive::CerealInputArchive<Muesli>, T,
     std::enable_if_t<
         (is_trivially_serializable<T>::value &&
-            !cereal::traits::is_text_archive<Muesli>::value) || cereal::traits::is_text_archive<Muesli>::value>>
+            !cereal::traits::is_text_archive<Muesli>::value) ||
+            (cereal::traits::detail::count_output_serializers<T, Muesli>::value != 0 &&
+             cereal::traits::is_text_archive<Muesli>::value)>>
     : std::true_type {};
 
 }  // namespace madness

--- a/src/madness/world/test_ar.cc
+++ b/src/madness/world/test_ar.cc
@@ -89,7 +89,7 @@ public:
     A(float a = 0.0) : a(a) {};
 
     template <class Archive>
-    inline void serialize(const Archive& ar) {
+    inline void serialize(Archive& ar) {
         ar & a;
     }
 };

--- a/src/madness/world/test_ar.cc
+++ b/src/madness/world/test_ar.cc
@@ -56,6 +56,12 @@ using madness::archive::VectorOutputArchive;
 using madness::archive::BufferInputArchive;
 using madness::archive::BufferOutputArchive;
 
+#include <madness/world/cereal_archive.h>
+#ifdef MADNESS_HAS_CEREAL
+using CerealBinaryFstreamInputArchive = madness::archive::MadnessCerealInputArchive<cereal::BinaryInputArchive>;
+using CerealBinaryFstreamOutputArchive = madness::archive::MadnessCerealOutputArchive<cereal::BinaryOutputArchive>;
+#endif
+
 #include <madness/world/array_addons.h>
 
 // A is a class that provides a symmetric serialize method
@@ -594,5 +600,21 @@ int main() {
         iar.close();
     }
 
-    return 0;
+#ifdef MADNESS_HAS_CEREAL
+    {
+        const char* f = "test.dat";
+        cout << endl << "testing binary Cereal fstream archive" << endl;
+        std::ofstream fout(f);
+        CerealBinaryFstreamOutputArchive oar(fout);
+        test_out(oar);
+        oar.close();
+
+        std::ifstream fin(f);
+        CerealBinaryFstreamInputArchive iar(fin);
+        test_in(iar);
+        iar.close();
+    }
+#endif  // MADNESS_HAS_CEREAL
+
+  return 0;
 }

--- a/src/madness/world/type_traits.h
+++ b/src/madness/world/type_traits.h
@@ -162,6 +162,22 @@ using std::void_t;
     template <typename T>
     struct is_serializable<archive::MPIInputArchive, T, std::enable_if_t<is_trivially_serializable<T>::value>> : std::true_type {};
 
+    /// \brief This trait types tests if \c Archive is a text archive
+    /// \tparam Archive an archive type
+    /// \note much be specialized for each archive
+    template <typename Archive, typename Enabler = void>
+    struct is_text_archive : std::false_type {};
+
+    template <>
+    struct is_text_archive<archive::TextFstreamOutputArchive> : std::true_type {};
+    template <>
+    struct is_text_archive<archive::TextFstreamInputArchive> : std::true_type {};
+
+    /// \brief \c is_text_archive_v<A> is a shorthand for \c is_text_archive<A>::value
+    /// \tparam Archive an archive type
+    template <typename Archive>
+    constexpr const bool is_text_archive_v = is_text_archive<Archive>::value;
+
     /* Macros to make some of this stuff more readable */
 
     /**


### PR DESCRIPTION
Only binary archives work currently. `__has_include` is used to detect Cereal, so `cereal/cereal.hpp` must be in the include path.

TODO:
- support for JSON and XML archives
- extend parallel archive to be able to use Cereal as backend
- (optional) let cmake find and/or install cereal
