### PR TITLE
Update cmake.yml

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -40,7 +40,7 @@ jobs:
         -DMPIEXEC_PREFLAGS='--bind-to;none;--allow-run-as-root'
         -DBUILD_TESTING=ON
         -DMADNESS_ENABLE_CEREAL=ON
-        -DMADNESS_BUILD_MADWORLD_ONLY=${{ matrix.task_backend != 'Threads' || matrix.build_type == 'Debug' }}
+        -DMADNESS_BUILD_MADWORLD_ONLY=${{ matrix.task_backend != 'Threads' }}
         -DMADNESS_BUILD_LIBRARIES_ONLY=${{ matrix.build_type != 'Debug' }}
 
     steps:
@@ -134,11 +134,13 @@ jobs:
       run: cmake --build . --target check-short-madness
 
     - name: Install
+      if: matrix.build_type != 'Debug'
       working-directory: ${{github.workspace}}/build
       shell: bash
       run: cmake --build . --target install
 
     - name: Test Install Tree
+      if: matrix.build_type != 'Debug'
       working-directory: ${{github.workspace}}/build
       shell: bash
       run: |
@@ -146,6 +148,6 @@ jobs:
         cmake --build test_install
         test_install/test_runtime
         # if built more than just MADWorld run the HF test
-        if [ "X${{ matrix.task_backend }}" = "XThreads" && "X${{ matrix.build_type }}" != "XDebug" ]; then
+        if [ "X${{ matrix.task_backend }}" = "XThreads" ]; then
            test_install/simple_hf
         fi


### PR DESCRIPTION
Alternate solution to the test failures fixed in #532. We now don't install in debug mode, but still run all non-install tests.