### PR TITLE
madness::detail::deferred_cleanup: can bypass uniqueness check ...

### DIFF
--- a/src/madness/world/deferred_cleanup.h
+++ b/src/madness/world/deferred_cleanup.h
@@ -49,7 +49,7 @@ namespace madness {
     namespace detail {
 
         template <typename objT>
-        inline void deferred_cleanup(World& world, const std::shared_ptr<objT>& p);
+        inline void deferred_cleanup(World& world, const std::shared_ptr<objT>& p, bool assume_p_is_unique = false);
 
         /// Deferred cleanup of shared_ptr's
 
@@ -75,7 +75,7 @@ namespace madness {
             DeferredCleanup& operator=(const DeferredCleanup&);
 
             template <typename objT>
-            friend void deferred_cleanup(World& world, const std::shared_ptr<objT>& p);
+            friend void deferred_cleanup(World&, const std::shared_ptr<objT>&, bool);
 
             /// Access deferred cleanup object of world
 
@@ -127,11 +127,14 @@ namespace madness {
         /// Defer the cleanup of a shared pointer to the end of the next fence
 
         /// Call this function before destroying a shared pointer. If the shared
-        /// pointer is the last reference to the object, it is placed in the
-        /// deferred deletion list. Otherwise, nothing is done with the pointer.
+        /// pointer is the last reference to the object,
+        /// or \p assume_p_is_unique is true,
+        /// it is placed in the deferred deletion list.
+        /// Otherwise, nothing is done with the pointer.
         template <typename objT>
-        inline void deferred_cleanup(World& world, const std::shared_ptr<objT>& p) {
-            if(p.unique()) {
+        inline void deferred_cleanup(World& world, const std::shared_ptr<objT>& p,
+                                     bool assume_p_is_unique) {
+            if(p.unique() || assume_p_is_unique) {
                 // This is the last local pointer so we will place it in the
                 // deferred deleter list for later cleanup.
                 DeferredCleanup::get_deferred_cleanup(world)->add(p);


### PR DESCRIPTION
... if the ref count is artificially augmented by the tasks in the queue

the default behavior is same as now: do nothing unless the given pointer is unique