### PR TITLE
changed HAVE_MKL to HAVE_INTEL_MKL

### DIFF
--- a/src/madness/tensor/mxm.h
+++ b/src/madness/tensor/mxm.h
@@ -181,7 +181,7 @@ namespace madness {
     }
     
 
-#if defined(HAVE_FAST_BLAS) && !defined(HAVE_MKL)
+#if defined(HAVE_FAST_BLAS) && !defined(HAVE_INTEL_MKL)
     // MKL provides support for mixed real/complex operations but most other libraries do not
     
     /// Matrix += Matrix * matrix ... BLAS/MKL interface version
@@ -265,7 +265,7 @@ namespace madness {
     }
 #endif
     
-#ifdef HAVE_MKL
+#ifdef HAVE_INTEL_MKL
     /// Matrix += Matrix * matrix ... MKL interface version
     
     /// Does \c C=C+A*B 
@@ -703,7 +703,7 @@ namespace madness {
 //                double* MADNESS_RESTRICT c, const double* a, const double* b);
 #endif // HAVE_IBMBGQ
 
-#endif // HAVE_MKL
+#endif // HAVE_INTEL_MKL
     
 }    
 #endif // MADNESS_TENSOR_MXM_H__INCLUDED

--- a/src/madness/tensor/vmath.cc
+++ b/src/madness/tensor/vmath.cc
@@ -42,7 +42,7 @@
 typedef std::complex<double> double_complex;
 
 #include <madness/madness_config.h>
-#ifdef HAVE_MKL
+#ifdef HAVE_INTEL_MKL
 #include <mkl.h>
 
 #elif defined(HAVE_ACML)

--- a/src/madness/tensor/vmath.h
+++ b/src/madness/tensor/vmath.h
@@ -35,7 +35,7 @@
 
 #include <madness/madness_config.h>
 
-#ifdef HAVE_MKL
+#ifdef HAVE_INTEL_MKL
 #include <mkl.h>
 
 #elif defined(HAVE_ACML)


### PR DESCRIPTION
Three files in tensor (mxm.h, vmath.cc, and vmath.h) were still using the old HAVE_MKL macro name instead of the new HAVE_INTEL_MKL.