### PR TITLE
Fix typo in PaRSEC task backend

### DIFF
--- a/src/madness/world/thread.cc
+++ b/src/madness/world/thread.cc
@@ -362,7 +362,7 @@ namespace madness {
             MADNESS_EXCEPTION("pthread_setspecific failed", rc);
 #if HAVE_PARSEC
         assert(nullptr == parsec_runtime);
-        parsec_runtime = new ParsecRuntime(nthread);
+        parsec_runtime = new ParsecRuntime(nthreads);
 #elif HAVE_INTEL_TBB
 // #if HAVE_INTEL_TBB
 


### PR DESCRIPTION
the PaRSEC task backend is using the madness::initialize() input parameter instead of the computed value for the number of threads, defaulting to -1 if MADNESS is initialized without specifying a number of threads, even if MAD_NUM_THREADS is set
