### PR TITLE
skip task buffering when submitting from non-madness thread

### DIFF
--- a/src/madness/world/CMakeLists.txt
+++ b/src/madness/world/CMakeLists.txt
@@ -11,7 +11,7 @@ set(MADWORLD_HEADERS
     uniqueid.h worldprofile.h timers.h binary_fstream_archive.h mpi_archive.h 
     text_fstream_archive.h worlddc.h mem_func_wrapper.h taskfn.h group.h 
     dist_cache.h distributed_id.h type_traits.h function_traits.h stubmpi.h 
-    bgq_atomics.h binsorter.h parsec.h meta.h worldinit.h)
+    bgq_atomics.h binsorter.h parsec.h meta.h worldinit.h thread_info.h)
 set(MADWORLD_SOURCES
     madness_exception.cc world.cc timers.cc future.cc redirectio.cc
     archive_type_names.cc info.cc debug.cc print.cc worldmem.cc worldrmi.cc

--- a/src/madness/world/dqueue.h
+++ b/src/madness/world/dqueue.h
@@ -42,13 +42,14 @@
 // If defined capture stats on dqueue class --- seems to have small overhead
 #define MADNESS_DQ_STATS
 
-#include <madness/config.h>
-#include <madness/world/worldmutex.h>
-#include <cstddef>
-#include <utility>
 #include <algorithm>
+#include <cstddef>
 #include <iostream>
+#include <madness/config.h>
+#include <madness/world/thread_info.h>
+#include <madness/world/worldmutex.h>
 #include <stdint.h>
+#include <utility>
 
 /// \file dqueue.h
 /// \brief Implements DQueue
@@ -341,7 +342,7 @@ namespace madness {
     template <typename T>
     void DQueue<T>::push_front(const T& value) {
 #ifdef MADNESS_DQ_USE_PREBUF
-        if (ninprebufhi < NPREBUF) {
+        if (is_madness_thread() && ninprebufhi < NPREBUF) {
              prebufhi[ninprebufhi++] = value;
              return;
         }
@@ -355,7 +356,7 @@ namespace madness {
     template <typename T>
     void DQueue<T>::push_back(const T& value, int ncopy) {
 #ifdef MADNESS_DQ_USE_PREBUF
-        if (ncopy==1 && ninprebuf < NPREBUF) {
+        if (is_madness_thread() && ncopy==1 && ninprebuf < NPREBUF) {
              prebuf[ninprebuf++] = value;
              return;
         }

--- a/src/madness/world/thread.cc
+++ b/src/madness/world/thread.cc
@@ -113,6 +113,9 @@ namespace madness {
         if(rc != 0)
             MADNESS_EXCEPTION("pthread_setspecific failed", rc);
 
+        // mark as a MADNESS thread
+        set_thread_tag(ThreadTag_MADNESS);
+
         try {
             ((ThreadBase*)(self))->run();
         }

--- a/src/madness/world/thread.h
+++ b/src/madness/world/thread.h
@@ -38,6 +38,7 @@
  \ingroup threads
 */
 
+#include <madness/world/thread_info.h>
 #include <madness/world/dqueue.h>
 #include <madness/world/function_traits.h>
 #include <vector>

--- a/src/madness/world/thread_info.h
+++ b/src/madness/world/thread_info.h
@@ -1,0 +1,76 @@
+/*
+  This file is part of MADNESS.
+
+  Copyright (C) 2007,2010 Oak Ridge National Laboratory
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+  For more information please contact:
+
+  Robert J. Harrison
+  Oak Ridge National Laboratory
+  One Bethel Valley Road
+  P.O. Box 2008, MS-6367
+
+  email: harrisonrj@ornl.gov
+  tel:   865-241-3937
+  fax:   865-572-0680
+*/
+
+#ifndef MADNESS_WORLD_THREAD_INFO_H__INCLUDED
+#define MADNESS_WORLD_THREAD_INFO_H__INCLUDED
+
+/**
+ \file thread_info.h
+ \brief Implements thread introspection
+ \ingroup threads
+*/
+
+namespace madness {
+
+    /// bitfield describing thread type
+    enum ThreadTag {
+        ThreadTag_NonMADNESS = 0b0000,
+        ThreadTag_MADNESS = 0b0001,
+        ThreadTag_Main = 0b0010
+    };
+
+    namespace detail {
+        inline ThreadTag& thread_tag_accessor() {
+            thread_local ThreadTag value = ThreadTag_NonMADNESS;
+            return value;
+        }
+    }   // namespace madness::detail
+
+    /// sets the thread tag for the thread invoking this function
+    /// @param tag thread tag for the calling thread
+    inline void set_thread_tag(ThreadTag tag) {
+        detail::thread_tag_accessor() = tag;
+    }
+
+    /// sets the thread tag for the thread invoking this function
+    /// @param tag thread tag for the calling thread
+    inline void set_thread_tag(int tag) {
+        detail::thread_tag_accessor() = static_cast<ThreadTag>(tag);
+    }
+
+    /// @return true if this thread is managed by MADNESS
+    inline bool is_madness_thread() {
+        return detail::thread_tag_accessor() & ThreadTag_MADNESS;
+    }
+
+}  // namespace madness
+
+#endif // MADNESS_WORLD_THREAD_INFO_H__INCLUDED

--- a/src/madness/world/world.cc
+++ b/src/madness/world/world.cc
@@ -219,6 +219,8 @@ namespace madness {
         elem::Initialize(argc,argv);
 #endif // HAVE_ELEMENTAL
 
+        // mark this thread as part of MADNESS pool
+        set_thread_tag(ThreadTag_MADNESS | ThreadTag_Main);
         madness_initialized_ = true;
         if(!quiet && comm.Get_rank() == 0)
             std::cout << "MADNESS runtime initialized with " << ThreadPool::size()


### PR DESCRIPTION
tested w/ TA submitting tasks from CUDA threads