### PR TITLE
Only rank 0 reads and updates the calc_info_schema

### DIFF
--- a/src/apps/moldft/moldft.cc
+++ b/src/apps/moldft/moldft.cc
@@ -161,9 +161,11 @@ int main(int argc, char **argv) {
                 } else {
                     MolecularEnergy E(world, calc);
                     double energy = E.value(calc.molecule.get_all_coords().flat()); // ugh!
-                    if ((world.rank() == 0) and (calc.param.print_level() > 0))
+                    if ((world.rank() == 0) and (calc.param.print_level() > 0)){
                         printf("final energy=%16.8f \n", energy);
-                    E.output_calc_info_schema();
+                        E.output_calc_info_schema();
+                    }
+
 
                     functionT rho = calc.make_density(world, calc.aocc, calc.amo);
                     functionT brho = rho;


### PR DESCRIPTION
Fixes a bug when multiple words try to read/write to the same json file and corrupt the file.  Usually with an extra }.  
My fix is to have only world 0 call `E.output_calc_finfo_schema().  A better fix would be to have world 0 do the reading and writing deeper in the function calls, but I would have to change function signatures to pass world in, which is easy enough in Clion