### PR TITLE
misc cleanup of world id handling

### DIFF
--- a/src/madness/world/world.cc
+++ b/src/madness/world/world.cc
@@ -67,9 +67,9 @@ namespace madness {
     } // namespace
 
     // World static member variables
-    std::list<World*> World::worlds; ///< List of \c World pointers in the parallel runtime.
+    std::list<World*> World::worlds; ///< List of \c World pointers in the parallel runtime EXCEPT the default World
     World* World::default_world = nullptr; ///< The default \c World.
-    unsigned long World::idbase = 0; ///< \todo Verify: Base unique ID for objects in the runtime.
+    std::pair<std::uint64_t, std::uint64_t> World::world_id__next_last{};
 
     bool initialized() {
       return madness_initialized_;
@@ -87,32 +87,17 @@ namespace madness {
             , gop(* (new WorldGopInterface(*this)))
             , myrand_next(0)
     {
-        worlds.push_back(this);
-        srand();  // Initialize random number generator
-        cpu_frequency();
-
-        // Assign a globally (within COMM_WORLD) unique ID to this
-        // world by assigning to each processor a unique range of indices
-        // and broadcasting from node 0 of the current communicator.
-        // Each process in COMM_WORLD is given unique ids for 10K new worlds
-        if(idbase == 0 && rank()) {
-            idbase = rank()*10000;
-        }
-        // The id of a new world is taken from the unique range of ids
-        // assigned to the process with rank=0 in the sub-communicator
         if(rank() == 0) {
-            _id = idbase++;
+            _id = next_world_id();
         }
+
         // Use MPI for broadcast as incoming messages may try to access an
         // uninitialized world.
         mpi.Bcast(_id, 0);
-//        gop.broadcast(_id);
-//        gop.barrier();
         am.worldid = _id;
 
-        //std::cout << "JUST MADE WORLD " << id() << " with "
-        //          << comm.Get_size() << " members (I am # "
-        //          << comm.Get_rank() << ")"<< std::endl;
+        if (_id != 0)
+          worlds.push_back(this);
     }
 
 
@@ -129,11 +114,22 @@ namespace madness {
 //        stray WorldObjects are allowed as long as they outlive madness::finalize() :(
 //        MADNESS_ASSERT_NOEXCEPT(map_ptr_to_id.size() == 0);
 //        MADNESS_ASSERT_NOEXCEPT(map_id_to_ptr.size() == 0);
-        worlds.remove(this);
+        if (this->_id != 0) worlds.remove(this);
         delete &taskq;
         delete &gop;
         delete &am;
         delete &mpi;
+    }
+
+    void World::initialize_world_id_range(int global_rank) {
+      constexpr std::uint64_t range_size = 1ul<<32;
+      constexpr std::uint64_t range_size_minus_1 = 1ul<<32 - 1;
+      world_id__next_last = std::make_pair(global_rank * range_size, global_rank * range_size + range_size_minus_1);
+    }
+
+    std::uint64_t World::next_world_id() {
+      MADNESS_ASSERT(world_id__next_last.first != world_id__next_last.second);
+      return world_id__next_last.first++;
     }
 
     void error(const char *msg) {
@@ -205,6 +201,11 @@ namespace madness {
         ThreadBase::set_hpm_thread_env(hpm_thread_id);
 #endif
         detail::WorldMpi::initialize(argc, argv, MADNESS_MPI_THREAD_LEVEL);
+
+        // Assign a range of globally (within COMM_WORLD) unique IDs to each
+        // rank, these will be used to assign globally unique ID to a new World
+        // requiring only communication within its (sub)communicator
+        World::initialize_world_id_range(comm.Get_rank());
 
         // Construct the default world before starting RMI so that incoming active messages can find this world
         World::default_world = new World(comm);

--- a/src/madness/world/world.h
+++ b/src/madness/world/world.h
@@ -56,9 +56,10 @@
 
 // Standard C++ header files needed by MADworld.h
 #include <iostream>
-#include <list>
-#include <utility>
+#include <list>     // std::list
+#include <utility>  // std::pair
 #include <cstddef>
+#include <cstdint>  // std::uint64_t
 
 #ifdef HAVE_RANDOM
 #include <cstdlib>
@@ -135,9 +136,9 @@ namespace madness {
         friend void finalize();
 
         // Static member variables
-        static unsigned long idbase; ///< Base for unique world ID range for this process.
+        static std::pair<std::uint64_t, std::uint64_t> world_id__next_last; ///< Unique {next, last} world IDs to be used by this rank.
         static World* default_world; ///< Default world.
-        static std::list<World*> worlds; ///< Maintains list of active worlds.
+        static std::list<World*> worlds; ///< Maintains list of active worlds, EXCLUDES default_world
 
         /// \todo Brief description needed.
         struct hashuniqueT {
@@ -172,12 +173,18 @@ namespace madness {
         map_ptr_to_idT map_ptr_to_id; ///< \todo Verify: Map from a pointer to its unique hash ID.
 
 
-        unsigned long _id; ///< Universe wide unique ID of this world.
+        std::uint64_t _id; ///< Universe wide unique ID of this world.
         unsigned long obj_id; ///< Counter for generating unique IDs within this world.
         void* user_state; ///< Holds a user-defined and managed local state.
 
         // Default copy constructor and assignment won't compile
         // (which is good) due to reference members.
+
+        /// initializes the value of world_id__next_last to {global_rank*2^32, (global_rank+1)*2^32-1}
+        /// \param global_rank rank of this process in COMM_WORLD
+        static void initialize_world_id_range(int global_rank);
+        /// \return next unique World id
+        static std::uint64_t next_world_id();
 
     public:
         // !!! Order of declaration is important for correct order of initialization !!!
@@ -204,12 +211,16 @@ namespace madness {
         /// \return Pointer to the World that was constructed from \c comm;
         ///     if such a World does not exist, return 0.
         static World* find_instance(const SafeMPI::Intracomm& comm) {
-            typedef std::list<World*>::const_iterator citer;
-            for(citer it = worlds.begin(); it != worlds.end(); ++it) {
-                if ((*it)->mpi.comm() == comm)
-                    return *it;
+          if (default_world->mpi.comm() == comm)
+            return default_world;
+          else {
+            typedef std::list<World *>::const_iterator citer;
+            for (citer it = worlds.begin(); it != worlds.end(); ++it) {
+              if ((*it)->mpi.comm() == comm)
+                return *it;
             }
-            return 0;
+            return nullptr;
+          }
         }
 
         /// Check if the World exists in the registry.
@@ -217,7 +228,7 @@ namespace madness {
         /// \param[in] world pointer to a World object
         /// \return true if \c world exists
         static bool exists(World* world) {
-          return std::find(worlds.begin(), worlds.end(), world) != worlds.end();
+          return world->id() == 0 || std::find(worlds.begin(), worlds.end(), world) != worlds.end();
         }
 
         /// Default World object accessor.
@@ -427,11 +438,17 @@ namespace madness {
         /// not include the calling process.
         /// \param[in] id The ID of the \c World.
         /// \return A pointer to the world associated with \c id, or \c NULL.
-        static World* world_from_id(unsigned long id) {
-            for (std::list<World *>::iterator it=worlds.begin(); it != worlds.end(); ++it) {
-                if ((*it) && (*it)->_id == id) return *it;
+        static World* world_from_id(std::uint64_t id) {
+          if (id != 0) {
+            for (std::list<World *>::iterator it = worlds.begin();
+                 it != worlds.end(); ++it) {
+              if ((*it) && (*it)->_id == id)
+                return *it;
             }
             return nullptr;
+          }
+          else
+            return default_world;
         }
 
     private:

--- a/src/madness/world/worldam.h
+++ b/src/madness/world/worldam.h
@@ -86,7 +86,7 @@ namespace madness {
 
         unsigned char header[RMI::HEADER_LEN]; // !!!!!!!!!  MUST BE FIRST !!!!!!!!!!
         std::size_t nbyte;      // Size of user payload
-        unsigned long worldid;  // Id of associated world
+        std::uint64_t worldid;  // Id of associated world
         std::ptrdiff_t func;    // User function to call, as a relative fn ptr (see archive::to_rel_fn_ptr)
         ProcessID src;          // Rank of process sending the message
         unsigned int flags;     // Misc. bit flags
@@ -154,7 +154,7 @@ namespace madness {
         World* get_world() const { return World::world_from_id(worldid); }
 
         /// Return the world id
-        unsigned long get_worldid() const { return worldid; }
+        std::uint64_t get_worldid() const { return worldid; }
     };
 
 

--- a/src/madness/world/worldmpi.h
+++ b/src/madness/world/worldmpi.h
@@ -430,7 +430,7 @@ namespace madness {
         template <typename T>
         typename std::enable_if<!std::is_pointer<T>::value, void>::type
         Bcast(T& buffer, int root) const {
-            SafeMPI::Intracomm::Bcast(&buffer, sizeof(T), MPI_BYTE,root);
+            SafeMPI::Intracomm::Bcast(&buffer, sizeof(T), MPI_BYTE, root);
         }
 
         /// Access the rank of this process.


### PR DESCRIPTION
- increased range of world ids allocated per rank to 2^32 + added id range checking
- optimized World::{world_from_id,exists,find_instance} for the most common case of world==default_world
- madness::initialize does not call srand() or cpu_frequency()