### PR TITLE
save separate real and imaginary MOs for znemo

### DIFF
--- a/src/madness/chem/znemo.cc
+++ b/src/madness/chem/znemo.cc
@@ -1189,17 +1189,30 @@ Znemo::canonicalize(std::vector<complex_function_3d>& amo,
 
 }
 
-
-void Znemo::save_orbitals(std::string suffix) const {
-	suffix="_"+suffix;
-	const real_function_3d& dia=diafac->factor();
-	for (size_t i=0; i<amo.size(); ++i) save(amo[i],"amo"+stringify(i)+suffix);
-	for (size_t i=0; i<bmo.size(); ++i) save(bmo[i],"bmo"+stringify(i)+suffix);
-	for (size_t i=0; i<amo.size(); ++i) save(madness::abs(amo[i]),"absamo"+stringify(i)+suffix);
-	for (size_t i=0; i<bmo.size(); ++i) save(madness::abs(bmo[i]),"absbmo"+stringify(i)+suffix);
-	for (size_t i=0; i<amo.size(); ++i) save(madness::abs(amo[i]*dia),"diaamo"+stringify(i)+suffix);
-	for (size_t i=0; i<bmo.size(); ++i) save(madness::abs(bmo[i]*dia),"diabmo"+stringify(i)+suffix);
-
+void Znemo::save_orbitals(std::string suffix) const
+{
+	suffix = "_" + suffix;
+	const real_function_3d &dia = diafac->factor();
+	for (size_t i = 0; i < amo.size(); ++i)
+		save(amo[i], "amo" + stringify(i) + suffix);
+	for (size_t i = 0; i < bmo.size(); ++i)
+		save(bmo[i], "bmo" + stringify(i) + suffix);
+	for (size_t i = 0; i < amo.size(); ++i)
+		save(real(amo[i]), "amo_real" + stringify(i) + suffix);
+	for (size_t i = 0; i < amo.size(); ++i)
+		save(imag(amo[i]), "amo_imag" + stringify(i) + suffix);
+	for (size_t i = 0; i < bmo.size(); ++i)
+		save(real(bmo[i]), "bmo_real" + stringify(i) + suffix);
+	for (size_t i = 0; i < bmo.size(); ++i)
+		save(imag(bmo[i]), "bmo_imag" + stringify(i) + suffix);
+	for (size_t i = 0; i < amo.size(); ++i)
+		save(madness::abs(amo[i]), "absamo" + stringify(i) + suffix);
+	for (size_t i = 0; i < bmo.size(); ++i)
+		save(madness::abs(bmo[i]), "absbmo" + stringify(i) + suffix);
+	for (size_t i = 0; i < amo.size(); ++i)
+		save(madness::abs(amo[i] * dia), "diaamo" + stringify(i) + suffix);
+	for (size_t i = 0; i < bmo.size(); ++i)
+		save(madness::abs(bmo[i] * dia), "diabmo" + stringify(i) + suffix);
 }
 
 } // namespace madness


### PR DESCRIPTION
Now `znemo` saves real and imaginary molecular orbitals also separately so one can view the real MOs in an orbital visualization program.