### PR TITLE
Templated wrapper interface for select LAPACK routines

### DIFF
--- a/src/madness/tensor/CMakeLists.txt
+++ b/src/madness/tensor/CMakeLists.txt
@@ -30,7 +30,7 @@ set(MADTENSOR_SOURCES tensor.cc tensoriter.cc basetensor.cc vmath.cc)
 # Source lists for MADclapack
 set(MADCLAPACK_HEADERS cblas.h cblas_types.h
         clapack.h clapack_fortran.h
-        lapacke_types.h) # this part of MADlinalg is purely independent of MADtensor
+        lapacke_types.h linalg_wrappers.h ) # this part of MADlinalg is purely independent of MADtensor
 
 # Source lists for MADlinalg
 set(MADLINALG_HEADERS ${MADCLAPACK_HEADERS} tensor_lapack.h solvers.h elem.h)

--- a/src/madness/tensor/CMakeLists.txt
+++ b/src/madness/tensor/CMakeLists.txt
@@ -34,7 +34,7 @@ set(MADCLAPACK_HEADERS cblas.h cblas_types.h
 
 # Source lists for MADlinalg
 set(MADLINALG_HEADERS ${MADCLAPACK_HEADERS} tensor_lapack.h solvers.h elem.h)
-set(MADLINALG_SOURCES lapack.cc solvers.cc elem.cc)
+set(MADLINALG_SOURCES lapack.cc solvers.cc elem.cc linalg_wrappers.cc )
 
 # Create libraries MADtensor and MADlinalg
 add_mad_library(tensor MADTENSOR_SOURCES MADTENSOR_HEADERS "misc" "madness/tensor")

--- a/src/madness/tensor/linalg_wrappers.cc
+++ b/src/madness/tensor/linalg_wrappers.cc
@@ -468,6 +468,7 @@ namespace madness {
         spotrf_( &uplo, &n, A, &lda, &info, sizeof(char) );
     #endif
     
+        LINALG_ASSERT( (info==0), "Cholesky Failed", info);
     }
     
     template <>
@@ -481,6 +482,7 @@ namespace madness {
         dpotrf_( &uplo, &n, A, &lda, &info, sizeof(char) );
     #endif
     
+        LINALG_ASSERT( (info==0), "Cholesky Failed", info);
     }
     
     template <>
@@ -494,6 +496,7 @@ namespace madness {
         cpotrf_( &uplo, &n, A, &lda, &info, sizeof(char) );
     #endif
     
+        LINALG_ASSERT( (info==0), "Cholesky Failed", info);
     }
     
     template <>
@@ -507,6 +510,7 @@ namespace madness {
         zpotrf_( &uplo, &n, A, &lda, &info, sizeof(char) );
     #endif
     
+        LINALG_ASSERT( (info==0), "Cholesky Failed", info);
     }
 
 

--- a/src/madness/tensor/linalg_wrappers.cc
+++ b/src/madness/tensor/linalg_wrappers.cc
@@ -132,7 +132,7 @@ namespace madness {
         complex_real8 lwork_dummy;
     
     #if MADNESS_LINALG_USE_LAPACKE
-        zgesvd_( &jobu, &jobvt, &m, &n, to_cptr(A), &lda, S, to_cptr(U), &ldu, to_cptr(VT), &ldvt, to_cptr(&lwork_dummy),
+        zgesvd_( &jobu, &jobvt, &m, &n, to_zptr(A), &lda, S, to_zptr(U), &ldu, to_zptr(VT), &ldvt, to_zptr(&lwork_dummy),
                  &lwork, rwork.data(), &info );
     #else
         zgesvd_( &jobu, &jobvt, &m, &n, A, &lda, S, U, &ldu, VT, &ldvt, &lwork_dummy,
@@ -144,7 +144,7 @@ namespace madness {
         std::vector<complex_real8> work( lwork );
     
     #if MADNESS_LINALG_USE_LAPACKE
-        zgesvd_( &jobu, &jobvt, &m, &n, to_cptr(A), &lda, S, to_cptr(U), &ldu, to_cptr(VT), &ldvt, to_cptr(work.data()),
+        zgesvd_( &jobu, &jobvt, &m, &n, to_zptr(A), &lda, S, to_zptr(U), &ldu, to_zptr(VT), &ldvt, to_zptr(work.data()),
                  &lwork, rwork.data(), &info );
     #else
         zgesvd_( &jobu, &jobvt, &m, &n, A, &lda, S, U, &ldu, VT, &ldvt, work.data(),
@@ -274,7 +274,7 @@ namespace madness {
         complex_real8 lwork_dummy;
     
     #if MADNESS_LINALG_USE_LAPACKE
-        zheev_( &jobz, &uplo, &n, to_cptr(A), &lda, W, to_cptr(&lwork_dummy), &lwork, rwork.data(), &info );
+        zheev_( &jobz, &uplo, &n, to_zptr(A), &lda, W, to_zptr(&lwork_dummy), &lwork, rwork.data(), &info );
     #else
         zheev_( &jobz, &uplo, &n, A, &lda, W, &lwork_dummy, &lwork, rwork.data(), &info, 
                 sizeof(char), sizeof(char) );
@@ -285,7 +285,7 @@ namespace madness {
         std::vector<complex_real8> work( lwork );
     
     #if MADNESS_LINALG_USE_LAPACKE
-        zheev_( &jobz, &uplo, &n, to_cptr(A), &lda, W, to_cptr(work.data()), &lwork, rwork.data(), &info );
+        zheev_( &jobz, &uplo, &n, to_zptr(A), &lda, W, to_zptr(work.data()), &lwork, rwork.data(), &info );
     #else
         zheev_( &jobz, &uplo, &n, A, &lda, W, work.data(), &lwork, rwork.data(), &info, 
                 sizeof(char), sizeof(char) );
@@ -423,7 +423,7 @@ namespace madness {
         complex_real8 lwork_dummy;
     
     #if MADNESS_LINALG_USE_LAPACKE
-        zhegv_( &itype, &jobz, &uplo, &n, to_cptr(A), &lda, to_cptr(B), &ldb, W, to_cptr(&lwork_dummy), &lwork, 
+        zhegv_( &itype, &jobz, &uplo, &n, to_zptr(A), &lda, to_zptr(B), &ldb, W, to_zptr(&lwork_dummy), &lwork, 
                 rwork.data(), &info );
     #else
         zhegv_( &itype, &jobz, &uplo, &n, A, &lda, B, &ldb, W, &lwork_dummy, &lwork, 
@@ -435,7 +435,7 @@ namespace madness {
         std::vector<complex_real8> work( lwork );
     
     #if MADNESS_LINALG_USE_LAPACKE
-        zhegv_( &itype, &jobz, &uplo, &n, to_cptr(A), &lda, to_cptr(B), &ldb, W, to_cptr(work.data()), &lwork, 
+        zhegv_( &itype, &jobz, &uplo, &n, to_zptr(A), &lda, to_zptr(B), &ldb, W, to_zptr(work.data()), &lwork, 
                 rwork.data(), &info );
     #else
         zhegv_( &itype, &jobz, &uplo, &n, A, &lda, B, &ldb, W, work.data(), &lwork, 
@@ -510,7 +510,7 @@ namespace madness {
         integer info;
     
     #if MADNESS_LINALG_USE_LAPACKE
-        zpotrf_( &uplo, &n, to_cptr(A), &lda, &info );
+        zpotrf_( &uplo, &n, to_zptr(A), &lda, &info );
     #else
         zpotrf_( &uplo, &n, A, &lda, &info, sizeof(char) );
     #endif

--- a/src/madness/tensor/linalg_wrappers.cc
+++ b/src/madness/tensor/linalg_wrappers.cc
@@ -1,0 +1,514 @@
+#include <vector>
+#include <madness/madness_config.h>
+#include <madness/tensor/linalg_wrappers.h>
+
+
+namespace madness {
+
+    template <>
+    void svd( char jobu, char jobvt, integer m, integer n, real4* A, integer lda,
+              real4* S, real4* U, integer ldu, real4* VT, integer ldvt ) { 
+    
+    
+        integer lwork = -1;
+        integer info;
+    
+        real4 lwork_dummy;
+    
+    #if MADNESS_LINALG_USE_LAPACKE
+        sgesvd_( &jobu, &jobvt, &m, &n, A, &lda, S, U, &ldu, VT, &ldvt, &lwork_dummy,
+                 &lwork, &info );
+    #else
+        sgesvd_( &jobu, &jobvt, &m, &n, A, &lda, S, U, &ldu, VT, &ldvt, &lwork_dummy,
+                 &lwork, &info, sizeof(char), sizeof(char) );
+    #endif
+    
+        lwork = integer(lwork_dummy);
+    
+        std::vector<real4> work( lwork );
+    
+    #if MADNESS_LINALG_USE_LAPACKE
+        sgesvd_( &jobu, &jobvt, &m, &n, A, &lda, S, U, &ldu, VT, &ldvt, work.data(),
+                 &lwork, &info );
+    #else
+        sgesvd_( &jobu, &jobvt, &m, &n, A, &lda, S, U, &ldu, VT, &ldvt, work.data(),
+                 &lwork, &info, sizeof(char), sizeof(char) );
+    #endif
+    
+        LINALG_ASSERT( (info==0), "SVD Failed", info);
+    
+    }
+    
+    template <>
+    void svd( char jobu, char jobvt, integer m, integer n, real8* A, integer lda,
+              real8* S, real8* U, integer ldu, real8* VT, integer ldvt ) { 
+    
+    
+        integer lwork = -1;
+        integer info;
+    
+        real8 lwork_dummy;
+    
+    #if MADNESS_LINALG_USE_LAPACKE
+        dgesvd_( &jobu, &jobvt, &m, &n, A, &lda, S, U, &ldu, VT, &ldvt, &lwork_dummy,
+                 &lwork, &info );
+    #else
+        dgesvd_( &jobu, &jobvt, &m, &n, A, &lda, S, U, &ldu, VT, &ldvt, &lwork_dummy,
+                 &lwork, &info, sizeof(char), sizeof(char) );
+    #endif
+    
+        lwork = integer(lwork_dummy);
+    
+        std::vector<real8> work( lwork );
+    
+    #if MADNESS_LINALG_USE_LAPACKE
+        dgesvd_( &jobu, &jobvt, &m, &n, A, &lda, S, U, &ldu, VT, &ldvt, work.data(),
+                 &lwork, &info );
+    #else
+        dgesvd_( &jobu, &jobvt, &m, &n, A, &lda, S, U, &ldu, VT, &ldvt, work.data(),
+                 &lwork, &info, sizeof(char), sizeof(char) );
+    #endif
+    
+        LINALG_ASSERT( (info==0), "SVD Failed", info);
+    }
+    
+    
+    
+    
+    template <>
+    void svd( char jobu, char jobvt, integer m, integer n, complex_real4* A, 
+              integer lda, real4* S, complex_real4* U, integer ldu, complex_real4* VT, 
+              integer ldvt ) { 
+    
+    
+        integer lwork = -1;
+        integer lrwork = 5 * std::min(m,n);
+        integer info;
+    
+        std::vector<real4> rwork( lrwork );
+    
+        complex_real4 lwork_dummy;
+    
+    #if MADNESS_LINALG_USE_LAPACKE
+        cgesvd_( &jobu, &jobvt, &m, &n, A, &lda, S, U, &ldu, VT, &ldvt, &lwork_dummy,
+                 &lwork, rwork.data(), &info );
+    #else
+        cgesvd_( &jobu, &jobvt, &m, &n, A, &lda, S, U, &ldu, VT, &ldvt, &lwork_dummy,
+                 &lwork, rwork.data(), &info, sizeof(char), sizeof(char) );
+    #endif
+    
+        lwork = integer(lwork_dummy.real());
+    
+        std::vector<complex_real4> work( lwork );
+    
+    #if MADNESS_LINALG_USE_LAPACKE
+        cgesvd_( &jobu, &jobvt, &m, &n, A, &lda, S, U, &ldu, VT, &ldvt, work.data(),
+                 &lwork, rwork.data(), &info );
+    #else
+        cgesvd_( &jobu, &jobvt, &m, &n, A, &lda, S, U, &ldu, VT, &ldvt, work.data(),
+                 &lwork, rwork.data(), &info, sizeof(char), sizeof(char) );
+    #endif
+    
+        LINALG_ASSERT( (info==0), "SVD Failed", info);
+    }
+    
+    template <>
+    void svd( char jobu, char jobvt, integer m, integer n, complex_real8* A, 
+              integer lda, real8* S, complex_real8* U, integer ldu, complex_real8* VT, 
+              integer ldvt ) { 
+    
+    
+        integer lwork = -1;
+        integer lrwork = 5 * std::min(m,n);
+        integer info;
+    
+        std::vector<real8> rwork( lrwork );
+    
+        complex_real8 lwork_dummy;
+    
+    #if MADNESS_LINALG_USE_LAPACKE
+        zgesvd_( &jobu, &jobvt, &m, &n, A, &lda, S, U, &ldu, VT, &ldvt, &lwork_dummy,
+                 &lwork, rwork.data(), &info );
+    #else
+        zgesvd_( &jobu, &jobvt, &m, &n, A, &lda, S, U, &ldu, VT, &ldvt, &lwork_dummy,
+                 &lwork, rwork.data(), &info, sizeof(char), sizeof(char) );
+    #endif
+    
+        lwork = integer(lwork_dummy.real());
+    
+        std::vector<complex_real8> work( lwork );
+    
+    #if MADNESS_LINALG_USE_LAPACKE
+        zgesvd_( &jobu, &jobvt, &m, &n, A, &lda, S, U, &ldu, VT, &ldvt, work.data(),
+                 &lwork, rwork.data(), &info );
+    #else
+        zgesvd_( &jobu, &jobvt, &m, &n, A, &lda, S, U, &ldu, VT, &ldvt, work.data(),
+                 &lwork, rwork.data(), &info, sizeof(char), sizeof(char) );
+    #endif
+    
+        LINALG_ASSERT( (info==0), "SVD Failed", info);
+    }
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    template <>
+    void hereig( char jobz, char uplo, integer n, real4* A, integer lda, real4* W ) {
+    
+        integer lwork = -1;
+        integer info;
+    
+        real4 lwork_dummy;
+    
+    #if MADNESS_LINALG_USE_LAPACKE
+        ssyev_( &jobz, &uplo, &n, A, &lda, W, &lwork_dummy, &lwork, &info );
+    #else
+        ssyev_( &jobz, &uplo, &n, A, &lda, W, &lwork_dummy, &lwork, &info, 
+                sizeof(char), sizeof(char) );
+    #endif
+    
+        lwork = integer(lwork_dummy);
+    
+        std::vector<real4> work( lwork );
+    
+    #if MADNESS_LINALG_USE_LAPACKE
+        ssyev_( &jobz, &uplo, &n, A, &lda, W, work.data(), &lwork, &info );
+    #else
+        ssyev_( &jobz, &uplo, &n, A, &lda, W, work.data(), &lwork, &info, 
+                sizeof(char), sizeof(char) );
+    #endif
+    
+    
+        LINALG_ASSERT( (info==0), "EVP Failed", info);
+    }
+    
+    template <>
+    void hereig( char jobz, char uplo, integer n, real8* A, integer lda, real8* W ) {
+    
+        integer lwork = -1;
+        integer info;
+    
+        real8 lwork_dummy;
+    
+    #if MADNESS_LINALG_USE_LAPACKE
+        dsyev_( &jobz, &uplo, &n, A, &lda, W, &lwork_dummy, &lwork, &info );
+    #else
+        dsyev_( &jobz, &uplo, &n, A, &lda, W, &lwork_dummy, &lwork, &info, 
+                sizeof(char), sizeof(char) );
+    #endif
+    
+        lwork = integer(lwork_dummy);
+    
+        std::vector<real8> work( lwork );
+    
+    #if MADNESS_LINALG_USE_LAPACKE
+        dsyev_( &jobz, &uplo, &n, A, &lda, W, work.data(), &lwork, &info );
+    #else
+        dsyev_( &jobz, &uplo, &n, A, &lda, W, work.data(), &lwork, &info, 
+                sizeof(char), sizeof(char) );
+    #endif
+    
+    
+        LINALG_ASSERT( (info==0), "EVP Failed", info);
+    }
+    
+    template <>
+    void hereig( char jobz, char uplo, integer n, complex_real4* A, integer lda, 
+      real4* W ) {
+    
+        integer lwork = -1;
+        integer lrwork = std::max(1, 3*n-2);
+        integer info;
+    
+        std::vector<real4> rwork( lrwork );
+    
+        complex_real4 lwork_dummy;
+    
+    #if MADNESS_LINALG_USE_LAPACKE
+        cheev_( &jobz, &uplo, &n, A, &lda, W, &lwork_dummy, &lwork, rwork.data(), &info );
+    #else
+        cheev_( &jobz, &uplo, &n, A, &lda, W, &lwork_dummy, &lwork, rwork.data(), &info, 
+                sizeof(char), sizeof(char) );
+    #endif
+    
+        lwork = integer(lwork_dummy.real());
+    
+        std::vector<complex_real4> work( lwork );
+    
+    #if MADNESS_LINALG_USE_LAPACKE
+        cheev_( &jobz, &uplo, &n, A, &lda, W, work.data(), &lwork, rwork.data(), &info );
+    #else
+        cheev_( &jobz, &uplo, &n, A, &lda, W, work.data(), &lwork, rwork.data(), &info, 
+                sizeof(char), sizeof(char) );
+    #endif
+    
+    
+        LINALG_ASSERT( (info==0), "EVP Failed", info);
+    }
+    
+    template <>
+    void hereig( char jobz, char uplo, integer n, complex_real8* A, integer lda, 
+      real8* W ) {
+    
+        integer lwork = -1;
+        integer lrwork = std::max(1, 3*n-2);
+        integer info;
+    
+        std::vector<real8> rwork( lrwork );
+    
+        complex_real8 lwork_dummy;
+    
+    #if MADNESS_LINALG_USE_LAPACKE
+        zheev_( &jobz, &uplo, &n, A, &lda, W, &lwork_dummy, &lwork, rwork.data(), &info );
+    #else
+        zheev_( &jobz, &uplo, &n, A, &lda, W, &lwork_dummy, &lwork, rwork.data(), &info, 
+                sizeof(char), sizeof(char) );
+    #endif
+    
+        lwork = integer(lwork_dummy.real());
+    
+        std::vector<complex_real8> work( lwork );
+    
+    #if MADNESS_LINALG_USE_LAPACKE
+        zheev_( &jobz, &uplo, &n, A, &lda, W, work.data(), &lwork, rwork.data(), &info );
+    #else
+        zheev_( &jobz, &uplo, &n, A, &lda, W, work.data(), &lwork, rwork.data(), &info, 
+                sizeof(char), sizeof(char) );
+    #endif
+    
+    
+        LINALG_ASSERT( (info==0), "EVP Failed", info);
+    
+    }
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    template <>
+    void hereig_gen( integer itype, char jobz, char uplo, integer n, real4* A, 
+                     integer lda, real4* B, int ldb, real4* W ) {
+    
+        integer lwork = -1;
+        integer info;
+    
+        real4 lwork_dummy;
+    
+    #if MADNESS_LINALG_USE_LAPACKE
+        ssygv_( &itype, &jobz, &uplo, &n, A, &lda, B, &ldb, W, &lwork_dummy, &lwork, 
+                &info );
+    #else
+        ssygv_( &itype, &jobz, &uplo, &n, A, &lda, B, &ldb, W, &lwork_dummy, &lwork, 
+                &info, sizeof(char), sizeof(char) );
+    #endif
+    
+        lwork = integer(lwork_dummy);
+    
+        std::vector<real4> work( lwork );
+    
+    #if MADNESS_LINALG_USE_LAPACKE
+        ssygv_( &itype, &jobz, &uplo, &n, A, &lda, B, &ldb, W, work.data(), &lwork, 
+                &info );
+    #else
+        ssygv_( &itype, &jobz, &uplo, &n, A, &lda, B, &ldb, W, work.data(), &lwork, 
+                &info, sizeof(char), sizeof(char) );
+    #endif
+    
+    
+        LINALG_ASSERT( (info==0), "EVP Failed", info);
+    }
+    
+    template <>
+    void hereig_gen( integer itype, char jobz, char uplo, integer n, real8* A, 
+                     integer lda, real8* B, int ldb, real8* W ) {
+    
+        integer lwork = -1;
+        integer info;
+    
+        real8 lwork_dummy;
+    
+    #if MADNESS_LINALG_USE_LAPACKE
+        dsygv_( &itype, &jobz, &uplo, &n, A, &lda, B, &ldb, W, &lwork_dummy, &lwork, 
+                &info );
+    #else
+        dsygv_( &itype, &jobz, &uplo, &n, A, &lda, B, &ldb, W, &lwork_dummy, &lwork, 
+                &info, sizeof(char), sizeof(char) );
+    #endif
+    
+        lwork = integer(lwork_dummy);
+    
+        std::vector<real8> work( lwork );
+    
+    #if MADNESS_LINALG_USE_LAPACKE
+        dsygv_( &itype, &jobz, &uplo, &n, A, &lda, B, &ldb, W, work.data(), &lwork, 
+                &info );
+    #else
+        dsygv_( &itype, &jobz, &uplo, &n, A, &lda, B, &ldb, W, work.data(), &lwork, 
+                &info, sizeof(char), sizeof(char) );
+    #endif
+    
+    
+        LINALG_ASSERT( (info==0), "EVP Failed", info);
+    }
+    
+    template <>
+    void hereig_gen( integer itype, char jobz, char uplo, integer n, complex_real4* A, 
+                     integer lda, complex_real4* B, integer ldb, real4* W ) {
+    
+        integer lwork = -1;
+        integer lrwork = std::max(1, 3*n-2);
+        integer info;
+    
+        std::vector<real4> rwork( lrwork );
+    
+        complex_real4 lwork_dummy;
+    
+    #if MADNESS_LINALG_USE_LAPACKE
+        chegv_( &itype, &jobz, &uplo, &n, A, &lda, B, &ldb, W, &lwork_dummy, &lwork, 
+                rwork.data(), &info );
+    #else
+        chegv_( &itype, &jobz, &uplo, &n, A, &lda, B, &ldb, W, &lwork_dummy, &lwork, 
+                rwork.data(), &info, sizeof(char), sizeof(char) );
+    #endif
+    
+        lwork = integer(lwork_dummy.real());
+    
+        std::vector<complex_real4> work( lwork );
+    
+    #if MADNESS_LINALG_USE_LAPACKE
+        chegv_( &itype, &jobz, &uplo, &n, A, &lda, B, &ldb, W, work.data(), &lwork, 
+                rwork.data(), &info );
+    #else
+        chegv_( &itype, &jobz, &uplo, &n, A, &lda, B, &ldb, W, work.data(), &lwork, 
+                rwork.data(), &info, sizeof(char), sizeof(char) );
+    #endif
+    
+    
+        LINALG_ASSERT( (info==0), "EVP Failed", info);
+    }
+    
+    template <>
+    void hereig_gen( integer itype, char jobz, char uplo, integer n, complex_real8* A, 
+                     integer lda, complex_real8* B, integer ldb, real8* W ) {
+    
+        integer lwork = -1;
+        integer lrwork = std::max(1, 3*n-2);
+        integer info;
+      
+        std::vector<real8> rwork( lrwork );
+      
+        complex_real8 lwork_dummy;
+    
+    #if MADNESS_LINALG_USE_LAPACKE
+        zhegv_( &itype, &jobz, &uplo, &n, A, &lda, B, &ldb, W, &lwork_dummy, &lwork, 
+                rwork.data(), &info );
+    #else
+        zhegv_( &itype, &jobz, &uplo, &n, A, &lda, B, &ldb, W, &lwork_dummy, &lwork, 
+                rwork.data(), &info, sizeof(char), sizeof(char) );
+    #endif
+    
+        lwork = integer(lwork_dummy.real());
+    
+        std::vector<complex_real8> work( lwork );
+    
+    #if MADNESS_LINALG_USE_LAPACKE
+        zhegv_( &itype, &jobz, &uplo, &n, A, &lda, B, &ldb, W, work.data(), &lwork, 
+                rwork.data(), &info );
+    #else
+        zhegv_( &itype, &jobz, &uplo, &n, A, &lda, B, &ldb, W, work.data(), &lwork, 
+                rwork.data(), &info, sizeof(char), sizeof(char) );
+    #endif
+    
+    
+        LINALG_ASSERT( (info==0), "EVP Failed", info);
+    }
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    template <>
+    void cholesky( char uplo, integer n, real4* A, integer lda ) {
+    
+        integer info;
+    
+    #if MADNESS_LINALG_USE_LAPACKE
+        spotrf_( &uplo, &n, A, &lda, &info );
+    #else
+        spotrf_( &uplo, &n, A, &lda, &info, sizeof(char) );
+    #endif
+    
+    }
+    
+    template <>
+    void cholesky( char uplo, integer n, real8* A, integer lda ) {
+    
+        integer info;
+    
+    #if MADNESS_LINALG_USE_LAPACKE
+        dpotrf_( &uplo, &n, A, &lda, &info );
+    #else
+        dpotrf_( &uplo, &n, A, &lda, &info, sizeof(char) );
+    #endif
+    
+    }
+    
+    template <>
+    void cholesky( char uplo, integer n, complex_real4* A, integer lda ) {
+    
+        integer info;
+    
+    #if MADNESS_LINALG_USE_LAPACKE
+        cpotrf_( &uplo, &n, A, &lda, &info );
+    #else
+        cpotrf_( &uplo, &n, A, &lda, &info, sizeof(char) );
+    #endif
+    
+    }
+    
+    template <>
+    void cholesky( char uplo, integer n, complex_real8* A, integer lda ) {
+    
+        integer info;
+    
+    #if MADNESS_LINALG_USE_LAPACKE
+        zpotrf_( &uplo, &n, A, &lda, &info );
+    #else
+        zpotrf_( &uplo, &n, A, &lda, &info, sizeof(char) );
+    #endif
+    
+    }
+
+
+
+}

--- a/src/madness/tensor/linalg_wrappers.cc
+++ b/src/madness/tensor/linalg_wrappers.cc
@@ -2,6 +2,11 @@
 #include <madness/madness_config.h>
 #include <madness/tensor/linalg_wrappers.h>
 
+#ifdef MADNESS_LINALG_USE_LAPACKE
+using madness::lapacke::to_cptr;
+using madness::lapacke::to_zptr;
+#endif
+
 
 namespace madness {
 
@@ -90,7 +95,7 @@ namespace madness {
         complex_real4 lwork_dummy;
     
     #if MADNESS_LINALG_USE_LAPACKE
-        cgesvd_( &jobu, &jobvt, &m, &n, A, &lda, S, U, &ldu, VT, &ldvt, &lwork_dummy,
+        cgesvd_( &jobu, &jobvt, &m, &n, to_cptr(A), &lda, S, to_cptr(U), &ldu, to_cptr(VT), &ldvt, to_cptr(&lwork_dummy),
                  &lwork, rwork.data(), &info );
     #else
         cgesvd_( &jobu, &jobvt, &m, &n, A, &lda, S, U, &ldu, VT, &ldvt, &lwork_dummy,
@@ -102,7 +107,7 @@ namespace madness {
         std::vector<complex_real4> work( lwork );
     
     #if MADNESS_LINALG_USE_LAPACKE
-        cgesvd_( &jobu, &jobvt, &m, &n, A, &lda, S, U, &ldu, VT, &ldvt, work.data(),
+        cgesvd_( &jobu, &jobvt, &m, &n, to_cptr(A), &lda, S, to_cptr(U), &ldu, to_cptr(VT), &ldvt, to_cptr(work.data()),
                  &lwork, rwork.data(), &info );
     #else
         cgesvd_( &jobu, &jobvt, &m, &n, A, &lda, S, U, &ldu, VT, &ldvt, work.data(),
@@ -127,7 +132,7 @@ namespace madness {
         complex_real8 lwork_dummy;
     
     #if MADNESS_LINALG_USE_LAPACKE
-        zgesvd_( &jobu, &jobvt, &m, &n, A, &lda, S, U, &ldu, VT, &ldvt, &lwork_dummy,
+        zgesvd_( &jobu, &jobvt, &m, &n, to_cptr(A), &lda, S, to_cptr(U), &ldu, to_cptr(VT), &ldvt, to_cptr(&lwork_dummy),
                  &lwork, rwork.data(), &info );
     #else
         zgesvd_( &jobu, &jobvt, &m, &n, A, &lda, S, U, &ldu, VT, &ldvt, &lwork_dummy,
@@ -139,7 +144,7 @@ namespace madness {
         std::vector<complex_real8> work( lwork );
     
     #if MADNESS_LINALG_USE_LAPACKE
-        zgesvd_( &jobu, &jobvt, &m, &n, A, &lda, S, U, &ldu, VT, &ldvt, work.data(),
+        zgesvd_( &jobu, &jobvt, &m, &n, to_cptr(A), &lda, S, to_cptr(U), &ldu, to_cptr(VT), &ldvt, to_cptr(work.data()),
                  &lwork, rwork.data(), &info );
     #else
         zgesvd_( &jobu, &jobvt, &m, &n, A, &lda, S, U, &ldu, VT, &ldvt, work.data(),
@@ -235,7 +240,7 @@ namespace madness {
         complex_real4 lwork_dummy;
     
     #if MADNESS_LINALG_USE_LAPACKE
-        cheev_( &jobz, &uplo, &n, A, &lda, W, &lwork_dummy, &lwork, rwork.data(), &info );
+        cheev_( &jobz, &uplo, &n, to_cptr(A), &lda, W, to_cptr(&lwork_dummy), &lwork, rwork.data(), &info );
     #else
         cheev_( &jobz, &uplo, &n, A, &lda, W, &lwork_dummy, &lwork, rwork.data(), &info, 
                 sizeof(char), sizeof(char) );
@@ -246,7 +251,7 @@ namespace madness {
         std::vector<complex_real4> work( lwork );
     
     #if MADNESS_LINALG_USE_LAPACKE
-        cheev_( &jobz, &uplo, &n, A, &lda, W, work.data(), &lwork, rwork.data(), &info );
+        cheev_( &jobz, &uplo, &n, to_cptr(A), &lda, W, to_cptr(work.data()), &lwork, rwork.data(), &info );
     #else
         cheev_( &jobz, &uplo, &n, A, &lda, W, work.data(), &lwork, rwork.data(), &info, 
                 sizeof(char), sizeof(char) );
@@ -269,7 +274,7 @@ namespace madness {
         complex_real8 lwork_dummy;
     
     #if MADNESS_LINALG_USE_LAPACKE
-        zheev_( &jobz, &uplo, &n, A, &lda, W, &lwork_dummy, &lwork, rwork.data(), &info );
+        zheev_( &jobz, &uplo, &n, to_cptr(A), &lda, W, to_cptr(&lwork_dummy), &lwork, rwork.data(), &info );
     #else
         zheev_( &jobz, &uplo, &n, A, &lda, W, &lwork_dummy, &lwork, rwork.data(), &info, 
                 sizeof(char), sizeof(char) );
@@ -280,7 +285,7 @@ namespace madness {
         std::vector<complex_real8> work( lwork );
     
     #if MADNESS_LINALG_USE_LAPACKE
-        zheev_( &jobz, &uplo, &n, A, &lda, W, work.data(), &lwork, rwork.data(), &info );
+        zheev_( &jobz, &uplo, &n, to_cptr(A), &lda, W, to_cptr(work.data()), &lwork, rwork.data(), &info );
     #else
         zheev_( &jobz, &uplo, &n, A, &lda, W, work.data(), &lwork, rwork.data(), &info, 
                 sizeof(char), sizeof(char) );
@@ -382,7 +387,7 @@ namespace madness {
         complex_real4 lwork_dummy;
     
     #if MADNESS_LINALG_USE_LAPACKE
-        chegv_( &itype, &jobz, &uplo, &n, A, &lda, B, &ldb, W, &lwork_dummy, &lwork, 
+        chegv_( &itype, &jobz, &uplo, &n, to_cptr(A), &lda, to_cptr(B), &ldb, W, to_cptr(&lwork_dummy), &lwork, 
                 rwork.data(), &info );
     #else
         chegv_( &itype, &jobz, &uplo, &n, A, &lda, B, &ldb, W, &lwork_dummy, &lwork, 
@@ -394,7 +399,7 @@ namespace madness {
         std::vector<complex_real4> work( lwork );
     
     #if MADNESS_LINALG_USE_LAPACKE
-        chegv_( &itype, &jobz, &uplo, &n, A, &lda, B, &ldb, W, work.data(), &lwork, 
+        chegv_( &itype, &jobz, &uplo, &n, to_cptr(A), &lda, to_cptr(B), &ldb, W, to_cptr(work.data()), &lwork, 
                 rwork.data(), &info );
     #else
         chegv_( &itype, &jobz, &uplo, &n, A, &lda, B, &ldb, W, work.data(), &lwork, 
@@ -418,7 +423,7 @@ namespace madness {
         complex_real8 lwork_dummy;
     
     #if MADNESS_LINALG_USE_LAPACKE
-        zhegv_( &itype, &jobz, &uplo, &n, A, &lda, B, &ldb, W, &lwork_dummy, &lwork, 
+        zhegv_( &itype, &jobz, &uplo, &n, to_cptr(A), &lda, to_cptr(B), &ldb, W, to_cptr(&lwork_dummy), &lwork, 
                 rwork.data(), &info );
     #else
         zhegv_( &itype, &jobz, &uplo, &n, A, &lda, B, &ldb, W, &lwork_dummy, &lwork, 
@@ -430,7 +435,7 @@ namespace madness {
         std::vector<complex_real8> work( lwork );
     
     #if MADNESS_LINALG_USE_LAPACKE
-        zhegv_( &itype, &jobz, &uplo, &n, A, &lda, B, &ldb, W, work.data(), &lwork, 
+        zhegv_( &itype, &jobz, &uplo, &n, to_cptr(A), &lda, to_cptr(B), &ldb, W, to_cptr(work.data()), &lwork, 
                 rwork.data(), &info );
     #else
         zhegv_( &itype, &jobz, &uplo, &n, A, &lda, B, &ldb, W, work.data(), &lwork, 
@@ -491,7 +496,7 @@ namespace madness {
         integer info;
     
     #if MADNESS_LINALG_USE_LAPACKE
-        cpotrf_( &uplo, &n, A, &lda, &info );
+        cpotrf_( &uplo, &n, to_cptr(A), &lda, &info );
     #else
         cpotrf_( &uplo, &n, A, &lda, &info, sizeof(char) );
     #endif
@@ -505,7 +510,7 @@ namespace madness {
         integer info;
     
     #if MADNESS_LINALG_USE_LAPACKE
-        zpotrf_( &uplo, &n, A, &lda, &info );
+        zpotrf_( &uplo, &n, to_cptr(A), &lda, &info );
     #else
         zpotrf_( &uplo, &n, A, &lda, &info, sizeof(char) );
     #endif

--- a/src/madness/tensor/linalg_wrappers.h
+++ b/src/madness/tensor/linalg_wrappers.h
@@ -1,0 +1,111 @@
+#include <madness/tensor/clapack.h>
+#include <madness/fortran_ctypes.h>
+
+/*!
+  \file linalg_wrappers.h
+  \brief Template wrappers for LAPACK routines 
+  \ingroup linalg
+@{
+*/
+
+namespace madness {
+namespace detail {
+
+    template <typename T>
+    struct real_type {
+      using type = T;
+    };
+  
+    template <typename T>
+    struct real_type< std::complex<T> > {
+      using type = T;
+    };
+
+}
+
+  
+    /// Compute the SVD via LAPACK
+    template <typename T>
+    void svd( char jobu, char jobvt, integer m, integer n, T* A, integer lda,
+              typename detail::real_type<T>::type* S, T* U, integer ldu,
+              T* VT, integer ldvt ); 
+
+    /// Solve the EVP via LAPACK
+    template <typename T>
+    void hereig( char jobz, char uplo, integer n, T* A, integer lda, 
+                 typename detail::real_type<T>::type* W );
+
+    /// Solve the Generalized EVP via LAPACK
+    template <typename T>
+    void hereig_gen( integer itype, char jobz, char uplo, integer n, T* A, 
+                     integer lda, T* B, integer ldb, 
+                     typename detail::real_type<T>::type* W );
+
+    /// Compute the Cholesky Factorization via LAPACK
+    template <typename T>
+    void cholesky( char uplo, integer n, T* A, integer lda );
+
+
+
+
+
+    /// Linear algebra Exception
+    class LinAlgException : public std::exception {
+        const char* msg;
+        const char* assertion;
+        int value;
+        int line;
+        const char *function;
+        const char *filename;
+  
+public:
+        LinAlgException(const char* s, const char *a, int err, 
+                        int lin, const char *func, const char *file)
+                : msg(s)
+                , assertion(a)
+                , value(err)
+                , line(lin)
+                , function(func)
+                , filename(file) { }
+
+        virtual const char* what() const throw() {
+            return msg;
+        }
+
+        virtual ~LinAlgException() throw() {}
+
+    friend std::ostream& operator <<(std::ostream& out, const LinAlgException& e) {
+        out << "LinAlgException: msg='";
+        if (e.msg) out << e.msg;
+        out << "'\n";
+        if (e.assertion) out << "                 failed assertion='" <<
+            e.assertion << "'\n";
+        out << "                 value=" << e.value << "\n";
+        if (e.line) out << "                 line=" << e.line << "\n";
+        if (e.function) out << "                 function='" <<
+            e.function << "'\n";
+        if (e.filename) out << "                 filename='" <<
+            e.filename << "'\n";
+
+        return out;
+    }
+
+    };
+
+
+
+#define LINALG_STRINGIZE(X) #X
+#define LINALG_EXCEPTION_AT(F, L) LINALG_STRINGIZE(F) "(" LINALG_STRINGIZE(L) ")"
+
+#define LINALG_EXCEPTION(msg,value) \
+    throw ::madness::LinAlgException("LINALG EXCEPTION: " LINALG_EXCEPTION_AT( __FILE__, __LINE__ ) ": " msg , \
+    0,value,__LINE__,__FUNCTION__,__FILE__)
+
+#define LINALG_ASSERT(condition,msg,value) \
+do {if (!(condition)) \
+        throw ::madness::LinAlgException("LINALG ASSERTION FAILED: " LINALG_EXCEPTION_AT( __FILE__, __LINE__ ) ": " msg , \
+        #condition,value,__LINE__,__FUNCTION__,__FILE__); \
+   } while (0)
+}
+
+/* @} */


### PR DESCRIPTION
Currently, there is only an "internal use" implementation of template wrappers for LAPACK routines interfaced to raw pointers with the correct LAPACK/LAPACKE function wrappers. This PR exports a templated API which delegates to the proper LAPACK/LAPACK wrappers and can be used downstream.

This PR adds template wrappers for the following LAPACK routines:
- XGESVD
- X{SY,HE}EV
- X{SY,HE}GV
- XPOTRF

