### PR TITLE
[ci] update GHA MacOS runner

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -69,7 +69,7 @@ jobs:
     - name: Install prerequisite MacOS packages
       if: ${{ matrix.os == 'macos-latest' }}
       run: |
-        brew install ninja gcc@10 boost eigen open-mpi bison ccache
+        brew install ninja boost eigen open-mpi bison ccache
         if [ "X${{ matrix.task_backend }}" = "XLegacyTBB" ]; then
           brew install tbb@2020
           echo "TBBROOT=/usr/local/opt/tbb@2020" >> $GITHUB_ENV


### PR DESCRIPTION
MacOS builds were broken due to trying to obtain `gcc@10` ... it's not used anyway

The issue triggered by the switch of `macos-latest` runners to Sonoma/M1 hw

- https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image/
- https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/