### PR TITLE
`ThreadPool::default_nthread` is public and static

### DIFF
--- a/src/madness/world/parsec.cc
+++ b/src/madness/world/parsec.cc
@@ -226,13 +226,13 @@ namespace madness {
         if (*made_new_ctx) {
             parsec_context_wait(ctx);
             parsec_fini(&ctx);
-            if (nullptr != madness_comm_thread_es) {
+            ctx = nullptr;
+        }
+        if (nullptr != madness_comm_thread_es) {
               /* madness_comm_thread_es is just a copy of ES[0]. Resources (including es->profiling_es) are
              * actually freed during parsec_fini. Just need to free memory allocated to store it. */
               free(madness_comm_thread_es);
               madness_comm_thread_es = nullptr;
-            }
-            ctx = nullptr;
         }
     }
 

--- a/src/madness/world/thread.h
+++ b/src/madness/world/thread.h
@@ -1122,7 +1122,12 @@ namespace madness {
       void operator=(const ThreadPool&) = delete;
       void operator=(ThreadPool&&) = delete;
 
-     private:
+      /// Get the number of threads from the environment.
+
+      /// \return The number of threads.
+      static int default_nthread();
+
+    private:
         friend class WorldTaskQueue;
 
         // Thread pool data
@@ -1146,11 +1151,6 @@ namespace madness {
         /// \todo Description needed.
         /// \param[in] nthread Description needed.
         ThreadPool(int nthread=-1);
-
-        /// Get the number of threads from the environment.
-
-        /// \return The number of threads.
-        int default_nthread();
 
        /// Run the next task.
 


### PR DESCRIPTION
useful if need to initialize thread pool (e.g. PaRSEC's) externally