### PR TITLE
fix screening logic bug in do_apply

### DIFF
--- a/src/madness/mra/funcimpl.h
+++ b/src/madness/mra/funcimpl.h
@@ -4788,8 +4788,9 @@ template<size_t NDIM>
 
             const std::vector<opkeyT>& disp = op->get_disp(key.level()); // list of displacements sorted in orer of increasing distance
             const std::vector<bool> is_periodic(NDIM,false); // Periodic sum is already done when making rnlp
-	    int ndone=1;	// Counts #done at each distance
-	    uint64_t distsq = 99999999999999; 
+            int nvalid=1;       // Counts #valid at each distance
+            int nused=1;	// Counts #used at each distance
+	    uint64_t distsq = 99999999999999;
             for (typename std::vector<opkeyT>::const_iterator it=disp.begin(); it != disp.end(); ++it) {
 	        keyT d;
                 Key<NDIM-opdim> nullkey(key.level());
@@ -4798,24 +4799,26 @@ template<size_t NDIM>
 
 		uint64_t dsq = d.distsq();
 		if (dsq != distsq) { // Moved to next shell of neighbors
-		    if (ndone == 0 && dsq > 1) {
+		    if (nvalid > 0 && nused == 0 && dsq > 1) {
 		        // Have at least done the input box and all first
 		        // nearest neighbors, and for all of the last set
 		        // of neighbors had no contribution.  Thus,
 		        // assuming monotonic decrease, we are done.
 		        break;
 		    }
-		    ndone = 0;
+		    nused = 0;
+                    nvalid = 0;
 		    distsq = dsq;
 		} 
 
                 keyT dest = neighbor(key, d, is_periodic);
                 if (dest.is_valid()) {
+                    nvalid++;
                     double opnorm = op->norm(key.level(), *it, source);
                     double tol = truncate_tol(thresh, key);
 
                     if (cnorm*opnorm> tol/fac) {
-		        ndone++;
+                        nused++;
 		        tensorT result = op->apply(source, *it, c, tol/fac/cnorm);
 			if (result.normf() > 0.3*tol/fac) {
 			  if (coeffs.is_local(dest))


### PR DESCRIPTION
switch to shell-based screening in https://github.com/m-a-d-n-e-s-s/madness/commit/8523617d827b6278f6f01a546818da8703027601 that supports anisotropic interactions did not account for shells entirely outside the simulation cell  ... this causes qualitative errors in application of periodic GFs, but  non-periodic case is also affected (imperceptibly?).