### PR TITLE
World ctor calls MPI_Barrier, unless fence=false

### DIFF
--- a/src/madness/world/future.h
+++ b/src/madness/world/future.h
@@ -650,19 +650,19 @@ namespace madness {
         }
 
 
-        /// \todo Brief description needed.
+        /// Checks the future remoteness trait
 
-        /// \todo Description needed.
-        /// \return Description needed.
+        /// \return true if the future refers to an already available or
+        /// to-be-locally-produced result
         inline bool is_local() const {
             return (f && f->is_local()) || value;
         }
 
 
-        /// \todo Brief description needed.
+        /// Checks the future remoteness trait
 
-        /// \todo Description needed.
-        /// \return Description needed.
+        /// \return true if the future refers to another future on a another rank, i.e. it will be set when the
+        /// referred-to future is set
         inline bool is_remote() const {
             return !is_local();
         }

--- a/src/madness/world/world.cc
+++ b/src/madness/world/world.cc
@@ -78,7 +78,8 @@ namespace madness {
       return madness_quiet_;
     }
 
-    World::World(const SafeMPI::Intracomm& comm)
+    World::World(const SafeMPI::Intracomm& comm,
+                 bool fence)
             : obj_id(1)          ///< start from 1 so that 0 is an invalid id
             , user_state(0)
             , mpi(*(new WorldMpiInterface(comm)))
@@ -98,6 +99,9 @@ namespace madness {
 
         if (_id != 0)
           worlds.push_back(this);
+
+        if (fence)
+          mpi.Barrier();
     }
 
 

--- a/src/madness/world/world.cc
+++ b/src/madness/world/world.cc
@@ -127,7 +127,7 @@ namespace madness {
 
     void World::initialize_world_id_range(int global_rank) {
       constexpr std::uint64_t range_size = 1ul<<32;
-      constexpr std::uint64_t range_size_minus_1 = 1ul<<32 - 1;
+      constexpr std::uint64_t range_size_minus_1 = (1ul<<32) - 1;
       world_id__next_last = std::make_pair(global_rank * range_size, global_rank * range_size + range_size_minus_1);
     }
 

--- a/src/madness/world/world.h
+++ b/src/madness/world/world.h
@@ -234,7 +234,7 @@ namespace madness {
         /// \param[in] world pointer to a World object
         /// \return true if \c world exists
         static bool exists(World* world) {
-          return world->id() == 0 || std::find(worlds.begin(), worlds.end(), world) != worlds.end();
+          return world == default_world || std::find(worlds.begin(), worlds.end(), world) != worlds.end();
         }
 
         /// Default World object accessor.

--- a/src/madness/world/world.h
+++ b/src/madness/world/world.h
@@ -203,7 +203,13 @@ namespace madness {
         /// the same communicator. Use instance() to check this.
         ///
         /// \param[in] comm The communicator.
-        World(const SafeMPI::Intracomm& comm);
+        /// \param[in] fence if true, will synchronize ranks before exiting;
+        ///                  setting to false removes the extra synchronization
+        ///                  but may cause premature arrival of RMI messages
+        ///                  that refer to this world while it's being
+        ///                  registered
+        World(const SafeMPI::Intracomm& comm,
+              bool fence = true);
 
         /// Find the World (if it exists) corresponding to the given communicator.
 

--- a/src/madness/world/worldref.h
+++ b/src/madness/world/worldref.h
@@ -384,7 +384,7 @@ namespace madness {
     /// This class was intended only for internal use and is still rather
     /// poorly thought through, however, it seems to fill a wider need.
     /// \note Do not serialize via wrap_opaque().
-    /// \note Ownership of a reference is transfered when serialized on a remote
+    /// \note Ownership of a reference is transferred when serialized on a remote
     /// node. You should not attempt to send a remote reference to more than one
     /// node except from the owning node. If you do serialize more than once,
     /// this will cause an invalid memory access on the owning node.


### PR DESCRIPTION
to prevent ranks exiting until new world is in the registry everywhere

this changes the current behavior