### PR TITLE
make template class static vars inline

### DIFF
--- a/doc/libraries/parallel_runtime.dox
+++ b/doc/libraries/parallel_runtime.dox
@@ -205,19 +205,4 @@ and other resources necessary to build new distributed capabilities.
 The distributed container class (madness::WorldContainer) actually inherits
 most of its functionality from madness::WorldObject.
 
-\par Static data, etc., for templated classes
-
-Several of the templated classes (currently just the
-madness::DistributedContainer, madness::Future and madness::RemoteReference classes) have static
-data or helper functions associated with them.  These must be defined
-in one and only one file.  To facilitate this definition, the
-necessary templates have been wrapped in C-preprocessor conditional
-block so that they are only enabled if \c
-WORLD_INSTANTIATE_STATIC_TEMPLATES is defined.  In just one of your source
-(not a header) files,
-define this macro \em before including \c parallel_runtime.h, and then
-instantiate the templates that you are using.  
-
-\note Applications using the multiresolution numerical tools probably
-do not need to define this macro.
  */

--- a/src/apps/cc2/cc2.cc
+++ b/src/apps/cc2/cc2.cc
@@ -37,9 +37,6 @@
   $Id$
  */
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
-
-
 #include "madness/chem/CC2.h"
 #include "madness/misc/info.h"
 

--- a/src/apps/interior_bc/embedded_dirichlet.cc
+++ b/src/apps/interior_bc/embedded_dirichlet.cc
@@ -69,7 +69,6 @@
        .
     for their effect on convergence of the solution. */
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/tensor/gmres.h>
 #include <madness/external/muParser/muParser.h>

--- a/src/apps/interior_bc/test_problems.h
+++ b/src/apps/interior_bc/test_problems.h
@@ -64,7 +64,6 @@
 #ifndef MADNESS_INTERIOR_BC_TEST_PROBLEMS_H__INCLUDED
 #define MADNESS_INTERIOR_BC_TEST_PROBLEMS_H__INCLUDED
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/mra/lbdeux.h>
 #include <madness/mra/sdf_shape_3D.h>

--- a/src/apps/moldft/preal.cc
+++ b/src/apps/moldft/preal.cc
@@ -1,4 +1,3 @@
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/tensor/solvers.h>
 #include <madness/external/tinyxml/tinyxml.h>

--- a/src/apps/moldft/testcosine.cc
+++ b/src/apps/moldft/testcosine.cc
@@ -1,4 +1,3 @@
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/tensor/solvers.h>
 using namespace madness;

--- a/src/apps/moldft/testperiodicdft.cc
+++ b/src/apps/moldft/testperiodicdft.cc
@@ -8,7 +8,6 @@
  */
 
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/tensor/solvers.h>
 #include<madness/chem/molecule.h>

--- a/src/apps/moldft/testpg.cc
+++ b/src/apps/moldft/testpg.cc
@@ -29,7 +29,6 @@
   fax:   865-572-0680
 */
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/world/MADworld.h>
 #include <moldft/pointgroup.h>
 

--- a/src/apps/moldft/wst_functional.h
+++ b/src/apps/moldft/wst_functional.h
@@ -1,5 +1,3 @@
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES  
-
 #include <madness/mra/mra.h>
 #include<madness/chem/xcfunctional.h>
 

--- a/src/apps/mp2/mp2.cc
+++ b/src/apps/mp2/mp2.cc
@@ -38,7 +38,6 @@
 */
 
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include "madness/chem/mp2.h"
 #include "madness/misc/info.h"
 

--- a/src/apps/nemo/nemo.cc
+++ b/src/apps/nemo/nemo.cc
@@ -31,8 +31,6 @@
   $Id$
 */
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
-
 
 /*!
   \file examples/nemo.cc

--- a/src/apps/oep/oep.cc
+++ b/src/apps/oep/oep.cc
@@ -29,8 +29,6 @@
   fax:   865-572-0680
 */
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
-
 /*!
   \file examples/oep.cc
   \brief optimized effective potentials for DFT

--- a/src/apps/periodic_old/dft.cc
+++ b/src/apps/periodic_old/dft.cc
@@ -30,7 +30,6 @@
 
   $Id$
 */
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include "dft.h"
 #include "util.h"
 //#include <moldft/xc/f2c.h>

--- a/src/apps/periodic_old/eigsolver.cc
+++ b/src/apps/periodic_old/eigsolver.cc
@@ -30,7 +30,6 @@
 
   $Id$
 */
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 
 #include "eigsolver.h"
 #include "util.h"

--- a/src/apps/periodic_old/ewald.cc
+++ b/src/apps/periodic_old/ewald.cc
@@ -1,4 +1,3 @@
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 
 #include <madness/mra/mra.h>
 #include "mentity.h"

--- a/src/apps/periodic_old/hartreefock.cc
+++ b/src/apps/periodic_old/hartreefock.cc
@@ -30,7 +30,6 @@
   
   $Id$
 */
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include "hartreefock.h"
 
 namespace madness

--- a/src/apps/periodic_old/lda.h
+++ b/src/apps/periodic_old/lda.h
@@ -39,7 +39,6 @@
 #ifndef LDA_H_
 #define LDA_H_
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/world/MADworld.h>
 #include <math.h>

--- a/src/apps/periodic_old/libxc.h
+++ b/src/apps/periodic_old/libxc.h
@@ -39,7 +39,6 @@
 #ifndef LIBXC_H_
 #define LIBXC_H_
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/world/MADworld.h>
 //#include "xc.h"

--- a/src/apps/periodic_old/solver_driver.cc
+++ b/src/apps/periodic_old/solver_driver.cc
@@ -30,8 +30,6 @@
 
   $Id$
 */
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
-
 #include "electronicstructureapp.h"
 #include "solver.h"
 

--- a/src/apps/periodic_old/test_comm.cc
+++ b/src/apps/periodic_old/test_comm.cc
@@ -29,7 +29,6 @@
   fax:   865-572-0680
 */
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/world/MADworld.h>
 
 using namespace std;

--- a/src/apps/periodic_old/test_coulomb.cc
+++ b/src/apps/periodic_old/test_coulomb.cc
@@ -30,7 +30,6 @@
 
   $Id$
 */
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/constants.h>
 #include "eigsolver.h"

--- a/src/apps/periodic_old/test_lattice.cc
+++ b/src/apps/periodic_old/test_lattice.cc
@@ -30,7 +30,6 @@
 
   $Id$
 */
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include "poperator.h"
 

--- a/src/apps/periodic_old/testconv.cc
+++ b/src/apps/periodic_old/testconv.cc
@@ -29,7 +29,6 @@
   fax:   865-572-0680
 */
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/world/MADworld.h>
 
 using namespace std;

--- a/src/apps/pno/pno.cpp
+++ b/src/apps/pno/pno.cpp
@@ -1,4 +1,3 @@
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <iomanip>
 #include<madness/chem/SCF.h>
 #include<madness/chem/nemo.h>

--- a/src/apps/tdse/tdse.cc
+++ b/src/apps/tdse/tdse.cc
@@ -34,7 +34,6 @@
 /// \brief Evolves the hydrogen atom in imaginary and also real time
 
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/mra/qmprop.h>
 #include <madness/mra/operator.h>

--- a/src/apps/tdse/tdse.confused.cc
+++ b/src/apps/tdse/tdse.confused.cc
@@ -34,7 +34,6 @@
 /// \brief Evolves the hydrogen atom in imaginary and also real time
 
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/mra/qmprop.h>
 #include <madness/mra/operator.h>

--- a/src/apps/tdse/tdse4.cc
+++ b/src/apps/tdse/tdse4.cc
@@ -34,7 +34,6 @@
 /// \brief Evolves the hydrogen molecular ion in 4D ... 3 electron + 1 nuclear degree of freedom
 
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/mra/funcimpl.h>
 #include <madness/mra/qmprop.h>

--- a/src/apps/zcis/zcis.cc
+++ b/src/apps/zcis/zcis.cc
@@ -31,9 +31,6 @@
   $Id$
 */
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
-
-
 /*!
   \file examples/znemo.cc
   \brief solve the HF equations using numerical exponential MOs

--- a/src/apps/znemo/znemo.cc
+++ b/src/apps/znemo/znemo.cc
@@ -31,9 +31,6 @@
   $Id$
 */
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
-
-
 /*!
   \file examples/znemo.cc
   \brief solve the HF equations using numerical exponential MOs

--- a/src/examples/3dharmonic.cc
+++ b/src/examples/3dharmonic.cc
@@ -113,7 +113,6 @@
   let us know.]
 */
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/mra/funcplot.h>
 #include <madness/mra/nonlinsol.h>

--- a/src/examples/array_worldobject.cc
+++ b/src/examples/array_worldobject.cc
@@ -1,4 +1,3 @@
-#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/world/world.h>
 #include <madness/world/worldgop.h>
 #include <madness/world/world_object.h>

--- a/src/examples/binaryop.cc
+++ b/src/examples/binaryop.cc
@@ -106,7 +106,6 @@
 
 */
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 
 using namespace madness;

--- a/src/examples/colloid.cc
+++ b/src/examples/colloid.cc
@@ -28,7 +28,6 @@ This proram simulates the effect of surface solute interaction between a colloid
 */
 
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 //#include <madness/mra/operator.h>
 #include "molecularmask.h"
 #include <madness/mra/nonlinsol.h>

--- a/src/examples/compiler/mra-driver.hh
+++ b/src/examples/compiler/mra-driver.hh
@@ -590,7 +590,6 @@ public:
         }
         else if (c.size() == 0) {
             if (s=="Let") {
-	        //file << "#define WORLD_INSTANTIATE_STATIC_TEMPLATES\n";
                 file << "#include <madness/mra/mra.h>\n";
                 file << "using namespace madness;\n";
             }

--- a/src/examples/csqrt.cc
+++ b/src/examples/csqrt.cc
@@ -31,7 +31,6 @@
   $Id$
 */
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/mra/operator.h>
 #include <complex>

--- a/src/examples/dataloadbal.cc
+++ b/src/examples/dataloadbal.cc
@@ -128,7 +128,6 @@
 */
 
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/mra/operator.h>
 #include <madness/mra/vmra.h>

--- a/src/examples/density_smoothing.cc
+++ b/src/examples/density_smoothing.cc
@@ -31,9 +31,6 @@
   $Id$
  */
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
-
-
 /*!
   \file examples/nemo.cc
   \brief solve the HF equations using numerical exponential MOs

--- a/src/examples/dielectric.cc
+++ b/src/examples/dielectric.cc
@@ -168,7 +168,6 @@
 */
 
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/mra/operator.h>
 #include <madness/mra/funcplot.h>

--- a/src/examples/dielectric_external_field.cc
+++ b/src/examples/dielectric_external_field.cc
@@ -92,7 +92,6 @@
 */
 
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/mra/operator.h>
 #include <madness/mra/funcplot.h>

--- a/src/examples/functionio.cc
+++ b/src/examples/functionio.cc
@@ -89,7 +89,6 @@
 
  */
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/constants.h>
 using namespace madness;

--- a/src/examples/graveyard
+++ b/src/examples/graveyard
@@ -32,7 +32,6 @@
   
   $Id$
 */
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES  
 #include <madness/mra/mra.h>
 #include <madness/mra/mra.h>
 #include <madness/mra/operator.h>
@@ -345,7 +344,6 @@ int main(int argc, char** argv) {
 /// \file bigboy.cc
 /// \brief artificial benchmark for Cray XT testing
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES  
 #include <madness/mra/mra.h>
 using namespace madness;
 
@@ -541,7 +539,6 @@ int main(int argc, char** argv) {
   
   $Id$
 */
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES  
 #include <madness/mra/mra.h>
 #include <madness/mra/mra.h>
 #include <madness/mra/operator.h>
@@ -929,7 +926,6 @@ end
   
   $Id$
 */
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES  
 #include <madness/mra/mra.h>
 #include <madness/mra/mra.h>
 #include <madness/mra/operator.h>

--- a/src/examples/gygi_soltion.cc
+++ b/src/examples/gygi_soltion.cc
@@ -49,7 +49,6 @@ $Id$
   - The test system isa hydrogen atom (1s orbital)
 */
  //We will test this for a hydrogen atom
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/constants.h>
 #include <ctime>

--- a/src/examples/h2.cc
+++ b/src/examples/h2.cc
@@ -47,7 +47,6 @@
 */
 
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/mra/operator.h>
 

--- a/src/examples/h2dft.cc
+++ b/src/examples/h2dft.cc
@@ -1,4 +1,3 @@
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/mra/operator.h>
 #include <madness/mra/nonlinsol.h>
@@ -6,7 +5,6 @@
 
 
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/mra/operator.h>
 

--- a/src/examples/h2dynamic.cc
+++ b/src/examples/h2dynamic.cc
@@ -1,4 +1,3 @@
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/mra/operator.h>
 #include <madness/mra/nonlinsol.h>

--- a/src/examples/hatom_1d.cc
+++ b/src/examples/hatom_1d.cc
@@ -41,7 +41,6 @@
 */
 
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/mra/operator.h>
 

--- a/src/examples/hatom_energy.cc
+++ b/src/examples/hatom_energy.cc
@@ -30,7 +30,6 @@
 
   $Id$
 */
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 
 /*!
   \file examples/hatom_energy.cc

--- a/src/examples/he.cc
+++ b/src/examples/he.cc
@@ -1,4 +1,3 @@
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/mra/operator.h>
 #include <madness/mra/lbdeux.h>

--- a/src/examples/heat.cc
+++ b/src/examples/heat.cc
@@ -56,7 +56,6 @@
 
 */
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/mra/operator.h>
 #include <madness/constants.h>

--- a/src/examples/heat2.cc
+++ b/src/examples/heat2.cc
@@ -30,7 +30,6 @@
 
   $Id$
 */
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/mra/operator.h>
 #include <madness/constants.h>

--- a/src/examples/hedft.cc
+++ b/src/examples/hedft.cc
@@ -1,4 +1,3 @@
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/mra/operator.h>
 #include <madness/mra/nonlinsol.h>
@@ -6,7 +5,6 @@
 
 
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/mra/operator.h>
 

--- a/src/examples/hefxc.cc
+++ b/src/examples/hefxc.cc
@@ -1,4 +1,3 @@
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/mra/operator.h>
 #include <madness/mra/nonlinsol.h>
@@ -6,7 +5,6 @@
 
 
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/mra/operator.h>
 

--- a/src/examples/hehf.cc
+++ b/src/examples/hehf.cc
@@ -92,7 +92,6 @@
 
 */
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/mra/operator.h>
 

--- a/src/examples/helium_exact.cc
+++ b/src/examples/helium_exact.cc
@@ -39,7 +39,6 @@
 
  */
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/misc/info.h>
 #include <madness/mra/mra.h>
 #include <madness/mra/operator.h>

--- a/src/examples/helium_mp2.cc
+++ b/src/examples/helium_mp2.cc
@@ -37,7 +37,6 @@
 */
 
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/mra/operator.h>
 #include <madness/mra/funcplot.h>

--- a/src/examples/molecularsurface.cc
+++ b/src/examples/molecularsurface.cc
@@ -1,4 +1,3 @@
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/mra/sdf_shape_3D.h>
 #include <madness/mra/funcplot.h>

--- a/src/examples/navstokes_cosines.cc
+++ b/src/examples/navstokes_cosines.cc
@@ -78,7 +78,6 @@
 */
 
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/vmra.h>
 #include <madness/constants.h>
 

--- a/src/examples/newsolver.cc
+++ b/src/examples/newsolver.cc
@@ -1,4 +1,3 @@
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES  
 #include <madness/mra/mra.h>
 #include <madness/mra/operator.h>
 #include <madness/mra/nonlinsol.h>

--- a/src/examples/newsolver_lda.cc
+++ b/src/examples/newsolver_lda.cc
@@ -1,5 +1,4 @@
 
-#define WORLD_INSTANTIATE_STATIC_TEMPLATES  
 #include <type_traits>
 #include <madness/mra/mra.h>
 #include <madness/mra/operator.h>

--- a/src/examples/nonlinschro.cc
+++ b/src/examples/nonlinschro.cc
@@ -105,7 +105,6 @@
 */
 
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/mra/operator.h>
 #include <algorithm>

--- a/src/examples/ploterr.cc
+++ b/src/examples/ploterr.cc
@@ -1,4 +1,3 @@
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 
 using namespace madness;

--- a/src/examples/sdf_shape_tester.cc
+++ b/src/examples/sdf_shape_tester.cc
@@ -52,7 +52,6 @@
  */
 
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/mra/sdf_shape_3D.h>
 #include <madness/constants.h>

--- a/src/examples/sininteg.cc
+++ b/src/examples/sininteg.cc
@@ -29,8 +29,6 @@
   fax:   865-572-0680
 */
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
-
 /*!
   \file examples/sininteg.cc
   \brief Compute the integral sin(x) x=0..10

--- a/src/examples/svpe.cc
+++ b/src/examples/svpe.cc
@@ -31,7 +31,6 @@
   $Id$
 */
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/mra/operator.h>
 #include <madness/mra/funcplot.h>

--- a/src/examples/tdse1d.cc
+++ b/src/examples/tdse1d.cc
@@ -98,7 +98,6 @@
 */
 
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #define NO_GENTENSOR
 #include <madness/mra/mra.h>
 #include <madness/mra/qmprop.h>

--- a/src/examples/tdse_example.cc
+++ b/src/examples/tdse_example.cc
@@ -34,7 +34,6 @@
 /// \brief Evolves the hydrogen atom in imaginary and also real time
 
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/lbdeux.h>
 #include <madness/mra/mra.h>
 #include <madness/mra/qmprop.h>

--- a/src/examples/test_gmres.cc
+++ b/src/examples/test_gmres.cc
@@ -46,7 +46,6 @@
 /// Tightening up the default tolerance of the MADNESS functions makes this
 /// go away.
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/tensor/gmres.h>
 

--- a/src/examples/testspectralprop.cc
+++ b/src/examples/testspectralprop.cc
@@ -1,6 +1,4 @@
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
-
 #include <madness/mra/mra.h>
 #include <iostream>
 #include <vector>

--- a/src/examples/testttg.cc
+++ b/src/examples/testttg.cc
@@ -32,7 +32,6 @@
   $Id$
 */
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/mra/operator.h>
 #include <madness/mra/vmra.h>

--- a/src/examples/tiny.cc
+++ b/src/examples/tiny.cc
@@ -43,7 +43,6 @@
 */
 
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/mra/operator.h>
 #include <madness/mra/funcplot.h>

--- a/src/examples/vnucso.cc
+++ b/src/examples/vnucso.cc
@@ -64,7 +64,6 @@
 */
 
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/mra/vmra.h>
 #include <madness/mra/operator.h>

--- a/src/madness/chem/CMakeLists.txt
+++ b/src/madness/chem/CMakeLists.txt
@@ -97,7 +97,7 @@ set(MADCHEM_SOURCES
     PNO.cpp  PNOF12Potentials.cpp  PNOGuessFunctions.cpp  PNOParameters.cpp  PNOStructures.cpp
 )
 # these source files require specific header order inclusion ... just skip them from unity build for now
-set_source_files_properties(PNO.cpp  PNOF12Potentials.cpp  PNOGuessFunctions.cpp  PNOParameters.cpp  PNOStructures.cpp
+set_source_files_properties(PNO.cpp  PNOF12Potentials.cpp  PNOGuessFunctions.cpp  PNOParameters.cpp  PNOStructures.cpp SCFOperators.cc
         PROPERTIES SKIP_UNITY_BUILD_INCLUSION TRUE)
 if(LIBXC_FOUND)
   list(APPEND MADCHEM_SOURCES xcfunctional_libxc.cc)

--- a/src/madness/chem/SCF.cc
+++ b/src/madness/chem/SCF.cc
@@ -34,8 +34,6 @@
 /// \defgroup moldft The molecular density functional and Hartree-Fock code
 
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
-
 
 #include <madness/world/worldmem.h>
 #include<madness.h>

--- a/src/madness/chem/SCF.h
+++ b/src/madness/chem/SCF.h
@@ -40,8 +40,6 @@
 #ifndef MADNESS_CHEM_SCF_H__INCLUDED
 #define MADNESS_CHEM_SCF_H__INCLUDED
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
-
 #include <memory>
 
 #include<madness/chem/molecular_functors.h>

--- a/src/madness/chem/benchmark_exchange_operator.cc
+++ b/src/madness/chem/benchmark_exchange_operator.cc
@@ -1,5 +1,4 @@
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness.h>
 #include <madness/chem/SCF.h>
 #include <madness/chem/SCFOperators.h>

--- a/src/madness/chem/correlationfactor.cc
+++ b/src/madness/chem/correlationfactor.cc
@@ -31,9 +31,6 @@
   $Id$
 */
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
-
-
 #include<madness/chem/correlationfactor.h>
 
 namespace madness{

--- a/src/madness/chem/correlationfactor.h
+++ b/src/madness/chem/correlationfactor.h
@@ -29,8 +29,6 @@
   fax:   865-572-0680
 */
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
-
 /*!
   \file apps/chem/correlationfactor.h
   \brief class for regularizing singular potentials in the molecular

--- a/src/madness/chem/exchangeoperator.cc
+++ b/src/madness/chem/exchangeoperator.cc
@@ -1,4 +1,3 @@
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include<madness/chem/exchangeoperator.h>
 
 #include<madness/chem/SCF.h>

--- a/src/madness/chem/gth_pseudopotential.h
+++ b/src/madness/chem/gth_pseudopotential.h
@@ -5,8 +5,6 @@
 #ifndef MADNESS_CHEM_GTH_PSEUDOPOTENTIAL_H__INCLUDED
 #define MADNESS_CHEM_GTH_PSEUDOPOTENTIAL_H__INCLUDED
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
-
 #include <madness/mra/mra.h>
 #include <madness/external/tinyxml/tinyxml.h>
 

--- a/src/madness/chem/mp2.h
+++ b/src/madness/chem/mp2.h
@@ -39,7 +39,6 @@
 #ifndef MP2_H_
 #define MP2_H_
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/mra/lbdeux.h>
 #include<madness/chem/QCCalculationParametersBase.h>

--- a/src/madness/chem/nemo.cc
+++ b/src/madness/chem/nemo.cc
@@ -29,8 +29,6 @@
  fax:   865-572-0680
 */
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
-
 /*!
  \file examples/nemo.cc
  \brief solve the HF equations using numerical exponential MOs

--- a/src/madness/chem/nemo.h
+++ b/src/madness/chem/nemo.h
@@ -29,8 +29,6 @@
  fax:   865-572-0680
  */
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
-
 /*!
  \file examples/nemo.h
  \brief solve the HF equations using numerical exponential MOs

--- a/src/madness/chem/plotxc.cc
+++ b/src/madness/chem/plotxc.cc
@@ -30,7 +30,6 @@
   
   $Id$
 */
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/world/world.h>
 #include <madness/mra/mra.h>
 #include <madness/tensor/tensor.h>

--- a/src/madness/chem/pointgroupoperator.h
+++ b/src/madness/chem/pointgroupoperator.h
@@ -31,8 +31,6 @@
   $Id$
 */
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
-
 
 /*!
   \file chem/pointgroupoperator.h

--- a/src/madness/chem/pointgroupsymmetry.cc
+++ b/src/madness/chem/pointgroupsymmetry.cc
@@ -31,8 +31,6 @@
   $Id$
 */
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
-
 
 /*!
   \file chem/pointgroupsymmetry.cc

--- a/src/madness/chem/pointgroupsymmetry.h
+++ b/src/madness/chem/pointgroupsymmetry.h
@@ -31,8 +31,6 @@
   $Id$
 */
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
-
 
 /*!
   \file chem/pointgroupsymmetry.cc

--- a/src/madness/chem/test_SCFOperators.cc
+++ b/src/madness/chem/test_SCFOperators.cc
@@ -29,7 +29,6 @@
   fax:   865-572-0680
 */
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness.h>
 #include<madness/chem/SCFOperators.h>
 #include<madness/chem/SCF.h>

--- a/src/madness/chem/test_dft.cc
+++ b/src/madness/chem/test_dft.cc
@@ -29,7 +29,6 @@
   fax:   865-572-0680
 */
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness.h>
 #include<madness/chem/SCFOperators.h>
 

--- a/src/madness/chem/testxc.cc
+++ b/src/madness/chem/testxc.cc
@@ -29,7 +29,6 @@
   fax:   865-572-0680
 */
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/world/MADworld.h>
 #include <madness/mra/mra.h>
 #include <madness/tensor/tensor.h>

--- a/src/madness/mra/graveyard
+++ b/src/madness/mra/graveyard
@@ -101,7 +101,6 @@
 //         inline void unfilter_inplace(tensorT& s) {
 //             transform_inplace(s, cdata.hg, cdata.work2);
 //         };
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/loadbal.h>
 
 using namespace std;
@@ -982,7 +981,6 @@ template class LBTree<5,MyProcmap<5> >;
 template class LBTree<6,MyProcmap<6> >;
 >>>>>>> .r223
 }
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #ifndef LOADBAL_H
 #define LOADBAL_H
 
@@ -2417,7 +2415,6 @@ runvalg2:
 */
 
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <madness/world/worldhashmap.h>
 

--- a/src/madness/mra/mraimpl.h
+++ b/src/madness/mra/mraimpl.h
@@ -36,7 +36,6 @@
 #error "mraimpl.h should ONLY be included in one of the mraX.cc files (x=1..6)"
 #endif
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <memory>
 #include <math.h>
 #include <cmath>

--- a/src/madness/mra/testinnerext.cc
+++ b/src/madness/mra/testinnerext.cc
@@ -1,6 +1,5 @@
 
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/mra/mra.h>
 #include <array>
 using namespace madness;

--- a/src/madness/tensor/test_distributed_matrix.cc
+++ b/src/madness/tensor/test_distributed_matrix.cc
@@ -1,4 +1,3 @@
-#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 
 #include <madness/madness_config.h>
 #include <madness/world/MADworld.h>

--- a/src/madness/tensor/test_elemental.cc
+++ b/src/madness/tensor/test_elemental.cc
@@ -1,7 +1,6 @@
 #include <madness/madness_config.h>
 
 
-#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/world/MADworld.h>
 using namespace madness;
 using namespace std;

--- a/src/madness/tensor/testseprep.cc
+++ b/src/madness/tensor/testseprep.cc
@@ -2,8 +2,6 @@
 /// \file testSepRep.cc
 /// \brief test the SeparatedRepresentation (SepRep) for representing matrices
 
-//#define WORLD_INSTANTIATE_STATIC_TEMPLATES
-
 #include <madness/tensor/gentensor.h>
 
 using namespace madness;

--- a/src/madness/world/dqueue.h
+++ b/src/madness/world/dqueue.h
@@ -92,9 +92,9 @@ namespace madness {
 
 #ifdef MADNESS_DQ_USE_PREBUF
 	static const size_t NPREBUF=MADNESS_DQ_PREBUF_SIZE;
-	static thread_local T prebuf[NPREBUF]; // relies on this being a singleton class!!!!!!!!!!!!!!!!!!
-	static thread_local T prebufhi[NPREBUF]; // relies on this being a singleton class!!!!!!!!!!!!!!!!!!
-	static thread_local size_t ninprebuf, ninprebufhi;
+	inline static thread_local T prebuf[NPREBUF] = {T{}}; // relies on this being a singleton class!!!!!!!!!!!!!!!!!!
+	inline static thread_local T prebufhi[NPREBUF] = {T{}}; // relies on this being a singleton class!!!!!!!!!!!!!!!!!!
+	inline static thread_local size_t ninprebuf = 0, ninprebufhi = 0;
 #endif
 
         void grow() {
@@ -333,13 +333,6 @@ namespace madness {
             return stats;
         }
     };
-
-#if defined(MADNESS_DQ_USE_PREBUF) && !defined(MADNESS_CXX_COMPILER_IS_ICC)
-    template <typename T> thread_local T DQueue<T>::prebuf[DQueue<T>::NPREBUF] = {T{}};
-    template <typename T> thread_local T DQueue<T>::prebufhi[DQueue<T>::NPREBUF] = {T{}};
-    template <typename T> thread_local size_t DQueue<T>::ninprebuf = 0;
-    template <typename T> thread_local size_t DQueue<T>::ninprebufhi = 0;
-#endif
 
     template <typename T>
     void DQueue<T>::lock_and_flush_prebuf() {

--- a/src/madness/world/future.h
+++ b/src/madness/world/future.h
@@ -1012,8 +1012,6 @@ namespace madness {
     std::ostream& operator<<(std::ostream& out, const Future<void>& f);
 
 
-#ifdef WORLD_INSTANTIATE_STATIC_TEMPLATES
-
     /// \todo Brief description needed.
 
     /// \todo Descriptions needed.
@@ -1022,15 +1020,13 @@ namespace madness {
     /// \param[in] f The future to be output.
     /// \return The output stream.
     template <typename T>
-    std::ostream& operator<<(std::ostream& out, const Future<T>& f) {
+    inline std::ostream& operator<<(std::ostream& out, const Future<T>& f) {
         if (f.probe()) out << f.get();
         else if (f.is_remote()) out << f.f->remote_ref;
         else if (f.f) out << "<unassigned refcnt=" << f.f.use_count() << ">";
         else out << "<unassigned>";
         return out;
     }
-
-#endif
 
 } // namespace madness
 

--- a/src/madness/world/test_binsorter.cc
+++ b/src/madness/world/test_binsorter.cc
@@ -1,4 +1,3 @@
-#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/world/MADworld.h>
 #include <madness/world/binsorter.h>
 

--- a/src/madness/world/test_dc.cc
+++ b/src/madness/world/test_dc.cc
@@ -29,7 +29,6 @@
   fax:   865-572-0680
 */
 
-#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/world/MADworld.h>
 #include <madness/world/worlddc.h>
 #include <madness/world/atomicint.h>

--- a/src/madness/world/test_future2.cc
+++ b/src/madness/world/test_future2.cc
@@ -29,7 +29,6 @@
   fax:   865-572-0680
 */
 
-#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/world/MADworld.h>
 #include <madness/world/world_object.h>
 #include <iomanip>

--- a/src/madness/world/test_future3.cc
+++ b/src/madness/world/test_future3.cc
@@ -29,7 +29,6 @@
   fax:   865-572-0680
 */
 
-#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/world/MADworld.h>
 #include <madness/world/world_object.h>
 

--- a/src/madness/world/test_hashdc.cc
+++ b/src/madness/world/test_hashdc.cc
@@ -29,7 +29,6 @@
   fax:   865-572-0680
 */
 
-#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/world/MADworld.h>
 #include <madness/world/worlddc.h>
 

--- a/src/madness/world/test_tree.cc
+++ b/src/madness/world/test_tree.cc
@@ -30,7 +30,6 @@
 */
 
 
-#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/world/MADworld.h>
 #include <madness/world/worldhash.h>
 

--- a/src/madness/world/test_world.cc
+++ b/src/madness/world/test_world.cc
@@ -33,7 +33,6 @@
 #include <numeric>
 #include <algorithm>
 
-#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/world/MADworld.h>
 #include <madness/world/world_object.h>
 #include <madness/world/worlddc.h>

--- a/src/madness/world/test_worldptr.cc
+++ b/src/madness/world/test_worldptr.cc
@@ -34,7 +34,6 @@
 #ifdef MADNESS_HAS_GOOGLE_TEST
 
 #define MADNESS_DISPLAY_EXCEPTION_BREAK_MESSAGE 0
-#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/world/worldptr.h>
 #include <madness/world/MADworld.h>
 #include <madness/world/world_object.h>

--- a/src/madness/world/test_worldref.cc
+++ b/src/madness/world/test_worldref.cc
@@ -33,7 +33,6 @@
 #ifdef MADNESS_HAS_GOOGLE_TEST
 
 //#define MADNESS_DISPLAY_EXCEPTION_BREAK_MESSAGE 0
-#define WORLD_INSTANTIATE_STATIC_TEMPLATES
 #include <madness/world/worldref.h>
 #include <madness/world/MADworld.h>
 #include <madness/world/world_object.h>

--- a/src/madness/world/thread.cc
+++ b/src/madness/world/thread.cc
@@ -544,11 +544,4 @@ namespace madness {
         return instance()->queue.get_stats();
     }
 
-#if defined(MADNESS_DQ_USE_PREBUF) && defined(MADNESS_CXX_COMPILER_IS_ICC)
-    thread_local PoolTaskInterface* DQueue<PoolTaskInterface*>::prebuf[DQueue<PoolTaskInterface*>::NPREBUF] = {};
-    thread_local PoolTaskInterface* DQueue<PoolTaskInterface*>::prebufhi[DQueue<PoolTaskInterface*>::NPREBUF] = {};
-    thread_local size_t DQueue<PoolTaskInterface*>::ninprebuf = 0;
-    thread_local size_t DQueue<PoolTaskInterface*>::ninprebufhi = 0;
-#endif
-
 } // namespace madness

--- a/src/madness/world/world_object.h
+++ b/src/madness/world/world_object.h
@@ -378,8 +378,8 @@ namespace madness {
         uniqueidT objid; ///< Sense of self.
 
 
-        static Spinlock pending_mutex; ///< \todo Description needed.
-        static volatile pendingT pending; ///< Buffer for pending messages.
+        inline static Spinlock pending_mutex; ///< \todo Description needed.
+        inline static volatile pendingT pending; ///< Buffer for pending messages.
 
 
         /// \todo Complete: Determine if [unknown] is ready (for ...).
@@ -1439,15 +1439,6 @@ namespace madness {
         };
     }
 }
-
-#ifdef WORLD_INSTANTIATE_STATIC_TEMPLATES
-template <typename Derived>
-volatile std::list<madness::detail::PendingMsg> madness::WorldObject<Derived>::pending;
-
-template <typename Derived>
-madness::Spinlock madness::WorldObject<Derived>::pending_mutex;
-
-#endif
 
 #endif // MADNESS_WORLD_WORLD_OBJECT_H__INCLUDED
 


### PR DESCRIPTION
by making them explicit linkage this should resolve issues with duplicate definitions and eliminate the need for `WORLD_INSTANTIATE_STATIC_TEMPLATES`