### PR TITLE
fix molecule eprec handling

### DIFF
--- a/src/madness/chem/molecule.h
+++ b/src/madness/chem/molecule.h
@@ -313,6 +313,10 @@ public:
     /// Makes a molecule with zero atoms
     Molecule() : atoms(), rcut(), core_pot(), field(3L) {};
 
+    /// makes a molecule from a list of atoms
+    Molecule(std::vector<Atom> atoms, double eprec, CorePotentialManager core_pot = {}, madness::Tensor<double> field = madness::Tensor<double>(3L));
+
+    /// makes a molecule using contents of \p parser
     Molecule(World& world, const commandlineparser& parser);
 
     void get_structure();

--- a/src/madness/chem/test_SCFOperators.cc
+++ b/src/madness/chem/test_SCFOperators.cc
@@ -704,7 +704,6 @@ int dnuclear_anchor_test(World& world) {
     parser.set_keyval("input",test_input.filename());
     SCF calc(world,parser);
     calc.molecule.update_rcut_with_eprec(thresh*0.1);
-    calc.molecule.parameters.set_user_defined_value("eprec",thresh*0.1);
     calc.make_nuclear_potential(world);
 
     // derivative of atom wrt axis

--- a/src/madness/mra/key.h
+++ b/src/madness/mra/key.h
@@ -275,12 +275,12 @@ namespace madness {
             for (int i=0; i<static_cast<int>(LDIM); ++i) {
                 l1[i]=l[i];
             }
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Waggressive-loop-optimizations"
+MADNESS_PRAGMA_GCC(diagnostic push)
+MADNESS_PRAGMA_GCC(diagnostic ignored "-Waggressive-loop-optimizations")
             for (size_t i=LDIM; i<NDIM; ++i) {
                 l2[i-LDIM]=l[i];
             }
-#pragma GCC diagnostic pop
+MADNESS_PRAGMA_GCC(diagnostic pop)
 	    
             key1=Key<LDIM>(n,l1);
             key2=Key<KDIM>(n,l2);

--- a/src/madness/mra/mra.h
+++ b/src/madness/mra/mra.h
@@ -568,7 +568,7 @@ namespace madness {
         }
 
 
-        /// Sets the vaule of the truncation threshold.  Optional global fence.
+        /// Sets the value of the truncation threshold.  Optional global fence.
 
         /// A fence is required to ensure consistent global state.
         void set_thresh(double value, bool fence = true) {

--- a/src/madness/tensor/tensor.h
+++ b/src/madness/tensor/tensor.h
@@ -365,12 +365,12 @@ namespace madness {
                 }
                 catch (...) {
 		  // Ideally use if constexpr here but want headers C++14 for cuda compatibility
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Warray-bounds"
+MADNESS_PRAGMA_GCC(diagnostic push)
+MADNESS_PRAGMA_GCC(diagnostic ignored "-Warray-bounds")
                     std::printf("new failed nd=%ld type=%ld size=%ld\n", nd, id(), _size);
                     std::printf("  %ld %ld %ld %ld %ld %ld\n",
                                 d[0], d[1], d[2], d[3], d[4], d[5]);
-#pragma GCC diagnostic pop
+MADNESS_PRAGMA_GCC(diagnostic pop)
                     TENSOR_EXCEPTION("new failed",_size,this);
                 }
                 //std::printf("allocated %p [%ld]  %ld\n", _p, size, p.use_count());
@@ -443,13 +443,13 @@ namespace madness {
                 _shptr = t._shptr;
                 _size = t._size;
                 _ndim = t._ndim;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"		
+MADNESS_PRAGMA_GCC(diagnostic push)
+MADNESS_PRAGMA_GCC(diagnostic ignored "-Wmaybe-uninitialized")
                 for (int i=0; i<TENSOR_MAXDIM; ++i) {
                     _dim[i] = t._dim[i];
                     _stride[i] = t._stride[i];
                 }
-#pragma GCC diagnostic pop
+MADNESS_PRAGMA_GCC(diagnostic pop)
             }
             return *this;
         }

--- a/src/madness/world/vector.h
+++ b/src/madness/world/vector.h
@@ -130,11 +130,11 @@ namespace madness {
 
         /// \param[in] other The \c Vector to copy.
         Vector(const Vector<T,N>& other) {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wuninitialized"
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+MADNESS_PRAGMA_GCC(diagnostic push)
+MADNESS_PRAGMA_GCC(diagnostic ignored "-Wuninitialized")
+MADNESS_PRAGMA_GCC(diagnostic ignored "-Wmaybe-uninitialized")
             data_ = other.data_;
-#pragma GCC diagnostic pop
+MADNESS_PRAGMA_GCC(diagnostic pop)
         }
 
         /// Copy constructor is deep (because \c Vector is POD).

--- a/src/madness/world/worldref.h
+++ b/src/madness/world/worldref.h
@@ -499,7 +499,7 @@ namespace madness {
             return pointer_;
         }
 
-        /// Reference shared_ptr accssor
+        /// Reference shared_ptr accessor
 
         /// \return A const reference to the references shared pointer
         /// \throw MadnessException If the pointer is not local


### PR DESCRIPTION
- `Molecule::update_rcut_with_eprec` changes `eprec`, as it did before https://github.com/m-a-d-n-e-s-s/madness/commit/ae801e24ca5426d82e66de085438b3ddd1bda2b2#r82992324
- added Molecule ctor that obviates the need for `Molecule::update_rcut_with_eprec`

it should be safe to remove `Molecule::update_rcut_with_eprec` from the public API, but it is currently used in a test