### PR TITLE
added ability to "trace" (count) futures associated with WorldObjects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,6 +249,12 @@ add_feature_info(TASK_DEBUG_TRACE ENABLE_TASK_DEBUG_TRACE "supports debug trace 
 set(MADNESS_TASK_DEBUG_TRACE ${ENABLE_TASK_DEBUG_TRACE} CACHE BOOL
         "Enable task debug tracing.")
 
+option(ENABLE_WORLDOBJECT_FUTURE_TRACE
+        "Enable tracing of futures assicuated with WorldObjects." OFF)
+add_feature_info(WORLDOBJECT_FUTURE_TRACE ENABLE_WORLDOBJECT_FUTURE_TRACE "supports tracing of futures associated with WorldObjects")
+set(MADNESS_WORLDOBJECT_FUTURE_TRACE ${ENABLE_WORLDOBJECT_FUTURE_TRACE} CACHE BOOL
+        "Enable tracing of futures assicuated with WorldObjects.")
+
 set(FORTRAN_INTEGER_SIZE 4 CACHE STRING "The fortran integer size (4 or 8 bytes) used for BLAS and LAPACK function calls")
 if(NOT (FORTRAN_INTEGER_SIZE EQUAL 4 OR FORTRAN_INTEGER_SIZE EQUAL 8))
   message(FATAL_ERROR "Incorrect fortran integer size '${FORTRAN_INTEGER_SIZE}'\n"

--- a/cmake/config.h.in
+++ b/cmake/config.h.in
@@ -126,6 +126,9 @@
 #cmakedefine MADNESS_DQ_USE_PREBUF 1
 #cmakedefine MADNESS_DQ_PREBUF_SIZE @MADNESS_DQ_PREBUF_SIZE@
 #cmakedefine MADNESS_ASSUMES_ASLR_DISABLED 1
+#cmakedefine MADNESS_WORLDOBJECT_FUTURE_TRACE 1
+#cmakedefine MADNESS_WORLDOBJECT_FUTURE_TRACE_WORLD_ID @MADNESS_WORLDOBJECT_FUTURE_TRACE_WORLD_ID@
+#cmakedefine MADNESS_WORLDOBJECT_FUTURE_TRACE_MAX_NOBJECTS @MADNESS_WORLDOBJECT_FUTURE_TRACE_MAX_NOBJECTS@
 
 /* Define to the equivalent of the C99 'restrict' keyword, or to
    nothing if this is not supported.  Do not define if restrict is


### PR DESCRIPTION
convenience for tracking whether there are unassigned futures associated with a WorldObject, even after the WorldObject is gone