### PR TITLE
Fixed GGA bug in SCFOperators.cc and removed derivative choices

### DIFF
--- a/src/madness/chem/CalculationParameters.h
+++ b/src/madness/chem/CalculationParameters.h
@@ -70,8 +70,6 @@ struct CalculationParameters : public QCCalculationParametersBase {
 		initialize<std::vector<std::string> >("convergence_criteria",{"bsh_residual","total_energy"},"possible values are: bsh_residual, total_energy, each_energy, density");
 		initialize<int>   ("k",-1,"polynomial order");
 		initialize<double>("l",20,"user coordinates box size");
-		initialize<std::string>("deriv","abgv","derivative method",{"abgv","bspline","ble"});
-		initialize<std::string>("dft_deriv","abgv","derivative method for gga potentials",{"abgv","bspline","ble"});
 		initialize<double>("maxrotn",0.25,"step restriction used in autoshift algorithm");
 		initialize<int>   ("nvalpha",0,"number of alpha virtuals to compute");
 		initialize<int>   ("nvbeta",0,"number of beta virtuals to compute");
@@ -190,8 +188,6 @@ struct CalculationParameters : public QCCalculationParametersBase {
 	int maxiter() const {return get<int>("maxiter");}
 	double orbitalshift() const {return get<double>("orbitalshift");}
 
-	std::string deriv() const {return get<std::string>("deriv");}
-	std::string dft_deriv() const {return get<std::string>("dft_deriv");}
 	std::string pcm_data() const {return get<std::string>("pcm_data");}
 	std::string ac_data() const {return get<std::string>("ac_data");}
 	std::string xc() const {return get<std::string>("xc");}

--- a/src/madness/chem/SCF.cc
+++ b/src/madness/chem/SCF.cc
@@ -1224,7 +1224,7 @@ vecfuncT SCF::apply_potential(World& world, const tensorT& occ,
     if (xc.is_dft() && !(xc.hf_exchange_coefficient() == 1.0)) {
         START_TIMER(world);
 
-        XCOperator<double, 3> xcoperator(world, this, ispin, param.dft_deriv());
+        XCOperator<double, 3> xcoperator(world, this, ispin);
         if (ispin == 0) exc = xcoperator.compute_xc_energy();
         vloc += xcoperator.make_xc_potential();
 

--- a/src/madness/chem/SCF.h
+++ b/src/madness/chem/SCF.h
@@ -275,13 +275,6 @@ public:
         coulop = poperatorT(CoulombOperatorPtr(world, param.lo(), thresh));
         gradop = gradient_operator<double, 3>(world);
 
-        // Update coefficients if using a different derivative
-        if (param.deriv() == "bspline") {
-            for (int i = 0; i < 3; ++i) (*gradop[i]).set_bspline1();
-        } else if (param.deriv() == "ble") {
-            for (int i = 0; i < 3; ++i) (*gradop[i]).set_ble1();
-        }
-
         mask = functionT(factoryT(world).f(mask3).initial_level(4).norefine());
         if (world.rank() == 0 and param.print_level() > 1) {
             print("\nSolving NDIM=", NDIM, " with thresh", thresh, "    k",

--- a/src/madness/chem/SCFOperators.h
+++ b/src/madness/chem/SCFOperators.h
@@ -635,18 +635,17 @@ public:
 
     /// custom ctor with information about the XC functional
     XCOperator(World& world, std::string xc_data, const bool spin_polarized,
-            const real_function_3d& arho, const real_function_3d& brho,
-            std::string deriv="abgv");
+            const real_function_3d& arho, const real_function_3d& brho);
 
     /// ctor with an SCF calculation, will initialize the necessary intermediates
-    XCOperator(World& world, const SCF* scf, int ispin=0, std::string deriv="abgv");
+    XCOperator(World& world, const SCF* scf, int ispin=0);
 
     /// ctor with a Nemo calculation, will initialize the necessary intermediates
     XCOperator(World& world, const Nemo* nemo, int ispin=0);
 
     /// ctor with an SCF calculation, will initialize the necessary intermediates
     XCOperator(World& world, const SCF* scf, const real_function_3d& arho,
-            const real_function_3d& brho, int ispin=0, std::string deriv="abgv");
+            const real_function_3d& brho, int ispin=0);
 
     /// ctor with an Nemo calculation, will initialize the necessary intermediates
     XCOperator(World& world, const Nemo* scf, const real_function_3d& arho,
@@ -700,9 +699,6 @@ private:
 
     /// the world
     World& world;
-
-    /// which derivative operator to use
-    std::string dft_deriv;
 
 public:
     /// interface to the actual XC functionals

--- a/src/madness/chem/oep.h
+++ b/src/madness/chem/oep.h
@@ -333,7 +333,6 @@ public:
 
 	    for (int idim=0; idim<3; ++idim) {
 	    	real_derivative_3d D(world,idim);
-	    	if(param.dft_deriv() == "bspline") D.set_bspline1();
 	    	vecfuncT nemo_copy=copy(world,nemo);
 	    	refine(world,nemo_copy);
 	    	std::vector<real_function_3d> dnemo=apply(world,D,nemo_copy);
@@ -358,9 +357,7 @@ public:
 	    for (long i = 0; i < nemo.size(); i++) {
 	    	vecfuncT nemo_copy=copy(world,nemo);
 	    	refine(world,nemo_copy);
-
-	    	if(param.dft_deriv() == "bspline") grad_nemo[i] = grad_bspline_one(nemo_copy[i]);  // gradient using b-spline
-	    	else grad_nemo[i] = grad(nemo_copy[i]);  // default gradient using abgv
+	    	grad_nemo[i] = grad(nemo_copy[i]);  // default gradient using abgv
 	    }
 
 	    vecfuncT grad_nemo_term;


### PR DESCRIPTION
Changed wrong use of alpha spin to beta spin density in SCFOperators.cc that caused errors for open shell systems and removed derivative choices from CalculationParameters.h, only keeping the usual abgv.