### PR TITLE
Hotfix for MADNESS_LINALG_USE_LAPACKE = true

### DIFF
--- a/src/madness/tensor/lapack.cc
+++ b/src/madness/tensor/lapack.cc
@@ -476,11 +476,7 @@ STATIC inline void geqrf_(integer *m, integer *n,
 STATIC inline void geqrf_(integer *m, integer *n,
                           real8 *a, integer *lda, real8 *tau,
                           real8 *work, integer *lwork, integer *infoOUT) {
-#if MADNESS_LINALG_USE_LAPACKE
-	dgeqrf_(LAPACK_ROW_MAJOR, m, n, a, lda, tau, infoOUT);
-#else
 	dgeqrf_(m, n, a, lda, tau, work, lwork, infoOUT);
-#endif
 }
 
 STATIC inline void geqrf_(integer *m, integer *n,


### PR DESCRIPTION
### Description
Although CI passed on this repo, MPQC catches an error when MADNESS_LINALG_USE_LAPACKE = true.
Error is in `dgeqrf_(LAPACK_ROW_MAJOR, m, n, a, lda, tau, infoOUT);`

### Details
- [X] Remove if/else in geqrf_ wrapper for real8 type