### PR TITLE
removed `using namespace madness` from chem headers

### DIFF
--- a/src/madness/chem/QCPropertyInterface.h
+++ b/src/madness/chem/QCPropertyInterface.h
@@ -3,54 +3,55 @@
 
 #include <madness/mra/mra.h>
 #include<madness/chem/molecule.h>
-using namespace madness;
 //class NuclearCorrelationFactor;
 
+namespace madness {
 
 /// class implementing properties of QC models
 class QCPropertyInterface {
 
-    virtual std::string name() const =0;
+  virtual std::string name() const = 0;
 
-    virtual bool selftest() =0;
+  virtual bool selftest() = 0;
 
-    virtual Tensor<double> nuclear_derivative(const real_function_3d& density,
-                                              const Molecule& molecule,
-                                              const std::shared_ptr<NuclearCorrelationFactor> ncf=0) const {
-        print("nuclear_derivative not implemented in ",name());
-        MADNESS_EXCEPTION("feature not implemented",1);
-        return Tensor<double>();
-    }
+  virtual Tensor<double> nuclear_derivative(
+      const real_function_3d &density, const Molecule &molecule,
+      const std::shared_ptr<NuclearCorrelationFactor> ncf = 0) const {
+    print("nuclear_derivative not implemented in ", name());
+    MADNESS_EXCEPTION("feature not implemented", 1);
+    return Tensor<double>();
+  }
 
-    virtual real_function_3d density() const {
-        print("density not implemented in ",name());
-        MADNESS_EXCEPTION("feature not implemented",1);
-    }
+  virtual real_function_3d density() const {
+    print("density not implemented in ", name());
+    MADNESS_EXCEPTION("feature not implemented", 1);
+  }
 
-    virtual real_function_3d no_cusp_density() const {
-        print("no_cusp_density not implemented in ",name());
-        MADNESS_EXCEPTION("feature not implemented",1);
-    }
+  virtual real_function_3d no_cusp_density() const {
+    print("no_cusp_density not implemented in ", name());
+    MADNESS_EXCEPTION("feature not implemented", 1);
+  }
 
-    virtual real_function_3d spindensity(const int spin) const {
-        MADNESS_ASSERT(spin==0 or spin==1); // alpha or beta
-        print("spindensity not implemented in ",name());
-        MADNESS_EXCEPTION("feature not implemented",1);
-    }
+  virtual real_function_3d spindensity(const int spin) const {
+    MADNESS_ASSERT(spin == 0 or spin == 1); // alpha or beta
+    print("spindensity not implemented in ", name());
+    MADNESS_EXCEPTION("feature not implemented", 1);
+  }
 
-    virtual real_function_3d no_cusp_spindensity(const int spin) const {
-        MADNESS_ASSERT(spin==0 or spin==1); // alpha or beta
-        print("no_cusp_spindensity not implemented in ",name());
-        MADNESS_EXCEPTION("feature not implemented",1);
-    }
+  virtual real_function_3d no_cusp_spindensity(const int spin) const {
+    MADNESS_ASSERT(spin == 0 or spin == 1); // alpha or beta
+    print("no_cusp_spindensity not implemented in ", name());
+    MADNESS_EXCEPTION("feature not implemented", 1);
+  }
 
-    virtual std::vector<double> multipole_moment(const real_function_3d& density, const int l,
-        const Molecule& molecule,
-        const std::shared_ptr<NuclearCorrelationFactor> ncf=0) const {
-            print("dipole moment not implemented in ",name());
-            MADNESS_EXCEPTION("feature not implemented",1);
-    }
-
+  virtual std::vector<double> multipole_moment(
+      const real_function_3d &density, const int l, const Molecule &molecule,
+      const std::shared_ptr<NuclearCorrelationFactor> ncf = 0) const {
+    print("dipole moment not implemented in ", name());
+    MADNESS_EXCEPTION("feature not implemented", 1);
+  }
 };
+
+}  // namespace madness
 
 #endif //MADNESS_QCPROPERTYINTERFACE_H

--- a/src/madness/chem/SCF.cc
+++ b/src/madness/chem/SCF.cc
@@ -36,9 +36,9 @@
 
 
 #include <madness/world/worldmem.h>
-#include<madness.h>
-#include<madness/chem/SCF.h>
-#include<madchem.h>
+#include <madness.h>
+#include <madness/chem/SCF.h>
+#include <madchem.h>
 
 #if defined(__has_include)
 #  if __has_include(<filesystem>)
@@ -138,7 +138,6 @@ tensorT Q2(const tensorT& s) {
     return Q;
 }
 
-}// namespace madness
 // void SCF::output_scf_info_schema(const std::map<std::string, double> &vals,
 //                                  const tensorT &dipole_T) const {
 //     nlohmann::json j = {};
@@ -212,7 +211,7 @@ scf_data::scf_data() : iter(0) {
 
 
 void scf_data::to_json(json &j) const {
-    ::print("SCF DATA TO JSON");
+    madness::print("SCF DATA TO JSON");
 
     j["scf_e_data"] = json();
     j["scf_e_data"]["iterations"] = iter;
@@ -2367,3 +2366,4 @@ void SCF::solve(World& world) {
 
 }        // end solve function
 
+} // namespace madness


### PR DESCRIPTION
`QCPropertyInterface.h`, included throughout chem headers, imported namespace `madness` into global space which amazingly did not break anything until recently