### PR TITLE
serialization sfinae

### DIFF
--- a/src/madness/world/archive.h
+++ b/src/madness/world/archive.h
@@ -1166,7 +1166,7 @@ namespace madness {
 
             /// \param[in] ar The archive.
             /// \param[in] v The \c vector.
-            template <typename U = T, typename = std::enable_if_t<is_default_serializable<Archive,U>::value>>
+            template <typename U = T, typename = std::enable_if_t<is_default_serializable_v<Archive,U>>>
             static inline void store(const Archive& ar, const std::vector<U, Alloc>& v) {
                 MAD_ARCHIVE_DEBUG(std::cout << "serialize std::vector of plain data" << std::endl);
                 ar & v.size();
@@ -1178,7 +1178,7 @@ namespace madness {
             /// \param[in] ar The archive.
             /// \param[in] v The \c vector.
             template <typename U = T>
-            static inline void store(const Archive& ar, const std::vector<U, Alloc>& v, std::enable_if_t<!is_default_serializable<Archive,U>::value>* = nullptr) {
+            static inline void store(const Archive& ar, const std::vector<U, Alloc>& v, std::enable_if_t<!is_default_serializable_v<Archive,U>>* = nullptr) {
                 MAD_ARCHIVE_DEBUG(std::cout << "serialize std::vector of non-plain data" << std::endl);
                 ar & v.size();
                 for(const auto& elem: v) {
@@ -1202,7 +1202,7 @@ namespace madness {
             /// Clears and resizes the \c vector as necessary.
             /// \param[in] ar The archive.
             /// \param[out] v The \c vector.
-            template <typename U = T, typename = std::enable_if_t<is_default_serializable<Archive,U>::value>>
+            template <typename U = T, typename = std::enable_if_t<is_default_serializable_v<Archive,U>>>
             static void load(const Archive& ar, std::vector<U, Alloc>& v) {
                 MAD_ARCHIVE_DEBUG(std::cout << "deserialize std::vector of plain data" << std::endl);
                 std::size_t n = 0ul;
@@ -1220,7 +1220,7 @@ namespace madness {
             /// \param[in] ar The archive.
             /// \param[out] v The \c vector.
             template <typename U = T>
-            static void load(const Archive& ar, std::vector<U, Alloc>& v, std::enable_if_t<!is_default_serializable<Archive,U>::value>* = nullptr) {
+            static void load(const Archive& ar, std::vector<U, Alloc>& v, std::enable_if_t<!is_default_serializable_v<Archive,U>>* = nullptr) {
                 MAD_ARCHIVE_DEBUG(std::cout << "deserialize std::vector of non-plain data" << std::endl);
                 std::size_t n = 0ul;
                 ar & n;

--- a/src/madness/world/archive.h
+++ b/src/madness/world/archive.h
@@ -42,6 +42,7 @@
 #include <type_traits>
 #include <complex>
 #include <iostream>
+#include <cassert>
 #include <cstdio>
 #include <cstddef>
 #include <cstring>

--- a/src/madness/world/cereal_archive.h
+++ b/src/madness/world/cereal_archive.h
@@ -81,7 +81,7 @@ public:
           cereal::traits::is_text_archive<Cereal>::value,void>
   store(const T *t, long n) const {
     for (long i = 0; i != n; ++i)
-      *muesli & t[i];
+      (*muesli)(t[i]);
   }
 
   void open(std::size_t hint) {}
@@ -119,7 +119,7 @@ public:
       void>
   load(T *t, long n) const {
     for (long i = 0; i != n; ++i)
-      *muesli & t[i];
+      (*muesli)(t[i]);
   }
 
   void open(std::size_t hint) {}
@@ -161,6 +161,12 @@ template <typename Muesli>
 struct is_cereal_archive<archive::CerealOutputArchive<Muesli>> : std::true_type {};
 template <typename Muesli>
 struct is_cereal_archive<archive::CerealInputArchive<Muesli>> : std::true_type {};
+
+// must also be able to introspect bare cereal archives to be able to reuse serialize methods for both
+template <typename T>
+struct is_output_archive<T, std::enable_if_t<std::is_base_of_v<cereal::detail::OutputArchiveBase, T>>> : std::true_type {};
+template <typename T>
+struct is_input_archive<T, std::enable_if_t<std::is_base_of_v<cereal::detail::InputArchiveBase, T>>> : std::true_type {};
 
 }  // namespace madness
 

--- a/src/madness/world/cereal_archive.h
+++ b/src/madness/world/cereal_archive.h
@@ -164,6 +164,18 @@ struct is_cereal_archive<archive::CerealInputArchive<Muesli>> : std::true_type {
 
 // must also be able to introspect bare cereal archives to be able to reuse serialize methods for both
 template <typename T>
+struct is_archive<archive::CerealOutputArchive<T>, std::enable_if_t<std::is_base_of_v<cereal::detail::OutputArchiveBase, T>>> : std::true_type {};
+template <typename T>
+struct is_archive<archive::CerealInputArchive<T>, std::enable_if_t<std::is_base_of_v<cereal::detail::InputArchiveBase, T>>> : std::true_type {};
+template <typename T>
+struct is_output_archive<archive::CerealOutputArchive<T>, std::enable_if_t<std::is_base_of_v<cereal::detail::OutputArchiveBase, T>>> : std::true_type {};
+template <typename T>
+struct is_input_archive<archive::CerealInputArchive<T>, std::enable_if_t<std::is_base_of_v<cereal::detail::InputArchiveBase, T>>> : std::true_type {};
+template <typename T>
+struct is_archive<T, std::enable_if_t<std::is_base_of_v<cereal::detail::OutputArchiveBase, T>>> : std::true_type {};
+template <typename T>
+struct is_archive<T, std::enable_if_t<std::is_base_of_v<cereal::detail::InputArchiveBase, T>>> : std::true_type {};
+template <typename T>
 struct is_output_archive<T, std::enable_if_t<std::is_base_of_v<cereal::detail::OutputArchiveBase, T>>> : std::true_type {};
 template <typename T>
 struct is_input_archive<T, std::enable_if_t<std::is_base_of_v<cereal::detail::InputArchiveBase, T>>> : std::true_type {};

--- a/src/madness/world/cereal_archive.h
+++ b/src/madness/world/cereal_archive.h
@@ -140,7 +140,7 @@ struct is_text_archive<
     : std::true_type {};
 
 template <typename Muesli, typename T>
-struct is_serializable_helper<
+struct is_default_serializable_helper<
     archive::CerealOutputArchive<Muesli>, T,
     std::enable_if_t<(is_trivially_serializable<T>::value &&
         !cereal::traits::is_text_archive<Muesli>::value) ||
@@ -148,7 +148,7 @@ struct is_serializable_helper<
          cereal::traits::is_text_archive<Muesli>::value)>>
     : std::true_type {};
 template <typename Muesli, typename T>
-struct is_serializable_helper<
+struct is_default_serializable_helper<
     archive::CerealInputArchive<Muesli>, T,
     std::enable_if_t<
         (is_trivially_serializable<T>::value &&

--- a/src/madness/world/test_ar.cc
+++ b/src/madness/world/test_ar.cc
@@ -87,6 +87,33 @@ static_assert(madness::is_text_archive_v<CerealXMLOutputArchive>, "ouch");
 #include <madness/world/world.h>
 #include <madness/world/worldgop.h>
 
+template <typename T>
+struct type_printer;
+
+///// basic traits tests
+
+static_assert(!madness::has_member_serialize_v<int, madness::archive::BufferOutputArchive>);
+static_assert(!madness::has_member_serialize_v<int, madness::archive::BufferInputArchive>);
+static_assert(!madness::has_member_serialize_with_version_v<int, madness::archive::BufferOutputArchive>);
+static_assert(!madness::has_member_serialize_with_version_v<int, madness::archive::BufferInputArchive>);
+static_assert(!madness::has_nonmember_serialize_v<int, madness::archive::BufferOutputArchive>);
+static_assert(!madness::has_nonmember_serialize_v<int, madness::archive::BufferInputArchive>);
+static_assert(!madness::has_freestanding_serialize_v<int, madness::archive::BufferOutputArchive>);
+static_assert(!madness::has_freestanding_serialize_v<int, madness::archive::BufferInputArchive>);
+static_assert(!madness::has_freestanding_serialize_with_size_v<int*, madness::archive::BufferOutputArchive>);
+static_assert(!madness::has_freestanding_serialize_with_size_v<int*, madness::archive::BufferInputArchive>);
+static_assert(!madness::has_freestanding_serialize_with_version_v<int, madness::archive::BufferOutputArchive>);
+static_assert(!madness::has_freestanding_serialize_with_version_v<int, madness::archive::BufferInputArchive>);
+static_assert(madness::has_freestanding_default_serialize_v<int, madness::archive::BufferOutputArchive>);
+static_assert(madness::has_freestanding_default_serialize_v<int, madness::archive::BufferInputArchive>);
+static_assert(madness::has_freestanding_default_serialize_with_size_v<int*, madness::archive::BufferOutputArchive>);
+static_assert(madness::has_freestanding_default_serialize_with_size_v<int*, madness::archive::BufferInputArchive>);
+static_assert(madness::has_freestanding_default_serialize_with_size_v<int*, madness::archive::BinaryFstreamOutputArchive>);
+static_assert(madness::has_nonmember_store_v<int, madness::archive::BufferOutputArchive>);
+static_assert(madness::has_nonmember_load_v<int, madness::archive::BufferInputArchive>);
+static_assert(!madness::is_user_serializable_v<int, madness::archive::BufferOutputArchive>);
+static_assert(!madness::is_user_serializable_v<int, madness::archive::BufferInputArchive>);
+
 // A is a class that provides a symmetric serialize method
 class A {
 public:
@@ -234,17 +261,6 @@ static_assert(madness::is_istreammable_v<int>, "int is istreammable");
 static_assert(!madness::is_istreammable_v<std::array<int,3>>, "std::array<int,3> is not istreammable");
 static_assert(!madness::is_istreammable_v<std::vector<int>>, "std::vector<int> is not istreammable");
 static_assert(!madness::is_istreammable_v<NotStreammable>, "NotStreammable is not istreammable");
-
-static_assert(!madness::has_member_serialize_v<C, madness::archive::BufferOutputArchive>);
-static_assert(!madness::has_member_serialize_v<C, madness::archive::BufferInputArchive>);
-static_assert(!madness::has_member_serialize_with_version_v<C, madness::archive::BufferOutputArchive>);
-static_assert(!madness::has_member_serialize_with_version_v<C, madness::archive::BufferInputArchive>);
-static_assert(!madness::has_nonmember_serialize_v<C, madness::archive::BufferOutputArchive>);
-static_assert(!madness::has_nonmember_serialize_v<C, madness::archive::BufferInputArchive>);
-static_assert(madness::has_nonmember_store_v<C, madness::archive::BufferOutputArchive>);
-static_assert(madness::has_nonmember_load_v<C, madness::archive::BufferInputArchive>);
-static_assert(madness::has_nonmember_load_and_store_v<C, madness::archive::BufferOutputArchive>);
-static_assert(madness::has_nonmember_load_and_store_v<C, madness::archive::BufferInputArchive>);
 
 // serialization of trivially-serializable types can be overloaded
 struct G1 {

--- a/src/madness/world/test_ar.cc
+++ b/src/madness/world/test_ar.cc
@@ -99,6 +99,19 @@ public:
     }
 };
 
+static_assert(madness::has_member_serialize_v<A, madness::archive::BufferOutputArchive>);
+static_assert(madness::has_member_serialize_v<A, madness::archive::BufferInputArchive>);
+static_assert(!madness::has_member_serialize_with_version_v<A, madness::archive::BufferOutputArchive>);
+static_assert(!madness::has_member_serialize_with_version_v<A, madness::archive::BufferInputArchive>);
+// N.B. nonmember serialize is provided for types with serialize member
+static_assert(madness::has_nonmember_serialize_v<A, madness::archive::BufferOutputArchive>);
+static_assert(madness::has_nonmember_serialize_v<A, madness::archive::BufferInputArchive>);
+// N.B. nonmember load/store is provided for types with serialize member
+static_assert(madness::has_nonmember_store_v<A, madness::archive::BufferOutputArchive>);
+static_assert(madness::has_nonmember_load_v<A, madness::archive::BufferInputArchive>);
+static_assert(!madness::has_nonmember_load_and_store_v<A, madness::archive::BufferOutputArchive>);
+static_assert(!madness::has_nonmember_load_and_store_v<A, madness::archive::BufferInputArchive>);
+
 // B is a class without a serialize method but with symmetric serialization.
 class B {
 public:
@@ -117,6 +130,18 @@ namespace madness {
         };
     }
 }
+
+static_assert(!madness::has_member_serialize_v<B, madness::archive::BufferOutputArchive>);
+static_assert(!madness::has_member_serialize_v<B, madness::archive::BufferInputArchive>);
+static_assert(!madness::has_member_serialize_with_version_v<B, madness::archive::BufferOutputArchive>);
+static_assert(!madness::has_member_serialize_with_version_v<B, madness::archive::BufferInputArchive>);
+static_assert(madness::has_nonmember_serialize_v<B, madness::archive::BufferOutputArchive>);
+static_assert(madness::has_nonmember_serialize_v<B, madness::archive::BufferInputArchive>);
+// N.B. nonmember load/store is provided for types with nonmember serialize
+static_assert(madness::has_nonmember_store_v<B, madness::archive::BufferOutputArchive>);
+static_assert(madness::has_nonmember_load_v<B, madness::archive::BufferInputArchive>);
+static_assert(!madness::has_nonmember_load_and_store_v<B, madness::archive::BufferOutputArchive>);
+static_assert(!madness::has_nonmember_load_and_store_v<B, madness::archive::BufferInputArchive>);
 
 // C is a class with asymmetric load/store.
 class C {
@@ -143,11 +168,34 @@ namespace madness {
     }
 }
 
+static_assert(!madness::has_member_serialize_v<C, madness::archive::BufferOutputArchive>);
+static_assert(!madness::has_member_serialize_v<C, madness::archive::BufferInputArchive>);
+static_assert(!madness::has_member_serialize_with_version_v<C, madness::archive::BufferOutputArchive>);
+static_assert(!madness::has_member_serialize_with_version_v<C, madness::archive::BufferInputArchive>);
+static_assert(!madness::has_nonmember_serialize_v<C, madness::archive::BufferOutputArchive>);
+static_assert(!madness::has_nonmember_serialize_v<C, madness::archive::BufferInputArchive>);
+static_assert(madness::has_nonmember_store_v<C, madness::archive::BufferOutputArchive>);
+static_assert(madness::has_nonmember_load_v<C, madness::archive::BufferInputArchive>);
+static_assert(madness::has_nonmember_load_and_store_v<C, madness::archive::BufferOutputArchive>);
+static_assert(madness::has_nonmember_load_and_store_v<C, madness::archive::BufferInputArchive>);
+
 // POD can be serialized to most (except text stream) archives without any effort
 struct D {
   int32_t i;
   int64_t l;
 };
+
+static_assert(!madness::has_member_serialize_v<D, madness::archive::BufferOutputArchive>);
+static_assert(!madness::has_member_serialize_v<D, madness::archive::BufferInputArchive>);
+static_assert(!madness::has_member_serialize_with_version_v<D, madness::archive::BufferOutputArchive>);
+static_assert(!madness::has_member_serialize_with_version_v<D, madness::archive::BufferInputArchive>);
+static_assert(!madness::has_nonmember_serialize_v<D, madness::archive::BufferOutputArchive>);
+static_assert(!madness::has_nonmember_serialize_v<D, madness::archive::BufferInputArchive>);
+// N.B. nonmember load/store is provided for default-serializable types
+static_assert(madness::has_nonmember_store_v<D, madness::archive::BufferOutputArchive>);
+static_assert(madness::has_nonmember_load_v<D, madness::archive::BufferInputArchive>);
+static_assert(!madness::has_nonmember_load_and_store_v<D, madness::archive::BufferOutputArchive>);
+static_assert(!madness::has_nonmember_load_and_store_v<D, madness::archive::BufferInputArchive>);
 
 // to serialize a POD to a text stream just overload stream redirection operators
 struct F {
@@ -186,6 +234,36 @@ static_assert(madness::is_istreammable_v<int>, "int is istreammable");
 static_assert(!madness::is_istreammable_v<std::array<int,3>>, "std::array<int,3> is not istreammable");
 static_assert(!madness::is_istreammable_v<std::vector<int>>, "std::vector<int> is not istreammable");
 static_assert(!madness::is_istreammable_v<NotStreammable>, "NotStreammable is not istreammable");
+
+static_assert(!madness::has_member_serialize_v<C, madness::archive::BufferOutputArchive>);
+static_assert(!madness::has_member_serialize_v<C, madness::archive::BufferInputArchive>);
+static_assert(!madness::has_member_serialize_with_version_v<C, madness::archive::BufferOutputArchive>);
+static_assert(!madness::has_member_serialize_with_version_v<C, madness::archive::BufferInputArchive>);
+static_assert(!madness::has_nonmember_serialize_v<C, madness::archive::BufferOutputArchive>);
+static_assert(!madness::has_nonmember_serialize_v<C, madness::archive::BufferInputArchive>);
+static_assert(madness::has_nonmember_store_v<C, madness::archive::BufferOutputArchive>);
+static_assert(madness::has_nonmember_load_v<C, madness::archive::BufferInputArchive>);
+static_assert(madness::has_nonmember_load_and_store_v<C, madness::archive::BufferOutputArchive>);
+static_assert(madness::has_nonmember_load_and_store_v<C, madness::archive::BufferInputArchive>);
+
+// serialization of trivially-serializable types can be overloaded
+struct G1 {
+  int32_t i;
+  int64_t l;
+  template <typename Archive>
+  void serialize(Archive& ar) {
+    ar & i & l;
+    if constexpr (madness::is_input_archive_v<Archive>) {
+      int junk;
+      ar >> junk;
+      MADNESS_ASSERT(junk == 17);
+    }
+    else {
+      static_assert(madness::is_output_archive_v<Archive>);
+      ar << 17;
+    }
+  }
+};
 
 // A better example of a class with asym load/store
 class linked_list {
@@ -319,6 +397,7 @@ void test_out(const OutputArchive& oar) {
     C c, cn[n];
     D d, dn[n];
     F f, fn[n];
+    G1 g1, g1n[n];
     int i, in[n];
     double *p = new double[n];
     A *q = new A[n];
@@ -338,12 +417,15 @@ void test_out(const OutputArchive& oar) {
     a.a = 1; b.b = 1; c.c = 1; i = 1;
     d.i = 1;  d.l = 2;
     f.i = 1;  f.l = 2;
+    g1.i = 1; g1.l = 2;
     for (int k=0; k<n; ++k) {
         p[k] = q[k].a = an[k].a = v[k] = arr[k] = cn[k].c = in[k] = k;
         dn[k].i = k+1;
         dn[k].l = k+2;
         fn[k].i = k+3;
         fn[k].l = k+4;
+        g1n[k].i = k+5;
+        g1n[k].l = k+6;
         vv[k] = {k+1, k+2, k+3, k+4};
         bn[k].b = k&1;
         m[k] = double_complex(k,k);
@@ -383,6 +465,9 @@ void test_out(const OutputArchive& oar) {
       MAD_ARCHIVE_DEBUG(std::cout << std::endl << " F" << std::endl);
       pod_serialize_dispatch<F_is_serializable>{}(oar, f);
     }
+    MAD_ARCHIVE_DEBUG(std::cout << std::endl << " G1" << std::endl);
+    oar & g1;
+    oar << g1;
     MAD_ARCHIVE_DEBUG(std::cout << std::endl << " int[]" << std::endl);
     oar & in;
     oar << in;
@@ -405,6 +490,9 @@ void test_out(const OutputArchive& oar) {
       MAD_ARCHIVE_DEBUG(std::cout << std::endl << " F[]" << std::endl);
       pod_serialize_dispatch<F_is_serializable>{}(oar, fn);
     }
+    MAD_ARCHIVE_DEBUG(std::cout << std::endl << " G1[]" << std::endl);
+    oar << g1n;
+    oar & g1n;
     MAD_ARCHIVE_DEBUG(std::cout << std::endl << " double *p wrapped" << std::endl);
     oar << wrap(p,n);
     oar & wrap(p,n);
@@ -437,12 +525,12 @@ void test_out(const OutputArchive& oar) {
     if constexpr(ptr_is_serializable) {
       MAD_ARCHIVE_DEBUG(std::cout << std::endl
                                   << " function pointer" << std::endl);
-      oar &free_fn;
+      oar & free_fn;  // no difference between storing function ref and function pointer
       oar << (&free_fn);
       MAD_ARCHIVE_DEBUG(std::cout << std::endl
                                   << " static member function pointer"
                                   << std::endl);
-      oar &Member::static_fn;
+      oar & Member::static_fn;  // no difference between storing function ref and function pointer
       oar << (&Member::static_fn);
       MAD_ARCHIVE_DEBUG(std::cout << std::endl
                                   << " non-static member function pointer"
@@ -458,7 +546,7 @@ void test_out(const OutputArchive& oar) {
 
     oar & 1.0 & i & a & b & c & in & an & bn & cn & wrap(p,n) & wrap(q,n) & pp & m & t & str;
     if constexpr(ptr_is_serializable) {
-      oar &free_fn &(&free_fn) & Member::static_fn & (&Member::static_fn) & (&Member::fn) & (&Member::virtual_fn);
+      oar & free_fn &(&free_fn) & Member::static_fn & (&Member::static_fn) & (&Member::fn) & (&Member::virtual_fn);
     }
 
     if (D_is_serializable) {
@@ -479,6 +567,7 @@ void test_in(const InputArchive& iar) {
     C c, cn[n];
     D d, dn[n];
     F f, fn[n];
+    G1 g1, g1n[n];
     int i, in[n];
     double *p = new double[n];
     A *q = new A[n];
@@ -500,12 +589,15 @@ void test_in(const InputArchive& iar) {
     a.a = 0; b.b = 0; c.c = 0; i = 0;
     d.i = -1;  d.l = -1;
     f.i = -1;  f.l = -1;
+    g1.i = -1; g1.l = -1;
     for (int k=0; k<n; ++k) {
         p[k] = q[k].a = an[k].a = v[k] = arr[k] = cn[k].c = in[k] = -1;
         dn[k].i = -1;
         dn[k].l = -1;
         fn[k].i = -1;
         fn[k].l = -1;
+        g1n[k].i = -1;
+        g1n[k].l = -1;
         vv[k] = {};
         bn[k].b = (k+1)&1;
         m[k] = double_complex(0,0);
@@ -549,6 +641,9 @@ void test_in(const InputArchive& iar) {
       MAD_ARCHIVE_DEBUG(std::cout << std::endl << " F" << std::endl);
       pod_deserialize_dispatch<F_is_serializable>{}(iar, f);
     }
+    MAD_ARCHIVE_DEBUG(std::cout << std::endl << " G1" << std::endl);
+    iar & g1;
+    iar >> g1;
     MAD_ARCHIVE_DEBUG(std::cout << std::endl << " int[]" << std::endl);
     iar & in;
     iar >> in;
@@ -569,6 +664,9 @@ void test_in(const InputArchive& iar) {
       MAD_ARCHIVE_DEBUG(std::cout << std::endl << " F[]" << std::endl);
       pod_deserialize_dispatch<F_is_serializable>{}(iar, fn);
     }
+    MAD_ARCHIVE_DEBUG(std::cout << std::endl << " G1[]" << std::endl);
+    iar & g1n;
+    iar >> g1n;
     MAD_ARCHIVE_DEBUG(std::cout << std::endl << " double *p wrapped" << std::endl);
     iar & wrap(p,n);
     iar >> wrap(p,n);
@@ -597,16 +695,16 @@ void test_in(const InputArchive& iar) {
     iar & str;
     iar >> str;
 
-    constexpr const bool ptr_is_serializable = !madness::is_cereal_archive<InputArchive>::value;
+    constexpr const bool ptr_is_serializable = true && !madness::is_cereal_archive<InputArchive>::value;
     if constexpr(ptr_is_serializable) {
       MAD_ARCHIVE_DEBUG(std::cout << std::endl
                                   << " function pointer" << std::endl);
-      iar &free_fn_ptr1;
+      iar & free_fn_ptr1;
       iar >> free_fn_ptr2;
       MAD_ARCHIVE_DEBUG(std::cout << std::endl
                                   << " static member function pointer"
                                   << std::endl);
-      iar &static_member_fn_ptr1;
+      iar & static_member_fn_ptr1;
       iar >> static_member_fn_ptr2;
       MAD_ARCHIVE_DEBUG(std::cout << std::endl
                                   << " non-static member function pointer"
@@ -651,6 +749,8 @@ void test_in(const InputArchive& iar) {
       TEST(f.i == 1);
       TEST(f.l == 2);
     }
+    TEST(g1.i == 1);
+    TEST(g1.l == 2);
     TEST(i == 1);
     for (int k=0; k<n; ++k) {
         TEST(an[k].a == k);
@@ -664,6 +764,8 @@ void test_in(const InputArchive& iar) {
           TEST(fn[k].i == k + 3);
           TEST(fn[k].l == k + 4);
         }
+        TEST(g1n[k].i == k + 5);
+        TEST(g1n[k].l == k + 6);
         TEST(in[k] == k);
         TEST(p[k] == k);
         TEST(q[k].a == k);

--- a/src/madness/world/test_ar.cc
+++ b/src/madness/world/test_ar.cc
@@ -39,6 +39,9 @@ using std::endl;
 #include <madness/world/array_addons.h>
 #include <madness/world/print.h>
 
+template <typename T>
+struct type_printer;
+
 /// \file test.cc
 /// \brief Tests serialization by some of the archives
 
@@ -65,6 +68,9 @@ using madness::archive::BufferOutputArchive;
 #include <cereal/archives/binary.hpp>
 using CerealBinaryInputArchive = madness::archive::CerealInputArchive<cereal::BinaryInputArchive>;
 using CerealBinaryOutputArchive = madness::archive::CerealOutputArchive<cereal::BinaryOutputArchive>;
+static_assert(madness::is_archive_v<CerealBinaryInputArchive>);
+static_assert(madness::is_input_archive_v<CerealBinaryInputArchive>);
+static_assert(!madness::is_output_archive_v<CerealBinaryInputArchive>);
 static_assert(!madness::is_text_archive_v<CerealBinaryInputArchive>, "ouch");
 static_assert(!madness::is_text_archive_v<CerealBinaryInputArchive>, "ouch");
 #include <cereal/archives/portable_binary.hpp>
@@ -261,6 +267,9 @@ static_assert(madness::is_istreammable_v<int>, "int is istreammable");
 static_assert(!madness::is_istreammable_v<std::array<int,3>>, "std::array<int,3> is not istreammable");
 static_assert(!madness::is_istreammable_v<std::vector<int>>, "std::vector<int> is not istreammable");
 static_assert(!madness::is_istreammable_v<NotStreammable>, "NotStreammable is not istreammable");
+
+static_assert(!madness::is_default_serializable_v<madness::archive::TextFstreamOutputArchive,std::vector<std::vector<int>>>);
+static_assert(!madness::is_default_serializable_v<madness::archive::TextFstreamInputArchive,std::vector<std::vector<int>>>);
 
 // serialization of trivially-serializable types can be overloaded
 struct G1 {
@@ -715,6 +724,10 @@ void test_in(const InputArchive& iar) {
     if constexpr(ptr_is_serializable) {
       MAD_ARCHIVE_DEBUG(std::cout << std::endl
                                   << " function pointer" << std::endl);
+      static_assert(!madness::is_istreammable_v<void(*)()>);
+      static_assert(madness::is_ostreammable_v<void(*)()>);
+      static_assert(madness::is_default_serializable_v<madness::archive::TextFstreamInputArchive, void (*)()>);
+      static_assert(madness::is_default_serializable_v<madness::archive::TextFstreamInputArchive, void (*)()>);
       iar & free_fn_ptr1;
       iar >> free_fn_ptr2;
       MAD_ARCHIVE_DEBUG(std::cout << std::endl

--- a/src/madness/world/type_traits.h
+++ b/src/madness/world/type_traits.h
@@ -354,6 +354,8 @@ namespace madness {
     class MPIRawInputArchive;
     class MPIOutputArchive;
     class MPIInputArchive;
+    class ParallelOutputArchive;
+    class ParallelInputArchive;
     template <typename T>
     class archive_array;
     }  // namespace archive
@@ -460,6 +462,10 @@ namespace madness {
     struct is_archive<archive::MPIOutputArchive> : std::true_type {};
     template <>
     struct is_archive<archive::MPIInputArchive> : std::true_type {};
+    template <>
+    struct is_archive<archive::ParallelOutputArchive> : std::true_type {};
+    template <>
+    struct is_archive<archive::ParallelInputArchive> : std::true_type {};
 
     template <>
     struct is_output_archive<archive::BinaryFstreamOutputArchive> : std::true_type {};
@@ -473,6 +479,8 @@ namespace madness {
     struct is_output_archive<archive::MPIRawOutputArchive> : std::true_type {};
     template <>
     struct is_output_archive<archive::MPIOutputArchive> : std::true_type {};
+    template <>
+    struct is_output_archive<archive::ParallelOutputArchive> : std::true_type {};
 
     template <>
     struct is_input_archive<archive::BinaryFstreamInputArchive> : std::true_type {};
@@ -486,6 +494,8 @@ namespace madness {
     struct is_input_archive<archive::MPIRawInputArchive> : std::true_type {};
     template <>
     struct is_input_archive<archive::MPIInputArchive> : std::true_type {};
+    template <>
+    struct is_input_archive<archive::ParallelInputArchive> : std::true_type {};
 
     /// Evaluates to true if can serialize an object of type `T` to an object of type `Archive` using user-provided methods
     /// \tparam Archive

--- a/src/madness/world/type_traits.h
+++ b/src/madness/world/type_traits.h
@@ -318,8 +318,11 @@ namespace madness {
     /// inherited from \c std::true_type, otherwise it is inherited from
     /// \c std::false_type.
     /// \tparam T The type to check.
+    template <typename T, typename Enabler = void>
+    struct is_input_archive : std::false_type {};
+
     template <typename T>
-    struct is_input_archive : public std::is_base_of<archive::BaseInputArchive, T> {};
+    struct is_input_archive<T, std::enable_if_t<std::is_base_of_v<archive::BaseInputArchive, T>>> : std::true_type {};
 
     template <typename T>
     inline constexpr bool is_input_archive_v = is_input_archive<T>::value;
@@ -330,8 +333,11 @@ namespace madness {
     /// be inherited from \c std::true_type, otherwise it is inherited from
     /// \c std::false_type.
     /// \tparam T The type to check.
+    template <typename T, typename Enabler = void>
+    struct is_output_archive : std::false_type {};
+
     template <typename T>
-    struct is_output_archive : public std::is_base_of<archive::BaseOutputArchive, T> {};
+    struct is_output_archive<T, std::enable_if_t<std::is_base_of_v<archive::BaseOutputArchive, T>>> : std::true_type {};
 
     template <typename T>
     inline constexpr bool is_output_archive_v = is_output_archive<T>::value;

--- a/src/madness/world/world.h
+++ b/src/madness/world/world.h
@@ -541,11 +541,6 @@ namespace madness {
 
     namespace archive {
 
-        template <typename, typename>
-        struct ArchiveLoadImpl;
-        template <typename, typename>
-        struct ArchiveStoreImpl;
-
         /// Specialization of \c ArchiveLoadImpl for \c World pointers.
 
         /// Helps in archiving (reading) \c World objects.

--- a/src/madness/world/world_task_queue.h
+++ b/src/madness/world/world_task_queue.h
@@ -601,7 +601,7 @@ namespace madness {
         add(fnT&& fn, argsT&&... args) {
           using taskT = typename meta::drop_last_arg_and_apply<TaskFn,
                                                                std::decay_t<fnT>,
-                                                               std::remove_const_t<std::remove_reference_t<argsT>>...>::type;
+                                                               std::remove_cv_t<std::remove_reference_t<argsT>>...>::type;
           return add(new taskT(typename taskT::futureT(), std::forward<fnT>(fn),
                                std::forward<argsT>(args)...));
         }
@@ -611,7 +611,7 @@ namespace madness {
                       !meta::taskattr_is_last_arg<argsT...>::value>>
         typename detail::function_enabler<fnT(future_to_ref_t<argsT>...)>::type add(
             fnT&& fn, argsT&&... args) {
-          using taskT = TaskFn<std::decay_t<fnT>, std::remove_const_t<std::remove_reference_t<argsT>>...>;
+          using taskT = TaskFn<std::decay_t<fnT>, std::remove_cv_t<std::remove_reference_t<argsT>>...>;
           return add(new taskT(typename taskT::futureT(), std::forward<fnT>(fn),
                                std::forward<argsT>(args)..., TaskAttributes()));
         }

--- a/src/madness/world/worldptr.h
+++ b/src/madness/world/worldptr.h
@@ -459,12 +459,6 @@ namespace madness {
     } // namespace detail
 
     namespace archive {
-        template <typename, typename>
-        struct ArchiveLoadImpl;
-
-        template <typename, typename>
-        struct ArchiveStoreImpl;
-
 
         /// Specialization of \c ArchiveLoadImpl for world pointers.
 

--- a/src/madness/world/worldref.h
+++ b/src/madness/world/worldref.h
@@ -57,14 +57,6 @@ namespace madness {
 //    template <typename T>
 //    std::ostream& operator<<(std::ostream& s, const RemoteReference<T>& ref);
 
-    namespace archive {
-        template <typename, typename>
-        struct ArchiveLoadImpl;
-
-        template <typename, typename>
-        struct ArchiveStoreImpl;
-    }
-
     namespace detail {
 
 
@@ -345,10 +337,10 @@ namespace madness {
 
         private:
 
-            template <typename, typename>
+            template <typename, typename, typename>
             friend struct archive::ArchiveLoadImpl;
 
-            template <typename, typename>
+            template <typename, typename, typename>
             friend struct archive::ArchiveStoreImpl;
 
             template <typename Archive>


### PR DESCRIPTION
- instantiations are protected by SFINAE to be able to detect serializability of a type correctly.
- user-provided serialization methods override default serialization for trivially-serializable methods

top level operators (`&`, `<<`, `>>`) are unprotected but static_assert serializability inside to produce more reasonable error messages.