### PR TITLE
Fixes problem with setting units to au or Bohr

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -40,7 +40,7 @@ jobs:
         -DMPIEXEC_PREFLAGS='--bind-to;none;--allow-run-as-root'
         -DBUILD_TESTING=ON
         -DMADNESS_ENABLE_CEREAL=ON
-        -DMADNESS_BUILD_MADWORLD_ONLY=${{ matrix.task_backend != 'Threads' || matrix.build_type == 'Debug' }}
+        -DMADNESS_BUILD_MADWORLD_ONLY=${{ matrix.task_backend != 'Threads' }}
         -DMADNESS_BUILD_LIBRARIES_ONLY=${{ matrix.build_type != 'Debug' }}
 
     steps:
@@ -134,11 +134,13 @@ jobs:
       run: cmake --build . --target check-short-madness
 
     - name: Install
+      if: matrix.build_type != 'Debug'
       working-directory: ${{github.workspace}}/build
       shell: bash
       run: cmake --build . --target install
 
     - name: Test Install Tree
+      if: matrix.build_type != 'Debug'
       working-directory: ${{github.workspace}}/build
       shell: bash
       run: |
@@ -146,6 +148,6 @@ jobs:
         cmake --build test_install
         test_install/test_runtime
         # if built more than just MADWorld run the HF test
-        if [ "X${{ matrix.task_backend }}" = "XThreads" && "X${{ matrix.build_type }}" != "XDebug" ]; then
+        if [ "X${{ matrix.task_backend }}" = "XThreads" ]; then
            test_install/simple_hf
         fi

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -40,7 +40,7 @@ jobs:
         -DMPIEXEC_PREFLAGS='--bind-to;none;--allow-run-as-root'
         -DBUILD_TESTING=ON
         -DMADNESS_ENABLE_CEREAL=ON
-        -DMADNESS_BUILD_MADWORLD_ONLY=${{ matrix.task_backend != 'Threads' }}
+        -DMADNESS_BUILD_MADWORLD_ONLY=${{ matrix.task_backend != 'Threads' || matrix.build_type == 'Debug' }}
         -DMADNESS_BUILD_LIBRARIES_ONLY=${{ matrix.build_type != 'Debug' }}
 
     steps:
@@ -145,6 +145,7 @@ jobs:
         cmake -S $GITHUB_WORKSPACE/doc/tutorial -B test_install -DCMAKE_PREFIX_PATH=${{github.workspace}}/install
         cmake --build test_install
         test_install/test_runtime
-        if [ "X${{ matrix.task_backend }}" = "XThreads" ]; then  # if built more than just MADWorld run the HF test
+        # if built more than just MADWorld run the HF test
+        if [ "X${{ matrix.task_backend }}" = "XThreads" && "X${{ matrix.build_type }}" != "XDebug" ]; then
            test_install/simple_hf
         fi

--- a/src/examples/dielectric.cc
+++ b/src/examples/dielectric.cc
@@ -256,11 +256,11 @@ int main(int argc, char **argv) {
     print("coords", atomic_coords);
 
     // Functors for mask related quantities
-    real_functor_3d volume_functor(new MolecularVolumeMask(sigma, atomic_radii, atomic_coords));
-    real_functor_3d gradx_functor(new MolecularVolumeMaskGrad(sigma, atomic_radii, atomic_coords, 0));
-    real_functor_3d grady_functor(new MolecularVolumeMaskGrad(sigma, atomic_radii, atomic_coords, 1));
-    real_functor_3d gradz_functor(new MolecularVolumeMaskGrad(sigma, atomic_radii, atomic_coords, 2));
-    real_functor_3d surface_functor(new MolecularSurface(sigma, atomic_radii, atomic_coords));
+    auto volume_functor = std::make_shared<MolecularVolumeMask>(sigma, atomic_radii, atomic_coords);
+    auto gradx_functor = std::make_shared<MolecularVolumeMaskGrad>(sigma, atomic_radii, atomic_coords, 0);
+    auto grady_functor = std::make_shared<MolecularVolumeMaskGrad>(sigma, atomic_radii, atomic_coords, 1);
+    auto gradz_functor = std::make_shared<MolecularVolumeMaskGrad>(sigma, atomic_radii, atomic_coords, 2);
+    auto surface_functor = std::make_shared<MolecularSurface>(sigma, atomic_radii, atomic_coords);
 
     // Make the actual functions
     TIME("make volume ", real_function_3d volume = real_factory_3d(world).functor(volume_functor));

--- a/src/examples/dielectric.cc
+++ b/src/examples/dielectric.cc
@@ -256,11 +256,11 @@ int main(int argc, char **argv) {
     print("coords", atomic_coords);
 
     // Functors for mask related quantities
-    auto volume_functor = std::make_shared<MolecularVolumeMask>(sigma, atomic_radii, atomic_coords);
-    auto gradx_functor = std::make_shared<MolecularVolumeMaskGrad>(sigma, atomic_radii, atomic_coords, 0);
-    auto grady_functor = std::make_shared<MolecularVolumeMaskGrad>(sigma, atomic_radii, atomic_coords, 1);
-    auto gradz_functor = std::make_shared<MolecularVolumeMaskGrad>(sigma, atomic_radii, atomic_coords, 2);
-    auto surface_functor = std::make_shared<MolecularSurface>(sigma, atomic_radii, atomic_coords);
+    auto volume_functor = MolecularVolumeMask(sigma, atomic_radii, atomic_coords);
+    auto gradx_functor = MolecularVolumeMaskGrad(sigma, atomic_radii, atomic_coords, 0);
+    auto grady_functor = MolecularVolumeMaskGrad(sigma, atomic_radii, atomic_coords, 1);
+    auto gradz_functor = MolecularVolumeMaskGrad(sigma, atomic_radii, atomic_coords, 2);
+    auto surface_functor = MolecularSurface(sigma, atomic_radii, atomic_coords);
 
     // Make the actual functions
     TIME("make volume ", real_function_3d volume = real_factory_3d(world).functor(volume_functor));

--- a/src/examples/dielectric_external_field.cc
+++ b/src/examples/dielectric_external_field.cc
@@ -147,12 +147,12 @@ int main(int argc, char **argv) {
     FunctionDefaults<3>::set_bc(BC_FREE);
 
     // The Coulomb operator (this is just 1/r ... whereas the notes are -1/4pir)
-    real_convolution_3d op = CoulombOperator(world, sigma*0.001, thresh*0.1);
+    auto op = CoulombOperator(world, sigma*0.001, thresh*0.1);
 
     // Derivative operators
-    real_derivative_3d Dx = free_space_derivative<double,3>(world, 0);
-    real_derivative_3d Dy = free_space_derivative<double,3>(world, 1);
-    real_derivative_3d Dz = free_space_derivative<double,3>(world, 2);
+    auto Dx = free_space_derivative<double,3>(world, 0);
+    auto Dy = free_space_derivative<double,3>(world, 1);
+    auto Dz = free_space_derivative<double,3>(world, 2);
 
     // We will have one sphere of radius R centered at the origin
     vector<double> atomic_radii(1,R-delta);
@@ -169,9 +169,9 @@ int main(int argc, char **argv) {
     print(MolecularVolumeExponentialSwitchLogGrad(sigma,epsilon_1,epsilon_0, atomic_radii, atomic_coords,0).special_points());
 
     // Log derivative of the dielectric function
-    real_function_3d logdx = real_factory_3d(world).functor(real_functor_3d(new MolecularVolumeExponentialSwitchLogGrad(sigma,epsilon_1,epsilon_0, atomic_radii, atomic_coords,0)));
-    real_function_3d logdy = real_factory_3d(world).functor(real_functor_3d(new MolecularVolumeExponentialSwitchLogGrad(sigma,epsilon_1,epsilon_0, atomic_radii, atomic_coords,1)));
-    real_function_3d logdz = real_factory_3d(world).functor(real_functor_3d(new MolecularVolumeExponentialSwitchLogGrad(sigma,epsilon_1,epsilon_0, atomic_radii, atomic_coords,2)));
+    std::vector<real_function_3d> logd(3);
+    for (int i = 0; i < 3; i++)
+      logd.emplace_back(real_factory_3d(world).functor(MolecularVolumeExponentialSwitchLogGrad(sigma,epsilon_1,epsilon_0, atomic_radii, atomic_coords,i)));
 
     //double area = 4*madness::constants::pi*R*R;
     //double simulation_volume = 8*L*L*L;
@@ -186,7 +186,7 @@ int main(int argc, char **argv) {
     real_function_3d surface_charge, old_surface_charge(world);
     for (int iter=0; iter<20; iter++) {
         // Scale with 1/4pi AFTER applying operator to get one more digit of accuracy
-        surface_charge = (logdx*Dx(u) + logdy*Dy(u) + logdz*(-Ez+Dz(u))).truncate();
+        surface_charge = (logd[0]*Dx(u) + logd[1]*Dy(u) + logd[2]*(-Ez+Dz(u))).truncate();
         real_function_3d r = (u - op(surface_charge).scale(rfourpi)).truncate(thresh*0.032);
         surface_charge.scale(rfourpi);
 

--- a/src/examples/dirac-hatom.cc
+++ b/src/examples/dirac-hatom.cc
@@ -961,12 +961,12 @@ struct ExactSpinor : public FunctionFunctorInterface<double_complex,3> {
     }
 
     void set_ansatz(const AnsatzBase& ansatz) {
-        compute_F =  (ansatz.iansatz==3) ? true  : false;
+        compute_F = (ansatz.iansatz == 3);
         cusp_a=ansatz.get_cusp_a();
-        regularized= (ansatz.iansatz==0) ? false : true;
+        regularized= !(ansatz.iansatz == 0);
     }
 
-    int l_char_to_int(const char lc) const {
+    static int l_char_to_int(const char lc) {
         int ll=0;
         if (lc=='S') ll=0;
         else if (lc=='P') ll=1;
@@ -1323,10 +1323,10 @@ void run(World& world, ansatzT ansatz, const int nuclear_charge, const commandli
         guess= schrodinger2dirac(wf,ansatz,nuclear_charge);
     } else {
         print("\nUsing exact spinor guess\n");
-        for (int i=0; i<nstates; ++i) {
-            states[i].set_ansatz(ansatz);
-            guess.push_back(states[i].get_spinor(world));
-            states[i].print();
+        for (auto& state: states) {
+            state.set_ansatz(ansatz);
+            guess.push_back(state.get_spinor(world));
+            state.print();
             guess.back().print_norms("guess");
 
         }

--- a/src/madness/chem/molecule.h
+++ b/src/madness/chem/molecule.h
@@ -209,7 +209,7 @@ public:
 //            }
 
             if (source_type()=="xyz") set_derived_value("units",std::string("angstrom"));
-            if (units()=="bohr" or units()=="au") set_derived_value("units","atomic");
+            if (units()=="bohr" or units()=="au") set_derived_value("units",std::string("atomic"));
         }
 
         std::string source_type() const {return get<std::string>("source_type");}

--- a/src/madness/mra/mraimpl.h
+++ b/src/madness/mra/mraimpl.h
@@ -1042,10 +1042,7 @@ namespace madness {
     template <typename T, std::size_t NDIM>
     void FunctionImpl<T,NDIM>::diff(const DerivativeBase<T,NDIM>* D, const implT* f, bool fence) {
         typedef std::pair<keyT,coeffT> argT;
-        typename dcT::const_iterator end = f->coeffs.end();
-        for (typename dcT::const_iterator it=f->coeffs.begin(); it!=end; ++it) {
-            const keyT& key = it->first;
-            const nodeT& node = it->second;
+        for (const auto& [key, node]: f->coeffs) {
             if (node.has_coeff()) {
                 Future<argT> left  = D->find_neighbor(f, key,-1);
                 argT center(key,node.coeff());


### PR DESCRIPTION
If using au or bohr the set_derived_value would fail when type checking bare "atomic" in function call.  std::string("atomic") ensures type checking will not fail. 