### PR TITLE
Fix set_derived_value type error

### DIFF
--- a/src/madness/chem/molecule.h
+++ b/src/madness/chem/molecule.h
@@ -219,7 +219,7 @@ public:
 //            }
 
             if (source_type()=="xyz") set_derived_value("units",std::string("angstrom"));
-            if (units()=="bohr" or units()=="au") set_derived_value("units","atomic");
+            if (units()=="bohr" or units()=="au") set_derived_value("units",std::string("atomic"));
         }
 
         std::string source_type() const {return get<std::string>("source_type");}


### PR DESCRIPTION
Without this change, the `moldft tests/h2o_hf.in` (modulo paths) complains about `type error in set_derived_value for key units`.