### PR TITLE
Fix to concat0

### DIFF
--- a/src/madness/world/worldgop.h
+++ b/src/madness/world/worldgop.h
@@ -957,24 +957,8 @@ namespace madness {
             world_.mpi.binary_tree_info(0, parent, child0, child1);
             int child0_nbatch = 0, child1_nbatch = 0;
 
-            struct free_dtor {
-              void operator()(std::byte *ptr) {
-                if (ptr != nullptr)
-                  std::free(ptr);
-              };
-            };
-            using sptr_t = std::unique_ptr<std::byte[], free_dtor>;
-
-            sptr_t buf0;
-            if (child0 != -1)
-              buf0 = sptr_t(static_cast<std::byte *>(std::aligned_alloc(
-                                std::alignment_of_v<T>, bufsz)),
-                            free_dtor{});
-            sptr_t buf1;
-            if (child1 != -1)
-              buf1 = sptr_t(static_cast<std::byte *>(std::aligned_alloc(
-                                std::alignment_of_v<T>, bufsz)),
-                            free_dtor{});
+            auto buf0 = std::make_unique<std::byte[]>(bufsz);
+            auto buf1 = std::make_unique<std::byte[]>(bufsz);
 
             // transfer data in chunks at most this large
             const int batch_size = static_cast<int>(

--- a/src/madness/world/worldgop.h
+++ b/src/madness/world/worldgop.h
@@ -799,7 +799,6 @@ namespace madness {
           };
           using sptr_t = std::unique_ptr<T[], free_dtor>;
 
-          sptr_t buf0;
           auto aligned_buf_alloc = [&]() -> T* {
             // posix_memalign requires alignment to be an integer multiple of sizeof(void*)!! so ensure that
             const std::size_t alignment =
@@ -813,9 +812,11 @@ namespace madness {
             }
             return static_cast<T *>(ptr);
 #else
-            return static_cast<T*>(std::aligned_alloc(alignment, buf_size));
+            return static_cast<T *>(std::aligned_alloc(alignment, buf_size));
 #endif
           };
+
+          sptr_t buf0;
           if (child0 != -1)
             buf0 = sptr_t(aligned_buf_alloc(),
                           free_dtor{});
@@ -977,7 +978,7 @@ namespace madness {
 
             // transfer data in chunks at most this large
             const int batch_size = static_cast<int>(
-                std::min(static_cast<size_t>(max_reducebcast_msg_size()),bufsz));
+                std::min(static_cast<size_t>(max_reducebcast_msg_size()), bufsz));
 
             // precompute max # of tags any node ... will need, and allocate them on every node to avoid tag counter divergence
             const int max_nbatch = bufsz / batch_size;


### PR DESCRIPTION
This PR addresses Issue #551 

Original code from commit c7e2673978583334a2a9b555477642ccdc601764 allowed nullptr for buf0 and buf1.

Fixes construction of unique_ptr and ensures buffer size `bufsz` is a multiple of alignment `size_of(void*)`.

Was able to run `mpirun -n 6 moldft input` successfully on my machine with a total cpu time of 321.7s.