### PR TITLE
introduced `WorldGopInterface::{set_,}max_reducebcast_msg_size()`

### DIFF
--- a/src/madness/world/safempi.h
+++ b/src/madness/world/safempi.h
@@ -533,6 +533,13 @@ namespace SafeMPI {
                 return result;
             }
 
+            /// \return the period of repeat of unique tags produces by unique_tag()
+            static int unique_tag_period() {
+              const auto min_tag_value = 1024;
+              const auto max_tag_value = 4094;
+              return max_tag_value - min_tag_value + 1;
+            }
+
             /// Returns a unique tag reserved for long-term use (0<tag<1000)
 
             /// Get a tag from this routine for long-term/repeated use.
@@ -810,7 +817,7 @@ namespace SafeMPI {
             MADNESS_MPI_TEST(MPI_Barrier(pimpl->comm));
         }
 
-        /// Returns a unique tag for temporary use (1023<tag<=4095)
+        /// Returns a unique tag for temporary use (1023<tag<4095)
 
         /// These tags are intended for one time use to avoid tag
         /// collisions with other messages around the same time period.
@@ -822,6 +829,11 @@ namespace SafeMPI {
         int unique_tag() {
             MADNESS_ASSERT(pimpl);
             return pimpl->unique_tag();
+        }
+
+        /// \return the period of repeat of unique tags produces by unique_tag()
+        static int unique_tag_period() {
+          return Impl::unique_tag_period();
         }
 
         /// Returns a unique tag reserved for long-term use (0<tag<1000)

--- a/src/madness/world/test_world.cc
+++ b/src/madness/world/test_world.cc
@@ -1178,10 +1178,15 @@ void test13(World& world) {
 void test14(World& world) {
 
   if (world.size() > 1) {
+    static size_t call_counter = 0;
+    ++call_counter;
+
     const auto n = 1 + std::numeric_limits<int>::max()/sizeof(int);
     auto iarray = std::make_unique<int[]>(n);
     iarray[0] = -1;
     iarray[n-1] = -1;
+
+    world.gop.set_max_reducebcast_msg_size(std::numeric_limits<int>::max()/(std::min(10ul,call_counter)));
     world.gop.broadcast(iarray.get(), n, 0);
 
     if (world.rank() == 1) {

--- a/src/madness/world/worldgop.cc
+++ b/src/madness/world/worldgop.cc
@@ -170,36 +170,40 @@ namespace madness {
       fence();
     }
 
-    /// Broadcasts bytes from process root while still processing AM & tasks
-    static void broadcast_impl(void* buf, int nbyte, ProcessID root, bool dowork, Tag bcast_tag, World &world) {
-        SafeMPI::Request req0, req1;
-        ProcessID parent, child0, child1;
-        world.mpi.binary_tree_info(root, parent, child0, child1);
+    void WorldGopInterface::broadcast(void* buf, size_t nbyte, ProcessID root, bool dowork, Tag bcast_tag) {
+      if (bcast_tag < 0)
+        bcast_tag = world_.mpi.unique_tag();
+      ProcessID parent, child0, child1;
+      world_.mpi.binary_tree_info(root, parent, child0, child1);
+      const size_t max_msg_size =
+          static_cast<size_t>(max_reducebcast_msg_size());
 
-        //print("BCAST TAG", bcast_tag);
+      auto broadcast_impl = [&, this](void *buf, int nbyte) {
+        SafeMPI::Request req0, req1;
+
+        // print("BCAST TAG", bcast_tag);
 
         if (parent != -1) {
-            req0 = world.mpi.Irecv(buf, nbyte, MPI_BYTE, parent, bcast_tag);
-            World::await(req0, dowork);
+          req0 = world_.mpi.Irecv(buf, nbyte, MPI_BYTE, parent, bcast_tag);
+          World::await(req0, dowork);
         }
 
-        if (child0 != -1) req0 = world.mpi.Isend(buf, nbyte, MPI_BYTE, child0, bcast_tag);
-        if (child1 != -1) req1 = world.mpi.Isend(buf, nbyte, MPI_BYTE, child1, bcast_tag);
+        if (child0 != -1)
+          req0 = world_.mpi.Isend(buf, nbyte, MPI_BYTE, child0, bcast_tag);
+        if (child1 != -1)
+          req1 = world_.mpi.Isend(buf, nbyte, MPI_BYTE, child1, bcast_tag);
 
-        if (child0 != -1) World::await(req0, dowork);
-        if (child1 != -1) World::await(req1, dowork);
-    }
+        if (child0 != -1)
+          World::await(req0, dowork);
+        if (child1 != -1)
+          World::await(req1, dowork);
+      };
 
-    /// Optimizations can be added for long messages
-    void WorldGopInterface::broadcast(void* buf, size_t nbyte, ProcessID root, bool dowork, Tag bcast_tag) {
-      if(bcast_tag < 0)
-        bcast_tag = world_.mpi.unique_tag();
-      const size_t max_msg_size = static_cast<size_t>(max_reducebcast_msg_size());
       while (nbyte) {
         const int n = static_cast<int>(std::min(max_msg_size, nbyte));
-        broadcast_impl(buf, n, root, dowork, bcast_tag, world_);
+        broadcast_impl(buf, n);
         nbyte -= n;
-        buf = static_cast<char*>(buf) + n;
+        buf = static_cast<char *>(buf) + n;
       }
     }
 

--- a/src/madness/world/worldgop.cc
+++ b/src/madness/world/worldgop.cc
@@ -194,9 +194,9 @@ namespace madness {
     void WorldGopInterface::broadcast(void* buf, size_t nbyte, ProcessID root, bool dowork, Tag bcast_tag) {
       if(bcast_tag < 0)
         bcast_tag = world_.mpi.unique_tag();
-      const size_t int_max = static_cast<size_t>(std::numeric_limits<int>::max());
+      const size_t max_msg_size = static_cast<size_t>(max_reducebcast_msg_size());
       while (nbyte) {
-        const int n = static_cast<int>(std::min(int_max, nbyte));
+        const int n = static_cast<int>(std::min(max_msg_size, nbyte));
         broadcast_impl(buf, n, root, dowork, bcast_tag, world_);
         nbyte -= n;
         buf = static_cast<char*>(buf) + n;


### PR DESCRIPTION
 They control the max size of buffers used by reduce/broadcast ... this may help the issues with MPI errors seen on Perlmutter when sum-reducing large arrays.

Control programmatically (`world.gop.set_max_reducebcast_msg_size()`) as needed or once at startup by setting environment variable `MAD_MAX_REDUCEBCAST_MSG_SIZE`
