### PR TITLE
madness serialization cleanup

### DIFF
--- a/src/madness/world/archive.h
+++ b/src/madness/world/archive.h
@@ -1081,7 +1081,7 @@ namespace madness {
         /// \tparam T The data type.
         /// \tparam n The array size.
         template <class Archive, class T, std::size_t n>
-        struct ArchiveImpl<Archive, T[n], std::enable_if_t<is_serializable_v<Archive, T>>> {
+        struct ArchiveImpl<Archive, T[n], std::enable_if_t<!std::is_same_v<T,char> && is_serializable_v<Archive, T>>> {
             /// Store the array, wrapped by the preamble/postamble.
 
             /// \param[in] ar The archive.

--- a/src/madness/world/archive.h
+++ b/src/madness/world/archive.h
@@ -1081,7 +1081,7 @@ namespace madness {
         /// \tparam T The data type.
         /// \tparam n The array size.
         template <class Archive, class T, std::size_t n>
-        struct ArchiveImpl<Archive, T[n]> {
+        struct ArchiveImpl<Archive, T[n], std::enable_if_t<is_serializable_v<Archive, T>>> {
             /// Store the array, wrapped by the preamble/postamble.
 
             /// \param[in] ar The archive.
@@ -1111,7 +1111,7 @@ namespace madness {
         /// \tparam Archive The archive type.
         /// \tparam T The data type underlying the complex number.
         template <class Archive, typename T>
-        struct ArchiveStoreImpl< Archive, std::complex<T> > {
+        struct ArchiveStoreImpl< Archive, std::complex<T>, std::enable_if_t<is_serializable_v<Archive, T>> > {
             /// Store a complex number.
 
             /// \param[in] ar The archive.
@@ -1128,7 +1128,7 @@ namespace madness {
         /// \tparam Archive the archive type.
         /// \tparam T The data type underlying the complex number.
         template <class Archive, typename T>
-        struct ArchiveLoadImpl< Archive, std::complex<T> > {
+        struct ArchiveLoadImpl< Archive, std::complex<T>, std::enable_if_t<is_serializable_v<Archive, T>> > {
             /// Load a complex number.
 
             /// \param[in] ar The archive.
@@ -1148,32 +1148,17 @@ namespace madness {
         /// \tparam T The data type stored in the \c vector.
         /// \tparam Alloc The allocator type.
         template <class Archive, typename T, typename Alloc>
-        struct ArchiveStoreImpl< Archive, std::vector<T, Alloc> > {
+        struct ArchiveStoreImpl< Archive, std::vector<T, Alloc>, std::enable_if_t<!is_future<T>::value && is_serializable_v<Archive, T>> > {
 
             /// Store a \c std::vector of plain data.
 
             /// \param[in] ar The archive.
             /// \param[in] v The \c vector.
-            template <typename U = T, typename = std::enable_if_t<is_default_serializable_v<Archive,U>>>
-            static inline void store(const Archive& ar, const std::vector<U, Alloc>& v) {
+            static inline void store(const Archive& ar, const std::vector<T, Alloc>& v) {
                 MAD_ARCHIVE_DEBUG(std::cout << "serialize std::vector of plain data" << std::endl);
                 ar & v.size();
                 ar & wrap(v.data(),v.size());
             }
-
-            /// Store a \c std::vector of non-plain data.
-
-            /// \param[in] ar The archive.
-            /// \param[in] v The \c vector.
-            template <typename U = T>
-            static inline void store(const Archive& ar, const std::vector<U, Alloc>& v, std::enable_if_t<!is_default_serializable_v<Archive,U>>* = nullptr) {
-                MAD_ARCHIVE_DEBUG(std::cout << "serialize std::vector of non-plain data" << std::endl);
-                ar & v.size();
-                for(const auto& elem: v) {
-                  ar & elem;
-                }
-            }
-
         };
 
 
@@ -1183,15 +1168,14 @@ namespace madness {
         /// \tparam T The data type stored in the \c vector.
         /// \tparam Alloc The allocator type.
         template <class Archive, typename T, typename Alloc>
-        struct ArchiveLoadImpl< Archive, std::vector<T, Alloc> > {
+        struct ArchiveLoadImpl< Archive, std::vector<T, Alloc>, std::enable_if_t<!is_future<T>::value && is_serializable_v<Archive, T>> > {
 
-            /// Load a \c std::vector of plain data.
+            /// Load a \c std::vector.
 
             /// Clears and resizes the \c vector as necessary.
             /// \param[in] ar The archive.
             /// \param[out] v The \c vector.
-            template <typename U = T, typename = std::enable_if_t<is_default_serializable_v<Archive,U>>>
-            static void load(const Archive& ar, std::vector<U, Alloc>& v) {
+            static void load(const Archive& ar, std::vector<T, Alloc>& v) {
                 MAD_ARCHIVE_DEBUG(std::cout << "deserialize std::vector of plain data" << std::endl);
                 std::size_t n = 0ul;
                 ar & n;
@@ -1200,25 +1184,6 @@ namespace madness {
                     v.resize(n);
                 }
                 ar & wrap((T *) v.data(),n);
-            }
-
-            /// Load a \c std::vector of non-plain data.
-
-            /// Clears and resizes the \c vector as necessary.
-            /// \param[in] ar The archive.
-            /// \param[out] v The \c vector.
-            template <typename U = T>
-            static void load(const Archive& ar, std::vector<U, Alloc>& v, std::enable_if_t<!is_default_serializable_v<Archive,U>>* = nullptr) {
-                MAD_ARCHIVE_DEBUG(std::cout << "deserialize std::vector of non-plain data" << std::endl);
-                std::size_t n = 0ul;
-                ar & n;
-                if (n != v.size()) {
-                    v.clear();
-                    v.resize(n);
-                }
-                for(auto& elem: v) {
-                  ar & elem;
-                }
             }
 
         };
@@ -1277,30 +1242,16 @@ namespace madness {
         /// \tparam T The data type stored in the \c std::array.
         /// \tparam N The size of the \c std::array.
         template <class Archive, typename T, std::size_t N>
-        struct ArchiveStoreImpl< Archive, std::array<T, N> > {
+        struct ArchiveStoreImpl< Archive, std::array<T, N>, std::enable_if_t<is_serializable_v<Archive, T>> > {
 
-            /// Store a \c std::array of plain data.
+            /// Store a \c std::array.
 
             /// \param[in] ar The archive.
             /// \param[in] v The array object to be serialized.
-            template <typename U = T, typename = std::enable_if_t<is_serializable<Archive,U>::value>>
-            static inline void store(const Archive& ar, const std::array<U, N>& v) {
+            static inline void store(const Archive& ar, const std::array<T, N>& v) {
                 MAD_ARCHIVE_DEBUG(std::cout << "serialize std::array<T," << N << ">, with T plain data" << std::endl);
                 ar & v.size();
                 ar & wrap(v.data(),v.size());
-            }
-
-            /// Store a \c std::array of non-plain data.
-
-            /// \param[in] ar The archive.
-            /// \param[in] v The array object to be serialized.
-            template <typename U = T>
-            static inline void store(const Archive& ar, const std::array<U, N>& v, std::enable_if_t<!is_serializable<Archive,U>::value>* = nullptr) {
-                MAD_ARCHIVE_DEBUG(std::cout << "serialize std::array<T," << N << ">, with T non-plain data" << std::endl);
-                ar & v.size();
-                for(const auto& elem: v) {
-                    ar & elem;
-                }
             }
 
         };
@@ -1311,34 +1262,18 @@ namespace madness {
         /// \tparam T The data type stored in the \c std::array.
         /// \tparam N The size of the \c std::array.
         template <class Archive, typename T, std::size_t N>
-        struct ArchiveLoadImpl< Archive, std::array<T, N> > {
+        struct ArchiveLoadImpl< Archive, std::array<T, N>, std::enable_if_t<is_serializable_v<Archive, T>> > {
 
-            /// Load a \c std::array of plain data.
+            /// Load a \c std::array.
 
             /// \param[in] ar The archive.
             /// \param[out] v The array to be deserialized.
-            template <typename U = T, typename = std::enable_if_t<is_serializable<Archive,U>::value>>
-            static void load(const Archive& ar, std::array<U, N>& v) {
+            static void load(const Archive& ar, std::array<T, N>& v) {
                 MAD_ARCHIVE_DEBUG(std::cout << "deserialize std::array<T," << N << ">, with T plain data" << std::endl);
                 std::size_t n = 0ul;
                 ar & n;
                 MADNESS_ASSERT(n == v.size());
                 ar & wrap((T *) v.data(),n);
-            }
-
-            /// Load a \c std::array of non-plain data.
-
-            /// \param[in] ar The archive.
-            /// \param[out] v The array to be deserialized.
-            template <typename U = T>
-            static void load(const Archive& ar, std::array<U, N>& v, std::enable_if_t<!is_serializable<Archive,U>::value>* = nullptr) {
-                MAD_ARCHIVE_DEBUG(std::cout << "deserialize std::array<T," << N << ">, with T non-plain data" << std::endl);
-                std::size_t n = 0ul;
-                ar & n;
-                MADNESS_ASSERT(n == v.size());
-                for(auto& elem: v) {
-                    ar & elem;
-                }
             }
 
         };
@@ -1389,7 +1324,7 @@ namespace madness {
         /// \tparam T The first data type in the pair.
         /// \tparam Q The second data type in the pair.
         template <class Archive, typename T, typename Q>
-        struct ArchiveSerializeImpl< Archive, std::pair<T, Q> > {
+        struct ArchiveSerializeImpl< Archive, std::pair<T, Q>, std::enable_if_t<is_serializable_v<Archive, T> && is_serializable_v<Archive, Q>> > {
             /// Serialize the \c pair.
 
             /// \param[in] ar The archive.
@@ -1426,7 +1361,7 @@ namespace madness {
         /// \tparam Archive The archive type.
         /// \tparam Types The tuple payload
         template <class Archive, typename... Types>
-        struct ArchiveSerializeImpl< Archive, std::tuple<Types...> > {
+        struct ArchiveSerializeImpl< Archive, std::tuple<Types...>, std::enable_if_t<(is_serializable_v<Archive, Types> && ... ) >> {
             /// Serialize the \c std::tuple.
 
             /// \param[in] ar The archive.
@@ -1446,7 +1381,7 @@ namespace madness {
         /// \tparam Compare The map's comparer type.
         /// \tparam Alloc The map's allocator type.
         template <class Archive, typename T, typename Q, typename Compare, typename Alloc>
-        struct ArchiveStoreImpl< Archive, std::map<T,Q,Compare,Alloc> > {
+        struct ArchiveStoreImpl< Archive, std::map<T,Q,Compare,Alloc>, std::enable_if_t<is_serializable_v<Archive, T> && is_serializable_v<Archive, Q>>  > {
             /// Store a \c map.
 
             /// \param[in] ar The archive.
@@ -1476,7 +1411,7 @@ namespace madness {
         /// \tparam Compare The map's comparer type.
         /// \tparam Alloc The map's allocator type.
         template <class Archive, typename T, typename Q, typename Compare, typename Alloc>
-        struct ArchiveLoadImpl< Archive, std::map<T,Q,Compare,Alloc> > {
+        struct ArchiveLoadImpl< Archive, std::map<T,Q,Compare,Alloc>, std::enable_if_t<is_serializable_v<Archive, T> && is_serializable_v<Archive, Q>>  > {
             /// Load a \c map.
 
             /// The \c map is \em not cleared; duplicate elements are replaced.

--- a/src/madness/world/future.h
+++ b/src/madness/world/future.h
@@ -57,131 +57,6 @@ namespace madness {
     // forward decl
     template <typename T> class Future;
 
-
-    /// Boost-type-trait-like test if a type is a future.
-
-    /// \tparam T The type to test.
-    template <typename T>
-    struct is_future : public std::false_type { };
-
-
-    /// Boost-type-trait-like test if a type is a future.
-
-    /// \tparam T The type to test.
-    template <typename T>
-    struct is_future< Future<T> > : public std::true_type { };
-
-
-    /// Boost-type-trait-like mapping of type \c T to \c Future<T>.
-
-    /// \tparam T The type to have future added.
-    template <typename T>
-    struct add_future {
-        /// Type with \c Future added.
-        typedef Future<T> type;
-    };
-
-    /// Boost-type-trait-like mapping of \c Future<T> to \c Future<T>.
-
-    /// Specialization of \c add_future<T> that properly forbids the type
-    /// \c Future< Future<T> >.
-    /// \tparam T The underlying data type.
-    template <typename T>
-    struct add_future< Future<T> > {
-        /// Type with \c Future added.
-        typedef Future<T> type;
-    };
-
-    /// Boost-type-trait-like mapping of \c Future<T> to \c T.
-
-    /// \tparam T The type to have future removed; in this case, do nothing.
-    template <typename T>
-    struct remove_future {
-        /// Type with \c Future removed.
-        typedef T type;
-    };
-
-    /// This metafunction maps \c Future<T> to \c T.
-
-    /// \internal Future is a wrapper for T (it acts like an Identity monad), so this
-    /// unwraps T. It makes sense that the result should preserve the access traits
-    /// of the Future, i.e. const Future<T> should map to const T, etc.
-
-    /// Specialization of \c remove_future for \c Future<T>
-    /// \tparam T The type to have future removed.
-    template <typename T>
-    struct remove_future< Future<T> > {
-        /// Type with \c Future removed.
-        typedef T type;
-    };
-
-    /// Specialization of \c remove_future for \c Future<T>
-    /// \tparam T The type to have future removed.
-    template <typename T>
-    struct remove_future< const Future<T> > {
-        /// Type with \c Future removed.
-        typedef const T type;
-    };
-
-    /// Specialization of \c remove_future for \c Future<T>&
-    /// \tparam T The type to have future removed.
-    template <typename T>
-    struct remove_future< Future<T>& > {
-        /// Type with \c Future removed.
-        typedef T& type;
-    };
-
-    /// Specialization of \c remove_future for \c Future<T>&&
-    /// \tparam T The type to have future removed.
-    template <typename T>
-    struct remove_future< Future<T>&& > {
-        /// Type with \c Future removed.
-        typedef T&& type;
-    };
-
-    /// Specialization of \c remove_future for \c const \c Future<T>&
-    /// \tparam T The type to have future removed.
-    template <typename T>
-    struct remove_future< const Future<T>& > {
-        /// Type with \c Future removed.
-        typedef const T& type;
-    };
-
-    /// Macro to determine type of future (by removing wrapping \c Future template).
-
-    /// \param T The type (possibly with \c Future).
-#define REMFUTURE(T) typename remove_future< T >::type
-
-    /// C++11 version of REMFUTURE
-    template <typename T>
-    using remove_future_t = typename remove_future< T >::type;
-
-    /// Similar to remove_future , but future_to_ref<Future<T>> evaluates to T& ,whereas
-    /// remove_future<Future<T>> evaluates to T .
-    /// \tparam T The type to have future removed; in this case, do nothing.
-    template <typename T>
-    struct future_to_ref {
-        typedef T type;
-    };
-    template <typename T>
-    struct future_to_ref<Future<T>> {
-      typedef T& type;
-    };
-    template <typename T>
-    struct future_to_ref<Future<T>*> {
-      typedef T& type;
-    };
-    template <typename T>
-    struct future_to_ref<Future<T>&> {
-      typedef T& type;
-    };
-    template <typename T>
-    struct future_to_ref<const Future<T>&> {
-      typedef T& type;
-    };
-    template <typename T>
-    using future_to_ref_t = typename future_to_ref< T >::type;
-
     /// Human readable printing of a \c Future to a stream.
 
     /// \tparam T The type of future.
@@ -985,13 +860,16 @@ namespace madness {
         /// \tparam Archive Archive type.
         /// \tparam T Future type.
         template <class Archive, typename T>
-        struct ArchiveStoreImpl< Archive, Future<T> > {
+        struct ArchiveStoreImpl< Archive, Future<T>, std::enable_if_t<!std::is_void_v<T>> > {
 
             /// Store the assigned future in an archive.
 
             /// \param[in,out] ar The archive.
             /// \param[in] f The future.
-            static inline void store(const Archive& ar, const Future<T>& f) {
+            template <typename U = T, typename A = Archive>
+            static inline
+                std::enable_if_t<is_serializable_v<A, U>,void>
+                store(const Archive& ar, const Future<T>& f) {
                 MAD_ARCHIVE_DEBUG(std::cout << "serializing future" << std::endl);
                 MADNESS_ASSERT(f.probe());
                 ar & f.get();
@@ -1004,13 +882,15 @@ namespace madness {
         /// \tparam Archive Archive type.
         /// \tparam T Future type.
         template <class Archive, typename T>
-        struct ArchiveLoadImpl< Archive, Future<T> > {
+        struct ArchiveLoadImpl< Archive, Future<T>, std::enable_if_t<!std::is_void_v<T>> > {
 
             /// Read into an unassigned future.
 
             /// \param[in,out] ar The archive.
             /// \param[out] f The future.
-            static inline void load(const Archive& ar, Future<T>& f) {
+            template <typename U = T, typename A = Archive>
+            static inline
+                std::enable_if_t<is_serializable_v<A, U>,void> load(const Archive& ar, Future<T>& f) {
                 MAD_ARCHIVE_DEBUG(std::cout << "deserializing future" << std::endl);
                 MADNESS_ASSERT(!f.probe());
                 T value;

--- a/src/madness/world/test_ar.cc
+++ b/src/madness/world/test_ar.cc
@@ -100,16 +100,12 @@ struct type_printer;
 
 static_assert(!madness::has_member_serialize_v<int, madness::archive::BufferOutputArchive>);
 static_assert(!madness::has_member_serialize_v<int, madness::archive::BufferInputArchive>);
-static_assert(!madness::has_member_serialize_with_version_v<int, madness::archive::BufferOutputArchive>);
-static_assert(!madness::has_member_serialize_with_version_v<int, madness::archive::BufferInputArchive>);
 static_assert(!madness::has_nonmember_serialize_v<int, madness::archive::BufferOutputArchive>);
 static_assert(!madness::has_nonmember_serialize_v<int, madness::archive::BufferInputArchive>);
 static_assert(!madness::has_freestanding_serialize_v<int, madness::archive::BufferOutputArchive>);
 static_assert(!madness::has_freestanding_serialize_v<int, madness::archive::BufferInputArchive>);
 static_assert(!madness::has_freestanding_serialize_with_size_v<int*, madness::archive::BufferOutputArchive>);
 static_assert(!madness::has_freestanding_serialize_with_size_v<int*, madness::archive::BufferInputArchive>);
-static_assert(!madness::has_freestanding_serialize_with_version_v<int, madness::archive::BufferOutputArchive>);
-static_assert(!madness::has_freestanding_serialize_with_version_v<int, madness::archive::BufferInputArchive>);
 static_assert(madness::has_freestanding_default_serialize_v<int, madness::archive::BufferOutputArchive>);
 static_assert(madness::has_freestanding_default_serialize_v<int, madness::archive::BufferInputArchive>);
 static_assert(madness::has_freestanding_default_serialize_with_size_v<int*, madness::archive::BufferOutputArchive>);
@@ -134,8 +130,6 @@ public:
 
 static_assert(madness::has_member_serialize_v<A, madness::archive::BufferOutputArchive>);
 static_assert(madness::has_member_serialize_v<A, madness::archive::BufferInputArchive>);
-static_assert(!madness::has_member_serialize_with_version_v<A, madness::archive::BufferOutputArchive>);
-static_assert(!madness::has_member_serialize_with_version_v<A, madness::archive::BufferInputArchive>);
 // N.B. nonmember serialize is provided for types with serialize member
 static_assert(madness::has_nonmember_serialize_v<A, madness::archive::BufferOutputArchive>);
 static_assert(madness::has_nonmember_serialize_v<A, madness::archive::BufferInputArchive>);
@@ -166,8 +160,6 @@ namespace madness {
 
 static_assert(!madness::has_member_serialize_v<B, madness::archive::BufferOutputArchive>);
 static_assert(!madness::has_member_serialize_v<B, madness::archive::BufferInputArchive>);
-static_assert(!madness::has_member_serialize_with_version_v<B, madness::archive::BufferOutputArchive>);
-static_assert(!madness::has_member_serialize_with_version_v<B, madness::archive::BufferInputArchive>);
 static_assert(madness::has_nonmember_serialize_v<B, madness::archive::BufferOutputArchive>);
 static_assert(madness::has_nonmember_serialize_v<B, madness::archive::BufferInputArchive>);
 // N.B. nonmember load/store is provided for types with nonmember serialize
@@ -203,8 +195,6 @@ namespace madness {
 
 static_assert(!madness::has_member_serialize_v<C, madness::archive::BufferOutputArchive>);
 static_assert(!madness::has_member_serialize_v<C, madness::archive::BufferInputArchive>);
-static_assert(!madness::has_member_serialize_with_version_v<C, madness::archive::BufferOutputArchive>);
-static_assert(!madness::has_member_serialize_with_version_v<C, madness::archive::BufferInputArchive>);
 static_assert(!madness::has_nonmember_serialize_v<C, madness::archive::BufferOutputArchive>);
 static_assert(!madness::has_nonmember_serialize_v<C, madness::archive::BufferInputArchive>);
 static_assert(madness::has_nonmember_store_v<C, madness::archive::BufferOutputArchive>);
@@ -220,8 +210,6 @@ struct D {
 
 static_assert(!madness::has_member_serialize_v<D, madness::archive::BufferOutputArchive>);
 static_assert(!madness::has_member_serialize_v<D, madness::archive::BufferInputArchive>);
-static_assert(!madness::has_member_serialize_with_version_v<D, madness::archive::BufferOutputArchive>);
-static_assert(!madness::has_member_serialize_with_version_v<D, madness::archive::BufferInputArchive>);
 static_assert(!madness::has_nonmember_serialize_v<D, madness::archive::BufferOutputArchive>);
 static_assert(!madness::has_nonmember_serialize_v<D, madness::archive::BufferInputArchive>);
 // N.B. nonmember load/store is provided for default-serializable types

--- a/src/madness/world/type_traits.h
+++ b/src/madness/world/type_traits.h
@@ -502,7 +502,6 @@ namespace madness {
     /// \tparam T
     template <typename Archive, typename T>
     inline constexpr bool is_user_serializable_v = is_archive_v<Archive> && (has_member_serialize_v<T, Archive> ||
-                                                                    has_member_serialize_with_version_v<T, Archive> ||
                                                                     has_nonmember_serialize_v<T, Archive> ||
                                                                     ((has_nonmember_load_v<T, Archive> || has_nonmember_wrap_load_v<T, Archive>) && is_input_archive_v<Archive> && !has_freestanding_default_serialize_v<T, Archive>) ||
                                                                     ((has_nonmember_store_v<T, Archive> || has_nonmember_wrap_store_v<T, Archive>) && is_output_archive_v<Archive> && !has_freestanding_default_serialize_v<T, Archive>));


### PR DESCRIPTION
this reverts the support for versioned variants of serialize introduced in #373 ... it's safer not to try to mimic interoperability with boost.

many more sfinae fortifications + removed some ambiguous overloads (they became  ambiguous *enough* after sfinae for the compiler to complain)