### PR TITLE
replace of the "fence" changes from PR #550

### DIFF
--- a/src/madness/world/worldgop.h
+++ b/src/madness/world/worldgop.h
@@ -706,14 +706,14 @@ namespace madness {
 
         /// Synchronizes all processes in communicator AND globally ensures no pending AM or tasks
 
-        /// \internal Runs Dykstra-like termination algorithm on binary tree by
-        /// locally ensuring ntask=0 and all am sent and processed,
-        /// and then participating in a global sum of nsent and nrecv.
-        /// Then globally checks that nsent=nrecv and that both are
-        /// constant over two traversals.  We are then sure
+        /// \internal Runs Dykstra-like termination algorithm on binary tree
+        /// which stops when global sum of # of tasks in queue (`ntask`) is
+        /// zero and global sum of the # of sent/received AMs (`nsent`/`nrecv`)
+        /// are equal and unchanged over two traversals.  We are then sure
         /// that all tasks and AM are processed and there no AM in
         /// flight.
         /// \param[in] debug set to true to print progress statistics using madness::print(); the default is false.
+        /// \post `this->gop.taskq.size()==0`
         void fence(bool debug = false);
 
         /// Executes an action on single (this) thread after ensuring all other work is done


### PR DESCRIPTION
#550 (namely, https://github.com/m-a-d-n-e-s-s/madness/commit/6ab44846c4e2e603d24e731c5bd7f18cbf22fbaf) introduced change in fence semantics that ensure that:
- local # of tasks is zero after reading AM counts
- repeat global termdet after epilogue/cleanup

this caused hangs in various parts of TiledArray when running in Github Action Runners (but not elsewhere). https://github.com/m-a-d-n-e-s-s/madness/commit/93a9a5cec2a8fa87fba3afe8056607e6062a9058 reverted it. This PR contains these changes for reconsideration.