### PR TITLE
Add matrix_dot function

### DIFF
--- a/src/madness/mra/funcimpl.h
+++ b/src/madness/mra/funcimpl.h
@@ -164,8 +164,9 @@ namespace madness {
 	        _coeffs(coeff), _norm_tree(norm_tree), _has_children(has_children), dnorm(dnorm), snorm(snorm) {
         }
 
-        FunctionNode(const FunctionNode<T, NDIM>& other) {
-            *this = other;
+        FunctionNode(const FunctionNode<T, NDIM>& other) :
+            _coeffs(other._coeffs), _norm_tree(other._norm_tree), _has_children(other._has_children),
+            dnorm(other.dnorm), snorm(other.snorm) {
         }
 
         FunctionNode<T, NDIM>&
@@ -493,7 +494,7 @@ namespace madness {
         long k;
         bool do_error_leaf_op() const { return false; }
 
-        hartree_leaf_op() {}
+        hartree_leaf_op() = default;
         hartree_leaf_op(const implT* f, const long& k) : f(f), k(k) {}
 
         /// no pre-determination
@@ -558,7 +559,7 @@ namespace madness {
         const implT* f;   ///< the source or result function, needed for truncate_tol
         bool do_error_leaf_op() const { return true; }
 
-        op_leaf_op() {}
+        op_leaf_op() = default;
         op_leaf_op(const opT* op, const implT* f) : op(op), f(f) {}
 
         /// pre-determination: we can't know if this will be a leaf node before we got the final coeffs
@@ -606,7 +607,7 @@ namespace madness {
         const opT* op;
         bool do_error_leaf_op() const { return false; }
 
-        hartree_convolute_leaf_op() {}
+        hartree_convolute_leaf_op() = default;
         hartree_convolute_leaf_op(const implT* f, const implL* g, const opT* op)
             : f(f), g(g), op(op) {}
 
@@ -1177,7 +1178,7 @@ template<size_t NDIM>
             FunctionImpl<T, NDIM>* f; ///< prefactor for current function impl
             T alpha; ///< the current function impl
             R beta; ///< prefactor for other function impl
-            do_gaxpy_inplace() {};
+            do_gaxpy_inplace() = default;
             do_gaxpy_inplace(FunctionImpl<T, NDIM>* f, T alpha, R beta) : f(f), alpha(alpha), beta(beta) {}
             bool operator()(typename rangeT::iterator& it) const {
                 const keyT& key = it->first;
@@ -1379,7 +1380,7 @@ template<size_t NDIM>
             double limit;
             bool log;
             static double lower() { return 1.e-10; };
-            do_convert_to_color() {};
+            do_convert_to_color() = default;
             do_convert_to_color(const double limit, const bool log) : limit(limit), log(log) {}
             double operator()(double val) const {
                 double color=0.0;
@@ -2056,7 +2057,7 @@ template<size_t NDIM>
 			// fast return if the node has children (not a leaf node)
 			if(node.has_children()) return;
 
-			const implT* g=this;
+			const implT* g = this;
 
 			// break the 6D key into two 3D keys (may also work for every even dimension)
 			Key<LDIM> key1, key2;
@@ -2180,7 +2181,7 @@ template<size_t NDIM>
             typedef Range<typename dcT::iterator> rangeT;
 
             /// constructor need impl for cdata
-            remove_internal_coeffs() {}
+            remove_internal_coeffs() = default;
 
             bool operator()(typename rangeT::iterator& it) const {
 
@@ -2198,7 +2199,7 @@ template<size_t NDIM>
             typedef Range<typename dcT::iterator> rangeT;
 
             /// constructor need impl for cdata
-            remove_leaf_coeffs() {}
+            remove_leaf_coeffs() = default;
 
             bool operator()(typename rangeT::iterator& it) const {
                 nodeT& node = it->second;
@@ -2238,7 +2239,7 @@ template<size_t NDIM>
             TensorArgs args;
 
             // constructor takes target precision
-            do_reduce_rank() {}
+            do_reduce_rank() = default;
             do_reduce_rank(const TensorArgs& targs) : args(targs) {}
             do_reduce_rank(const double& thresh) {
                 args.thresh = thresh;
@@ -2583,7 +2584,7 @@ template<size_t NDIM>
             implT* f;
 
             // constructor takes target precision
-            do_change_tensor_type() {}
+            do_change_tensor_type() = default;
             // do_change_tensor_type(const TensorArgs& targs) : targs(targs) {}
             do_change_tensor_type(const TensorArgs& targs, implT& g) : targs(targs), f(&g) {}
 
@@ -2607,7 +2608,7 @@ template<size_t NDIM>
             TensorArgs targs;
 
             // constructor takes target precision
-            do_consolidate_buffer() {}
+            do_consolidate_buffer() = default;
             do_consolidate_buffer(const TensorArgs& targs) : targs(targs) {}
             bool operator()(typename rangeT::iterator& it) const {
                 it->second.consolidate_buffer(targs);
@@ -3094,7 +3095,7 @@ template<size_t NDIM>
             const FunctionImpl<Q, NDIM>* impl_func;
             opT op;
 
-            coeff_value_adaptor() {};
+            coeff_value_adaptor() = default;
             coeff_value_adaptor(const FunctionImpl<Q, NDIM>* impl_func,
                                 const opT& op)
                 : impl_func(impl_func), op(op) {}
@@ -3478,7 +3479,7 @@ template<size_t NDIM>
             /// prefactor for f, g
             double alpha, beta;
 
-            add_op() {};
+            add_op() = default;
             add_op(const ctT& f, const ctT& g, const double alpha, const double beta)
                 : f(f), g(g), alpha(alpha), beta(beta){}
 
@@ -3834,7 +3835,7 @@ template<size_t NDIM>
         	double error = 0.0;
         	double lo = 0.0, hi = 0.0, lo1 = 0.0, hi1 = 0.0, lo2 = 0.0, hi2 = 0.0;
 
-    	    pointwise_multiplier() {}
+    	    pointwise_multiplier() = default;
         	pointwise_multiplier(const Key<NDIM> key, const coeffT& clhs) : coeff_lhs(clhs) {
                 const auto& fcf = FunctionCommonFunctionality<T, NDIM>(coeff_lhs.dim(0));
         		val_lhs = fcf.coeffs2values(key, coeff_lhs);
@@ -4576,7 +4577,7 @@ template<size_t NDIM>
             implT* impl;
 
             // constructor takes target precision
-            do_standard() {}
+            do_standard() = default;
             do_standard(implT* impl) : impl(impl) {}
 
             //
@@ -4610,7 +4611,7 @@ template<size_t NDIM>
             keyT dest;
             double tol, fac, cnorm;
 
-            do_op_args() {}
+            do_op_args() = default;
             do_op_args(const Key<OPDIM>& key, const Key<OPDIM>& d, const keyT& dest, double tol, double fac, double cnorm)
                 : key(key), d(d), dest(dest), tol(tol), fac(fac), cnorm(cnorm) {}
 
@@ -5039,7 +5040,7 @@ template<size_t NDIM>
             opT* apply_op;
 
             // ctor
-            recursive_apply_op() {}
+            recursive_apply_op() = default;
             recursive_apply_op(implT* result,
                                const CoeffTracker<T, LDIM>& iaf, const CoeffTracker<T, LDIM>& iag,
                                const opT* apply_op) : result(result), iaf(iaf), iag(iag), apply_op(apply_op)
@@ -5169,7 +5170,7 @@ template<size_t NDIM>
             const opT* apply_op;
 
             // ctor
-            recursive_apply_op2() {}
+            recursive_apply_op2() = default;
             recursive_apply_op2(implT* result, const ctT& iaf, const opT* apply_op)
             	: result(result), iaf(iaf), apply_op(apply_op) {}
 
@@ -5278,7 +5279,7 @@ template<size_t NDIM>
             Tensor<double> quad_phit;
             Tensor<double> quad_phiw;
         public:
-            do_err_box() {}
+            do_err_box() = default;
 
             do_err_box(const implT* impl, const opT* func, int npt, const Tensor<double>& qx,
                        const Tensor<double>& quad_phit, const Tensor<double>& quad_phiw)
@@ -5341,7 +5342,7 @@ template<size_t NDIM>
             }
 
             template <typename Archive> void serialize(const Archive& ar) {
-                throw "NOT IMPLEMENTED";
+                MADNESS_EXCEPTION("NOT IMPLEMENTED", 1);
             }
         };
 
@@ -5389,7 +5390,7 @@ template<size_t NDIM>
             }
 
             template <typename Archive> void serialize(const Archive& ar) {
-                throw "NOT IMPLEMENTED";
+                MADNESS_EXCEPTION("NOT IMPLEMENTED", 1);
             }
         };
 
@@ -5528,7 +5529,7 @@ template<size_t NDIM>
             }
 
             template <typename Archive> void serialize(const Archive& ar) {
-                throw "NOT IMPLEMENTED";
+                MADNESS_EXCEPTION("NOT IMPLEMENTED", 1);
             }
         };
 
@@ -6299,7 +6300,7 @@ template<size_t NDIM>
             }
 
             template <typename Archive> void serialize(const Archive& ar) {
-                throw "NOT IMPLEMENTED";
+                MADNESS_EXCEPTION("NOT IMPLEMENTED", 1);
             }
         };
 
@@ -6548,7 +6549,7 @@ template<size_t NDIM>
             int dim;				///< 0: project 0..LDIM-1, 1: project LDIM..NDIM-1
 
             // ctor
-            project_out_op() {}
+            project_out_op() = default;
             project_out_op(const implT* fimpl, implL1* result, const ctL& iag, const int dim)
                 : fimpl(fimpl), result(result), iag(iag), dim(dim) {}
             project_out_op(const project_out_op& other)

--- a/src/madness/mra/funcimpl.h
+++ b/src/madness/mra/funcimpl.h
@@ -1184,7 +1184,7 @@ template<size_t NDIM>
             T alpha; ///< the current function impl
             R beta; ///< prefactor for other function impl
             do_gaxpy_inplace() = default;
-            do_gaxpy_inplace(FunctionImpl<T, NDIM>* f, T alpha, R beta) : f(f), alpha(alpha), beta(beta) {}
+            do_gaxpy_inplace(FunctionImpl<T,NDIM>* f, T alpha, R beta) : f(f), alpha(alpha), beta(beta) {}
             bool operator()(typename rangeT::iterator& it) const {
                 const keyT& key = it->first;
                 const FunctionNode<Q,NDIM>& other_node = it->second;
@@ -1384,7 +1384,7 @@ template<size_t NDIM>
         struct do_convert_to_color {
             double limit;
             bool log;
-            static double lower() { return 1.e-10; };
+            static double lower() {return 1.e-10;};
             do_convert_to_color() = default;
             do_convert_to_color(const double limit, const bool log) : limit(limit), log(log) {}
             double operator()(double val) const {
@@ -2064,7 +2064,7 @@ template<size_t NDIM>
 			// fast return if the node has children (not a leaf node)
 			if(node.has_children()) return;
 
-			const implT* g = this;
+			const implT* g=this;
 
 			// break the 6D key into two 3D keys (may also work for every even dimension)
 			Key<LDIM> key1, key2;
@@ -3112,7 +3112,7 @@ template<size_t NDIM>
             opT op;
 
             coeff_value_adaptor() = default;
-            coeff_value_adaptor(const FunctionImpl<Q, NDIM>* impl_func,
+            coeff_value_adaptor(const FunctionImpl<Q,NDIM>* impl_func,
                                 const opT& op)
                 : impl_func(impl_func), op(op) {}
 
@@ -5433,7 +5433,7 @@ template<size_t NDIM>
             }
 
             resultT operator()(resultT a, resultT b) const {
-                return (a + b);
+                return (a+b);
             }
 
             template <typename Archive> void serialize(const Archive& ar) {
@@ -5636,7 +5636,7 @@ template<size_t NDIM>
         template <typename R>
         static void do_inner_localX(const typename mapT::iterator lstart,
                                     const typename mapT::iterator lend,
-                                    typename FunctionImpl<R, NDIM>::mapT* rmap_ptr,
+                                    typename FunctionImpl<R,NDIM>::mapT* rmap_ptr,
                                     const bool sym,
                                     Tensor< TENSOR_RESULT_TYPE(T,R) >* result_ptr,
                                     Mutex* mutex) {
@@ -5651,7 +5651,7 @@ template<size_t NDIM>
                     const int nleft = leftv.size();
                     const int nright= rightv.size();
 
-                    for (int iv = 0; iv < nleft; iv++) {
+                    for (int iv=0; iv<nleft; iv++) {
                         const int i = leftv[iv].first;
                         const GenTensor<T>* iptr = leftv[iv].second;
 
@@ -5659,8 +5659,8 @@ template<size_t NDIM>
                             const int j = rightv[jv].first;
                             const GenTensor<R>* jptr = rightv[jv].second;
 
-                            if (!sym || (sym && i <= j))
-                                r(i, j) += iptr->trace_conj(*jptr);
+                            if (!sym || (sym && i<=j))
+                                r(i,j) += iptr->trace_conj(*jptr);
                         }
                     }
                 }
@@ -5673,7 +5673,7 @@ template<size_t NDIM>
        template <typename R>
        static void do_inner_localX(const typename mapT::iterator lstart,
                                    const typename mapT::iterator lend,
-                                   typename FunctionImpl<R, NDIM>::mapT* rmap_ptr,
+                                   typename FunctionImpl<R,NDIM>::mapT* rmap_ptr,
                                    const bool sym,
                                    Tensor< TENSOR_RESULT_TYPE(T,R) >* result_ptr,
                                    Mutex* mutex) {
@@ -5817,10 +5817,10 @@ template<size_t NDIM>
             //                Rij += Aki*Bkj
 
             mapT lmap = make_key_vec_map(left);
-            typename FunctionImpl<R, NDIM>::mapT rmap;
-            auto* rmap_ptr = (typename FunctionImpl<R, NDIM>::mapT*)(&lmap);
-            if ((std::vector<const FunctionImpl<R, NDIM>*>*)(&left) != &right) {
-                rmap = FunctionImpl<R, NDIM>::make_key_vec_map(right);
+            typename FunctionImpl<R,NDIM>::mapT rmap;
+            auto* rmap_ptr = (typename FunctionImpl<R,NDIM>::mapT*)(&lmap);
+            if ((std::vector<const FunctionImpl<R,NDIM>*>*)(&left) != &right) {
+                rmap = FunctionImpl<R,NDIM>::make_key_vec_map(right);
                 rmap_ptr = &rmap;
             }
 
@@ -5829,7 +5829,7 @@ template<size_t NDIM>
             Tensor< TENSOR_RESULT_TYPE(T,R) > r(left.size(), right.size());
             Mutex mutex;
 
-            typename mapT::iterator lstart = lmap.begin();
+            typename mapT::iterator lstart=lmap.begin();
             while (lstart != lmap.end()) {
                 typename mapT::iterator lend = lstart;
                 advance(lend,chunk);

--- a/src/madness/mra/funcimpl.h
+++ b/src/madness/mra/funcimpl.h
@@ -1,7 +1,7 @@
 /*
   This file is part of MADNESS.
 
-  Copyright (C) 2007, 2010 Oak Ridge National Laboratory
+  Copyright (C) 2007,2010 Oak Ridge National Laboratory
 
   This program is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -130,15 +130,15 @@ namespace madness {
         // be no need to set as volatile since the container internally
         // stores the entire entry as volatile
 
-        coeffT _coeffs;       ///< The coefficients, if any
-        double _norm_tree;    ///< After norm_tree will contain norm of coefficients summed up tree
-        bool _has_children;   ///< True if there are children
-        coeffT buffer;        ///< The coefficients, if any
-        double dnorm = -1.0;  ///< norm of the d coefficients, also defined if there are no d coefficients
-        double snorm = -1.0;  ///< norm of the s coefficients
+        coeffT _coeffs; ///< The coefficients, if any
+        double _norm_tree; ///< After norm_tree will contain norm of coefficients summed up tree
+        bool _has_children; ///< True if there are children
+        coeffT buffer; ///< The coefficients, if any
+        double dnorm=-1.0;	///< norm of the d coefficients, also defined if there are no d coefficients
+        double snorm=-1.0;	///< norm of the s coefficients
 
     public:
-        typedef WorldContainer<Key<NDIM> , FunctionNode<T, NDIM>> dcT; ///< Type of container holding the nodes
+        typedef WorldContainer<Key<NDIM> , FunctionNode<T, NDIM> > dcT; ///< Type of container holding the nodes
         /// Default constructor makes node without coeff or children
         FunctionNode() :
             _coeffs(), _norm_tree(1e300), _has_children(false) {
@@ -161,7 +161,7 @@ namespace madness {
 
         explicit
         FunctionNode(const coeffT& coeff, double norm_tree, double snorm, double dnorm, bool has_children) :
-	        _coeffs(coeff), _norm_tree(norm_tree), _has_children(has_children), dnorm(dnorm), snorm(snorm) {
+	  _coeffs(coeff), _norm_tree(norm_tree), _has_children(has_children), dnorm(dnorm), snorm(snorm) {
         }
 
         FunctionNode(const FunctionNode<T, NDIM>& other) :
@@ -187,35 +187,41 @@ namespace madness {
         /// Choose to not overload copy and type conversion operators
         /// so there are no automatic type conversions.
         template<typename Q>
-        FunctionNode<Q, NDIM> convert() const {
-            return FunctionNode<Q, NDIM> (madness::convert<Q, T>(coeff()), _norm_tree, snorm, dnorm, _has_children);
+        FunctionNode<Q, NDIM>
+        convert() const {
+            return FunctionNode<Q, NDIM> (madness::convert<Q,T>(coeff()), _norm_tree, snorm, dnorm, _has_children);
         }
 
         /// Returns true if there are coefficients in this node
-        bool has_coeff() const {
+        bool
+        has_coeff() const {
             return _coeffs.has_data();
         }
 
 
         /// Returns true if this node has children
-        bool has_children() const {
+        bool
+        has_children() const {
             return _has_children;
         }
 
         /// Returns true if this does not have children
-        bool is_leaf() const {
+        bool
+        is_leaf() const {
             return !_has_children;
         }
 
         /// Returns true if this node is invalid (no coeffs and no children)
-        bool is_invalid() const {
+        bool
+        is_invalid() const {
             return !(has_coeff() || has_children());
         }
 
         /// Returns a non-const reference to the tensor containing the coeffs
 
         /// Returns an empty tensor if there are no coefficients.
-        coeffT& coeff() {
+        coeffT&
+        coeff() {
             MADNESS_ASSERT(_coeffs.ndim() == -1 || (_coeffs.dim(0) <= 2
                                                     * MAXK && _coeffs.dim(0) >= 0));
             return const_cast<coeffT&>(_coeffs);
@@ -224,7 +230,8 @@ namespace madness {
         /// Returns a const reference to the tensor containing the coeffs
 
         /// Returns an empty tensor if there are no coefficeints.
-        const coeffT& coeff() const {
+        const coeffT&
+        coeff() const {
             return const_cast<const coeffT&>(_coeffs);
         }
 
@@ -246,10 +253,10 @@ namespace madness {
         }
 
         /// Sets \c has_children attribute to true recurring up to ensure connected
-        void set_has_children_recursive(const typename FunctionNode<T, NDIM>::dcT& c, const Key<NDIM>& key) {
+        void set_has_children_recursive(const typename FunctionNode<T,NDIM>::dcT& c,const Key<NDIM>& key) {
             //madness::print("   set_chi_recu: ", key, *this);
             //PROFILE_MEMBER_FUNC(FunctionNode); // Too fine grain for routine profiling
-            if (!(has_children() || has_coeff() || key.level() == 0)) {
+            if (!(has_children() || has_coeff() || key.level()==0)) {
                 // If node already knows it has children or it has
                 // coefficients then it must already be connected to
                 // its parent.  If not, the node was probably just
@@ -259,9 +266,9 @@ namespace madness {
                 // Task on next line used to be TaskAttributes::hipri()) ... but deferring execution of this
                 // makes sense since it is not urgent and lazy connection will likely mean that less forwarding
                 // will happen since the upper level task will have already made the connection.
-                const_cast<dcT&>(c).task(parent, &FunctionNode<T, NDIM>::set_has_children_recursive, c, parent);
-                //const_cast<dcT&>(c).send(parent, &FunctionNode<T, NDIM>::set_has_children_recursive, c, parent);
-                //madness::print("   set_chi_recu: forwarding", key, parent);
+                const_cast<dcT&>(c).task(parent, &FunctionNode<T,NDIM>::set_has_children_recursive, c, parent);
+                //const_cast<dcT&>(c).send(parent, &FunctionNode<T,NDIM>::set_has_children_recursive, c, parent);
+                //madness::print("   set_chi_recu: forwarding",key,parent);
             }
             _has_children = true;
         }
@@ -274,16 +281,16 @@ namespace madness {
         /// Takes a \em shallow copy of the coeff --- same as \c this->coeff()=coeff
         void set_coeff(const coeffT& coeffs) {
             coeff() = coeffs;
-            if ((_coeffs.has_data()) and ((_coeffs.dim(0) < 0) || (_coeffs.dim(0) > 2 * MAXK))) {
+            if ((_coeffs.has_data()) and ((_coeffs.dim(0) < 0) || (_coeffs.dim(0)>2*MAXK))) {
                 print("set_coeff: may have a problem");
-                print("set_coeff: coeff.dim[0] =", coeffs.dim(0), ", 2* MAXK =", 2 * MAXK);
+                print("set_coeff: coeff.dim[0] =", coeffs.dim(0), ", 2* MAXK =", 2*MAXK);
             }
-            MADNESS_ASSERT(coeffs.dim(0) <= 2 * MAXK && coeffs.dim(0) >= 0);
+            MADNESS_ASSERT(coeffs.dim(0)<=2*MAXK && coeffs.dim(0)>=0);
         }
 
         /// Clears the coefficients (has_coeff() will subsequently return false)
         void clear_coeff() {
-            coeff() = coeffT();
+            coeff()=coeffT();
         }
 
         /// Scale the coefficients of this node
@@ -322,7 +329,7 @@ namespace madness {
             return snorm;
         }
 
-        void recompute_snorm_and_dnorm(const FunctionCommonData<T, NDIM>& cdata) {
+        void recompute_snorm_and_dnorm(const FunctionCommonData<T,NDIM>& cdata) {
             snorm = 0.0;
             dnorm = 0.0;
             if (coeff().size() == 0) { ;
@@ -352,64 +359,64 @@ namespace madness {
         /// This/other may not have coefficients.  Has_children will be
         /// true in the result if either this/other have children.
         template <typename Q, typename R>
-        void gaxpy_inplace(const T& alpha, const FunctionNode<Q, NDIM>& other, const R& beta) {
+        void gaxpy_inplace(const T& alpha, const FunctionNode<Q,NDIM>& other, const R& beta) {
             //PROFILE_MEMBER_FUNC(FuncNode);  // Too fine grain for routine profiling
             if (other.has_children())
                 _has_children = true;
             if (has_coeff()) {
                 if (other.has_coeff()) {
-                    coeff().gaxpy(alpha, other.coeff(), beta);
+                    coeff().gaxpy(alpha,other.coeff(),beta);
                 }
                 else {
                     coeff().scale(alpha);
                 }
             }
             else if (other.has_coeff()) {
-                coeff() = other.coeff() * beta; //? Is this the correct type conversion?
+                coeff() = other.coeff()*beta; //? Is this the correct type conversion?
             }
         }
 
         /// Accumulate inplace and if necessary connect node to parent
-        void accumulate2(const tensorT& t, const typename FunctionNode<T, NDIM>::dcT& c,
+        void accumulate2(const tensorT& t, const typename FunctionNode<T,NDIM>::dcT& c,
                            const Key<NDIM>& key) {
-	        // double cpu0 = cpu_time();
+	  // double cpu0=cpu_time();
             if (has_coeff()) {
             	MADNESS_ASSERT(coeff().is_full_tensor());
-                // if (coeff().type == TT_FULL) {
-                coeff() += coeffT(t, -1.0, TT_FULL);
-                // } else {
-                //     tensorT cc=coeff().full_tensor_copy();
-                //     cc += t;
-                //     coeff()=coeffT(cc, args);
-                // }
+                //            	if (coeff().type==TT_FULL) {
+                coeff() += coeffT(t,-1.0,TT_FULL);
+                //            	} else {
+                //            		tensorT cc=coeff().full_tensor_copy();;
+                //            		cc += t;
+                //            		coeff()=coeffT(cc,args);
+                //            	}
             }
             else {
                 // No coeff and no children means the node is newly
                 // created for this operation and therefore we must
                 // tell its parent that it exists.
-            	coeff() = coeffT(t, -1.0, TT_FULL);
-                // coeff() = copy(t);
-                // coeff() = coeffT(t, args);
+            	coeff() = coeffT(t,-1.0,TT_FULL);
+                //                coeff() = copy(t);
+                //                coeff() = coeffT(t,args);
                 if ((!_has_children) && key.level()> 0) {
                     Key<NDIM> parent = key.parent();
-                    if (c.is_local(parent))
-                        const_cast<dcT&>(c).send(parent, &FunctionNode<T, NDIM>::set_has_children_recursive, c, parent);
-                    else
-                        const_cast<dcT&>(c).task(parent, &FunctionNode<T, NDIM>::set_has_children_recursive, c, parent);
+		    if (c.is_local(parent))
+			const_cast<dcT&>(c).send(parent, &FunctionNode<T,NDIM>::set_has_children_recursive, c, parent);
+		    else
+		      const_cast<dcT&>(c).task(parent, &FunctionNode<T,NDIM>::set_has_children_recursive, c, parent);
                 }
             }
-            // double cpu1 = cpu_time();
+            //double cpu1=cpu_time();
         }
 
 
         /// Accumulate inplace and if necessary connect node to parent
-        void accumulate(const coeffT& t, const typename FunctionNode<T, NDIM>::dcT& c,
+        void accumulate(const coeffT& t, const typename FunctionNode<T,NDIM>::dcT& c,
                           const Key<NDIM>& key, const TensorArgs& args) {
             if (has_coeff()) {
-                coeff().add_SVD(t, args.thresh);
+                coeff().add_SVD(t,args.thresh);
                 if (buffer.rank()<coeff().rank()) {
                     if (buffer.has_data()) {
-                        buffer.add_SVD(coeff(), args.thresh);
+                        buffer.add_SVD(coeff(),args.thresh);
                     } else {
                         buffer=copy(coeff());
                     }
@@ -424,23 +431,23 @@ namespace madness {
                 if ((!_has_children) && key.level()> 0) {
                     Key<NDIM> parent = key.parent();
 		    if (c.is_local(parent)) 
-		      const_cast<dcT&>(c).send(parent, &FunctionNode<T, NDIM>::set_has_children_recursive, c, parent);
+		      const_cast<dcT&>(c).send(parent, &FunctionNode<T,NDIM>::set_has_children_recursive, c, parent);
 		    else
-		      const_cast<dcT&>(c).task(parent, &FunctionNode<T, NDIM>::set_has_children_recursive, c, parent);
+		      const_cast<dcT&>(c).task(parent, &FunctionNode<T,NDIM>::set_has_children_recursive, c, parent);
                 }
             }
         }
 
         void consolidate_buffer(const TensorArgs& args) {
             if ((coeff().has_data()) and (buffer.has_data())) {
-                coeff().add_SVD(buffer, args.thresh);
+                coeff().add_SVD(buffer,args.thresh);
             } else if (buffer.has_data()) {
-                coeff() = buffer;
+                coeff()=buffer;
             }
-            buffer = coeffT();
+            buffer=coeffT();
         }
 
-        T trace_conj(const FunctionNode<T, NDIM>& rhs) const {
+        T trace_conj(const FunctionNode<T,NDIM>& rhs) const {
             return this->_coeffs.trace_conj((rhs._coeffs));
         }
 
@@ -449,30 +456,30 @@ namespace madness {
             ar & coeff() & _has_children & _norm_tree & dnorm & snorm;
         }
 
-        /// like operator<<(ostream&, const FunctionNode<T, NDIM>&) but
+        /// like operator<<(ostream&, const FunctionNode<T,NDIM>&) but
         /// produces a sequence JSON-formatted key-value pairs
         /// @warning enclose the output in curly braces to make
         /// a valid JSON object
         void print_json(std::ostream& s) const {
             s << "\"has_coeff\":" << this->has_coeff()
-              << ", \"has_children\":" << this->has_children() << ", \"norm\":";
+              << ",\"has_children\":" << this->has_children() << ",\"norm\":";
             double norm = this->has_coeff() ? this->coeff().normf() : 0.0;
             if (norm < 1e-12)
                 norm = 0.0;
             double nt = this->get_norm_tree();
             if (nt == 1e300)
                 nt = 0.0;
-            s << norm << ", \"norm_tree\":" << nt << ", \"snorm\":"
-              << this->get_snorm() << ", \"dnorm\":" << this->get_dnorm()
-              << ", \"rank\":" << this->coeff().rank();
+            s << norm << ",\"norm_tree\":" << nt << ",\"snorm\":"
+              << this->get_snorm() << ",\"dnorm\":" << this->get_dnorm()
+              << ",\"rank\":" << this->coeff().rank();
             if (this->coeff().is_assigned())
-                s << ", \"dim\":" << this->coeff().dim(0);
+                s << ",\"dim\":" << this->coeff().dim(0);
         }
 
     };
 
     template <typename T, std::size_t NDIM>
-    std::ostream& operator<<(std::ostream& s, const FunctionNode<T, NDIM>& node) {
+    std::ostream& operator<<(std::ostream& s, const FunctionNode<T,NDIM>& node) {
         s << "(has_coeff=" << node.has_coeff() << ", has_children=" << node.has_children() << ", norm=";
         double norm = node.has_coeff() ? node.coeff().normf() : 0.0;
         if (norm < 1e-12)
@@ -489,20 +496,20 @@ namespace madness {
     template<typename T, size_t NDIM>
     struct hartree_leaf_op {
 
-        typedef FunctionImpl<T, NDIM> implT;
-        const FunctionImpl<T, NDIM>* f;
+        typedef FunctionImpl<T,NDIM> implT;
+        const FunctionImpl<T,NDIM>* f;
         long k;
-        bool do_error_leaf_op() const { return false; }
+        bool do_error_leaf_op() const {return false;}
 
         hartree_leaf_op() = default;
         hartree_leaf_op(const implT* f, const long& k) : f(f), k(k) {}
 
         /// no pre-determination
-        bool operator()(const Key<NDIM>& key) const { return false; }
+        bool operator()(const Key<NDIM>& key) const {return false;}
 
         /// no post-determination
         bool operator()(const Key<NDIM>& key, const GenTensor<T>& coeff) const {
-            MADNESS_EXCEPTION("no post-determination in hartree_leaf_op", 1);
+            MADNESS_EXCEPTION("no post-determination in hartree_leaf_op",1);
             return true;
         }
 
@@ -513,37 +520,36 @@ namespace madness {
         /// @param[in]  gcoeff coefficients of g of its appropriate key in NS form
         bool operator()(const Key<NDIM>& key, const Tensor<T>& fcoeff, const Tensor<T>& gcoeff) const {
 
-            if (key.level() < 2) return false;
-            Slice s = Slice(0, k - 1);
-            std::vector<Slice> s0(NDIM / 2, s);
+            if (key.level()<2) return false;
+            Slice s = Slice(0,k-1);
+            std::vector<Slice> s0(NDIM/2,s);
 
-            const double tol = f->get_thresh();
-            const double thresh = f->truncate_tol(tol, key) * 0.3;      // custom factor to "ensure" accuracy
+            const double tol=f->get_thresh();
+            const double thresh=f->truncate_tol(tol, key)*0.3;      // custom factor to "ensure" accuracy
             // include the wavelets in the norm, makes it much more accurate
-            const double fnorm = fcoeff.normf();
-            const double gnorm = gcoeff.normf();
+            const double fnorm=fcoeff.normf();
+            const double gnorm=gcoeff.normf();
 
             // if the final norm is small, perform the hartree product and return
-            const double norm = fnorm * gnorm;  // computing the outer product
+            const double norm=fnorm*gnorm;  // computing the outer product
             if (norm < thresh) return true;
 
             // norm of the scaling function coefficients
-            const double sfnorm = fcoeff(s0).normf();
-            const double sgnorm = gcoeff(s0).normf();
+            const double sfnorm=fcoeff(s0).normf();
+            const double sgnorm=gcoeff(s0).normf();
 
             // get the error of both functions and of the pair function;
             // need the abs for numerics: sfnorm might be equal fnorm.
-            const double ferror = sqrt(std::abs(fnorm * fnorm - sfnorm * sfnorm));
-            const double gerror = sqrt(std::abs(gnorm * gnorm - sgnorm * sgnorm));
+            const double ferror=sqrt(std::abs(fnorm*fnorm-sfnorm*sfnorm));
+            const double gerror=sqrt(std::abs(gnorm*gnorm-sgnorm*sgnorm));
 
             // if the expected error is small, perform the hartree product and return
-            const double error = fnorm * gerror + ferror * gnorm + ferror * gerror;
-            // const double error = sqrt(fnorm * fnorm * gnorm * gnorm - sfnorm * sfnorm * sgnorm * sgnorm);
+            const double error=fnorm*gerror + ferror*gnorm + ferror*gerror;
+            //            const double error=sqrt(fnorm*fnorm*gnorm*gnorm - sfnorm*sfnorm*sgnorm*sgnorm);
 
             if (error < thresh) return true;
             return false;
         }
-
         template <typename Archive> void serialize (Archive& ar) {
             ar & f & k;
         }
@@ -553,44 +559,45 @@ namespace madness {
     /// coefficients will be small
     template<typename T, size_t NDIM, typename opT>
     struct op_leaf_op {
-        typedef FunctionImpl<T, NDIM> implT;
+        typedef FunctionImpl<T,NDIM> implT;
 
         const opT* op;    ///< the convolution operator
         const implT* f;   ///< the source or result function, needed for truncate_tol
-        bool do_error_leaf_op() const { return true; }
+        bool do_error_leaf_op() const {return true;}
 
         op_leaf_op() = default;
         op_leaf_op(const opT* op, const implT* f) : op(op), f(f) {}
 
         /// pre-determination: we can't know if this will be a leaf node before we got the final coeffs
-        bool operator()(const Key<NDIM>& key) const { return true; }
+        bool operator()(const Key<NDIM>& key) const {return true;}
 
         /// post-determination: return true if operator and coefficient norms are small
         bool operator()(const Key<NDIM>& key, const GenTensor<T>& coeff) const {
-            if (key.level() < 2) return false;
-            const double cnorm = coeff.normf();
-            return this->operator()(key, cnorm);
+            if (key.level()<2) return false;
+            const double cnorm=coeff.normf();
+            return this->operator()(key,cnorm);
         }
 
         /// post-determination: return true if operator and coefficient norms are small
         bool operator()(const Key<NDIM>& key, const double& cnorm) const {
-            if (key.level() < 2) return false;
+            if (key.level()<2) return false;
 
             typedef Key<opT::opdim> opkeyT;
-            const opkeyT source = op->get_source_key(key);
+            const opkeyT source=op->get_source_key(key);
 
-            const double thresh = f->truncate_tol(f->get_thresh(), key);
+            const double thresh=f->truncate_tol(f->get_thresh(),key);
             const std::vector<opkeyT>& disp = op->get_disp(key.level());
             const opkeyT& d = *disp.begin();         // use the zero-displacement for screening
             const double opnorm = op->norm(key.level(), d, source);
-            const double norm = opnorm * cnorm;
-            return norm < thresh;
+            const double norm=opnorm*cnorm;
+            return norm<thresh;
 
         }
 
         template <typename Archive> void serialize (Archive& ar) {
             ar & op & f;
         }
+
     };
 
 
@@ -599,24 +606,24 @@ namespace madness {
     template<typename T, size_t NDIM, size_t LDIM, typename opT>
     struct hartree_convolute_leaf_op {
 
-        typedef FunctionImpl<T, NDIM> implT;
-        typedef FunctionImpl<T, LDIM> implL;
+        typedef FunctionImpl<T,NDIM> implT;
+        typedef FunctionImpl<T,LDIM> implL;
 
-        const FunctionImpl<T, NDIM>* f;
+        const FunctionImpl<T,NDIM>* f;
         const implL* g;     // for use of its cdata only
         const opT* op;
-        bool do_error_leaf_op() const { return false; }
+        bool do_error_leaf_op() const {return false;}
 
         hartree_convolute_leaf_op() = default;
         hartree_convolute_leaf_op(const implT* f, const implL* g, const opT* op)
             : f(f), g(g), op(op) {}
 
         /// no pre-determination
-        bool operator()(const Key<NDIM>& key) const { return true; }
+        bool operator()(const Key<NDIM>& key) const {return true;}
 
         /// no post-determination
         bool operator()(const Key<NDIM>& key, const GenTensor<T>& coeff) const {
-            MADNESS_EXCEPTION("no post-determination in hartree_convolute_leaf_op", 1);
+            MADNESS_EXCEPTION("no post-determination in hartree_convolute_leaf_op",1);
             return true;
         }
 
@@ -628,40 +635,39 @@ namespace madness {
         bool operator()(const Key<NDIM>& key, const Tensor<T>& fcoeff, const Tensor<T>& gcoeff) const {
             //        bool operator()(const Key<NDIM>& key, const GenTensor<T>& coeff) const {
 
-            if (key.level() < 2) return false;
+            if (key.level()<2) return false;
 
-            const double tol = f->get_thresh();
-            const double thresh = f->truncate_tol(tol, key);
+            const double tol=f->get_thresh();
+            const double thresh=f->truncate_tol(tol, key);
             // include the wavelets in the norm, makes it much more accurate
-            const double fnorm = fcoeff.normf();
-            const double gnorm = gcoeff.normf();
+            const double fnorm=fcoeff.normf();
+            const double gnorm=gcoeff.normf();
 
             // norm of the scaling function coefficients
-            const double sfnorm = fcoeff(g->get_cdata().s0).normf();
-            const double sgnorm = gcoeff(g->get_cdata().s0).normf();
+            const double sfnorm=fcoeff(g->get_cdata().s0).normf();
+            const double sgnorm=gcoeff(g->get_cdata().s0).normf();
 
             // if the final norm is small, perform the hartree product and return
-            const double norm = fnorm * gnorm;  // computing the outer product
+            const double norm=fnorm*gnorm;  // computing the outer product
             if (norm < thresh) return true;
 
             // get the error of both functions and of the pair function
-            const double ferror = sqrt(fnorm * fnorm - sfnorm * sfnorm);
-            const double gerror = sqrt(gnorm * gnorm - sgnorm * sgnorm);
+            const double ferror=sqrt(fnorm*fnorm-sfnorm*sfnorm);
+            const double gerror=sqrt(gnorm*gnorm-sgnorm*sgnorm);
 
             // if the expected error is small, perform the hartree product and return
-            const double error = fnorm * gerror + ferror * gnorm + ferror * gerror;
+            const double error=fnorm*gerror + ferror*gnorm + ferror*gerror;
             if (error < thresh) return true;
 
             // now check if the norm of this and the norm of the operator are significant
-            const std::vector<Key<NDIM>>& disp = op->get_disp(key.level());
-            const Key<NDIM>& d = *disp.begin();  // use the zero-displacement for screening
+            const std::vector<Key<NDIM> >& disp = op->get_disp(key.level());
+            const Key<NDIM>& d = *disp.begin();         // use the zero-displacement for screening
             const double opnorm = op->norm(key.level(), d, key);
-            const double final_norm = opnorm * sfnorm * sgnorm;
+            const double final_norm=opnorm*sfnorm*sgnorm;
             if (final_norm < thresh) return true;
 
             return false;
         }
-
         template <typename Archive> void serialize (Archive& ar) {
             ar & f & op;
         }
@@ -671,19 +677,20 @@ namespace madness {
     struct noop {
     	void operator()(const Key<NDIM>& key, const GenTensor<T>& coeff, const bool& is_leaf) const {}
         bool operator()(const Key<NDIM>& key, const GenTensor<T>& fcoeff, const GenTensor<T>& gcoeff) const {
-            MADNESS_EXCEPTION("in noop::operator()", 1);
+            MADNESS_EXCEPTION("in noop::operator()",1);
             return true;
         }
         template <typename Archive> void serialize (Archive& ar) {}
+
     };
 
     /// insert/replaces the coefficients into the function
     template<typename T, std::size_t NDIM>
     struct insert_op {
-    	typedef FunctionImpl<T, NDIM> implT;
+    	typedef FunctionImpl<T,NDIM> implT;
     	typedef Key<NDIM> keyT;
     	typedef GenTensor<T> coeffT;
-    	typedef FunctionNode<T, NDIM> nodeT;
+    	typedef FunctionNode<T,NDIM> nodeT;
 
     	implT* impl;
     	insert_op() : impl() {}
@@ -691,9 +698,8 @@ namespace madness {
     	insert_op(const insert_op& other) : impl(other.impl) {}
     	void operator()(const keyT& key, const coeffT& coeff, const bool& is_leaf) const {
     		MADNESS_ASSERT(impl->get_coeffs().is_local(key));
-            impl->get_coeffs().replace(key, nodeT(coeff, not is_leaf));
+            impl->get_coeffs().replace(key,nodeT(coeff,not is_leaf));
     	}
-
         template <typename Archive> void serialize (Archive& ar) {
             ar & impl;
         }
@@ -706,20 +712,20 @@ namespace madness {
     template<typename T, std::size_t NDIM>
     struct accumulate_op {
         typedef GenTensor<T> coeffT;
-        typedef FunctionNode<T, NDIM> nodeT;
+        typedef FunctionNode<T,NDIM> nodeT;
 
-        FunctionImpl<T, NDIM>* impl;
+        FunctionImpl<T,NDIM>* impl;
         accumulate_op() = default;
-        accumulate_op(FunctionImpl<T, NDIM>* f) : impl(f) {}
+        accumulate_op(FunctionImpl<T,NDIM>* f) : impl(f) {}
         accumulate_op(const accumulate_op& other) = default;
         void operator()(const Key<NDIM>& key, const coeffT& coeff, const bool& is_leaf) const {
             if (coeff.has_data())
                 impl->get_coeffs().task(key, &nodeT::accumulate, coeff, impl->get_coeffs(), key, impl->get_tensor_args());
         }
-
         template <typename Archive> void serialize (Archive& ar) {
             ar & impl;
         }
+
     };
 
 
@@ -727,10 +733,10 @@ template<size_t NDIM>
     struct true_op {
 
     	template<typename T>
-        bool operator()(const Key<NDIM>& key, const T& t) const { return true; }
+        bool operator()(const Key<NDIM>& key, const T& t) const {return true;}
 
     	template<typename T, typename R>
-        bool operator()(const Key<NDIM>& key, const T& t, const R& r) const { return true; }
+        bool operator()(const Key<NDIM>& key, const T& t, const R& r) const {return true;}
         template <typename Archive> void serialize (Archive& ar) {}
 
     };
@@ -741,13 +747,12 @@ template<size_t NDIM>
         typedef GenTensor<T> coeffT;
         coeffT _coeffs;
         bool _has_children;
-        double dnorm = -1.0;
-
+        double dnorm=-1.0;
         ShallowNode() : _coeffs(), _has_children(false) {}
-        ShallowNode(const FunctionNode<T, NDIM>& node)
+        ShallowNode(const FunctionNode<T,NDIM>& node)
             : _coeffs(node.coeff()), _has_children(node.has_children()),
 			  dnorm(node.get_dnorm()) {}
-        ShallowNode(const ShallowNode<T, NDIM>& node)
+        ShallowNode(const ShallowNode<T,NDIM>& node)
             : _coeffs(node.coeff()), _has_children(node._has_children),
 			  dnorm(node.dnorm) {}
 
@@ -782,10 +787,10 @@ template<size_t NDIM>
     template<typename T, size_t NDIM>
     class CoeffTracker {
 
-    	typedef FunctionImpl<T, NDIM> implT;
+    	typedef FunctionImpl<T,NDIM> implT;
     	typedef Key<NDIM> keyT;
     	typedef GenTensor<T> coeffT;
-        typedef std::pair<Key<NDIM>, ShallowNode<T, NDIM>> datumT;
+        typedef std::pair<Key<NDIM>,ShallowNode<T,NDIM> > datumT;
         enum LeafStatus {no, yes, unknown};
 
         /// the funcimpl that has the coeffs
@@ -797,7 +802,7 @@ template<size_t NDIM>
     	/// the coefficients belonging to key
     	coeffT coeff_;
     	/// norm of d coefficients corresponding to key
-    	double dnorm_ = -1.0;
+    	double dnorm_=-1.0;
 
     public:
 
@@ -806,15 +811,15 @@ template<size_t NDIM>
 
     	/// the initial ctor making the root key
     	CoeffTracker(const implT* impl) : impl(impl), key_(), is_leaf_(no) {
-            if (impl) key_ = impl->get_cdata().key0;
+            if (impl) key_=impl->get_cdata().key0;
     	}
 
-    	/// ctor with a pair<keyT, nodeT>
+    	/// ctor with a pair<keyT,nodeT>
     	explicit CoeffTracker(const CoeffTracker& other, const datumT& datum)
     		: impl(other.impl), key_(other.key_), coeff_(datum.second.coeff()),
     			dnorm_(datum.second.dnorm) {
-            if (datum.second.is_leaf()) is_leaf_ = yes;
-            else is_leaf_ = no;
+            if (datum.second.is_leaf()) is_leaf_=yes;
+            else is_leaf_=no;
     	}
 
     	/// copy ctor
@@ -822,13 +827,13 @@ template<size_t NDIM>
     			is_leaf_(other.is_leaf_), coeff_(other.coeff_), dnorm_(other.dnorm_) {};
 
     	/// const reference to impl
-    	const implT* get_impl() const { return impl; }
+    	const implT* get_impl() const {return impl;}
 
     	/// const reference to the coeffs
-    	const coeffT& coeff() const { return coeff_; }
+    	const coeffT& coeff() const {return coeff_;}
 
     	/// const reference to the key
-    	const keyT& key() const { return key_; }
+    	const keyT& key() const {return key_;}
 
     	/// return the coefficients belonging to the passed-in key
 
@@ -840,13 +845,13 @@ template<size_t NDIM>
             MADNESS_ASSERT(impl);
             if (impl->is_compressed() or impl->is_nonstandard() or
             		impl->is_nonstandard_with_leaves())
-                return impl->parent_to_child_NS(key, key_, coeff_);
-            return impl->parent_to_child(coeff_, key_, key);
+                return impl->parent_to_child_NS(key,key_,coeff_);
+            return impl->parent_to_child(coeff_,key_,key);
     	}
 
     	/// return the s and dnorm belonging to the passed-in key
     	double dnorm(const keyT& key) const {
-    		if (key == key_) return dnorm_;
+    		if (key==key_) return dnorm_;
     		MADNESS_ASSERT(key.is_child_of(key_));
     		return 0.0;
     	}
@@ -861,16 +866,16 @@ template<size_t NDIM>
             if ((not impl) or impl->is_on_demand()) return CoeffTracker(*this);
 
             // can't make a child without knowing if this is a leaf -- activate first
-            MADNESS_ASSERT((is_leaf_ == yes) or (is_leaf_ == no));
+            MADNESS_ASSERT((is_leaf_==yes) or (is_leaf_==no));
 
             CoeffTracker result;
             if (impl) {
                 result.impl=impl;
-                if (is_leaf_ == yes) result.key_=key_;
-                if (is_leaf_ == no) {
+                if (is_leaf_==yes) result.key_=key_;
+                if (is_leaf_==no) {
                     result.key_=child;
                     // check if child is direct descendent of this, but root node is special case
-                    if (child.level() > 0) MADNESS_ASSERT(result.key().level() == key().level()+1);
+                    if (child.level()>0) MADNESS_ASSERT(result.key().level()==key().level()+1);
                 }
                 result.is_leaf_=unknown;
             }
@@ -887,33 +892,33 @@ template<size_t NDIM>
             if (not impl) return Future<CoeffTracker>(CoeffTracker());
             if (impl->is_on_demand()) return Future<CoeffTracker>(CoeffTracker(impl));
 
-            // this will return a <keyT, nodeT> from a remote node
-            ProcessID p = impl->get_coeffs().owner(key());
-            Future<datumT> datum1 = impl->task(p, &implT::find_datum, key_, TaskAttributes::hipri());
+            // this will return a <keyT,nodeT> from a remote node
+            ProcessID p=impl->get_coeffs().owner(key());
+            Future<datumT> datum1=impl->task(p, &implT::find_datum,key_,TaskAttributes::hipri());
 
             // construct a new CoeffTracker locally
             return impl->world.taskq.add(*const_cast<CoeffTracker*> (this),
-                                         &CoeffTracker::forward_ctor, *this, datum1);
+                                         &CoeffTracker::forward_ctor,*this,datum1);
     	}
 
     private:
     	/// taskq-compatible forwarding to the ctor
     	CoeffTracker forward_ctor(const CoeffTracker& other, const datumT& datum) const {
-            return CoeffTracker(other, datum);
+            return CoeffTracker(other,datum);
     	}
 
     public:
     	/// serialization
         template <typename Archive> void serialize(const Archive& ar) {
-            int il = int(is_leaf_);
+            int il=int(is_leaf_);
             ar & impl & key_ & il & coeff_ & dnorm_;
-            is_leaf_ = LeafStatus(il);
+            is_leaf_=LeafStatus(il);
         }
     };
 
     template<typename T, std::size_t NDIM>
     std::ostream&
-    operator<<(std::ostream& s, const CoeffTracker<T, NDIM>& ct) {
+    operator<<(std::ostream& s, const CoeffTracker<T,NDIM>& ct) {
         s << ct.key() << ct.is_leaf() << " " << ct.get_impl();
         return s;
     }
@@ -934,21 +939,21 @@ template<size_t NDIM>
     /// abused ... NOTHING except FunctionImpl methods should mess with FunctionImplData.
     /// The LB stuff might have to be an exception.
     template <typename T, std::size_t NDIM>
-    class FunctionImpl : public WorldObject< FunctionImpl<T, NDIM>> {
+    class FunctionImpl : public WorldObject< FunctionImpl<T,NDIM> > {
     private:
-        typedef WorldObject< FunctionImpl<T, NDIM>> woT; ///< Base class world object type
+        typedef WorldObject< FunctionImpl<T,NDIM> > woT; ///< Base class world object type
     public:
         typedef T typeT;
-        typedef FunctionImpl<T, NDIM> implT; ///< Type of this class (implementation)
-        typedef std::shared_ptr< FunctionImpl<T, NDIM>> pimplT; ///< pointer to this class
+        typedef FunctionImpl<T,NDIM> implT; ///< Type of this class (implementation)
+        typedef std::shared_ptr< FunctionImpl<T,NDIM> > pimplT; ///< pointer to this class
         typedef Tensor<T> tensorT; ///< Type of tensor for anything but to hold coeffs
-        typedef Vector<Translation, NDIM> tranT; ///< Type of array holding translation
+        typedef Vector<Translation,NDIM> tranT; ///< Type of array holding translation
         typedef Key<NDIM> keyT; ///< Type of key
-        typedef FunctionNode<T, NDIM> nodeT; ///< Type of node
+        typedef FunctionNode<T,NDIM> nodeT; ///< Type of node
         typedef GenTensor<T> coeffT; ///< Type of tensor used to hold coeffs
-        typedef WorldContainer<keyT, nodeT> dcT; ///< Type of container holding the coefficients
-        typedef std::pair<const keyT, nodeT> datumT; ///< Type of entry in container
-        typedef Vector<double, NDIM> coordT; ///< Type of vector holding coordinates
+        typedef WorldContainer<keyT,nodeT> dcT; ///< Type of container holding the coefficients
+        typedef std::pair<const keyT,nodeT> datumT; ///< Type of entry in container
+        typedef Vector<double,NDIM> coordT; ///< Type of vector holding coordinates
 
         //template <typename Q, int D> friend class Function;
         template <typename Q, std::size_t D> friend class FunctionImpl;
@@ -956,31 +961,31 @@ template<size_t NDIM>
         World& world;
 
         /// getter
-        int get_initial_level() const { return initial_level; }
-        int get_special_level() const { return special_level; }
-        const std::vector<Vector<double, NDIM>>& get_special_points() const { return special_points; }
+        int get_initial_level()const{return initial_level;}
+        int get_special_level()const{return special_level;}
+        const std::vector<Vector<double,NDIM> >& get_special_points()const{return special_points;}
 
     private:
         int k; ///< Wavelet order
         double thresh; ///< Screening threshold
         int initial_level; ///< Initial level for refinement
         int special_level; ///< Minimium level for refinement on special points
-        std::vector<Vector<double, NDIM>> special_points; ///< special points for further refinement (needed for composite functions or multiplication)
+        std::vector<Vector<double,NDIM> > special_points; ///< special points for further refinement (needed for composite functions or multiplication)
         int max_refine_level; ///< Do not refine below this level
         int truncate_mode; ///< 0=default=(|d|<thresh), 1=(|d|<thresh/2^n), 1=(|d|<thresh/4^n);
         bool autorefine; ///< If true, autorefine where appropriate
         bool truncate_on_project; ///< If true projection inserts at level n-1 not n
         TensorArgs targs; ///< type of tensor to be used in the FunctionNodes
 
-        const FunctionCommonData<T, NDIM>& cdata;
+        const FunctionCommonData<T,NDIM>& cdata;
 
-        std::shared_ptr< FunctionFunctorInterface<T, NDIM>> functor;
+        std::shared_ptr< FunctionFunctorInterface<T,NDIM> > functor;
         TreeState tree_state;
 
         dcT coeffs; ///< The coefficients
 
         // Disable the default copy constructor
-        FunctionImpl(const FunctionImpl<T, NDIM>& p);
+        FunctionImpl(const FunctionImpl<T,NDIM>& p);
 
     public:
         Timer timer_accumulate;
@@ -993,40 +998,40 @@ template<size_t NDIM>
         AtomicInt large;
 
         /// Initialize function impl from data in factory
-        FunctionImpl(const FunctionFactory<T, NDIM>& factory)
-            : WorldObject<implT>(factory._world),
-              world(factory._world),
-              k(factory._k),
-              thresh(factory._thresh),
-              initial_level(factory._initial_level),
-	          special_level(factory._special_level),
-	          special_points(factory._special_points),
-              max_refine_level(factory._max_refine_level),
-              truncate_mode(factory._truncate_mode),
-              autorefine(factory._autorefine),
-              truncate_on_project(factory._truncate_on_project),
-              // nonstandard(false),
-              targs(factory._thresh, FunctionDefaults<NDIM>::get_tensor_type()),
-              cdata(FunctionCommonData<T, NDIM>::get(k)),
-              functor(factory.get_functor()),
-              // on_demand(factory._is_on_demand),
-              // compressed(factory._compressed),
-              // redundant(false),
-		      tree_state(factory._tree_state),
-              coeffs(world, factory._pmap, false)
-              // , bc(factory._bc)
+        FunctionImpl(const FunctionFactory<T,NDIM>& factory)
+            : WorldObject<implT>(factory._world)
+            , world(factory._world)
+            , k(factory._k)
+            , thresh(factory._thresh)
+            , initial_level(factory._initial_level)
+	    , special_level(factory._special_level)
+	    , special_points(factory._special_points)
+            , max_refine_level(factory._max_refine_level)
+            , truncate_mode(factory._truncate_mode)
+            , autorefine(factory._autorefine)
+            , truncate_on_project(factory._truncate_on_project)
+//		  , nonstandard(false)
+            , targs(factory._thresh,FunctionDefaults<NDIM>::get_tensor_type())
+            , cdata(FunctionCommonData<T,NDIM>::get(k))
+            , functor(factory.get_functor())
+//		  , on_demand(factory._is_on_demand)
+//		  , compressed(factory._compressed)
+//		  , redundant(false)
+		  , tree_state(factory._tree_state)
+            , coeffs(world,factory._pmap,false)
+            //, bc(factory._bc)
         {
             // PROFILE_MEMBER_FUNC(FunctionImpl); // No need to profile this
             // !!! Ensure that all local state is correctly formed
             // before invoking process_pending for the coeffs and
             // for this.  Otherwise, there is a race condition.
-            MADNESS_ASSERT(k > 0 && k <= MAXK);
+            MADNESS_ASSERT(k>0 && k<=MAXK);
 
             bool empty = (factory._empty or is_on_demand());
             bool do_refine = factory._refine;
 
             if (do_refine)
-                initial_level = std::max(0, initial_level - 1);
+                initial_level = std::max(0,initial_level - 1);
 
             if (empty) { // Do not set any coefficients at all
                 // additional functors are only evaluated on-demand
@@ -1037,9 +1042,9 @@ template<size_t NDIM>
                 if (!functor_special_points.empty()) special_points.insert(special_points.end(), functor_special_points.begin(), functor_special_points.end());
 
                 typename dcT::const_iterator end = coeffs.end();
-                for (typename dcT::const_iterator it = coeffs.begin(); it != end; ++it) {
+                for (typename dcT::const_iterator it=coeffs.begin(); it!=end; ++it) {
                     if (it->second.is_leaf())
-                        woT::task(coeffs.owner(it->first), &implT::project_refine_op, it->first, do_refine, 
+                        woT::task(coeffs.owner(it->first), &implT::project_refine_op, it->first, do_refine,
                                   special_points);
                 }
             }
@@ -1060,30 +1065,30 @@ template<size_t NDIM>
         /// By default takes pmap from other but can also specify a different pmap.
         /// Does \em not copy the coefficients ... creates an empty container.
         template <typename Q>
-        FunctionImpl(const FunctionImpl<Q, NDIM>& other, 
-                     const std::shared_ptr<WorldDCPmapInterface<Key<NDIM>>>& pmap, 
+        FunctionImpl(const FunctionImpl<Q,NDIM>& other,
+                     const std::shared_ptr< WorldDCPmapInterface< Key<NDIM> > >& pmap,
                      bool dozero)
-                : WorldObject<implT>(other.world),
-                  world(other.world),
-                  k(other.k),
-                  thresh(other.thresh),
-                  initial_level(other.initial_level),
-                  special_level(other.special_level),
-                  special_points(other.special_points),
-                  max_refine_level(other.max_refine_level),
-                  truncate_mode(other.truncate_mode),
-                  autorefine(other.autorefine),
-                  truncate_on_project(other.truncate_on_project),
-                  targs(other.targs),
-                  cdata(FunctionCommonData<T, NDIM>::get(k)),
-                  functor(),
-                  tree_state(other.tree_state),
-                  coeffs(world, pmap ? pmap : other.coeffs.get_pmap())
+                : WorldObject<implT>(other.world)
+                , world(other.world)
+                , k(other.k)
+                , thresh(other.thresh)
+                , initial_level(other.initial_level)
+                , special_level(other.special_level)
+                , special_points(other.special_points)
+                , max_refine_level(other.max_refine_level)
+                , truncate_mode(other.truncate_mode)
+                , autorefine(other.autorefine)
+                , truncate_on_project(other.truncate_on_project)
+                , targs(other.targs)
+                , cdata(FunctionCommonData<T,NDIM>::get(k))
+                , functor()
+                , tree_state(other.tree_state)
+                , coeffs(world, pmap ? pmap : other.coeffs.get_pmap())
         {
             if (dozero) {
                 initial_level = 1;
                 insert_zero_down_to_initial_level(cdata.key0);
-                // world.gop.fence(); <<<<<<<<<<<<<<<<<<<<<<   needs a fence argument
+                //world.gop.fence(); <<<<<<<<<<<<<<<<<<<<<<   needs a fence argument
             }
             coeffs.process_pending();
             this->process_pending();
@@ -1091,27 +1096,27 @@ template<size_t NDIM>
 
         virtual ~FunctionImpl() { }
 
-        const std::shared_ptr<WorldDCPmapInterface<Key<NDIM>>>& get_pmap() const;
+        const std::shared_ptr< WorldDCPmapInterface< Key<NDIM> > >& get_pmap() const;
 
         void replicate(bool fence=true) {
         	coeffs.replicate(fence);
         }
 
-        void distribute(std::shared_ptr<WorldDCPmapInterface<Key<NDIM>>> newmap) const {
-        	auto currentmap = coeffs.get_pmap();
-        	currentmap->redistribute(world, newmap);
+        void distribute(std::shared_ptr< WorldDCPmapInterface< Key<NDIM> > > newmap) const {
+        	auto currentmap=coeffs.get_pmap();
+        	currentmap->redistribute(world,newmap);
         }
 
 
         /// Copy coeffs from other into self
         template <typename Q>
-        void copy_coeffs(const FunctionImpl<Q, NDIM>& other, bool fence) {
-            typename FunctionImpl<Q, NDIM>::dcT::const_iterator end = other.coeffs.end();
-            for (typename FunctionImpl<Q, NDIM>::dcT::const_iterator it = other.coeffs.begin();
-                 it != end; ++it) {
+        void copy_coeffs(const FunctionImpl<Q,NDIM>& other, bool fence) {
+            typename FunctionImpl<Q,NDIM>::dcT::const_iterator end = other.coeffs.end();
+            for (typename FunctionImpl<Q,NDIM>::dcT::const_iterator it=other.coeffs.begin();
+                 it!=end; ++it) {
                 const keyT& key = it->first;
-                const typename FunctionImpl<Q, NDIM>::nodeT& node = it->second;
-                coeffs.replace(key, node. template convert<T>());
+                const typename FunctionImpl<Q,NDIM>::nodeT& node = it->second;
+                coeffs.replace(key,node. template convert<T>());
             }
             if (fence)
                 world.gop.fence();
@@ -1122,9 +1127,9 @@ template<size_t NDIM>
         /// @param[in]	beta	prefactor for other
         /// @param[in]	g       the other function, reconstructed
         template<typename Q, typename R>
-        void gaxpy_inplace_reconstructed(const T& alpha, const FunctionImpl<Q, NDIM>& g, const R& beta, const bool fence) {
+        void gaxpy_inplace_reconstructed(const T& alpha, const FunctionImpl<Q,NDIM>& g, const R& beta, const bool fence) {
             // merge g's tree into this' tree
-            this->merge_trees(beta, g, alpha, true);
+            this->merge_trees(beta,g,alpha,true);
 
             // sum down the sum coeffs into the leafs
             if (world.rank() == coeffs.owner(cdata.key0)) sum_down_spawn(cdata.key0, coeffT());
@@ -1141,9 +1146,9 @@ template<size_t NDIM>
         /// @param[in]	beta	prefactor for other
         /// @param[in]	other	the other function, reconstructed
         template<typename Q, typename R>
-        void merge_trees(const T alpha, const FunctionImpl<Q, NDIM>& other, const R beta, const bool fence=true) {
+        void merge_trees(const T alpha, const FunctionImpl<Q,NDIM>& other, const R beta, const bool fence=true) {
             MADNESS_ASSERT(get_pmap() == other.get_pmap());
-            other.flo_unary_op_node_inplace(do_merge_trees<Q, R>(alpha, beta, *this), fence);
+            other.flo_unary_op_node_inplace(do_merge_trees<Q,R>(alpha,beta,*this),fence);
             if (fence) world.gop.fence();
         }
 
@@ -1153,13 +1158,13 @@ template<size_t NDIM>
         /// result+=alpha* this
         /// @param[in]	alpha	prefactor for this
         template<typename Q, typename R>
-        void accumulate_trees(FunctionImpl<Q, NDIM>& result, const R alpha, const bool fence=true) const {
-            flo_unary_op_node_inplace(do_accumulate_trees<Q, R>(result, alpha), fence);
+        void accumulate_trees(FunctionImpl<Q,NDIM>& result, const R alpha, const bool fence=true) const {
+            flo_unary_op_node_inplace(do_accumulate_trees<Q,R>(result,alpha),fence);
         }
 
         /// perform: this= alpha*f + beta*g, invoked by result
 
-        /// f and g are reconstructed, so we can save on the compress operation, 
+        /// f and g are reconstructed, so we can save on the compress operation,
         /// walk down the joint tree, and add leaf coefficients; effectively refines
         /// to common finest level.
 
@@ -1168,23 +1173,23 @@ template<size_t NDIM>
         /// @param[in]  f       first addend
         /// @param[in]  beta    prefactor for g
         /// @param[in]  g       second addend
-        void gaxpy_oop_reconstructed(const double alpha, const implT& f, 
-                                     const double beta, const implT& g,
-                                     const bool fence);
+        void gaxpy_oop_reconstructed(const double alpha, const implT& f,
+                                     const double beta, const implT& g, const bool fence);
+
         /// functor for the gaxpy_inplace method
         template <typename Q, typename R>
         struct do_gaxpy_inplace {
-            typedef Range<typename FunctionImpl<Q, NDIM>::dcT::const_iterator> rangeT;
-            FunctionImpl<T, NDIM>* f; ///< prefactor for current function impl
+            typedef Range<typename FunctionImpl<Q,NDIM>::dcT::const_iterator> rangeT;
+            FunctionImpl<T,NDIM>* f; ///< prefactor for current function impl
             T alpha; ///< the current function impl
             R beta; ///< prefactor for other function impl
             do_gaxpy_inplace() = default;
             do_gaxpy_inplace(FunctionImpl<T, NDIM>* f, T alpha, R beta) : f(f), alpha(alpha), beta(beta) {}
             bool operator()(typename rangeT::iterator& it) const {
                 const keyT& key = it->first;
-                const FunctionNode<Q, NDIM>& other_node = it->second;
+                const FunctionNode<Q,NDIM>& other_node = it->second;
                 // Use send to get write accessor and automated construction if missing
-                f->coeffs.send(key, &nodeT:: template gaxpy_inplace<Q, R>, alpha, other_node, beta);
+                f->coeffs.send(key, &nodeT:: template gaxpy_inplace<Q,R>, alpha, other_node, beta);
                 return true;
             }
             template <typename Archive>
@@ -1198,12 +1203,12 @@ template<size_t NDIM>
         /// @param[in]  other   the other function impl
         /// @param[in]  beta    prefactor for other
         template <typename Q, typename R>
-        void gaxpy_inplace(const T& alpha, const FunctionImpl<Q, NDIM>& other, const R& beta, bool fence) {
-            // MADNESS_ASSERT(get_pmap() == other.get_pmap());
-            if (alpha != T(1.0)) scale_inplace(alpha, false);
-            typedef Range<typename FunctionImpl<Q, NDIM>::dcT::const_iterator> rangeT;
-            typedef do_gaxpy_inplace<Q, R> opT;
-            other.world.taskq. template for_each<rangeT, opT>(rangeT(other.coeffs.begin(), other.coeffs.end()), opT(this, T(1.0), beta));
+        void gaxpy_inplace(const T& alpha,const FunctionImpl<Q,NDIM>& other, const R& beta, bool fence) {
+//            MADNESS_ASSERT(get_pmap() == other.get_pmap());
+            if (alpha != T(1.0)) scale_inplace(alpha,false);
+            typedef Range<typename FunctionImpl<Q,NDIM>::dcT::const_iterator> rangeT;
+            typedef do_gaxpy_inplace<Q,R> opT;
+            other.world.taskq. template for_each<rangeT,opT>(rangeT(other.coeffs.begin(), other.coeffs.end()), opT(this, T(1.0), beta));
             if (fence)
                 other.world.gop.fence();
         }
@@ -1216,11 +1221,11 @@ template<size_t NDIM>
             int kk = 0;
             ar & kk;
 
-            MADNESS_ASSERT(kk == k);
+            MADNESS_ASSERT(kk==k);
 
             // note that functor should not be (re)stored
             ar & thresh & initial_level & max_refine_level & truncate_mode
-                & autorefine & truncate_on_project & tree_state; //nonstandard & compressed; // & bc;
+                & autorefine & truncate_on_project & tree_state;//nonstandard & compressed ; //& bc;
 
             ar & coeffs;
             world.gop.fence();
@@ -1234,7 +1239,7 @@ template<size_t NDIM>
 
             // note that functor should not be (re)stored
             ar & k & thresh & initial_level & max_refine_level & truncate_mode
-                & autorefine & truncate_on_project & tree_state; // nonstandard & compressed; // & bc;
+                & autorefine & truncate_on_project & tree_state;//nonstandard & compressed ; //& bc;
 
             ar & coeffs;
             world.gop.fence();
@@ -1263,11 +1268,11 @@ template<size_t NDIM>
 
         TreeState get_tree_state() const {return tree_state;}
 
-        void set_functor(const std::shared_ptr<FunctionFunctorInterface<T, NDIM>> functor1);
+        void set_functor(const std::shared_ptr<FunctionFunctorInterface<T,NDIM> > functor1);
 
-        std::shared_ptr<FunctionFunctorInterface<T, NDIM>> get_functor();
+        std::shared_ptr<FunctionFunctorInterface<T,NDIM> > get_functor();
 
-        std::shared_ptr<FunctionFunctorInterface<T, NDIM>> get_functor() const;
+        std::shared_ptr<FunctionFunctorInterface<T,NDIM> > get_functor() const;
 
         void unset_functor();
 
@@ -1291,7 +1296,7 @@ template<size_t NDIM>
 
         dcT& get_coeffs();
 
-        const FunctionCommonData<T, NDIM>& get_cdata() const;
+        const FunctionCommonData<T,NDIM>& get_cdata() const;
 
         void accumulate_timer(const double time) const; // !!!!!!!!!!!!  REDUNDANT !!!!!!!!!!!!!!!
 
@@ -1329,7 +1334,7 @@ template<size_t NDIM>
         /// @param[in] key the key to the current function node being evaluated for truncation
         /// @param[in] tol the tolerance for thresholding
         /// @param[in] v vector of Future<bool>'s that specify whether the current nodes children have coeffs
-        bool truncate_op(const keyT& key, double tol, const std::vector<Future<bool>>& v);
+        bool truncate_op(const keyT& key, double tol, const std::vector< Future<bool> >& v);
 
         /// Evaluate function at quadrature points in the specified box
 
@@ -1337,7 +1342,7 @@ template<size_t NDIM>
         /// @param[in] f the interface to the elementary function
         /// @param[in] qx quadrature points on a level=0 box
         /// @param[out] fval values
-        void fcube(const keyT& key, const FunctionFunctorInterface<T, NDIM>& f, const Tensor<double>& qx, tensorT& fval) const;
+        void fcube(const keyT& key, const FunctionFunctorInterface<T,NDIM>& f, const Tensor<double>& qx, tensorT& fval) const;
 
         /// Evaluate function at quadrature points in the specified box
 
@@ -1345,7 +1350,7 @@ template<size_t NDIM>
         /// @param[in] f the interface to the elementary function
         /// @param[in] qx quadrature points on a level=0 box
         /// @param[out] fval values
-        void fcube(const keyT& key, T (*f)(const coordT&), const Tensor<double>& qx, tensorT& fval) const;
+        void fcube(const keyT& key,  T (*f)(const coordT&), const Tensor<double>& qx, tensorT& fval) const;
 
         /// Returns cdata.key0
         const keyT& key0() const;
@@ -1374,8 +1379,8 @@ template<size_t NDIM>
         /// Functor for the do_print_tree_json method
         void do_print_tree_json(const keyT& key, std::multimap<Level, std::tuple<tranT, std::string>>& data, Level maxlevel) const;
 
-        /// convert a number [0, limit] to a hue color code [blue, red],
-        /// or, if log is set, a number [1.e-10, limit]
+        /// convert a number [0,limit] to a hue color code [blue,red],
+        /// or, if log is set, a number [1.e-10,limit]
         struct do_convert_to_color {
             double limit;
             bool log;
@@ -1386,14 +1391,14 @@ template<size_t NDIM>
                 double color=0.0;
 
                 if (log) {
-                    double val2 = log10(val) - log10(lower());  // will yield > 0.0
-                    double upper = log10(limit) - log10(lower());
-                    val2 = 0.7 - (0.7 / upper) * val2;
-                    color = std::max(0.0, val2);
-                    color = std::min(0.7, color);
+                    double val2=log10(val) - log10(lower());        // will yield >0.0
+                    double upper=log10(limit) -log10(lower());
+                    val2=0.7-(0.7/upper)*val2;
+                    color= std::max(0.0,val2);
+                    color= std::min(0.7,color);
                 } else {
-                    double hue = 0.7 - (0.7 / limit) * (val);
-                    color = std::max(0.0, hue);
+                    double hue=0.7-(0.7/limit)*(val);
+                    color= std::max(0.0,hue);
                 }
                 return color;
             }
@@ -1419,7 +1424,7 @@ template<size_t NDIM>
         /// @param[in] plotinfo plotting parameters
         /// @param[in]	xaxis	the x-axis in the plot (can be any axis of the MRA box)
         /// @param[in]	yaxis	the y-axis in the plot (can be any axis of the MRA box)
-        void do_print_plane(const std::string filename, std::vector<Tensor<double>> plotinfo,
+        void do_print_plane(const std::string filename, std::vector<Tensor<double> > plotinfo,
                             const int xaxis, const int yaxis, const coordT el2);
 
         /// print the grid (the roots of the quadrature of each leaf box)
@@ -1443,104 +1448,104 @@ template<size_t NDIM>
         /// @param[in]	gridfile 	file with grid points, w/o key, but with same ordering
         /// @param[in]	vnuc_functor	subtract the values of this functor if regularization is needed
         template<size_t FDIM>
-        typename std::enable_if<NDIM == FDIM>::type
+        typename std::enable_if<NDIM==FDIM>::type
         read_grid(const std::string keyfile, const std::string gridfile,
-                  std::shared_ptr< FunctionFunctorInterface<double, NDIM>> vnuc_functor) {
+                  std::shared_ptr< FunctionFunctorInterface<double,NDIM> > vnuc_functor) {
 
             std::ifstream kfile(keyfile.c_str());
             std::ifstream gfile(gridfile.c_str());
             std::string line;
 
-            long ndata, ndata1;
-            if (not (std::getline(kfile, line))) MADNESS_EXCEPTION("failed reading 1st line of key data", 0);
-            if (not (std::istringstream(line) >> ndata)) MADNESS_EXCEPTION("failed reading k", 0);
-            if (not (std::getline(gfile, line))) MADNESS_EXCEPTION("failed reading 1st line of grid data", 0);
-            if (not (std::istringstream(line) >> ndata1)) MADNESS_EXCEPTION("failed reading k", 0);
-            MADNESS_CHECK(ndata == ndata1);
-            if (not (std::getline(kfile, line))) MADNESS_EXCEPTION("failed reading 2nd line of key data", 0);
-            if (not (std::getline(gfile, line))) MADNESS_EXCEPTION("failed reading 2nd line of grid data", 0);
+            long ndata,ndata1;
+            if (not (std::getline(kfile,line))) MADNESS_EXCEPTION("failed reading 1st line of key data",0);
+            if (not (std::istringstream(line) >> ndata)) MADNESS_EXCEPTION("failed reading k",0);
+            if (not (std::getline(gfile,line))) MADNESS_EXCEPTION("failed reading 1st line of grid data",0);
+            if (not (std::istringstream(line) >> ndata1)) MADNESS_EXCEPTION("failed reading k",0);
+            MADNESS_CHECK(ndata==ndata1);
+            if (not (std::getline(kfile,line))) MADNESS_EXCEPTION("failed reading 2nd line of key data",0);
+            if (not (std::getline(gfile,line))) MADNESS_EXCEPTION("failed reading 2nd line of grid data",0);
 
             // the quadrature points in simulation coordinates of the root node
-            const Tensor<double> qx = cdata.quad_x;
+            const Tensor<double> qx=cdata.quad_x;
             const size_t npt = qx.dim(0);
 
-            // the number of coordinates (grid point tuples) per box ({x1}, {x2}, {x3}, .., {xNDIM})
-            long npoints = power<NDIM>(npt);
+            // the number of coordinates (grid point tuples) per box ({x1},{x2},{x3},..,{xNDIM})
+            long npoints=power<NDIM>(npt);
             // the number of boxes
-            long nboxes = ndata / npoints;
-            MADNESS_ASSERT(nboxes * npoints == ndata);
-            print("reading ", nboxes, "boxes from file", gridfile, keyfile);
+            long nboxes=ndata/npoints;
+            MADNESS_ASSERT(nboxes*npoints==ndata);
+            print("reading ",nboxes,"boxes from file",gridfile,keyfile);
 
             // these will be the data
-            Tensor<T> values(cdata.vk, false);
+            Tensor<T> values(cdata.vk,false);
 
-            int ii = 0;
-            std::string gline, kline;
+            int ii=0;
+            std::string gline,kline;
             //            while (1) {
-            while (std::getline(kfile, kline)) {
+            while (std::getline(kfile,kline)) {
 
-                double x, y, z, x1, y1, z1, val;
+                double x,y,z,x1,y1,z1,val;
 
                 // get the key
                 long nn;
-                Translation l1, l2, l3;
+                Translation l1,l2,l3;
                 // line looks like: # key:      n      l1   l2   l3
-                kline.erase(0, 7);
+                kline.erase(0,7);
                 std::stringstream(kline) >>  nn >> l1 >> l2 >> l3;
                 //				kfile >> s >>  nn >> l1 >> l2 >> l3;
-                const Vector<Translation, 3> ll{ l1, l2, l3 };
-                Key<3> key(nn, ll);
+                const Vector<Translation,3> ll{ l1,l2,l3 };
+                Key<3> key(nn,ll);
 
                 // this is borrowed from fcube
-                const Vector<Translation, 3>& l = key.translation();
+                const Vector<Translation,3>& l = key.translation();
                 const Level n = key.level();
-                const double h = std::pow(0.5, double(n));
+                const double h = std::pow(0.5,double(n));
                 coordT c; // will hold the point in user coordinates
                 const Tensor<double>& cell_width = FunctionDefaults<NDIM>::get_cell_width();
                 const Tensor<double>& cell = FunctionDefaults<NDIM>::get_cell();
 
 
                 if (NDIM == 3) {
-                    for (size_t i = 0; i < npt; ++i) {
-                        c[0] = cell(0, 0) + h * cell_width[0] * (l[0] + qx(i)); // x
-                        for (size_t j = 0; j < npt; ++j) {
-                            c[1] = cell(1, 0) + h * cell_width[1] * (l[1] + qx(j)); // y
-                            for (size_t k = 0; k < npt; ++k) {
-                                c[2] = cell(2, 0) + h * cell_width[2] * (l[2] + qx(k)); // z
-                                // fprintf(pFile, "%18.12f %18.12f %18.12f\n", c[0], c[1], c[2]);
-                                auto& success1 = std::getline(gfile, gline); MADNESS_CHECK(success1);
-                                auto& success2 = std::getline(kfile, kline); MADNESS_CHECK(success2);
+                    for (size_t i=0; i<npt; ++i) {
+                        c[0] = cell(0,0) + h*cell_width[0]*(l[0] + qx(i)); // x
+                        for (size_t j=0; j<npt; ++j) {
+                            c[1] = cell(1,0) + h*cell_width[1]*(l[1] + qx(j)); // y
+                            for (size_t k=0; k<npt; ++k) {
+                                c[2] = cell(2,0) + h*cell_width[2]*(l[2] + qx(k)); // z
+                                //								fprintf(pFile,"%18.12f %18.12f %18.12f\n",c[0],c[1],c[2]);
+                                auto& success1 = std::getline(gfile,gline); MADNESS_CHECK(success1);
+                                auto& success2 = std::getline(kfile,kline); MADNESS_CHECK(success2);
                                 std::istringstream(gline) >> x >> y >> z >> val;
                                 std::istringstream(kline) >> x1 >> y1 >> z1;
-                                MADNESS_CHECK(std::fabs(x - c[0]) < 1.e-4);
-                                MADNESS_CHECK(std::fabs(x1 - c[0]) < 1.e-4);
-                                MADNESS_CHECK(std::fabs(y - c[1]) < 1.e-4);
-                                MADNESS_CHECK(std::fabs(y1 - c[1]) < 1.e-4);
-                                MADNESS_CHECK(std::fabs(z - c[2]) < 1.e-4);
-                                MADNESS_CHECK(std::fabs(z1 - c[2]) < 1.e-4);
+                                MADNESS_CHECK(std::fabs(x-c[0])<1.e-4);
+                                MADNESS_CHECK(std::fabs(x1-c[0])<1.e-4);
+                                MADNESS_CHECK(std::fabs(y-c[1])<1.e-4);
+                                MADNESS_CHECK(std::fabs(y1-c[1])<1.e-4);
+                                MADNESS_CHECK(std::fabs(z-c[2])<1.e-4);
+                                MADNESS_CHECK(std::fabs(z1-c[2])<1.e-4);
 
                                 // regularize if a functor is given
-                                if (vnuc_functor) val -= (*vnuc_functor)(c);
-                                values(i, j, k)=val;
+                                if (vnuc_functor) val-=(*vnuc_functor)(c);
+                                values(i,j,k)=val;
                             }
                         }
                     }
                 } else {
-                    MADNESS_EXCEPTION("only NDIM = 3 in print_grid", 0);
+                    MADNESS_EXCEPTION("only NDIM=3 in print_grid",0);
                 }
 
                 // insert the new leaf node
-                const bool has_children = false;
-                coeffT coeff = coeffT(this->values2coeffs(key, values), targs);
-                nodeT node(coeff, has_children);
-                coeffs.replace(key, node);
-                const_cast<dcT&>(coeffs).send(key.parent(), &FunctionNode<T, NDIM>::set_has_children_recursive, coeffs, key.parent());
+                const bool has_children=false;
+                coeffT coeff=coeffT(this->values2coeffs(key,values),targs);
+                nodeT node(coeff,has_children);
+                coeffs.replace(key,node);
+                const_cast<dcT&>(coeffs).send(key.parent(), &FunctionNode<T,NDIM>::set_has_children_recursive, coeffs, key.parent());
                 ii++;
             }
 
             kfile.close();
             gfile.close();
-            MADNESS_CHECK(ii == nboxes);
+            MADNESS_CHECK(ii==nboxes);
 
         }
 
@@ -1550,94 +1555,95 @@ template<size_t NDIM>
         /// @param[in]	gridfile		file with keys and grid points and values for each key
         /// @param[in]	vnuc_functor	subtract the values of this functor if regularization is needed
         template<size_t FDIM>
-        typename std::enable_if<NDIM == FDIM>::type
+        typename std::enable_if<NDIM==FDIM>::type
         read_grid2(const std::string gridfile,
-                   std::shared_ptr< FunctionFunctorInterface<double, NDIM>> vnuc_functor) {
+                   std::shared_ptr< FunctionFunctorInterface<double,NDIM> > vnuc_functor) {
 
             std::ifstream gfile(gridfile.c_str());
             std::string line;
 
             long ndata;
-            if (not (std::getline(gfile, line))) MADNESS_EXCEPTION("failed reading 1st line of grid data", 0);
-            if (not (std::istringstream(line) >> ndata)) MADNESS_EXCEPTION("failed reading k", 0);
-            if (not (std::getline(gfile, line))) MADNESS_EXCEPTION("failed reading 2nd line of grid data", 0);
+            if (not (std::getline(gfile,line))) MADNESS_EXCEPTION("failed reading 1st line of grid data",0);
+            if (not (std::istringstream(line) >> ndata)) MADNESS_EXCEPTION("failed reading k",0);
+            if (not (std::getline(gfile,line))) MADNESS_EXCEPTION("failed reading 2nd line of grid data",0);
 
             // the quadrature points in simulation coordinates of the root node
-            const Tensor<double> qx = cdata.quad_x;
+            const Tensor<double> qx=cdata.quad_x;
             const size_t npt = qx.dim(0);
 
-            // the number of coordinates (grid point tuples) per box ({x1}, {x2}, {x3}, .., {xNDIM})
-            long npoints = power<NDIM>(npt);
+            // the number of coordinates (grid point tuples) per box ({x1},{x2},{x3},..,{xNDIM})
+            long npoints=power<NDIM>(npt);
             // the number of boxes
-            long nboxes = ndata / npoints;
-            MADNESS_CHECK(nboxes * npoints == ndata);
-            print("reading ", nboxes, "boxes from file", gridfile);
+            long nboxes=ndata/npoints;
+            MADNESS_CHECK(nboxes*npoints==ndata);
+            print("reading ",nboxes,"boxes from file",gridfile);
 
             // these will be the data
-            Tensor<T> values(cdata.vk, false);
+            Tensor<T> values(cdata.vk,false);
 
-            int ii = 0;
+            int ii=0;
             std::string gline;
             //            while (1) {
-            while (std::getline(gfile, gline)) {
+            while (std::getline(gfile,gline)) {
 
-                double x1, y1, z1, val;
+                double x1,y1,z1,val;
 
                 // get the key
                 long nn;
-                Translation l1, l2, l3;
+                Translation l1,l2,l3;
                 // line looks like: # key:      n      l1   l2   l3
-                gline.erase(0, 7);
+                gline.erase(0,7);
                 std::stringstream(gline) >>  nn >> l1 >> l2 >> l3;
-                const Vector<Translation, 3> ll{ l1, l2, l3 };
-                Key<3> key(nn, ll);
+                const Vector<Translation,3> ll{ l1,l2,l3 };
+                Key<3> key(nn,ll);
 
                 // this is borrowed from fcube
-                const Vector<Translation, 3>& l = key.translation();
+                const Vector<Translation,3>& l = key.translation();
                 const Level n = key.level();
-                const double h = std::pow(0.5, double(n));
+                const double h = std::pow(0.5,double(n));
                 coordT c; // will hold the point in user coordinates
                 const Tensor<double>& cell_width = FunctionDefaults<NDIM>::get_cell_width();
                 const Tensor<double>& cell = FunctionDefaults<NDIM>::get_cell();
 
-                if (NDIM == 3) {
-                    for (int i = 0; i < npt; ++i) {
-                        c[0] = cell(0, 0) + h * cell_width[0] * (l[0] + qx(i)); // x
-                        for (int j = 0; j < npt; ++j) {
-                            c[1] = cell(1, 0) + h * cell_width[1] * (l[1] + qx(j)); // y
-                            for (int k=0; k<npt; ++k) {
-                                c[2] = cell(2, 0) + h * cell_width[2] * (l[2] + qx(k)); // z
 
-                                auto& success = std::getline(gfile, gline);
+                if (NDIM == 3) {
+                    for (int i=0; i<npt; ++i) {
+                        c[0] = cell(0,0) + h*cell_width[0]*(l[0] + qx(i)); // x
+                        for (int j=0; j<npt; ++j) {
+                            c[1] = cell(1,0) + h*cell_width[1]*(l[1] + qx(j)); // y
+                            for (int k=0; k<npt; ++k) {
+                                c[2] = cell(2,0) + h*cell_width[2]*(l[2] + qx(k)); // z
+
+                                auto& success = std::getline(gfile,gline);
                                 MADNESS_CHECK(success);
                                 std::istringstream(gline) >> x1 >> y1 >> z1 >> val;
-                                MADNESS_CHECK(std::fabs(x1 - c[0]) < 1.e-4);
-                                MADNESS_CHECK(std::fabs(y1 - c[1]) < 1.e-4);
-                                MADNESS_CHECK(std::fabs(z1 - c[2]) < 1.e-4);
+                                MADNESS_CHECK(std::fabs(x1-c[0])<1.e-4);
+                                MADNESS_CHECK(std::fabs(y1-c[1])<1.e-4);
+                                MADNESS_CHECK(std::fabs(z1-c[2])<1.e-4);
 
                                 // regularize if a functor is given
-                                if (vnuc_functor) val -= (*vnuc_functor)(c);
-                                values(i, j, k) = val;
+                                if (vnuc_functor) val-=(*vnuc_functor)(c);
+                                values(i,j,k)=val;
                             }
                         }
                     }
                 } else {
-                    MADNESS_EXCEPTION("only NDIM=3 in print_grid", 0);
+                    MADNESS_EXCEPTION("only NDIM=3 in print_grid",0);
                 }
 
                 // insert the new leaf node
-                const bool has_children = false;
-                coeffT coeff = coeffT(this->values2coeffs(key, values), targs);
-                nodeT node(coeff, has_children);
-                coeffs.replace(key, node);
+                const bool has_children=false;
+                coeffT coeff=coeffT(this->values2coeffs(key,values),targs);
+                nodeT node(coeff,has_children);
+                coeffs.replace(key,node);
                 const_cast<dcT&>(coeffs).send(key.parent(),
-                                              &FunctionNode<T, NDIM>::set_has_children_recursive,
+                                              &FunctionNode<T,NDIM>::set_has_children_recursive,
                                               coeffs, key.parent());
                 ii++;
             }
 
             gfile.close();
-            MADNESS_CHECK(ii == nboxes);
+            MADNESS_CHECK(ii==nboxes);
 
         }
 
@@ -1667,12 +1673,12 @@ template<size_t NDIM>
         /// @param[in] specialpts vector of special points in the function where we need
         ///            to refine at a much finer level
         void project_refine_op(const keyT& key, bool do_refine,
-                               const std::vector<Vector<double, NDIM>>& specialpts);
+                               const std::vector<Vector<double,NDIM> >& specialpts);
 
         /// Compute the Legendre scaling functions for multiplication
 
         /// Evaluate parent polyn at quadrature points of a child.  The prefactor of
-        /// 2^n/2 is included.  The tensor must be preallocated as phi(k, npt).
+        /// 2^n/2 is included.  The tensor must be preallocated as phi(k,npt).
         /// Refer to the implementation notes for more info.
         /// @todo Robert please verify this comment. I don't understand this method.
         /// @param[in] np level of the parent function node (box)
@@ -1711,8 +1717,8 @@ template<size_t NDIM>
         template <typename Q>
         GenTensor<Q> coeffs2values(const keyT& key, const GenTensor<Q>& coeff) const {
             // PROFILE_MEMBER_FUNC(FunctionImpl); // Too fine grain for routine profiling
-            double scale = pow(2.0, 0.5 * NDIM * key.level()) / sqrt(FunctionDefaults<NDIM>::get_cell_volume());
-            return transform(coeff, cdata.quad_phit).scale(scale);
+            double scale = pow(2.0,0.5*NDIM*key.level())/sqrt(FunctionDefaults<NDIM>::get_cell_volume());
+            return transform(coeff,cdata.quad_phit).scale(scale);
         }
 
         /// convert S or NS coeffs to values on a 2k grid of the children
@@ -1727,27 +1733,27 @@ template<size_t NDIM>
         template <typename Q>
         GenTensor<Q> NScoeffs2values(const keyT& key, const GenTensor<Q>& coeff,
                                      const bool s_only) const {
-            // PROFILE_MEMBER_FUNC(FunctionImpl);  // Too fine grain for routine profiling
+            // PROFILE_MEMBER_FUNC(FunctionImpl); // Too fine grain for routine profiling
 
             // sanity checks
-            MADNESS_ASSERT((coeff.dim(0) == this->get_k()) == s_only);
-            MADNESS_ASSERT((coeff.dim(0) == this->get_k()) or (coeff.dim(0) == 2 * this->get_k()));
+            MADNESS_ASSERT((coeff.dim(0)==this->get_k()) == s_only);
+            MADNESS_ASSERT((coeff.dim(0)==this->get_k()) or (coeff.dim(0)==2*this->get_k()));
 
             // this is a block-diagonal matrix with the quadrature points on the diagonal
-            Tensor<double> quad_phit_2k(2 * cdata.k, 2 * cdata.npt);
-            quad_phit_2k(cdata.s[0], cdata.s[0]) = cdata.quad_phit;
-            quad_phit_2k(cdata.s[1], cdata.s[1]) = cdata.quad_phit;
+            Tensor<double> quad_phit_2k(2*cdata.k,2*cdata.npt);
+            quad_phit_2k(cdata.s[0],cdata.s[0])=cdata.quad_phit;
+            quad_phit_2k(cdata.s[1],cdata.s[1])=cdata.quad_phit;
 
             // the transformation matrix unfilters (cdata.hg) and transforms to values in one step
             const Tensor<double> transf = (s_only)
-                ? inner(cdata.hg(Slice(0, k-1), _), quad_phit_2k)	// S coeffs
-                : inner(cdata.hg, quad_phit_2k);					// NS coeffs
+                ? inner(cdata.hg(Slice(0,k-1),_),quad_phit_2k)	// S coeffs
+                : inner(cdata.hg,quad_phit_2k);					// NS coeffs
 
             // increment the level since the coeffs2values part happens on level n+1
-            const double scale = pow(2.0, 0.5 * NDIM * (key.level() + 1)) /
+            const double scale = pow(2.0,0.5*NDIM*(key.level()+1))/
                 sqrt(FunctionDefaults<NDIM>::get_cell_volume());
 
-           return transform(coeff, transf).scale(scale);
+           return transform(coeff,transf).scale(scale);
         }
 
         /// Compute the function values for multiplication
@@ -1766,38 +1772,39 @@ template<size_t NDIM>
             // PROFILE_MEMBER_FUNC(FunctionImpl); // Too fine grain for routine profiling
 
             // sanity checks
-            MADNESS_ASSERT((coeff.dim(0) == this->get_k()) == s_only);
-            MADNESS_ASSERT((coeff.dim(0) == this->get_k()) or (coeff.dim(0) == 2 * this->get_k()));
+            MADNESS_ASSERT((coeff.dim(0)==this->get_k()) == s_only);
+            MADNESS_ASSERT((coeff.dim(0)==this->get_k()) or (coeff.dim(0)==2*this->get_k()));
 
             // fast return if possible
-            // if (child.level() == parent.level()) return NScoeffs2values(child, coeff, s_only);
+            //            if (child.level()==parent.level()) return NScoeffs2values(child,coeff,s_only);
 
             if (s_only) {
+
                 Tensor<double> quad_phi[NDIM];
                 // tmp tensor
-                Tensor<double> phi1(cdata.k, cdata.npt);
+                Tensor<double> phi1(cdata.k,cdata.npt);
 
-                for (std::size_t d = 0; d < NDIM; ++d) {
+                for (std::size_t d=0; d<NDIM; ++d) {
 
                     // input is S coeffs (dimension k), output is values on 2*npt grid points
-                    quad_phi[d]=Tensor<double>(cdata.k, 2 * cdata.npt);
+                    quad_phi[d]=Tensor<double>(cdata.k,2*cdata.npt);
 
                     // for both children of "child" evaluate the Legendre polynomials
                     // first the left child on level n+1 and translations 2l
-                    phi_for_mul(parent.level(), parent.translation()[d],
-                                child.level() + 1, 2 * child.translation()[d], phi1);
-                    quad_phi[d](_, Slice(0, k - 1)) = phi1;
+                    phi_for_mul(parent.level(),parent.translation()[d],
+                                child.level()+1, 2*child.translation()[d], phi1);
+                    quad_phi[d](_,Slice(0,k-1))=phi1;
 
                     // next the right child on level n+1 and translations 2l+1
-                    phi_for_mul(parent.level(), parent.translation()[d],
-                                child.level() + 1, 2 * child.translation()[d] + 1, phi1);
-                    quad_phi[d](_, Slice(k, 2 * k - 1)) = phi1;
+                    phi_for_mul(parent.level(),parent.translation()[d],
+                                child.level()+1, 2*child.translation()[d]+1, phi1);
+                    quad_phi[d](_,Slice(k,2*k-1))=phi1;
                 }
 
-                const double scale = 1.0 / sqrt(FunctionDefaults<NDIM>::get_cell_volume());
-                return general_transform(coeff, quad_phi).scale(scale);
+                const double scale = 1.0/sqrt(FunctionDefaults<NDIM>::get_cell_volume());
+                return general_transform(coeff,quad_phi).scale(scale);
             }
-            MADNESS_EXCEPTION("you should not be here in NS_fcube_for_mul", 1);
+            MADNESS_EXCEPTION("you should not be here in NS_fcube_for_mul",1);
             return GenTensor<Q>();
         }
 
@@ -1813,21 +1820,21 @@ template<size_t NDIM>
             //PROFILE_MEMBER_FUNC(FunctionImpl);  // Too fine grain for routine profiling
 
             // sanity checks
-            MADNESS_ASSERT(values.dim(0) == 2 * this->get_k());
+            MADNESS_ASSERT(values.dim(0)==2*this->get_k());
 
             // this is a block-diagonal matrix with the quadrature points on the diagonal
-            Tensor<double> quad_phit_2k(2 * cdata.npt, 2 * cdata.k);
-            quad_phit_2k(cdata.s[0], cdata.s[0]) = cdata.quad_phiw;
-            quad_phit_2k(cdata.s[1], cdata.s[1]) = cdata.quad_phiw;
+            Tensor<double> quad_phit_2k(2*cdata.npt,2*cdata.k);
+            quad_phit_2k(cdata.s[0],cdata.s[0])=cdata.quad_phiw;
+            quad_phit_2k(cdata.s[1],cdata.s[1])=cdata.quad_phiw;
 
             // the transformation matrix unfilters (cdata.hg) and transforms to values in one step
-            const Tensor<double> transf=inner(quad_phit_2k, cdata.hgT);
+            const Tensor<double> transf=inner(quad_phit_2k,cdata.hgT);
 
             // increment the level since the values2coeffs part happens on level n+1
-            const double scale = pow(0.5, 0.5 * NDIM * (key.level() + 1))
-                * sqrt(FunctionDefaults<NDIM>::get_cell_volume());
+            const double scale = pow(0.5,0.5*NDIM*(key.level()+1))
+                *sqrt(FunctionDefaults<NDIM>::get_cell_volume());
 
-            return transform(values, transf).scale(scale);
+            return transform(values,transf).scale(scale);
         }
 
         /// Return the scaling function coeffs when given the function values at the quadrature points
@@ -1836,22 +1843,22 @@ template<size_t NDIM>
         template <typename Q>
         Tensor<Q> coeffs2values(const keyT& key, const Tensor<Q>& coeff) const {
             // PROFILE_MEMBER_FUNC(FunctionImpl); // Too fine grain for routine profiling
-            double scale = pow(2.0, 0.5 * NDIM * key.level()) / sqrt(FunctionDefaults<NDIM>::get_cell_volume());
-            return transform(coeff, cdata.quad_phit).scale(scale);
+            double scale = pow(2.0,0.5*NDIM*key.level())/sqrt(FunctionDefaults<NDIM>::get_cell_volume());
+            return transform(coeff,cdata.quad_phit).scale(scale);
         }
 
         template <typename Q>
         GenTensor<Q> values2coeffs(const keyT& key, const GenTensor<Q>& values) const {
             // PROFILE_MEMBER_FUNC(FunctionImpl); // Too fine grain for routine profiling
-            double scale = pow(0.5, 0.5*NDIM*key.level())*sqrt(FunctionDefaults<NDIM>::get_cell_volume());
-            return transform(values, cdata.quad_phiw).scale(scale);
+            double scale = pow(0.5,0.5*NDIM*key.level())*sqrt(FunctionDefaults<NDIM>::get_cell_volume());
+            return transform(values,cdata.quad_phiw).scale(scale);
         }
 
         template <typename Q>
         Tensor<Q> values2coeffs(const keyT& key, const Tensor<Q>& values) const {
             // PROFILE_MEMBER_FUNC(FunctionImpl); // Too fine grain for routine profiling
-            double scale = pow(0.5, 0.5 * NDIM * key.level()) * sqrt(FunctionDefaults<NDIM>::get_cell_volume());
-            return transform(values, cdata.quad_phiw).scale(scale);
+            double scale = pow(0.5,0.5*NDIM*key.level())*sqrt(FunctionDefaults<NDIM>::get_cell_volume());
+            return transform(values,cdata.quad_phiw).scale(scale);
         }
 
         /// Compute the function values for multiplication
@@ -1868,16 +1875,16 @@ template<size_t NDIM>
                 return coeffs2values(parent, coeff);
             }
             else if (child.level() < parent.level()) {
-                MADNESS_EXCEPTION("FunctionImpl: fcube_for_mul: child-parent relationship bad?", 0);
+                MADNESS_EXCEPTION("FunctionImpl: fcube_for_mul: child-parent relationship bad?",0);
             }
             else {
                 Tensor<double> phi[NDIM];
-                for (std::size_t d = 0; d < NDIM; ++d) {
-                    phi[d] = Tensor<double>(cdata.k, cdata.npt);
-                    phi_for_mul(parent.level(), parent.translation()[d],
+                for (std::size_t d=0; d<NDIM; ++d) {
+                    phi[d] = Tensor<double>(cdata.k,cdata.npt);
+                    phi_for_mul(parent.level(),parent.translation()[d],
                                 child.level(), child.translation()[d], phi[d]);
                 }
-                return general_transform(coeff, phi).scale(1.0 / sqrt(FunctionDefaults<NDIM>::get_cell_volume()));;
+                return general_transform(coeff,phi).scale(1.0/sqrt(FunctionDefaults<NDIM>::get_cell_volume()));;
             }
         }
 
@@ -1896,24 +1903,24 @@ template<size_t NDIM>
                 return coeffs2values(parent, coeff);
             }
             else if (child.level() < parent.level()) {
-                MADNESS_EXCEPTION("FunctionImpl: fcube_for_mul: child-parent relationship bad?", 0);
+                MADNESS_EXCEPTION("FunctionImpl: fcube_for_mul: child-parent relationship bad?",0);
             }
             else {
                 Tensor<double> phi[NDIM];
-                for (size_t d = 0; d < NDIM; d++) {
-                    phi[d] = Tensor<double>(cdata.k, cdata.npt);
-                    phi_for_mul(parent.level(), parent.translation()[d],
+                for (size_t d=0; d<NDIM; d++) {
+                    phi[d] = Tensor<double>(cdata.k,cdata.npt);
+                    phi_for_mul(parent.level(),parent.translation()[d],
                                 child.level(), child.translation()[d], phi[d]);
                 }
-                return general_transform(coeff, phi).scale(1.0 / sqrt(FunctionDefaults<NDIM>::get_cell_volume()));
+                return general_transform(coeff,phi).scale(1.0/sqrt(FunctionDefaults<NDIM>::get_cell_volume()));
             }
         }
 
 
         /// Functor for the mul method
         template <typename L, typename R>
-        void do_mul(const keyT& key, const Tensor<L>& left, const std::pair< keyT, Tensor<R>>& arg) {
-            // PROFILE_MEMBER_FUNC(FunctionImpl);  // Too fine grain for routine profiling
+        void do_mul(const keyT& key, const Tensor<L>& left, const std::pair< keyT, Tensor<R> >& arg) {
+            // PROFILE_MEMBER_FUNC(FunctionImpl); // Too fine grain for routine profiling
             const keyT& rkey = arg.first;
             const Tensor<R>& rcoeff = arg.second;
             //madness::print("do_mul: r", rkey, rcoeff.size());
@@ -1921,11 +1928,11 @@ template<size_t NDIM>
             //madness::print("do_mul: l", key, left.size());
             Tensor<L> lcube = fcube_for_mul(key, key, left);
 
-            Tensor<T> tcube(cdata.vk, false);
+            Tensor<T> tcube(cdata.vk,false);
             TERNARY_OPTIMIZED_ITERATOR(T, tcube, L, lcube, R, rcube, *_p0 = *_p1 * *_p2;);
-            double scale = pow(0.5, 0.5 * NDIM * key.level()) * sqrt(FunctionDefaults<NDIM>::get_cell_volume());
-            tcube = transform(tcube, cdata.quad_phiw).scale(scale);
-            coeffs.replace(key, nodeT(coeffT(tcube, targs), false));
+            double scale = pow(0.5,0.5*NDIM*key.level())*sqrt(FunctionDefaults<NDIM>::get_cell_volume());
+            tcube = transform(tcube,cdata.quad_phiw).scale(scale);
+            coeffs.replace(key, nodeT(coeffT(tcube,targs),false));
         }
 
 
@@ -1937,25 +1944,25 @@ template<size_t NDIM>
         /// @param[in]	npt	number of grid points (optional, default is cdata.npt)
         /// @return		coefficient tensor holding the product of the values of c1 and c2
         template<typename R>
-        Tensor<TENSOR_RESULT_TYPE(T, R)> mul(const Tensor<T>& c1, const Tensor<R>& c2,
+        Tensor<TENSOR_RESULT_TYPE(T,R)> mul(const Tensor<T>& c1, const Tensor<R>& c2,
                                             const int npt, const keyT& key) const {
-            typedef TENSOR_RESULT_TYPE(T, R) resultT;
+            typedef TENSOR_RESULT_TYPE(T,R) resultT;
 
-            const FunctionCommonData<T, NDIM>& cdata2 = FunctionCommonData<T, NDIM>::get(npt);
+            const FunctionCommonData<T,NDIM>& cdata2=FunctionCommonData<T,NDIM>::get(npt);
 
             // construct a tensor with the npt coeffs
             Tensor<T> c11(cdata2.vk), c22(cdata2.vk);
-            c11(this->cdata.s0) = c1;
-            c22(this->cdata.s0) = c2;
+            c11(this->cdata.s0)=c1;
+            c22(this->cdata.s0)=c2;
 
             // it's sufficient to scale once
-            double scale = pow(2.0, 0.5 * NDIM * key.level()) / sqrt(FunctionDefaults<NDIM>::get_cell_volume());
-            Tensor<T> c1value = transform(c11, cdata2.quad_phit).scale(scale);
-            Tensor<R> c2value = transform(c22, cdata2.quad_phit);
-            Tensor<resultT> resultvalue(cdata2.vk, false);
+            double scale = pow(2.0,0.5*NDIM*key.level())/sqrt(FunctionDefaults<NDIM>::get_cell_volume());
+            Tensor<T> c1value=transform(c11,cdata2.quad_phit).scale(scale);
+            Tensor<R> c2value=transform(c22,cdata2.quad_phit);
+            Tensor<resultT> resultvalue(cdata2.vk,false);
             TERNARY_OPTIMIZED_ITERATOR(resultT, resultvalue, T, c1value, R, c2value, *_p0 = *_p1 * *_p2;);
 
-            Tensor<resultT> result=transform(resultvalue, cdata2.quad_phiw);
+            Tensor<resultT> result=transform(resultvalue,cdata2.quad_phiw);
 
             // return a copy of the slice to have the tensor contiguous
             return copy(result(this->cdata.s0));
@@ -1964,21 +1971,21 @@ template<size_t NDIM>
 
         /// Functor for the binary_op method
         template <typename L, typename R, typename opT>
-	    void do_binary_op(const keyT& key, const Tensor<L>& left,
-			    const std::pair< keyT, Tensor<R>>& arg,
+	  void do_binary_op(const keyT& key, const Tensor<L>& left,
+			    const std::pair< keyT, Tensor<R> >& arg,
 			    const opT& op) {
-            // PROFILE_MEMBER_FUNC(FunctionImpl); // Too fine grain for routine profiling
-            const keyT& rkey = arg.first;
-            const Tensor<R>& rcoeff = arg.second;
-            Tensor<R> rcube = fcube_for_mul(key, rkey, rcoeff);
-            Tensor<L> lcube = fcube_for_mul(key, key, left);
+            //PROFILE_MEMBER_FUNC(FunctionImpl); // Too fine grain for routine profiling
+	  const keyT& rkey = arg.first;
+	  const Tensor<R>& rcoeff = arg.second;
+	  Tensor<R> rcube = fcube_for_mul(key, rkey, rcoeff);
+	  Tensor<L> lcube = fcube_for_mul(key, key, left);
 
-            Tensor<T> tcube(cdata.vk, false);
-            op(key, tcube, lcube, rcube);
-            double scale = pow(0.5, 0.5*NDIM*key.level())*sqrt(FunctionDefaults<NDIM>::get_cell_volume());
-            tcube = transform(tcube, cdata.quad_phiw).scale(scale);
-            coeffs.replace(key, nodeT(coeffT(tcube, targs), false));
-	    }
+	  Tensor<T> tcube(cdata.vk,false);
+	  op(key, tcube, lcube, rcube);
+	  double scale = pow(0.5,0.5*NDIM*key.level())*sqrt(FunctionDefaults<NDIM>::get_cell_volume());
+	  tcube = transform(tcube,cdata.quad_phiw).scale(scale);
+	  coeffs.replace(key, nodeT(coeffT(tcube,targs),false));
+	}
 
         /// Invoked by result to perform result += alpha*left+beta*right in wavelet basis
 
@@ -1987,26 +1994,26 @@ template<size_t NDIM>
         /// out of place gaxpy.  If all functions have the same distribution there is
         /// no communication except for the optional fence.
         template <typename L, typename R>
-        void gaxpy(T alpha, const FunctionImpl<L, NDIM>& left,
-                   T beta, const FunctionImpl<R, NDIM>& right, bool fence) {
+        void gaxpy(T alpha, const FunctionImpl<L,NDIM>& left,
+                   T beta, const FunctionImpl<R,NDIM>& right, bool fence) {
             // Loop over local nodes in both functions.  Add in left and subtract right.
             // Not that efficient in terms of memory bandwidth but ensures we do
             // not miss any nodes.
-            typename FunctionImpl<L, NDIM>::dcT::const_iterator left_end = left.coeffs.end();
-            for (typename FunctionImpl<L, NDIM>::dcT::const_iterator it = left.coeffs.begin();
-                 it != left_end;
+            typename FunctionImpl<L,NDIM>::dcT::const_iterator left_end = left.coeffs.end();
+            for (typename FunctionImpl<L,NDIM>::dcT::const_iterator it=left.coeffs.begin();
+                 it!=left_end;
                  ++it) {
                 const keyT& key = it->first;
-                const typename FunctionImpl<L, NDIM>::nodeT& other_node = it->second;
-                coeffs.send(key, &nodeT:: template gaxpy_inplace<T, L>, 1.0, other_node, alpha);
+                const typename FunctionImpl<L,NDIM>::nodeT& other_node = it->second;
+                coeffs.send(key, &nodeT:: template gaxpy_inplace<T,L>, 1.0, other_node, alpha);
             }
-            typename FunctionImpl<R, NDIM>::dcT::const_iterator right_end = right.coeffs.end();
-            for (typename FunctionImpl<R, NDIM>::dcT::const_iterator it = right.coeffs.begin();
-                 it != right_end;
+            typename FunctionImpl<R,NDIM>::dcT::const_iterator right_end = right.coeffs.end();
+            for (typename FunctionImpl<R,NDIM>::dcT::const_iterator it=right.coeffs.begin();
+                 it!=right_end;
                  ++it) {
                 const keyT& key = it->first;
-                const typename FunctionImpl<L, NDIM>::nodeT& other_node = it->second;
-                coeffs.send(key, &nodeT:: template gaxpy_inplace<T, R>, 1.0, other_node, beta);
+                const typename FunctionImpl<L,NDIM>::nodeT& other_node = it->second;
+                coeffs.send(key, &nodeT:: template gaxpy_inplace<T,R>, 1.0, other_node, beta);
             }
             if (fence)
                 world.gop.fence();
@@ -2017,16 +2024,16 @@ template<size_t NDIM>
         template <typename opT>
         void unary_op_coeff_inplace(const opT& op, bool fence) {
             typename dcT::iterator end = coeffs.end();
-            for (typename dcT::iterator it = coeffs.begin(); it != end; ++it) {
+            for (typename dcT::iterator it=coeffs.begin(); it!=end; ++it) {
                 const keyT& parent = it->first;
                 nodeT& node = it->second;
                 if (node.has_coeff()) {
-                    // op(parent, node.coeff());
-                    TensorArgs full(-1.0, TT_FULL);
-                    change_tensor_type(node.coeff(), full);
+                    //                    op(parent, node.coeff());
+                    TensorArgs full(-1.0,TT_FULL);
+                    change_tensor_type(node.coeff(),full);
                     op(parent, node.coeff().full_tensor());
-                    change_tensor_type(node.coeff(), targs);
-                    // op(parent, node);
+                    change_tensor_type(node.coeff(),targs);
+                    //                	op(parent,node);
                 }
             }
             if (fence)
@@ -2038,7 +2045,7 @@ template<size_t NDIM>
         template <typename opT>
         void unary_op_node_inplace(const opT& op, bool fence) {
             typename dcT::iterator end = coeffs.end();
-            for (typename dcT::iterator it = coeffs.begin(); it != end; ++it) {
+            for (typename dcT::iterator it=coeffs.begin(); it!=end; ++it) {
                 const keyT& parent = it->first;
                 nodeT& node = it->second;
                 op(parent, node);
@@ -2048,12 +2055,12 @@ template<size_t NDIM>
         }
 
         /// Integrate over one particle of a two particle function and get a one particle function
-        /// bsp \int g(1, 2) \delta(2-1) d2 = f(1)
+        /// bsp \int g(1,2) \delta(2-1) d2 = f(1)
         /// The overall dimension of g should be even
 
 		/// The operator
         template<std::size_t LDIM>
-		void dirac_convolution_op(const keyT &key, const nodeT &node, FunctionImpl<T, LDIM>* f) const {
+		void dirac_convolution_op(const keyT &key, const nodeT &node, FunctionImpl<T,LDIM>* f) const {
 			// fast return if the node has children (not a leaf node)
 			if(node.has_children()) return;
 
@@ -2061,52 +2068,53 @@ template<size_t NDIM>
 
 			// break the 6D key into two 3D keys (may also work for every even dimension)
 			Key<LDIM> key1, key2;
-			key.break_apart(key1, key2);
+			key.break_apart(key1,key2);
 
 			// get the coefficients of the 6D function g
 			const coeffT& g_coeff = node.coeff();
 
 			// get the values of the 6D function g
-			coeffT g_values = g->coeffs2values(key, g_coeff);
+			coeffT g_values = g->coeffs2values(key,g_coeff);
 
 			// Determine rank and k
-			const long rank = g_values.rank();
-			const long maxk = f->get_k();
-			MADNESS_ASSERT(maxk == g_coeff.dim(0));
+			const long rank=g_values.rank();
+			const long maxk=f->get_k();
+			MADNESS_ASSERT(maxk==g_coeff.dim(0));
 
 			// get tensors for particle 1 and 2 (U and V in SVD)
-			tensorT vec1 = copy(g_values.get_svdtensor().ref_vector(0).reshape(rank, maxk, maxk, maxk));
-			tensorT vec2 = g_values.get_svdtensor().ref_vector(1).reshape(rank, maxk, maxk, maxk);
-			tensorT result(maxk, maxk, maxk);  // should give zero tensor
+			tensorT vec1=copy(g_values.get_svdtensor().ref_vector(0).reshape(rank,maxk,maxk,maxk));
+			tensorT vec2=g_values.get_svdtensor().ref_vector(1).reshape(rank,maxk,maxk,maxk);
+			tensorT result(maxk,maxk,maxk);  // should give zero tensor
 			// Multiply the values of each U and V vector
-			for (long i = 0; i < rank; ++i) {
-				tensorT c1 = vec1(Slice(i, i), _, _, _); // shallow copy (!)
-				tensorT c2 = vec2(Slice(i, i), _, _, _);
+			for (long i=0; i<rank; ++i) {
+				tensorT c1=vec1(Slice(i,i),_,_,_); // shallow copy (!)
+				tensorT c2=vec2(Slice(i,i),_,_,_);
 				c1.emul(c2); // this changes vec1 because of shallow copy, but not the g function because of the deep copy made above
 				double singular_value_i = g_values.get_svdtensor().weights(i);
-				result += (singular_value_i * c1);
+				result += (singular_value_i*c1);
 			}
 
 			// accumulate coefficients (since only diagonal boxes are used the coefficients get just replaced, but accumulate is needed to create the right tree structure
-			tensorT f_coeff = f->values2coeffs(key1, result);
-			f->coeffs.task(key1, &FunctionNode<T, LDIM>::accumulate2, f_coeff, f->coeffs, key1, TaskAttributes::hipri());
-            // coeffs.task(dest, &nodeT::accumulate2, result, coeffs, dest, TaskAttributes::hipri());
+			tensorT f_coeff = f->values2coeffs(key1,result);
+			f->coeffs.task(key1, &FunctionNode<T,LDIM>::accumulate2, f_coeff, f->coeffs, key1, TaskAttributes::hipri());
+//             coeffs.task(dest, &nodeT::accumulate2, result, coeffs, dest, TaskAttributes::hipri());
+
 
 			return;
 		}
 
 
         template<std::size_t LDIM>
-        void do_dirac_convolution(FunctionImpl<T, LDIM>* f, bool fence) const {
+        void do_dirac_convolution(FunctionImpl<T,LDIM>* f, bool fence) const {
             typename dcT::const_iterator end = this->coeffs.end();
-            for (typename dcT::const_iterator it = this->coeffs.begin(); it != end; ++it) {
+            for (typename dcT::const_iterator it=this->coeffs.begin(); it!=end; ++it) {
                 // looping through all the leaf(!) coefficients in the NDIM function ("this")
                 const keyT& key = it->first;
-                const FunctionNode<T, NDIM>& node = it->second;
+                const FunctionNode<T,NDIM>& node = it->second;
                 if (node.is_leaf()) {
                 	// only process the diagonal boxes
         			Key<LDIM> key1, key2;
-        			key.break_apart(key1, key2);
+        			key.break_apart(key1,key2);
         			if(key1 == key2){
                         ProcessID p = coeffs.owner(key);
                         woT::task(p, &implT:: template dirac_convolution_op<LDIM>, key, node, f);
@@ -2116,9 +2124,9 @@ template<size_t NDIM>
             world.gop.fence(); // fence is necessary if trickle down is used afterwards
             // trickle down and undo redundand shouldnt change anything if only the diagonal elements are considered above -> check this
             f->trickle_down(true); // fence must be true otherwise undo_redundant will have trouble
-            // f->undo_redundant(true);
+//            f->undo_redundant(true);
             f->verify_tree();
-            // if (fence) world.gop.fence(); // unnecessary, fence is activated in undo_redundant
+            //if (fence) world.gop.fence(); // unnecessary, fence is activated in undo_redundant
 
         }
 
@@ -2128,8 +2136,8 @@ template<size_t NDIM>
         template <typename opT>
         void flo_unary_op_node_inplace(const opT& op, bool fence) {
             typedef Range<typename dcT::iterator> rangeT;
-            // typedef do_unary_op_value_inplace<opT> xopT;
-            world.taskq.for_each<rangeT, opT>(rangeT(coeffs.begin(), coeffs.end()), op);
+//            typedef do_unary_op_value_inplace<opT> xopT;
+            world.taskq.for_each<rangeT,opT>(rangeT(coeffs.begin(), coeffs.end()), op);
             if (fence) world.gop.fence();
         }
 
@@ -2138,8 +2146,8 @@ template<size_t NDIM>
         template <typename opT>
         void flo_unary_op_node_inplace(const opT& op, bool fence) const {
             typedef Range<typename dcT::const_iterator> rangeT;
-            // typedef do_unary_op_value_inplace<opT> xopT;
-            world.taskq.for_each<rangeT, opT>(rangeT(coeffs.begin(), coeffs.end()), op);
+//            typedef do_unary_op_value_inplace<opT> xopT;
+            world.taskq.for_each<rangeT,opT>(rangeT(coeffs.begin(), coeffs.end()), op);
             if (fence)
                 world.gop.fence();
         }
@@ -2165,15 +2173,15 @@ template<size_t NDIM>
 
                 if (node.is_leaf() and node.coeff().has_data()) {
                     coeffT d = copy(node.coeff());
-                    d(f->cdata.s0) = 0.0;
-                    const double error = d.normf();
-                    const double tol = f->truncate_tol(f->get_thresh(), key);
-                    if (error<tol) node.coeff() = copy(node.coeff()(f->cdata.s0));
+                    d(f->cdata.s0)=0.0;
+                    const double error=d.normf();
+                    const double tol=f->truncate_tol(f->get_thresh(),key);
+                    if (error<tol) node.coeff()=copy(node.coeff()(f->cdata.s0));
                 }
                 return true;
             }
-
             template <typename Archive> void serialize(const Archive& ar) {}
+
         };
 
         /// remove all coefficients of internal nodes
@@ -2189,7 +2197,6 @@ template<size_t NDIM>
                 if (node.has_children()) node.clear_coeff();
                 return true;
             }
-
             template <typename Archive> void serialize(const Archive& ar) {}
 
         };
@@ -2206,8 +2213,8 @@ template<size_t NDIM>
                 if (not node.has_children()) node.clear_coeff();
                 return true;
             }
-
             template <typename Archive> void serialize(const Archive& ar) {}
+
         };
 
 
@@ -2226,8 +2233,8 @@ template<size_t NDIM>
                 node.coeff()=s;
                 return true;
             }
-
             template <typename Archive> void serialize(const Archive& ar) {}
+
         };
 
 
@@ -2242,16 +2249,16 @@ template<size_t NDIM>
             do_reduce_rank() = default;
             do_reduce_rank(const TensorArgs& targs) : args(targs) {}
             do_reduce_rank(const double& thresh) {
-                args.thresh = thresh;
+                args.thresh=thresh;
             }
 
             //
             bool operator()(typename rangeT::iterator& it) const {
+
                 nodeT& node = it->second;
                 node.reduceRank(args.thresh);
                 return true;
             }
-
             template <typename Archive> void serialize(const Archive& ar) {}
         };
 
@@ -2266,70 +2273,73 @@ template<size_t NDIM>
 
             /// return the norm of the difference of this node and its "mirror" node
             double operator()(typename rangeT::iterator& it) const {
-                // Temporary fix to GCC whining about out of range access for NDIM != 6
-                if constexpr(NDIM == 6) {
-                    const keyT& key = it->first;
-                    const nodeT& fnode = it->second;
 
-                    // skip internal nodes
-                    if (fnode.has_children()) return 0.0;
+	      // Temporary fix to GCC whining about out of range access for NDIM!=6
+  	      if constexpr(NDIM==6) {
+                const keyT& key = it->first;
+                const nodeT& fnode = it->second;
 
-                    if (f->world.size()>1) return 0.0;
+                // skip internal nodes
+                if (fnode.has_children()) return 0.0;
 
-                    // exchange particles
-                    std::vector<long> map(NDIM);
-                    map[0]=3; map[1]=4; map[2]=5;
-                    map[3]=0; map[4]=1; map[5]=2;
+                if (f->world.size()>1) return 0.0;
 
-                    // make mapped key
-                    Vector<Translation, NDIM> l;
-                    for (std::size_t i = 0; i < NDIM; ++i) l[map[i]] = key.translation()[i];
-                    const keyT mapkey(key.level(), l);
+                // exchange particles
+                std::vector<long> map(NDIM);
+                map[0]=3; map[1]=4; map[2]=5;
+                map[3]=0; map[4]=1; map[5]=2;
 
-                    double norm = 0.0;
+                // make mapped key
+                Vector<Translation,NDIM> l;
+                for (std::size_t i=0; i<NDIM; ++i) l[map[i]] = key.translation()[i];
+                const keyT mapkey(key.level(),l);
+
+                double norm=0.0;
 
 
-                    // hope it's local
-                    if (f->get_coeffs().probe(mapkey)) {
-                        MADNESS_ASSERT(f->get_coeffs().probe(mapkey));
-                        const nodeT& mapnode = f->get_coeffs().find(mapkey).get()->second;
+                // hope it's local
+                if (f->get_coeffs().probe(mapkey)) {
+                    MADNESS_ASSERT(f->get_coeffs().probe(mapkey));
+                    const nodeT& mapnode=f->get_coeffs().find(mapkey).get()->second;
 
-                        // bool have_c1 = fnode.coeff().has_data() and fnode.coeff().config().has_data();
-                        // bool have_c2 = mapnode.coeff().has_data() and mapnode.coeff().config().has_data();
-                        bool have_c1 = fnode.coeff().has_data();
-                        bool have_c2 = mapnode.coeff().has_data();
+//                    bool have_c1=fnode.coeff().has_data() and fnode.coeff().config().has_data();
+//                    bool have_c2=mapnode.coeff().has_data() and mapnode.coeff().config().has_data();
+                    bool have_c1=fnode.coeff().has_data();
+                    bool have_c2=mapnode.coeff().has_data();
 
-                        if (have_c1 and have_c2) {
-                            tensorT c1 = fnode.coeff().full_tensor_copy();
-                            tensorT c2 = mapnode.coeff().full_tensor_copy();
-                            c2 = copy(c2.mapdim(map));
-                            norm = (c1 - c2).normf();
-                        } else if (have_c1) {
-                            tensorT c1 = fnode.coeff().full_tensor_copy();
-                            norm = c1.normf();
-                        } else if (have_c2) {
-                            tensorT c2 = mapnode.coeff().full_tensor_copy();
-                            norm = c2.normf();
-                        } else {
-                            norm = 0.0;
-                        }
+                    if (have_c1 and have_c2) {
+                        tensorT c1=fnode.coeff().full_tensor_copy();
+                        tensorT c2=mapnode.coeff().full_tensor_copy();
+                        c2 = copy(c2.mapdim(map));
+                        norm=(c1-c2).normf();
+                    } else if (have_c1) {
+                        tensorT c1=fnode.coeff().full_tensor_copy();
+                        norm=c1.normf();
+                    } else if (have_c2) {
+                        tensorT c2=mapnode.coeff().full_tensor_copy();
+                        norm=c2.normf();
                     } else {
-                        norm = fnode.coeff().normf();
+                        norm=0.0;
                     }
-                    return norm * norm;
+                } else {
+                    norm=fnode.coeff().normf();
                 }
-                else {
-                    throw "ONLY FOR DIM 6!";
-                }
-            }  // end operator()
+                return norm*norm;
+	      }
+	      else {
+		throw "ONLY FOR DIM 6!";
+	      }
+            }
 
             double operator()(double a, double b) const {
-                return (a + b);
+                return (a+b);
             }
 
             template <typename Archive> void serialize(const Archive& ar) {
-                MADNESS_EXCEPTION("no serialization of do_check_symmetry yet", 1);
+                MADNESS_EXCEPTION("no serialization of do_check_symmetry yet",1);
             }
+
+
         };
 
         /// merge the coefficent boxes of this into result's tree
@@ -2338,25 +2348,26 @@ template<size_t NDIM>
         /// this and result don't have to have the same distribution or live in the same world
         /// no comm, and the tree should be in an consistent state by virtue
         template<typename Q, typename R>
-        struct do_accumulate_trees {
+        struct do_accumulate_trees{
             typedef Range<typename dcT::const_iterator> rangeT;
-            FunctionImpl<Q, NDIM>* result = 0;
-            T alpha = T(1.0);
+            FunctionImpl<Q,NDIM>* result=0;
+            T alpha=T(1.0);
             do_accumulate_trees() = default;
-            do_accumulate_trees(FunctionImpl<Q, NDIM>& result, const T alpha)
+            do_accumulate_trees(FunctionImpl<Q,NDIM>& result, const T alpha)
                 : result(&result), alpha(alpha) {}
 
             /// return the norm of the difference of this node and its "mirror" node
             bool operator()(typename rangeT::iterator& it) const {
+
                 const keyT& key = it->first;
                 const nodeT& node = it->second;
                 if (node.has_coeff()) result->get_coeffs().task(key, &nodeT::accumulate,
-                    alpha * node.coeff(), result->get_coeffs(), key, result->targs);
+                    alpha*node.coeff(), result->get_coeffs(), key, result->targs);
                 return true;
             }
 
             template <typename Archive> void serialize(const Archive& ar) {
-                MADNESS_EXCEPTION("no serialization of do_accumulate_trees", 1);
+                MADNESS_EXCEPTION("no serialization of do_accumulate_trees",1);
             }
         };
 
@@ -2368,34 +2379,35 @@ template<size_t NDIM>
         template<typename Q, typename R>
         struct do_merge_trees {
             typedef Range<typename dcT::const_iterator> rangeT;
-            FunctionImpl<Q, NDIM>* other;
+            FunctionImpl<Q,NDIM>* other;
             T alpha;
             R beta;
             do_merge_trees() : other(0) {}
-            do_merge_trees(const T alpha, const R beta, FunctionImpl<Q, NDIM>& other)
+            do_merge_trees(const T alpha, const R beta, FunctionImpl<Q,NDIM>& other)
                 : other(&other), alpha(alpha), beta(beta) {}
 
             /// return the norm of the difference of this node and its "mirror" node
             bool operator()(typename rangeT::iterator& it) const {
+
                 const keyT& key = it->first;
                 const nodeT& fnode = it->second;
 
                 // if other's node exists: add this' coeffs to it
                 // otherwise insert this' node into other's tree
                 typename dcT::accessor acc;
-                if (other->get_coeffs().find(acc, key)) {
+                if (other->get_coeffs().find(acc,key)) {
                     nodeT& gnode=acc->second;
-                    gnode.gaxpy_inplace(beta, fnode, alpha);
+                    gnode.gaxpy_inplace(beta,fnode,alpha);
                 } else {
                     nodeT gnode=fnode;
                     gnode.scale(alpha);
-                    other->get_coeffs().replace(key, gnode);
+                    other->get_coeffs().replace(key,gnode);
                 }
                 return true;
             }
 
             template <typename Archive> void serialize(const Archive& ar) {
-                MADNESS_EXCEPTION("no serialization of do_merge_trees", 1);
+                MADNESS_EXCEPTION("no serialization of do_merge_trees",1);
             }
         };
 
@@ -2411,22 +2423,23 @@ template<size_t NDIM>
             do_mapdim(const std::vector<long> map, implT& f) : map(map), f(&f) {}
 
             bool operator()(typename rangeT::iterator& it) const {
+
                 const keyT& key = it->first;
                 const nodeT& node = it->second;
 
-                Vector<Translation, NDIM> l;
-                for (std::size_t i = 0; i < NDIM; ++i) l[map[i]] = key.translation()[i];
+                Vector<Translation,NDIM> l;
+                for (std::size_t i=0; i<NDIM; ++i) l[map[i]] = key.translation()[i];
                 tensorT c = node.coeff().reconstruct_tensor();
                 if (c.size()) c = copy(c.mapdim(map));
-                coeffT cc(c, f->get_tensor_args());
-                f->get_coeffs().replace(keyT(key.level(), l), nodeT(cc, node.has_children()));
+                coeffT cc(c,f->get_tensor_args());
+                f->get_coeffs().replace(keyT(key.level(),l), nodeT(cc,node.has_children()));
 
                 return true;
             }
-
             template <typename Archive> void serialize(const Archive& ar) {
-                MADNESS_EXCEPTION("no serialization of do_mapdim", 1);
+                MADNESS_EXCEPTION("no serialization of do_mapdim",1);
             }
+
         };
 
         /// mirror dimensions of this, write result on f
@@ -2440,14 +2453,15 @@ template<size_t NDIM>
             do_mirror(const std::vector<long> mirror, implT& f) : mirror(mirror), f(&f) {}
 
             bool operator()(typename rangeT::iterator& it) const {
+
                 const keyT& key = it->first;
                 const nodeT& node = it->second;
 
                 // mirror translation index: l_new + l_old = l_max
-                Vector<Translation, NDIM> l=key.translation();
-                Translation lmax = (Translation(1) << key.level()) - 1;
-                for (std::size_t i = 0; i < NDIM; ++i) {
-                	if (mirror[i] == -1) l[i] = lmax - key.translation()[i];
+                Vector<Translation,NDIM> l=key.translation();
+                Translation lmax = (Translation(1)<<key.level()) - 1;
+                for (std::size_t i=0; i<NDIM; ++i) {
+                	if (mirror[i]==-1) l[i]= lmax - key.translation()[i];
                 }
 
                 // mirror coefficients: multiply all odd-k slices with -1
@@ -2456,33 +2470,33 @@ template<size_t NDIM>
             		std::vector<Slice> s(___);
 
                 	// loop over dimensions and over k
-                	for (size_t i = 0; i < NDIM; ++i) {
-                		std::size_t kmax = c.dim(i);
-                		if (mirror[i] == -1) {
-                			for (size_t k = 1; k < kmax; k += 2) {
-                				s[i] = Slice(k, k, 1);
-                				c(s) *= (-1.0);
+                	for (size_t i=0; i<NDIM; ++i) {
+                		std::size_t kmax=c.dim(i);
+                		if (mirror[i]==-1) {
+                			for (size_t k=1; k<kmax; k+=2) {
+                				s[i]=Slice(k,k,1);
+                				c(s)*=(-1.0);
                 			}
-                			s[i] = _;
+                			s[i]=_;
                 		}
                 	}
                 }
-                coeffT cc(c, f->get_tensor_args());
-                f->get_coeffs().replace(keyT(key.level(), l), nodeT(cc, node.has_children()));
+                coeffT cc(c,f->get_tensor_args());
+                f->get_coeffs().replace(keyT(key.level(),l), nodeT(cc,node.has_children()));
 
                 return true;
             }
-
             template <typename Archive> void serialize(const Archive& ar) {
-                MADNESS_EXCEPTION("no serialization of do_mirror", 1);
+                MADNESS_EXCEPTION("no serialization of do_mirror",1);
             }
+
         };
 
         /// mirror dimensions of this, write result on f
         struct do_map_and_mirror {
             typedef Range<typename dcT::iterator> rangeT;
 
-            std::vector<long> map, mirror;
+            std::vector<long> map,mirror;
             implT* f;
 
             do_map_and_mirror() = default;
@@ -2495,52 +2509,54 @@ template<size_t NDIM>
                 const nodeT& node = it->second;
 
                 tensorT c = node.coeff().full_tensor_copy();
-                Vector<Translation, NDIM> l = key.translation();
+                Vector<Translation,NDIM> l=key.translation();
 
                 // do the mapping first (if present)
-                if (map.size() > 0) {
-                	Vector<Translation, NDIM> l1 = l;
-                	for (std::size_t i = 0; i < NDIM; ++i) l1[map[i]] = l[i];
-                	std::swap(l, l1);
+                if (map.size()>0) {
+                	Vector<Translation,NDIM> l1=l;
+                	for (std::size_t i=0; i<NDIM; ++i) l1[map[i]] = l[i];
+                	std::swap(l,l1);
                 	if (c.size()) c = copy(c.mapdim(map));
                 }
 
-                if (mirror.size() > 0) {
+                if (mirror.size()>0) {
 					// mirror translation index: l_new + l_old = l_max
-                	Vector<Translation, NDIM> l1 = l;
-					Translation lmax = (Translation(1) << key.level()) - 1;
-					for (std::size_t i = 0; i < NDIM; ++i) {
-						if (mirror[i] == -1) l1[i] = lmax - l[i];
+                	Vector<Translation,NDIM> l1=l;
+					Translation lmax = (Translation(1)<<key.level()) - 1;
+					for (std::size_t i=0; i<NDIM; ++i) {
+						if (mirror[i]==-1) l1[i]= lmax - l[i];
 					}
-                	std::swap(l, l1);
+                	std::swap(l,l1);
 
                 	// mirror coefficients: multiply all odd-k slices with -1
 					if (c.size()) {
 						std::vector<Slice> s(___);
 
 						// loop over dimensions and over k
-						for (size_t i = 0; i < NDIM; ++i) {
-							std::size_t kmax = c.dim(i);
-							if (mirror[i] == -1) {
-								for (size_t k = 1; k < kmax; k += 2) {
-									s[i] = Slice(k, k, 1);
-									c(s) *= (-1.0);
+						for (size_t i=0; i<NDIM; ++i) {
+							std::size_t kmax=c.dim(i);
+							if (mirror[i]==-1) {
+								for (size_t k=1; k<kmax; k+=2) {
+									s[i]=Slice(k,k,1);
+									c(s)*=(-1.0);
 								}
-								s[i] = _;
+								s[i]=_;
 							}
 						}
 					}
                 }
 
-                coeffT cc(c, f->get_tensor_args());
-                f->get_coeffs().replace(keyT(key.level(), l), nodeT(cc, node.has_children()));
+                coeffT cc(c,f->get_tensor_args());
+                f->get_coeffs().replace(keyT(key.level(),l), nodeT(cc,node.has_children()));
                 return true;
             }
-
             template <typename Archive> void serialize(const Archive& ar) {
-                MADNESS_EXCEPTION("no serialization of do_mirror", 1);
+                MADNESS_EXCEPTION("no serialization of do_mirror",1);
             }
+
         };
+
+
 
         /// "put" this on g
         struct do_average {
@@ -2562,11 +2578,11 @@ template<size_t NDIM>
 
                     // check if there is a node already existing
                     typename dcT::accessor acc;
-                    if (g->get_coeffs().find(acc, key)) {
+                    if (g->get_coeffs().find(acc,key)) {
                         nodeT& gnode=acc->second;
                         if (gnode.has_coeff()) gnode.coeff()+=fnode.coeff();
                     } else {
-                        g->get_coeffs().replace(key, fnode);
+                        g->get_coeffs().replace(key,fnode);
                     }
                 }
 
@@ -2590,14 +2606,16 @@ template<size_t NDIM>
 
             //
             bool operator()(typename rangeT::iterator& it) const {
-            	double cpu0 = cpu_time();
-                nodeT& node = it->second;
-                change_tensor_type(node.coeff(), targs);
-            	double cpu1 = cpu_time();
-                f->timer_change_tensor_type.accumulate(cpu1 - cpu0);
-                return true;
-            }
 
+            	double cpu0=cpu_time();
+                nodeT& node = it->second;
+                change_tensor_type(node.coeff(),targs);
+            	double cpu1=cpu_time();
+                f->timer_change_tensor_type.accumulate(cpu1-cpu0);
+
+                return true;
+
+            }
             template <typename Archive> void serialize(const Archive& ar) {}
         };
 
@@ -2614,7 +2632,6 @@ template<size_t NDIM>
                 it->second.consolidate_buffer(targs);
                 return true;
             }
-
             template <typename Archive> void serialize(const Archive& ar) {}
         };
 
@@ -2626,70 +2643,69 @@ template<size_t NDIM>
             implT* impl;
             opT op;
             do_unary_op_value_inplace(implT* impl, const opT& op) : impl(impl), op(op) {}
-
             bool operator()(typename rangeT::iterator& it) const {
                 const keyT& key = it->first;
                 nodeT& node = it->second;
                 if (node.has_coeff()) {
-                    const TensorArgs full_args(-1.0, TT_FULL);
-                    change_tensor_type(node.coeff(), full_args);
-                    tensorT& t = node.coeff().full_tensor();
-                    // double before = t.normf();
+                    const TensorArgs full_args(-1.0,TT_FULL);
+                    change_tensor_type(node.coeff(),full_args);
+                    tensorT& t= node.coeff().full_tensor();
+                    //double before = t.normf();
                     tensorT values = impl->fcube_for_mul(key, key, t);
                     op(key, values);
-                    double scale = pow(0.5, 0.5 * NDIM * key.level()) * sqrt(FunctionDefaults<NDIM>::get_cell_volume());
-                    t = transform(values, impl->cdata.quad_phiw).scale(scale);
-                    node.coeff() = coeffT(t, impl->get_tensor_args());
-                    // double after = t.normf();
-                    // madness::print("XOP:", key, before, after);
+                    double scale = pow(0.5,0.5*NDIM*key.level())*sqrt(FunctionDefaults<NDIM>::get_cell_volume());
+                    t = transform(values,impl->cdata.quad_phiw).scale(scale);
+                    node.coeff()=coeffT(t,impl->get_tensor_args());
+                    //double after = t.normf();
+                    //madness::print("XOP:", key, before, after);
                 }
                 return true;
             }
-
             template <typename Archive> void serialize(const Archive& ar) {}
         };
 
         template <typename Q, typename R>
         /// @todo I don't know what this does other than a trasform
-        void vtransform_doit(const std::shared_ptr< FunctionImpl<R, NDIM>>& right,
+        void vtransform_doit(const std::shared_ptr< FunctionImpl<R,NDIM> >& right,
                              const Tensor<Q>& c,
-                             const std::vector< std::shared_ptr< FunctionImpl<T, NDIM>> >& vleft,
+                             const std::vector< std::shared_ptr< FunctionImpl<T,NDIM> > >& vleft,
                              double tol) {
             // To reduce crunch on vectors being transformed each task
             // does them in a random order
             std::vector<unsigned int> ind(vleft.size());
-            for (unsigned int i = 0; i < vleft.size(); ++i) {
+            for (unsigned int i=0; i<vleft.size(); ++i) {
                 ind[i] = i;
             }
-            for (unsigned int i = 0; i < vleft.size(); ++i) {
-                unsigned int j = RandomValue<int>() % vleft.size();
-                std::swap(ind[i], ind[j]);
+            for (unsigned int i=0; i<vleft.size(); ++i) {
+                unsigned int j = RandomValue<int>()%vleft.size();
+                std::swap(ind[i],ind[j]);
             }
 
-            typename FunctionImpl<R, NDIM>::dcT::const_iterator end = right->coeffs.end();
-            for (typename FunctionImpl<R, NDIM>::dcT::const_iterator it = right->coeffs.begin(); it != end; ++it) {
+            typename FunctionImpl<R,NDIM>::dcT::const_iterator end = right->coeffs.end();
+            for (typename FunctionImpl<R,NDIM>::dcT::const_iterator it=right->coeffs.begin(); it != end; ++it) {
                 if (it->second.has_coeff()) {
                     const Key<NDIM>& key = it->first;
                     const GenTensor<R>& r = it->second.coeff();
                     double norm = r.normf();
-                    double keytol = truncate_tol(tol, key);
+                    double keytol = truncate_tol(tol,key);
 
-                    for (unsigned int j = 0; j < vleft.size(); ++j) {
+                    for (unsigned int j=0; j<vleft.size(); ++j) {
                         unsigned int i = ind[j]; // Random permutation
                         if (std::abs(norm*c(i)) > keytol) {
                             implT* left = vleft[i].get();
                             typename dcT::accessor acc;
-                            bool newnode = left->coeffs.insert(acc, key);
+                            bool newnode = left->coeffs.insert(acc,key);
                             if (newnode && key.level()>0) {
                                 Key<NDIM> parent = key.parent();
-                                if (left->coeffs.is_local(parent))
-                                    left->coeffs.send(parent, &nodeT::set_has_children_recursive, left->coeffs, parent);
-                                else
-                                    left->coeffs.task(parent, &nodeT::set_has_children_recursive, left->coeffs, parent);
+				if (left->coeffs.is_local(parent))
+				  left->coeffs.send(parent, &nodeT::set_has_children_recursive, left->coeffs, parent);
+				else
+				  left->coeffs.task(parent, &nodeT::set_has_children_recursive, left->coeffs, parent);
+
                             }
                             nodeT& node = acc->second;
                             if (!node.has_coeff())
-                                node.set_coeff(coeffT(cdata.v2k, targs));
+                                node.set_coeff(coeffT(cdata.v2k,targs));
                             coeffT& t = node.coeff();
                             t.gaxpy(1.0, r, c(i));
                         }
@@ -2703,7 +2719,7 @@ template<size_t NDIM>
         /// @param v the vector of functions we are refining.
         /// @param key the current node.
         /// @param c the vector of coefficients passed from above.
-        void refine_to_common_level(const std::vector<FunctionImpl<T, NDIM>*>& v,
+        void refine_to_common_level(const std::vector<FunctionImpl<T,NDIM>*>& v,
                                     const std::vector<tensorT>& c,
                                     const keyT key);
 
@@ -2714,14 +2730,14 @@ template<size_t NDIM>
         template <typename opT>
         void multiop_values_doit(const keyT& key, const opT& op, const std::vector<implT*>& v) {
             std::vector<tensorT> c(v.size());
-            for (unsigned int i = 0; i < v.size(); i++) {
+            for (unsigned int i=0; i<v.size(); i++) {
                 if (v[i]) {
                     coeffT cc = coeffs2values(key, v[i]->coeffs.find(key).get()->second.coeff());
-                    c[i] = cc.full_tensor();
+                    c[i]=cc.full_tensor();
                 }
             }
             tensorT r = op(key, c);
-            coeffs.replace(key, nodeT(coeffT(values2coeffs(key, r), targs), false));
+            coeffs.replace(key, nodeT(coeffT(values2coeffs(key, r),targs),false));
         }
 
         /// Inplace operate on many functions (impl's) with an operator within a certain box
@@ -2731,18 +2747,18 @@ template<size_t NDIM>
         template <typename opT>
         void multiop_values(const opT& op, const std::vector<implT*>& v) {
             // rough check on refinement level (ignore non-initialized functions
-            for (std::size_t i = 1; i < v.size(); ++i) {
-                if (v[i] and v[i - 1]) {
-                    MADNESS_ASSERT(v[i]->coeffs.size() == v[i - 1]->coeffs.size());
+            for (std::size_t i=1; i<v.size(); ++i) {
+                if (v[i] and v[i-1]) {
+                    MADNESS_ASSERT(v[i]->coeffs.size()==v[i-1]->coeffs.size());
                 }
             }
             typename dcT::iterator end = v[0]->coeffs.end();
-            for (typename dcT::iterator it = v[0]->coeffs.begin(); it != end; ++it) {
+            for (typename dcT::iterator it=v[0]->coeffs.begin(); it!=end; ++it) {
                 const keyT& key = it->first;
                 if (it->second.has_coeff())
                     world.taskq.add(*this, &implT:: template multiop_values_doit<opT>, key, op, v);
                 else
-                    coeffs.replace(key, nodeT(coeffT(), true));
+                    coeffs.replace(key, nodeT(coeffT(),true));
             }
             world.gop.fence();
         }
@@ -2757,16 +2773,16 @@ template<size_t NDIM>
         void multi_to_multi_op_values_doit(const keyT& key, const opT& op,
                 const std::vector<implT*>& vin, std::vector<implT*>& vout) {
             std::vector<tensorT> c(vin.size());
-            for (unsigned int i = 0; i < vin.size(); i++) {
+            for (unsigned int i=0; i<vin.size(); i++) {
                 if (vin[i]) {
                     coeffT cc = coeffs2values(key, vin[i]->coeffs.find(key).get()->second.coeff());
-                    c[i] = cc.full_tensor();
+                    c[i]=cc.full_tensor();
                 }
             }
             std::vector<tensorT> r = op(key, c);
-            MADNESS_ASSERT(r.size() == vout.size());
-            for (std::size_t i = 0; i < vout.size(); ++i) {
-                vout[i]->coeffs.replace(key, nodeT(coeffT(values2coeffs(key, r[i]), targs), false));
+            MADNESS_ASSERT(r.size()==vout.size());
+            for (std::size_t i=0; i<vout.size(); ++i) {
+                vout[i]->coeffs.replace(key, nodeT(coeffT(values2coeffs(key, r[i]),targs),false));
             }
         }
 
@@ -2780,13 +2796,13 @@ template<size_t NDIM>
         void multi_to_multi_op_values(const opT& op, const std::vector<implT*>& vin,
                 std::vector<implT*>& vout, const bool fence=true) {
             // rough check on refinement level (ignore non-initialized functions
-            for (std::size_t i = 1; i < vin.size(); ++i) {
+            for (std::size_t i=1; i<vin.size(); ++i) {
                 if (vin[i] and vin[i-1]) {
-                    MADNESS_ASSERT(vin[i]->coeffs.size() == vin[i - 1]->coeffs.size());
+                    MADNESS_ASSERT(vin[i]->coeffs.size()==vin[i-1]->coeffs.size());
                 }
             }
             typename dcT::iterator end = vin[0]->coeffs.end();
-            for (typename dcT::iterator it = vin[0]->coeffs.begin(); it != end; ++it) {
+            for (typename dcT::iterator it=vin[0]->coeffs.begin(); it!=end; ++it) {
                 const keyT& key = it->first;
                 if (it->second.has_coeff())
                     world.taskq.add(*this, &implT:: template multi_to_multi_op_values_doit<opT>,
@@ -2794,25 +2810,25 @@ template<size_t NDIM>
                 else {
                     // fill result functions with empty box in this key
                     for (implT* it2 : vout) {
-                        it2->coeffs.replace(key, nodeT(coeffT(), true));
+                        it2->coeffs.replace(key, nodeT(coeffT(),true));
                     }
                 }
             }
             if (fence) world.gop.fence();
         }
 
-        /// Transforms a vector of functions left[i] = sum[j] right[j]*c[j, i] using sparsity
+        /// Transforms a vector of functions left[i] = sum[j] right[j]*c[j,i] using sparsity
         /// @param[in] vright vector of functions (impl's) on which to be transformed
         /// @param[in] c the tensor (matrix) transformer
         /// @param[in] vleft vector of of the *newly* transformed functions (impl's)
         template <typename Q, typename R>
-        void vtransform(const std::vector< std::shared_ptr< FunctionImpl<R, NDIM>> >& vright,
+        void vtransform(const std::vector< std::shared_ptr< FunctionImpl<R,NDIM> > >& vright,
                         const Tensor<Q>& c,
-                        const std::vector< std::shared_ptr< FunctionImpl<T, NDIM>> >& vleft,
+                        const std::vector< std::shared_ptr< FunctionImpl<T,NDIM> > >& vleft,
                         double tol,
                         bool fence) {
-            for (unsigned int j = 0; j < vright.size(); ++j) {
-                world.taskq.add(*this, &implT:: template vtransform_doit<Q, R>, vright[j], copy(c(j, _)), vleft, tol);
+            for (unsigned int j=0; j<vright.size(); ++j) {
+                world.taskq.add(*this, &implT:: template vtransform_doit<Q,R>, vright[j], copy(c(j,_)), vleft, tol);
             }
             if (fence)
                 world.gop.fence();
@@ -2824,7 +2840,7 @@ template<size_t NDIM>
         void unary_op_value_inplace(const opT& op, bool fence) {
             typedef Range<typename dcT::iterator> rangeT;
             typedef do_unary_op_value_inplace<opT> xopT;
-            world.taskq.for_each<rangeT, xopT>(rangeT(coeffs.begin(), coeffs.end()), xopT(this, op));
+            world.taskq.for_each<rangeT,xopT>(rangeT(coeffs.begin(), coeffs.end()), xopT(this,op));
             if (fence)
                 world.gop.fence();
         }
@@ -2842,13 +2858,13 @@ template<size_t NDIM>
         /// @param[out] vresultin the vector of resulting functions (impl's)
         template <typename L, typename R>
         void mulXXveca(const keyT& key,
-                       const FunctionImpl<L, NDIM>* left, const Tensor<L>& lcin,
-                       const std::vector<const FunctionImpl<R, NDIM>*> vrightin,
-                       const std::vector< Tensor<R>>& vrcin,
-                       const std::vector<FunctionImpl<T, NDIM>*> vresultin,
+                       const FunctionImpl<L,NDIM>* left, const Tensor<L>& lcin,
+                       const std::vector<const FunctionImpl<R,NDIM>*> vrightin,
+                       const std::vector< Tensor<R> >& vrcin,
+                       const std::vector<FunctionImpl<T,NDIM>*> vresultin,
                        double tol) {
-            typedef typename FunctionImpl<L, NDIM>::dcT::const_iterator literT;
-            typedef typename FunctionImpl<R, NDIM>::dcT::const_iterator riterT;
+            typedef typename FunctionImpl<L,NDIM>::dcT::const_iterator literT;
+            typedef typename FunctionImpl<R,NDIM>::dcT::const_iterator riterT;
 
             double lnorm = 1e99;
             Tensor<L> lc = lcin;
@@ -2861,16 +2877,16 @@ template<size_t NDIM>
             }
 
             // Loop thru RHS functions seeing if anything can be multiplied
-            std::vector<FunctionImpl<T, NDIM>*> vresult;
-            std::vector<const FunctionImpl<R, NDIM>*> vright;
-            std::vector< Tensor<R>> vrc;
+            std::vector<FunctionImpl<T,NDIM>*> vresult;
+            std::vector<const FunctionImpl<R,NDIM>*> vright;
+            std::vector< Tensor<R> > vrc;
             vresult.reserve(vrightin.size());
             vright.reserve(vrightin.size());
             vrc.reserve(vrightin.size());
 
-            for (unsigned int i = 0; i < vrightin.size(); ++i) {
-                FunctionImpl<T, NDIM>* result = vresultin[i];
-                const FunctionImpl<R, NDIM>* right = vrightin[i];
+            for (unsigned int i=0; i<vrightin.size(); ++i) {
+                FunctionImpl<T,NDIM>* result = vresultin[i];
+                const FunctionImpl<R,NDIM>* right = vrightin[i];
                 Tensor<R> rc = vrcin[i];
                 double rnorm;
                 if (rc.size() == 0) {
@@ -2885,13 +2901,13 @@ template<size_t NDIM>
                 }
 
                 if (rc.size() && lc.size()) { // Yipee!
-                    result->task(world.rank(), &implT:: template do_mul<L, R>, key, lc, std::make_pair(key, rc));
+                    result->task(world.rank(), &implT:: template do_mul<L,R>, key, lc, std::make_pair(key,rc));
                 }
                 else if (tol && lnorm*rnorm < truncate_tol(tol, key)) {
-                    result->coeffs.replace(key, nodeT(coeffT(cdata.vk, targs), false)); // Zero leaf
+                    result->coeffs.replace(key, nodeT(coeffT(cdata.vk,targs),false)); // Zero leaf
                 }
                 else {  // Interior node
-                    result->coeffs.replace(key, nodeT(coeffT(), true));
+                    result->coeffs.replace(key, nodeT(coeffT(),true));
                     vresult.push_back(result);
                     vright.push_back(right);
                     vrc.push_back(rc);
@@ -2906,8 +2922,8 @@ template<size_t NDIM>
                     lss = left->unfilter(ld);
                 }
 
-                std::vector< Tensor<R>> vrss(vresult.size());
-                for (unsigned int i = 0; i < vresult.size(); ++i) {
+                std::vector< Tensor<R> > vrss(vresult.size());
+                for (unsigned int i=0; i<vresult.size(); ++i) {
                     if (vrc[i].size()) {
                         Tensor<R> rd(cdata.v2k);
                         rd(cdata.s0) = vrc[i](___);
@@ -2924,13 +2940,13 @@ template<size_t NDIM>
                     if (lc.size())
                         ll = copy(lss(cp));
 
-                    std::vector< Tensor<R>> vv(vresult.size());
-                    for (unsigned int i = 0; i < vresult.size(); ++i) {
+                    std::vector< Tensor<R> > vv(vresult.size());
+                    for (unsigned int i=0; i<vresult.size(); ++i) {
                         if (vrc[i].size())
                             vv[i] = copy(vrss[i](cp));
                     }
 
-                    woT::task(coeffs.owner(child), &implT:: template mulXXveca<L, R>, child, left, ll, vright, vv, vresult, tol);
+                    woT::task(coeffs.owner(child), &implT:: template mulXXveca<L,R>, child, left, ll, vright, vv, vresult, tol);
                 }
             }
         }
@@ -2946,13 +2962,13 @@ template<size_t NDIM>
         ///            current box in the right function
         template <typename L, typename R>
         void mulXXa(const keyT& key,
-                    const FunctionImpl<L, NDIM>* left, const Tensor<L>& lcin,
-                    const FunctionImpl<R, NDIM>* right, const Tensor<R>& rcin,
+                    const FunctionImpl<L,NDIM>* left, const Tensor<L>& lcin,
+                    const FunctionImpl<R,NDIM>* right,const Tensor<R>& rcin,
                     double tol) {
-            typedef typename FunctionImpl<L, NDIM>::dcT::const_iterator literT;
-            typedef typename FunctionImpl<R, NDIM>::dcT::const_iterator riterT;
+            typedef typename FunctionImpl<L,NDIM>::dcT::const_iterator literT;
+            typedef typename FunctionImpl<R,NDIM>::dcT::const_iterator riterT;
 
-            double lnorm = 1e99, rnorm = 1e99;
+            double lnorm=1e99, rnorm=1e99;
 
             Tensor<L> lc = lcin;
             if (lc.size() == 0) {
@@ -2974,7 +2990,7 @@ template<size_t NDIM>
 
             // both nodes are leaf nodes: multiply and return
             if (rc.size() && lc.size()) { // Yipee!
-                do_mul<L, R>(key, lc, std::make_pair(key, rc));
+                do_mul<L,R>(key, lc, std::make_pair(key,rc));
                 return;
             }
 
@@ -2983,14 +2999,14 @@ template<size_t NDIM>
                     lnorm = lc.normf(); // Otherwise got from norm tree above
                 if (rc.size())
                     rnorm = rc.normf();
-                if (lnorm * rnorm < truncate_tol(tol, key)) {
-                    coeffs.replace(key, nodeT(coeffT(cdata.vk, targs), false)); // Zero leaf node
+                if (lnorm*rnorm < truncate_tol(tol, key)) {
+                    coeffs.replace(key, nodeT(coeffT(cdata.vk,targs),false)); // Zero leaf node
                     return;
                 }
             }
 
             // Recur down
-            coeffs.replace(key, nodeT(coeffT(), true)); // Interior node
+            coeffs.replace(key, nodeT(coeffT(),true)); // Interior node
 
             Tensor<L> lss;
             if (lc.size()) {
@@ -3015,7 +3031,7 @@ template<size_t NDIM>
                 if (rc.size())
                     rr = copy(rss(child_patch(child)));
 
-                woT::task(coeffs.owner(child), &implT:: template mulXXa<L, R>, child, left, ll, right, rr, tol);
+                woT::task(coeffs.owner(child), &implT:: template mulXXa<L,R>, child, left, ll, right, rr, tol);
             }
         }
 
@@ -3032,11 +3048,11 @@ template<size_t NDIM>
         /// @param[in] op the binary operator
         template <typename L, typename R, typename opT>
         void binaryXXa(const keyT& key,
-                       const FunctionImpl<L, NDIM>* left, const Tensor<L>& lcin,
-                       const FunctionImpl<R, NDIM>* right, const Tensor<R>& rcin,
+                       const FunctionImpl<L,NDIM>* left, const Tensor<L>& lcin,
+                       const FunctionImpl<R,NDIM>* right,const Tensor<R>& rcin,
                        const opT& op) {
-            typedef typename FunctionImpl<L, NDIM>::dcT::const_iterator literT;
-            typedef typename FunctionImpl<R, NDIM>::dcT::const_iterator riterT;
+            typedef typename FunctionImpl<L,NDIM>::dcT::const_iterator literT;
+            typedef typename FunctionImpl<R,NDIM>::dcT::const_iterator riterT;
 
             Tensor<L> lc = lcin;
             if (lc.size() == 0) {
@@ -3055,12 +3071,12 @@ template<size_t NDIM>
             }
 
             if (rc.size() && lc.size()) { // Yipee!
-                do_binary_op<L, R>(key, lc, std::make_pair(key, rc), op);
+                do_binary_op<L,R>(key, lc, std::make_pair(key,rc), op);
                 return;
             }
 
             // Recur down
-            coeffs.replace(key, nodeT(coeffT(), true)); // Interior node
+            coeffs.replace(key, nodeT(coeffT(),true)); // Interior node
 
             Tensor<L> lss;
             if (lc.size()) {
@@ -3085,14 +3101,14 @@ template<size_t NDIM>
                 if (rc.size())
                     rr = copy(rss(child_patch(child)));
 
-                woT::task(coeffs.owner(child), &implT:: template binaryXXa<L, R, opT>, child, left, ll, right, rr, op);
+                woT::task(coeffs.owner(child), &implT:: template binaryXXa<L,R,opT>, child, left, ll, right, rr, op);
             }
         }
 
         template <typename Q, typename opT>
         struct coeff_value_adaptor {
             typedef typename opT::resultT resultT;
-            const FunctionImpl<Q, NDIM>* impl_func;
+            const FunctionImpl<Q,NDIM>* impl_func;
             opT op;
 
             coeff_value_adaptor() = default;
@@ -3124,22 +3140,22 @@ template<size_t NDIM>
         /// @param[in] op the unary operator
         template <typename Q, typename opT>
         void unaryXXa(const keyT& key,
-                      const FunctionImpl<Q, NDIM>* func, const opT& op) {
+                      const FunctionImpl<Q,NDIM>* func, const opT& op) {
 
             //            const Tensor<Q>& fc = func->coeffs.find(key).get()->second.full_tensor_copy();
             const Tensor<Q> fc = func->coeffs.find(key).get()->second.coeff().reconstruct_tensor();
 
             if (fc.size() == 0) {
                 // Recur down
-                coeffs.replace(key, nodeT(coeffT(), true)); // Interior node
+                coeffs.replace(key, nodeT(coeffT(),true)); // Interior node
                 for (KeyChildIterator<NDIM> kit(key); kit; ++kit) {
                     const keyT& child = kit.key();
-                    woT::task(coeffs.owner(child), &implT:: template unaryXXa<Q, opT>, child, func, op);
+                    woT::task(coeffs.owner(child), &implT:: template unaryXXa<Q,opT>, child, func, op);
                 }
             }
             else {
-                tensorT t = op(key, fc);
-                coeffs.replace(key, nodeT(coeffT(t, targs), false)); // Leaf node
+                tensorT t=op(key,fc);
+                coeffs.replace(key, nodeT(coeffT(t,targs),false)); // Leaf node
             }
         }
 
@@ -3148,11 +3164,12 @@ template<size_t NDIM>
         /// @param[in] right pointer to the right function impl
         /// @param[in] tol numerical tolerance
         template <typename L, typename R>
-        void mulXX(const FunctionImpl<L, NDIM>* left, const FunctionImpl<R, NDIM>* right, double tol, bool fence) {
+        void mulXX(const FunctionImpl<L,NDIM>* left, const FunctionImpl<R,NDIM>* right, double tol, bool fence) {
             if (world.rank() == coeffs.owner(cdata.key0))
                 mulXXa(cdata.key0, left, Tensor<L>(), right, Tensor<R>(), tol);
             if (fence)
                 world.gop.fence();
+
             //verify_tree();
         }
 
@@ -3161,12 +3178,13 @@ template<size_t NDIM>
         /// @param[in] right pointer to the right function impl
         /// @param[in] op the binary operator
         template <typename L, typename R, typename opT>
-        void binaryXX(const FunctionImpl<L, NDIM>* left, const FunctionImpl<R, NDIM>* right,
+        void binaryXX(const FunctionImpl<L,NDIM>* left, const FunctionImpl<R,NDIM>* right,
                       const opT& op, bool fence) {
             if (world.rank() == coeffs.owner(cdata.key0))
                 binaryXXa(cdata.key0, left, Tensor<L>(), right, Tensor<R>(), op);
             if (fence)
                 world.gop.fence();
+
             //verify_tree();
         }
 
@@ -3174,11 +3192,12 @@ template<size_t NDIM>
         /// @param[in] func function impl of the operand
         /// @param[in] op the unary operator
         template <typename Q, typename opT>
-        void unaryXX(const FunctionImpl<Q, NDIM>* func, const opT& op, bool fence) {
+        void unaryXX(const FunctionImpl<Q,NDIM>* func, const opT& op, bool fence) {
             if (world.rank() == coeffs.owner(cdata.key0))
                 unaryXXa(cdata.key0, func, op);
             if (fence)
                 world.gop.fence();
+
             //verify_tree();
         }
 
@@ -3186,11 +3205,12 @@ template<size_t NDIM>
         /// @param[in] func function impl of the operand
         /// @param[in] op the unary operator
         template <typename Q, typename opT>
-        void unaryXXvalues(const FunctionImpl<Q, NDIM>* func, const opT& op, bool fence) {
+        void unaryXXvalues(const FunctionImpl<Q,NDIM>* func, const opT& op, bool fence) {
             if (world.rank() == coeffs.owner(cdata.key0))
-                unaryXXa(cdata.key0, func, coeff_value_adaptor<Q, opT>(func, op));
+                unaryXXa(cdata.key0, func, coeff_value_adaptor<Q,opT>(func,op));
             if (fence)
                 world.gop.fence();
+
             //verify_tree();
         }
 
@@ -3201,12 +3221,12 @@ template<size_t NDIM>
         /// @param[in] tol numerical tolerance
         /// @param[out] vresult vector of pointers to the resulting function impl's
         template <typename L, typename R>
-        void mulXXvec(const FunctionImpl<L, NDIM>* left,
-                      const std::vector<const FunctionImpl<R, NDIM>*>& vright,
-                      const std::vector<FunctionImpl<T, NDIM>*>& vresult,
+        void mulXXvec(const FunctionImpl<L,NDIM>* left,
+                      const std::vector<const FunctionImpl<R,NDIM>*>& vright,
+                      const std::vector<FunctionImpl<T,NDIM>*>& vresult,
                       double tol,
                       bool fence) {
-            std::vector< Tensor<R>> vr(vright.size());
+            std::vector< Tensor<R> > vr(vright.size());
             if (world.rank() == coeffs.owner(cdata.key0))
                 mulXXveca(cdata.key0, left, Tensor<L>(), vright, vr, vresult, tol);
             if (fence)
@@ -3233,7 +3253,7 @@ template<size_t NDIM>
         /// useful for debugging and paranoia.
         void verify_tree() const;
 
-        /// Walk up the tree returning pair(key, node) for first node with coefficients
+        /// Walk up the tree returning pair(key,node) for first node with coefficients
 
         /// Three possibilities.
         ///
@@ -3252,18 +3272,19 @@ template<size_t NDIM>
         /// parallelism but much less communication.
         /// @todo Robert .... help!
         void sock_it_to_me(const keyT& key,
-                           const RemoteReference< FutureImpl< std::pair<keyT, coeffT>> >& ref) const;
+                           const RemoteReference< FutureImpl< std::pair<keyT,coeffT> > >& ref) const;
         /// As above, except
         /// 3) The coeffs are constructed from the avg of nodes further down the tree
         /// @todo Robert .... help!
         void sock_it_to_me_too(const keyT& key,
-                               const RemoteReference< FutureImpl< std::pair<keyT, coeffT>> >& ref) const;
+                               const RemoteReference< FutureImpl< std::pair<keyT,coeffT> > >& ref) const;
 
         /// @todo help!
-        void plot_cube_kernel(archive::archive_ptr< Tensor<T>> ptr,
+        void plot_cube_kernel(archive::archive_ptr< Tensor<T> > ptr,
                               const keyT& key,
-                              const coordT& plotlo, const coordT& plothi, const std::vector<long>& npt, 
+                              const coordT& plotlo, const coordT& plothi, const std::vector<long>& npt,
                               bool eval_refine) const;
+
 
         /// Evaluate a cube/slice of points ... plotlo and plothi are already in simulation coordinates
         /// No communications
@@ -3275,18 +3296,20 @@ template<size_t NDIM>
                                  const std::vector<long>& npt,
                                  const bool eval_refine = false) const;
 
-        /// Evaluate function only if point is local returning (true, value); otherwise return (false, 0.0)
+
+        /// Evaluate function only if point is local returning (true,value); otherwise return (false,0.0)
 
         /// maxlevel is the maximum depth to search down to --- the max local depth can be
         /// computed with max_local_depth();
-        std::pair<bool, T> eval_local_only(const Vector<double, NDIM>& xin, Level maxlevel) ;
+        std::pair<bool,T> eval_local_only(const Vector<double,NDIM>& xin, Level maxlevel) ;
+
 
         /// Evaluate the function at a point in \em simulation coordinates
 
         /// Only the invoking process will get the result via the
         /// remote reference to a future.  Active messages may be sent
         /// to other nodes.
-        void eval(const Vector<double, NDIM>& xin,
+        void eval(const Vector<double,NDIM>& xin,
                   const keyT& keyin,
                   const typename Future<T>::remote_refT& ref);
 
@@ -3297,7 +3320,7 @@ template<size_t NDIM>
         /// to other nodes.
         ///
         /// This function is a minimally-modified version of eval()
-        void evaldepthpt(const Vector<double, NDIM>& xin,
+        void evaldepthpt(const Vector<double,NDIM>& xin,
                          const keyT& keyin,
                          const typename Future<Level>::remote_refT& ref);
 
@@ -3308,7 +3331,7 @@ template<size_t NDIM>
         /// to other nodes.
         ///
         /// This function is a minimally-modified version of eval()
-        void evalR(const Vector<double, NDIM>& xin,
+        void evalR(const Vector<double,NDIM>& xin,
                    const keyT& keyin,
                    const typename Future<long>::remote_refT& ref);
 
@@ -3320,8 +3343,8 @@ template<size_t NDIM>
         /// ... lo ... the block of t for all polynomials of order < k/2
         /// ... hi ... the block of t for all polynomials of order >= k/2
         ///
-        /// k=5   0, 1, 2, 3, 4     --> 0, 1, 2 ... 3, 4
-        /// k=6   0, 1, 2, 3, 4, 5   --> 0, 1, 2 ... 3, 4, 5
+        /// k=5   0,1,2,3,4     --> 0,1,2 ... 3,4
+        /// k=6   0,1,2,3,4,5   --> 0,1,2 ... 3,4,5
         ///
         /// k=number of wavelets, so k=5 means max order is 4, so max exactly
         /// representable squarable polynomial is of order 2.
@@ -3357,16 +3380,16 @@ template<size_t NDIM>
         /// After 1d push operator must sum coeffs down the tree to restore correct scaling function coefficients
         void sum_down(bool fence);
 
-        /// perform this multiplication: h(1, 2) = f(1, 2) * g(1)
+        /// perform this multiplication: h(1,2) = f(1,2) * g(1)
         template<size_t LDIM>
         struct multiply_op {
 
-            static bool randomize() { return false; }
-            typedef CoeffTracker<T, NDIM> ctT;
-            typedef CoeffTracker<T, LDIM> ctL;
+            static bool randomize() {return false;}
+            typedef CoeffTracker<T,NDIM> ctT;
+            typedef CoeffTracker<T,LDIM> ctL;
             typedef multiply_op<LDIM> this_type;
 
-            implT* h;     ///< the result function h(1, 2) = f(1, 2) * g(1)
+            implT* h;     ///< the result function h(1,2) = f(1,2) * g(1)
             ctT f;
             ctL g;
             int particle;       ///< if g is g(1) or g(2)
@@ -3385,12 +3408,12 @@ template<size_t NDIM>
                 MADNESS_ASSERT(g.get_impl());
                 MADNESS_ASSERT(h);
 
-                double glo = 0.0, ghi = 0.0, flo = 0.0, fhi = 0.0;
+                double glo=0.0, ghi=0.0, flo=0.0, fhi=0.0;
                 g.get_impl()->tnorm(gcoeff.get_tensor(), &glo, &ghi);
-                g.get_impl()->tnorm(fcoeff.get_svdtensor(), &flo, &fhi, particle);
+                g.get_impl()->tnorm(fcoeff.get_svdtensor(),&flo,&fhi,particle);
 
-                double total_hi = glo * fhi + ghi * flo + fhi * ghi;
-                return (total_hi<h->truncate_tol(h->get_thresh(), key));
+                double total_hi=glo*fhi + ghi*flo + fhi*ghi;
+                return (total_hi<h->truncate_tol(h->get_thresh(),key));
 
             }
 
@@ -3398,66 +3421,67 @@ template<size_t NDIM>
 
             /// @param[in]  key key for FunctionNode in f and g, (g: broken into particles)
             /// @return <this node is a leaf, coefficients of this node>
-            std::pair<bool, coeffT> operator()(const Key<NDIM>& key) const {
-                // bool is_leaf=(not fdatum.second.has_children());
-                // if (not is_leaf) return std::pair<bool, coeffT> (is_leaf, coeffT());
+            std::pair<bool,coeffT> operator()(const Key<NDIM>& key) const {
+
+                //                bool is_leaf=(not fdatum.second.has_children());
+                //                if (not is_leaf) return std::pair<bool,coeffT> (is_leaf,coeffT());
 
                 // break key into particles (these are the child keys, with f/gdatum come the parent keys)
-                Key<LDIM> key1, key2;
-                key.break_apart(key1, key2);
-                const Key<LDIM> gkey = (particle == 1) ? key1 : key2;
+                Key<LDIM> key1,key2;
+                key.break_apart(key1,key2);
+                const Key<LDIM> gkey= (particle==1) ? key1 : key2;
 
                 // get coefficients of the actual FunctionNode
-                coeffT coeff1 = f.get_impl()->parent_to_child(f.coeff(), f.key(), key);
+                coeffT coeff1=f.get_impl()->parent_to_child(f.coeff(),f.key(),key);
                 coeff1.normalize();
-                const coeffT coeff2 = g.get_impl()->parent_to_child(g.coeff(), g.key(), gkey);
+                const coeffT coeff2=g.get_impl()->parent_to_child(g.coeff(),g.key(),gkey);
 
                 // multiplication is done in TT_2D
-                coeffT coeff1_2D = coeff1.convert(TensorArgs(h->get_thresh(), TT_2D));
+                coeffT coeff1_2D=coeff1.convert(TensorArgs(h->get_thresh(),TT_2D));
                 coeff1_2D.normalize();
 
-                bool is_leaf = screen(coeff1_2D, coeff2, key);
-                if (key.level() < 2) is_leaf = false;
+                bool is_leaf=screen(coeff1_2D,coeff2,key);
+                if (key.level()<2) is_leaf=false;
 
                 coeffT hcoeff;
                 if (is_leaf) {
 
                     // convert coefficients to values
-                    coeffT hvalues = f.get_impl()->coeffs2values(key, coeff1_2D);
-                    coeffT gvalues = g.get_impl()->coeffs2values(gkey, coeff2);
+                    coeffT hvalues=f.get_impl()->coeffs2values(key,coeff1_2D);
+                    coeffT gvalues=g.get_impl()->coeffs2values(gkey,coeff2);
 
                     // perform multiplication
-                    coeffT result_val = h->multiply(hvalues, gvalues, particle - 1);
+                    coeffT result_val=h->multiply(hvalues,gvalues,particle-1);
 
-                    hcoeff = h->values2coeffs(key, result_val);
+                    hcoeff=h->values2coeffs(key,result_val);
 
                     // conversion on coeffs, not on values, because it implies truncation!
                     if (not hcoeff.is_of_tensortype(h->get_tensor_type()))
-                        hcoeff = hcoeff.convert(h->get_tensor_args());
+                        hcoeff=hcoeff.convert(h->get_tensor_args());
                 }
 
-                return std::pair<bool, coeffT> (is_leaf, hcoeff);
+                return std::pair<bool,coeffT> (is_leaf,hcoeff);
             }
 
             this_type make_child(const keyT& child) const {
 
                 // break key into particles
                 Key<LDIM> key1, key2;
-                child.break_apart(key1, key2);
-                const Key<LDIM> gkey = (particle == 1) ? key1 : key2;
+                child.break_apart(key1,key2);
+                const Key<LDIM> gkey= (particle==1) ? key1 : key2;
 
-                return this_type(h, f.make_child(child), g.make_child(gkey), particle);
+                return this_type(h,f.make_child(child),g.make_child(gkey),particle);
             }
 
             Future<this_type> activate() const {
-            	Future<ctT> f1 = f.activate();
-            	Future<ctL> g1 = g.activate();
+            	Future<ctT> f1=f.activate();
+            	Future<ctL> g1=g.activate();
                 return h->world.taskq.add(detail::wrap_mem_fn(*const_cast<this_type *> (this),
-                                          &this_type::forward_ctor), h, f1, g1, particle);
+                                          &this_type::forward_ctor),h,f1,g1,particle);
             }
 
             this_type forward_ctor(implT* h1, const ctT& f1, const ctL& g1, const int particle) {
-            	return this_type(h1, f1, g1, particle);
+            	return this_type(h1,f1,g1,particle);
             }
 
             template <typename Archive> void serialize(const Archive& ar) {
@@ -3469,13 +3493,13 @@ template<size_t NDIM>
         /// add two functions f and g: result=alpha * f  +  beta * g
         struct add_op {
 
-            typedef CoeffTracker<T, NDIM> ctT;
+            typedef CoeffTracker<T,NDIM> ctT;
             typedef add_op this_type;
 
-            bool randomize() const { return false; }
+            bool randomize() const {return false;}
 
             /// tracking coeffs of first and second addend
-            ctT f, g;
+            ctT f,g;
             /// prefactor for f, g
             double alpha, beta;
 
@@ -3484,63 +3508,65 @@ template<size_t NDIM>
                 : f(f), g(g), alpha(alpha), beta(beta){}
 
             /// if we are at the bottom of the trees, return the sum of the coeffs
-            std::pair<bool, coeffT> operator()(const keyT& key) const {
+            std::pair<bool,coeffT> operator()(const keyT& key) const {
 
-                bool is_leaf = (f.is_leaf() and g.is_leaf());
-                if (not is_leaf) return std::pair<bool, coeffT> (is_leaf, coeffT());
+                bool is_leaf=(f.is_leaf() and g.is_leaf());
+                if (not is_leaf) return std::pair<bool,coeffT> (is_leaf,coeffT());
 
-                coeffT fcoeff = f.get_impl()->parent_to_child(f.coeff(), f.key(), key);
-                coeffT gcoeff = g.get_impl()->parent_to_child(g.coeff(), g.key(), key);
-                coeffT hcoeff = copy(fcoeff);
-                hcoeff.gaxpy(alpha, gcoeff, beta);
+                coeffT fcoeff=f.get_impl()->parent_to_child(f.coeff(),f.key(),key);
+                coeffT gcoeff=g.get_impl()->parent_to_child(g.coeff(),g.key(),key);
+                coeffT hcoeff=copy(fcoeff);
+                hcoeff.gaxpy(alpha,gcoeff,beta);
                 hcoeff.reduce_rank(f.get_impl()->get_tensor_args().thresh);
-                return std::pair<bool, coeffT> (is_leaf, hcoeff);
+                return std::pair<bool,coeffT> (is_leaf,hcoeff);
             }
 
             this_type make_child(const keyT& child) const {
-                return this_type(f.make_child(child), g.make_child(child), alpha, beta);
+                return this_type(f.make_child(child),g.make_child(child),alpha,beta);
             }
 
             /// retrieve the coefficients (parent coeffs might be remote)
             Future<this_type> activate() const {
-            	Future<ctT> f1 = f.activate();
-            	Future<ctT> g1 = g.activate();
-                return f.get_impl()->world.taskq.add(detail::wrap_mem_fn(*const_cast<this_type *> (this), 
-                                                     &this_type::forward_ctor), f1, g1, alpha, beta);
+            	Future<ctT> f1=f.activate();
+            	Future<ctT> g1=g.activate();
+                return f.get_impl()->world.taskq.add(detail::wrap_mem_fn(*const_cast<this_type *> (this),
+                                                     &this_type::forward_ctor),f1,g1,alpha,beta);
             }
 
             /// taskq-compatible ctor
             this_type forward_ctor(const ctT& f1, const ctT& g1, const double alpha, const double beta) {
-            	return this_type(f1, g1, alpha, beta);
+            	return this_type(f1,g1,alpha,beta);
             }
 
             template <typename Archive> void serialize(const Archive& ar) {
                 ar & f & g & alpha & beta;
             }
+
         };
 
         /// multiply f (a pair function of NDIM) with an orbital g (LDIM=NDIM/2)
 
-        /// as in (with h(1, 2)=*this) : h(1, 2) = g(1) * f(1, 2)
+        /// as in (with h(1,2)=*this) : h(1,2) = g(1) * f(1,2)
         /// use tnorm as a measure to determine if f (=*this) must be refined
-        /// @param[in]  f           the NDIM function f=f(1, 2)
+        /// @param[in]  f           the NDIM function f=f(1,2)
         /// @param[in]  g           the LDIM function g(1) (or g(2))
         /// @param[in]  particle    1 or 2, as in g(1) or g(2)
         template<size_t LDIM>
-        void multiply(const implT* f, const FunctionImpl<T, LDIM>* g, const int particle) {
-            CoeffTracker<T, NDIM> ff(f);
-            CoeffTracker<T, LDIM> gg(g);
+        void multiply(const implT* f, const FunctionImpl<T,LDIM>* g, const int particle) {
 
-            typedef multiply_op<LDIM> coeff_opT;
-            coeff_opT coeff_op(this, ff, gg, particle);
+                CoeffTracker<T,NDIM> ff(f);
+                CoeffTracker<T,LDIM> gg(g);
 
-            typedef insert_op<T, NDIM> apply_opT;
-            apply_opT apply_op(this);
+                typedef multiply_op<LDIM> coeff_opT;
+                coeff_opT coeff_op(this,ff,gg,particle);
 
-            keyT key0 = f->cdata.key0;
+                typedef insert_op<T,NDIM> apply_opT;
+                apply_opT apply_op(this);
+
+            keyT key0=f->cdata.key0;
 			if (world.rank() == coeffs.owner(key0)) {
-                ProcessID p = coeffs.owner(key0);
-                woT::task(p, &implT:: template forward_traverse<coeff_opT, apply_opT>, coeff_op, apply_op, key0);
+                ProcessID p= coeffs.owner(key0);
+                woT::task(p, &implT:: template forward_traverse<coeff_opT,apply_opT>, coeff_op, apply_op, key0);
             }
 
             set_tree_state(reconstructed);
@@ -3549,10 +3575,10 @@ template<size_t NDIM>
         /// Hartree product of two LDIM functions to yield a NDIM = 2*LDIM function
         template<size_t LDIM, typename leaf_opT>
         struct hartree_op {
-            bool randomize() const { return false; }
+            bool randomize() const {return false;}
 
-            typedef hartree_op<LDIM, leaf_opT> this_type;
-            typedef CoeffTracker<T, LDIM> ctL;
+            typedef hartree_op<LDIM,leaf_opT> this_type;
+            typedef CoeffTracker<T,LDIM> ctL;
 
             implT* result; 	    ///< where to construct the pair function
             ctL p1, p2;			///< tracking coeffs of the two lo-dim functions
@@ -3562,50 +3588,50 @@ template<size_t NDIM>
             hartree_op() : result() {}
             hartree_op(implT* result, const ctL& p11, const ctL& p22, const leaf_opT& leaf_op)
                 : result(result), p1(p11), p2(p22), leaf_op(leaf_op) {
-                MADNESS_ASSERT(LDIM+LDIM == NDIM);
+                MADNESS_ASSERT(LDIM+LDIM==NDIM);
             }
 
-            std::pair<bool, coeffT> operator()(const Key<NDIM>& key) const {
+            std::pair<bool,coeffT> operator()(const Key<NDIM>& key) const {
 
                 // break key into particles (these are the child keys, with datum1/2 come the parent keys)
-                Key<LDIM> key1, key2;
-                key.break_apart(key1, key2);
+                Key<LDIM> key1,key2;
+                key.break_apart(key1,key2);
 
                 // this returns the appropriate NS coeffs for key1 and key2 resp.
-            	const coeffT fcoeff = p1.coeff(key1);
-                const coeffT gcoeff = p2.coeff(key2);
-                bool is_leaf = leaf_op(key, fcoeff.full_tensor(), gcoeff.full_tensor());
-                if (not is_leaf) return std::pair<bool, coeffT> (is_leaf, coeffT());
+            	const coeffT fcoeff=p1.coeff(key1);
+                const coeffT gcoeff=p2.coeff(key2);
+                bool is_leaf=leaf_op(key,fcoeff.full_tensor(),gcoeff.full_tensor());
+                if (not is_leaf) return std::pair<bool,coeffT> (is_leaf,coeffT());
 
                 // extract the sum coeffs from the NS coeffs
-                const coeffT s1 = fcoeff(p1.get_impl()->cdata.s0);
-                const coeffT s2 = gcoeff(p2.get_impl()->cdata.s0);
+                const coeffT s1=fcoeff(p1.get_impl()->cdata.s0);
+                const coeffT s2=gcoeff(p2.get_impl()->cdata.s0);
 
                 // new coeffs are simply the hartree/kronecker/outer product --
-                coeffT coeff = outer(s1, s2, result->get_tensor_args());
+                coeffT coeff=outer(s1,s2,result->get_tensor_args());
                 // no post-determination
-                //                is_leaf=leaf_op(key, coeff);
-                return std::pair<bool, coeffT>(is_leaf, coeff);
+                //                is_leaf=leaf_op(key,coeff);
+                return std::pair<bool,coeffT>(is_leaf,coeff);
             }
 
             this_type make_child(const keyT& child) const {
 
                 // break key into particles
                 Key<LDIM> key1, key2;
-                child.break_apart(key1, key2);
+                child.break_apart(key1,key2);
 
-                return this_type(result, p1.make_child(key1), p2.make_child(key2), leaf_op);
+                return this_type(result,p1.make_child(key1),p2.make_child(key2),leaf_op);
             }
 
             Future<this_type> activate() const {
-            	Future<ctL> p11 = p1.activate();
-            	Future<ctL> p22 = p2.activate();
+            	Future<ctL> p11=p1.activate();
+            	Future<ctL> p22=p2.activate();
                 return result->world.taskq.add(detail::wrap_mem_fn(*const_cast<this_type *> (this),
-                                               &this_type::forward_ctor), result, p11, p22, leaf_op);
+                                               &this_type::forward_ctor),result,p11,p22,leaf_op);
             }
 
             this_type forward_ctor(implT* result1, const ctL& p11, const ctL& p22, const leaf_opT& leaf_op) {
-            	return this_type(result1, p11, p22, leaf_op);
+            	return this_type(result1,p11,p22,leaf_op);
             }
 
             template <typename Archive> void serialize(const Archive& ar) {
@@ -3622,8 +3648,8 @@ template<size_t NDIM>
         template<typename coeff_opT, typename apply_opT>
         void forward_traverse(const coeff_opT& coeff_op, const apply_opT& apply_op, const keyT& key) const {
             MADNESS_ASSERT(coeffs.is_local(key));
-            Future<coeff_opT> active_coeff = coeff_op.activate();
-            woT::task(world.rank(), &implT:: template traverse_tree<coeff_opT, apply_opT>, active_coeff, apply_op, key);
+            Future<coeff_opT> active_coeff=coeff_op.activate();
+            woT::task(world.rank(), &implT:: template traverse_tree<coeff_opT,apply_opT>, active_coeff, apply_op, key);
         }
 
 
@@ -3637,19 +3663,19 @@ template<size_t NDIM>
         void traverse_tree(const coeff_opT& coeff_op, const apply_opT& apply_op, const keyT& key) const {
             MADNESS_ASSERT(coeffs.is_local(key));
 
-            typedef typename std::pair<bool, coeffT> argT;
-            const argT arg = coeff_op(key);
-            apply_op.operator()(key, arg.second, arg.first);
+            typedef typename std::pair<bool,coeffT> argT;
+            const argT arg=coeff_op(key);
+            apply_op.operator()(key,arg.second,arg.first);
 
-            const bool has_children = (not arg.first);
+            const bool has_children=(not arg.first);
             if (has_children) {
                 for (KeyChildIterator<NDIM> kit(key); kit; ++kit) {
-                    const keyT& child = kit.key();
-                    coeff_opT child_op = coeff_op.make_child(child);
+                    const keyT& child=kit.key();
+                    coeff_opT child_op=coeff_op.make_child(child);
                     // spawn activation where child is local
-                    ProcessID p = coeffs.owner(child);
+                    ProcessID p=coeffs.owner(child);
 
-                    void (implT::*ft)(const coeff_opT&, const apply_opT&, const keyT&) const = &implT::forward_traverse<coeff_opT, apply_opT>;
+                    void (implT::*ft)(const coeff_opT&, const apply_opT&, const keyT&) const = &implT::forward_traverse<coeff_opT,apply_opT>;
 
                     woT::task(p, ft, child_op, apply_op, child);
                 }
@@ -3659,37 +3685,37 @@ template<size_t NDIM>
 
         /// given two functions of LDIM, perform the Hartree/Kronecker/outer product
 
-        /// |Phi(1, 2)> = |phi(1)> x |phi(2)>
+        /// |Phi(1,2)> = |phi(1)> x |phi(2)>
         /// @param[in]	p1	FunctionImpl of particle 1
         /// @param[in]	p2	FunctionImpl of particle 2
         /// @param[in]	leaf_op	operator determining of a given box will be a leaf
         template<std::size_t LDIM, typename leaf_opT>
-        void hartree_product(const std::vector<std::shared_ptr<FunctionImpl<T, LDIM>>> p1,
-                             const std::vector<std::shared_ptr<FunctionImpl<T, LDIM>>> p2,
+        void hartree_product(const std::vector<std::shared_ptr<FunctionImpl<T,LDIM>>> p1,
+                             const std::vector<std::shared_ptr<FunctionImpl<T,LDIM>>> p2,
                              const leaf_opT& leaf_op, bool fence) {
-            MADNESS_CHECK_THROW(p1.size() == p2.size(), "hartree_product: p1 and p2 must have the same size");
+            MADNESS_CHECK_THROW(p1.size()==p2.size(),"hartree_product: p1 and p2 must have the same size");
             for (auto& p : p1) MADNESS_CHECK(p->is_nonstandard() or p->is_nonstandard_with_leaves());
             for (auto& p : p2) MADNESS_CHECK(p->is_nonstandard() or p->is_nonstandard_with_leaves());
 
-            const keyT key0 = cdata.key0;
+            const keyT key0=cdata.key0;
 
-            for (std::size_t i = 0; i < p1.size(); ++i) {
+            for (std::size_t i=0; i<p1.size(); ++i) {
                 if (world.rank() == this->get_coeffs().owner(key0)) {
 
                     // prepare the CoeffTracker
-                    CoeffTracker<T, LDIM> iap1(p1[i].get());
-                    CoeffTracker<T, LDIM> iap2(p2[i].get());
+                    CoeffTracker<T,LDIM> iap1(p1[i].get());
+                    CoeffTracker<T,LDIM> iap2(p2[i].get());
 
                     // the operator making the coefficients
-                    typedef hartree_op<LDIM, leaf_opT> coeff_opT;
-                    coeff_opT coeff_op(this, iap1, iap2, leaf_op);
+                    typedef hartree_op<LDIM,leaf_opT> coeff_opT;
+                    coeff_opT coeff_op(this,iap1,iap2,leaf_op);
 
                     // this operator simply inserts the coeffs into this' tree
-                    // typedef insert_op<T, NDIM> apply_opT;
-                    typedef accumulate_op<T, NDIM> apply_opT;
+//                typedef insert_op<T,NDIM> apply_opT;
+                    typedef accumulate_op<T,NDIM> apply_opT;
                     apply_opT apply_op(this);
 
-                    woT::task(world.rank(), &implT:: template forward_traverse<coeff_opT, apply_opT>,
+                    woT::task(world.rank(), &implT:: template forward_traverse<coeff_opT,apply_opT>,
                               coeff_op, apply_op, cdata.key0);
 
                 }
@@ -3706,31 +3732,31 @@ template<size_t NDIM>
             const opT* op = pop.ptr;
             const Level n = key.level();
             const double cnorm = c.normf();
-            const double tol = truncate_tol(thresh, key) * 0.1; // ??? why this value????
+            const double tol = truncate_tol(thresh, key)*0.1; // ??? why this value????
 
-            Vector<Translation, NDIM> lnew(key.translation());
+            Vector<Translation,NDIM> lnew(key.translation());
             const Translation lold = lnew[axis];
             const Translation maxs = Translation(1)<<n;
 
             int nsmall = 0; // Counts neglected blocks to terminate s loop
-            for (Translation s = 0; s < maxs; ++s) {
+            for (Translation s=0; s<maxs; ++s) {
                 int maxdir = s ? 1 : -1;
-                for (int direction = -1; direction <= maxdir; direction += 2) {
-                    lnew[axis] = lold + direction * s;
+                for (int direction=-1; direction<=maxdir; direction+=2) {
+                    lnew[axis] = lold + direction*s;
                     if (lnew[axis] >= 0 && lnew[axis] < maxs) { // NON-ZERO BOUNDARY CONDITIONS IGNORED HERE !!!!!!!!!!!!!!!!!!!!
-                        const Tensor<typename opT::opT>& r = op->rnlij(n, s * direction, true);
+                        const Tensor<typename opT::opT>& r = op->rnlij(n, s*direction, true);
                         double Rnorm = r.normf();
 
                         if (Rnorm == 0.0) {
                             return; // Hard zero means finished!
                         }
 
-                        if (s <= 1 || r.normf() * cnorm > tol) { // Always do kernel and neighbor
+                        if (s <= 1  ||  r.normf()*cnorm > tol) { // Always do kernel and neighbor
                             nsmall = 0;
-                            tensorT result = transform_dir(c, r, axis);
+                            tensorT result = transform_dir(c,r,axis);
 
-                            if (result.normf() > tol * 0.3) {
-                                Key<NDIM> dest(n, lnew);
+                            if (result.normf() > tol*0.3) {
+                                Key<NDIM> dest(n,lnew);
                                 coeffs.task(dest, &nodeT::accumulate2, result, coeffs, dest, TaskAttributes::hipri());
                             }
                         }
@@ -3753,41 +3779,41 @@ template<size_t NDIM>
 
         template <typename opT, typename R>
         void
-        apply_1d_realspace_push(const opT& op, const FunctionImpl<R, NDIM>* f, int axis, bool fence) {
+        apply_1d_realspace_push(const opT& op, const FunctionImpl<R,NDIM>* f, int axis, bool fence) {
             MADNESS_ASSERT(!f->is_compressed());
 
-            typedef typename FunctionImpl<R, NDIM>::dcT::const_iterator fiterT;
-            typedef FunctionNode<R, NDIM> fnodeT;
+            typedef typename FunctionImpl<R,NDIM>::dcT::const_iterator fiterT;
+            typedef FunctionNode<R,NDIM> fnodeT;
             fiterT end = f->coeffs.end();
             ProcessID me = world.rank();
-            for (fiterT it = f->coeffs.begin(); it != end; ++it) {
+            for (fiterT it=f->coeffs.begin(); it!=end; ++it) {
                 const fnodeT& node = it->second;
                 if (node.has_coeff()) {
                     const keyT& key = it->first;
                     const Tensor<R>& c = node.coeff().full_tensor_copy();
-                    woT::task(me, &implT:: template apply_1d_realspace_push_op<opT, R>,
+                    woT::task(me, &implT:: template apply_1d_realspace_push_op<opT,R>,
                               archive::archive_ptr<const opT>(&op), axis, key, c);
                 }
             }
             if (fence) world.gop.fence();
         }
 
-        void forward_do_diff1(const DerivativeBase<T, NDIM>* D,
+        void forward_do_diff1(const DerivativeBase<T,NDIM>* D,
                               const implT* f,
                               const keyT& key,
-                              const std::pair<keyT, coeffT>& left,
-                              const std::pair<keyT, coeffT>& center,
-                              const std::pair<keyT, coeffT>& right);
+                              const std::pair<keyT,coeffT>& left,
+                              const std::pair<keyT,coeffT>& center,
+                              const std::pair<keyT,coeffT>& right);
 
-        void do_diff1(const DerivativeBase<T, NDIM>* D,
+        void do_diff1(const DerivativeBase<T,NDIM>* D,
                       const implT* f,
                       const keyT& key,
-                      const std::pair<keyT, coeffT>& left,
-                      const std::pair<keyT, coeffT>& center,
-                      const std::pair<keyT, coeffT>& right);
+                      const std::pair<keyT,coeffT>& left,
+                      const std::pair<keyT,coeffT>& center,
+                      const std::pair<keyT,coeffT>& right);
 
         // Called by result function to differentiate f
-        void diff(const DerivativeBase<T, NDIM>* D, const implT* f, bool fence);
+        void diff(const DerivativeBase<T,NDIM>* D, const implT* f, bool fence);
 
         /// Returns key of general neighbor enforcing BC
 
@@ -3797,14 +3823,14 @@ template<size_t NDIM>
         keyT neighbor(const keyT& key, const keyT& disp, const std::vector<bool>& is_periodic) const;
 
         /// find_me. Called by diff_bdry to get coefficients of boundary function
-        Future< std::pair<keyT, coeffT>> find_me(const keyT& key) const;
+        Future< std::pair<keyT,coeffT> > find_me(const keyT& key) const;
 
         /// return the a std::pair<key, node>, which MUST exist
-        std::pair<Key<NDIM>, ShallowNode<T, NDIM>> find_datum(keyT key) const;
+        std::pair<Key<NDIM>,ShallowNode<T,NDIM> > find_datum(keyT key) const;
 
-        /// multiply the ket with a one-electron potential rr(1, 2)= f(1, 2)*g(1)
+        /// multiply the ket with a one-electron potential rr(1,2)= f(1,2)*g(1)
 
-        /// @param[in]	val_ket	function values of f(1, 2)
+        /// @param[in]	val_ket	function values of f(1,2)
         /// @param[in]	val_pot	function values of g(1)
         /// @param[in]	particle	if 0 then g(1), if 1 then g(2)
         /// @return		the resulting function values
@@ -3813,8 +3839,8 @@ template<size_t NDIM>
 
         /// given several coefficient tensors, assemble a result tensor
 
-        /// the result looks like: 	(v(1, 2) + v(1) + v(2)) |ket(1, 2)>
-        /// or 						(v(1, 2) + v(1) + v(2)) |p(1) p(2)>
+        /// the result looks like: 	(v(1,2) + v(1) + v(2)) |ket(1,2)>
+        /// or 						(v(1,2) + v(1) + v(2)) |p(1) p(2)>
         /// i.e. coefficients for the ket and coefficients for the two particles are
         /// mutually exclusive. All potential terms are optional, just pass in empty coeffs.
         /// @param[in]	key			the key of the FunctionNode to which these coeffs belong
@@ -3831,63 +3857,63 @@ template<size_t NDIM>
         template<std::size_t LDIM>
         struct pointwise_multiplier {
         	coeffT val_lhs, coeff_lhs;
-            long oversampling = 1;
-        	double error = 0.0;
-        	double lo = 0.0, hi = 0.0, lo1 = 0.0, hi1 = 0.0, lo2 = 0.0, hi2 = 0.0;
+            long oversampling=1;
+        	double error=0.0;
+        	double lo=0.0, hi=0.0, lo1=0.0, hi1=0.0, lo2=0.0, hi2=0.0;
 
     	    pointwise_multiplier() = default;
         	pointwise_multiplier(const Key<NDIM> key, const coeffT& clhs) : coeff_lhs(clhs) {
-                const auto& fcf = FunctionCommonFunctionality<T, NDIM>(coeff_lhs.dim(0));
-        		val_lhs = fcf.coeffs2values(key, coeff_lhs);
-        		error = 0.0;
-        		implT::tnorm(coeff_lhs, &lo, &hi);
+                const auto& fcf=FunctionCommonFunctionality<T,NDIM>(coeff_lhs.dim(0));
+        		val_lhs=fcf.coeffs2values(key,coeff_lhs);
+        		error=0.0;
+        		implT::tnorm(coeff_lhs,&lo,&hi);
                 if (coeff_lhs.is_svd_tensor()) {
-                    FunctionImpl<T, LDIM>::tnorm(coeff_lhs.get_svdtensor(), &lo1, &hi1, 1);
-                    FunctionImpl<T, LDIM>::tnorm(coeff_lhs.get_svdtensor(), &lo2, &hi2, 2);
+                    FunctionImpl<T,LDIM>::tnorm(coeff_lhs.get_svdtensor(),&lo1,&hi1,1);
+                    FunctionImpl<T,LDIM>::tnorm(coeff_lhs.get_svdtensor(),&lo2,&hi2,2);
                 }
         	}
 
         	/// multiply values of rhs and lhs, result on rhs, rhs and lhs are of the same dimensions
         	tensorT operator()(const Key<NDIM> key, const tensorT& coeff_rhs) {
 
-				MADNESS_ASSERT(coeff_rhs.dim(0) == coeff_lhs.dim(0));
-                auto fcf = FunctionCommonFunctionality<T, NDIM>(coeff_lhs.dim(0));
+				MADNESS_ASSERT(coeff_rhs.dim(0)==coeff_lhs.dim(0));
+                auto fcf=FunctionCommonFunctionality<T,NDIM>(coeff_lhs.dim(0));
 
 				// the tnorm estimate is not tight enough to be efficient, better use oversampling
 				bool use_tnorm=false;
         		if (use_tnorm) {
 					double rlo, rhi;
-					implT::tnorm(coeff_rhs, &rlo, &rhi);
-					error = hi * rlo + rhi * lo + rhi * hi;
-					tensorT val_rhs = fcf.coeffs2values(key, coeff_rhs);
+					implT::tnorm(coeff_rhs,&rlo,&rhi);
+					error = hi*rlo + rhi*lo + rhi*hi;
+					tensorT val_rhs=fcf.coeffs2values(key, coeff_rhs);
 					val_rhs.emul(val_lhs.full_tensor_copy());
-					return fcf.values2coeffs(key, val_rhs);
+					return fcf.values2coeffs(key,val_rhs);
         		} else {	// use quadrature of order k+1
 
-    	            auto& cdata = FunctionCommonData<T, NDIM>::get(coeff_rhs.dim(0));  // npt=k+1
-                    auto& cdata_npt = FunctionCommonData<T, NDIM>::get(coeff_rhs.dim(0)+oversampling);  // npt=k+1
-                	FunctionCommonFunctionality<T, NDIM> fcf_hi_npt(cdata_npt);
+    	            auto& cdata=FunctionCommonData<T,NDIM>::get(coeff_rhs.dim(0));		// npt=k+1
+                    auto& cdata_npt=FunctionCommonData<T,NDIM>::get(coeff_rhs.dim(0)+oversampling);		// npt=k+1
+                	FunctionCommonFunctionality<T,NDIM> fcf_hi_npt(cdata_npt);
 
     	            // coeffs2values for rhs: k -> npt=k+1
 		            tensorT coeff1(cdata_npt.vk);
-		            coeff1(cdata.s0) = coeff_rhs;  // s0 is smaller than vk!
-		            tensorT val_rhs_k1 = fcf_hi_npt.coeffs2values(key, coeff1);
+		            coeff1(cdata.s0)=coeff_rhs;		// s0 is smaller than vk!
+		            tensorT val_rhs_k1=fcf_hi_npt.coeffs2values(key,coeff1);
 
 		            // coeffs2values for lhs: k -> npt=k+1
 		            tensorT coeff_lhs_k1(cdata_npt.vk);
-		            coeff_lhs_k1(cdata.s0) = coeff_lhs.full_tensor_copy();
-		            tensorT val_lhs_k1 = fcf_hi_npt.coeffs2values(key, coeff_lhs_k1);
+		            coeff_lhs_k1(cdata.s0)=coeff_lhs.full_tensor_copy();
+		            tensorT val_lhs_k1=fcf_hi_npt.coeffs2values(key,coeff_lhs_k1);
 
 		            // multiply
 		            val_lhs_k1.emul(val_rhs_k1);
 
                     // values2coeffs: npt = k+1-> k
-		            tensorT result1 = fcf_hi_npt.values2coeffs(key, val_lhs_k1);
+		            tensorT result1=fcf_hi_npt.values2coeffs(key,val_lhs_k1);
 
                     // extract coeffs up to k
-                    tensorT result = copy(result1(cdata.s0));
-                    result1(cdata.s0) = 0.0;
-                    error = result1.normf();
+                    tensorT result=copy(result1(cdata.s0));
+                    result1(cdata.s0)=0.0;
+                    error=result1.normf();
                     return result;
         		}
         	}
@@ -3895,44 +3921,44 @@ template<size_t NDIM>
         	/// multiply values of rhs and lhs, result on rhs, rhs and lhs are of differnet dimensions
         	coeffT operator()(const Key<NDIM> key, const tensorT& coeff_rhs, const int particle) {
                 Key<LDIM> key1, key2;
-                key.break_apart(key1, key2);
-                const long k = coeff_rhs.dim(0);
-                auto& cdata = FunctionCommonData<T, NDIM>::get(k);
-                auto& cdata_lowdim = FunctionCommonData<T, LDIM>::get(k);
-            	FunctionCommonFunctionality<T, LDIM> fcf_lo(cdata_lowdim);
-            	FunctionCommonFunctionality<T, NDIM> fcf_hi(cdata);
-            	FunctionCommonFunctionality<T, LDIM> fcf_lo_npt(k + oversampling);
-            	FunctionCommonFunctionality<T, NDIM> fcf_hi_npt(k + oversampling);
+                key.break_apart(key1,key2);
+                const long k=coeff_rhs.dim(0);
+                auto& cdata=FunctionCommonData<T,NDIM>::get(k);
+                auto& cdata_lowdim=FunctionCommonData<T,LDIM>::get(k);
+            	FunctionCommonFunctionality<T,LDIM> fcf_lo(cdata_lowdim);
+            	FunctionCommonFunctionality<T,NDIM> fcf_hi(cdata);
+            	FunctionCommonFunctionality<T,LDIM> fcf_lo_npt(k+oversampling);
+            	FunctionCommonFunctionality<T,NDIM> fcf_hi_npt(k+oversampling);
 
 
             	// make hi-dim values from lo-dim coeff_rhs on npt grid points
-                tensorT ones = tensorT(fcf_lo_npt.cdata.vk);
-                ones = 1.0;
+                tensorT ones=tensorT(fcf_lo_npt.cdata.vk);
+                ones=1.0;
 
                 tensorT coeff_rhs_npt1(fcf_lo_npt.cdata.vk);
-                coeff_rhs_npt1(fcf_lo.cdata.s0) = coeff_rhs;
-                tensorT val_rhs_npt1 = fcf_lo_npt.coeffs2values(key1, coeff_rhs_npt1);
+                coeff_rhs_npt1(fcf_lo.cdata.s0)=coeff_rhs;
+                tensorT val_rhs_npt1=fcf_lo_npt.coeffs2values(key1,coeff_rhs_npt1);
 
-                TensorArgs targs(-1.0, TT_2D);
+                TensorArgs targs(-1.0,TT_2D);
                 coeffT val_rhs;
-                if (particle == 1) val_rhs=outer(val_rhs_npt1, ones, targs);
-                if (particle == 2) val_rhs=outer(ones, val_rhs_npt1, targs);
+                if (particle==1) val_rhs=outer(val_rhs_npt1,ones,targs);
+                if (particle==2) val_rhs=outer(ones,val_rhs_npt1,targs);
 
             	// make values from hi-dim coeff_lhs on npt grid points
-	            coeffT coeff_lhs_k1(fcf_hi_npt.cdata.vk, coeff_lhs.tensor_type());
-	            coeff_lhs_k1(fcf_hi.cdata.s0) += coeff_lhs;
-	            coeffT val_lhs_npt = fcf_hi_npt.coeffs2values(key, coeff_lhs_k1);
+	            coeffT coeff_lhs_k1(fcf_hi_npt.cdata.vk,coeff_lhs.tensor_type());
+	            coeff_lhs_k1(fcf_hi.cdata.s0)+=coeff_lhs;
+	            coeffT val_lhs_npt=fcf_hi_npt.coeffs2values(key,coeff_lhs_k1);
 
 	            // multiply
 	            val_lhs_npt.emul(val_rhs);
 
                 // values2coeffs: npt = k+1-> k
-	            coeffT result1 = fcf_hi_npt.values2coeffs(key, val_lhs_npt);
+	            coeffT result1=fcf_hi_npt.values2coeffs(key,val_lhs_npt);
 
                 // extract coeffs up to k
-	            coeffT result = copy(result1(cdata.s0));
-                result1(cdata.s0) = 0.0;
-                error = result1.normf();
+	            coeffT result=copy(result1(cdata.s0));
+                result1(cdata.s0)=0.0;
+                error=result1.normf();
                 return result;
         	}
 
@@ -3952,11 +3978,11 @@ template<size_t NDIM>
         template<typename opT, size_t LDIM>
         struct Vphi_op_NS {
 
-            bool randomize() const { return true; }
+            bool randomize() const {return true;}
 
-            typedef Vphi_op_NS<opT, LDIM> this_type;
-            typedef CoeffTracker<T, NDIM> ctT;
-            typedef CoeffTracker<T, LDIM> ctL;
+            typedef Vphi_op_NS<opT,LDIM> this_type;
+            typedef CoeffTracker<T,NDIM> ctT;
+            typedef CoeffTracker<T,LDIM> ctL;
 
             implT* result;  		///< where to construct Vphi, no need to track parents
             opT leaf_op;    	    ///< deciding if a given FunctionNode will be a leaf node
@@ -3965,10 +3991,10 @@ template<size_t NDIM>
             ctL iav1, iav2;			///< potentials for particles 1 and 2
             const implT* eri;		///< 2-particle potential, must be on-demand
 
-            bool have_ket() const { return iaket.get_impl(); }
-            bool have_v1() const { return iav1.get_impl(); }
-            bool have_v2() const { return iav2.get_impl(); }
-            bool have_eri() const { return eri; }
+            bool have_ket() const {return iaket.get_impl();}
+            bool have_v1() const {return iav1.get_impl();}
+            bool have_v2() const {return iav2.get_impl();}
+            bool have_eri() const {return eri;}
 
             void accumulate_into_result(const Key<NDIM>& key, const coeffT& coeff) const {
                 result->get_coeffs().task(key, &nodeT::accumulate, coeff, result->get_coeffs(), key, result->targs);
@@ -3979,26 +4005,26 @@ template<size_t NDIM>
             Vphi_op_NS(implT* result, const opT& leaf_op, const ctT& iaket,
                        const ctL& iap1, const ctL& iap2, const ctL& iav1, const ctL& iav2,
                        const implT* eri)
-                    : result(result), leaf_op(leaf_op), iaket(iaket), iap1(iap1), iap2(iap2),
-                      iav1(iav1), iav2(iav2), eri(eri) {
+                    : result(result), leaf_op(leaf_op), iaket(iaket), iap1(iap1), iap2(iap2)
+                    , iav1(iav1), iav2(iav2), eri(eri) {
 
                 // 2-particle potential must be on-demand
                 if (eri) MADNESS_ASSERT(eri->is_on_demand());
             }
 
             /// make and insert the coefficients into result's tree
-            std::pair<bool, coeffT> operator()(const Key<NDIM>& key) const {
+            std::pair<bool,coeffT> operator()(const Key<NDIM>& key) const {
 
                 MADNESS_ASSERT(result->get_coeffs().is_local(key));
                 if(leaf_op.do_pre_screening()){
                     // this means that we only construct the boxes which are leaf boxes from the other function in the leaf_op
                     if(leaf_op.pre_screening(key)){
                         // construct sum_coefficients, insert them and leave
-                        auto [sum_coeff, error] = make_sum_coeffs(key);
-                        accumulate_into_result(key, sum_coeff);
-                        return std::pair<bool, coeffT> (true, coeffT());
+                        auto [sum_coeff, error]=make_sum_coeffs(key);
+                        accumulate_into_result(key,sum_coeff);
+                        return std::pair<bool,coeffT> (true,coeffT());
                     }else{
-                        return continue_recursion(std::vector<bool>(1<<NDIM, false), tensorT(), key);
+                        return continue_recursion(std::vector<bool>(1<<NDIM,false),tensorT(),key);
                     }
                 }
 
@@ -4007,32 +4033,32 @@ template<size_t NDIM>
                 // if the initial level is not reached then this must not be a leaf box
                 size_t il = result->get_initial_level();
                 if(FunctionDefaults<NDIM>::get_refine()) il+=1;
-                if(key.level() < int(il)){
-                    return continue_recursion(std::vector<bool>(1<<NDIM, false), tensorT(), key);
+                if(key.level()<int(il)){
+                    return continue_recursion(std::vector<bool>(1<<NDIM,false),tensorT(),key);
                 }
                 // if further refinement is needed (because we are at a special box, special point)
                 // and the special_level is not reached then this must not be a leaf box
-                if(key.level() < result->get_special_level() and leaf_op.special_refinement_needed(key)){
-                    return continue_recursion(std::vector<bool>(1 << NDIM, false), tensorT(), key);
+                if(key.level()<result->get_special_level() and leaf_op.special_refinement_needed(key)){
+                    return continue_recursion(std::vector<bool>(1<<NDIM,false),tensorT(),key);
                 }
 
-                auto [sum_coeff, error] = make_sum_coeffs(key);
+                auto [sum_coeff,error]=make_sum_coeffs(key);
 
                 // coeffs are leaf (for whatever reason), insert into tree and stop recursion
-                if(leaf_op.post_screening(key, sum_coeff)){
-                    accumulate_into_result(key, sum_coeff);
-                    return std::pair<bool, coeffT> (true, coeffT());
+                if(leaf_op.post_screening(key,sum_coeff)){
+                    accumulate_into_result(key,sum_coeff);
+                    return std::pair<bool,coeffT> (true,coeffT());
                 }
 
                 // coeffs are accurate, insert into tree and stop recursion
-                if(error<result->truncate_tol(result->get_thresh(), key)){
-                    accumulate_into_result(key, sum_coeff);
-                    return std::pair<bool, coeffT> (true, coeffT());
+                if(error<result->truncate_tol(result->get_thresh(),key)){
+                    accumulate_into_result(key,sum_coeff);
+                    return std::pair<bool,coeffT> (true,coeffT());
                 }
 
                 // coeffs are inaccurate, continue recursion
-                std::vector<bool> child_is_leaf(1<<NDIM, false);
-                return continue_recursion(child_is_leaf, tensorT(), key);
+                std::vector<bool> child_is_leaf(1<<NDIM,false);
+                return continue_recursion(child_is_leaf,tensorT(),key);
             }
 
 
@@ -4041,31 +4067,31 @@ template<size_t NDIM>
             /// @param[in]	child_is_leaf	for each child: is it a leaf?
             /// @param[in]	coeffs	coefficient tensor with 2^N sum coeffs (=unfiltered NS coeffs)
             /// @param[in]	key		the key for the NS coeffs (=parent key of the children)
-            /// @return		to avoid recursion outside this return: std::pair<is_leaf, coeff> = true, coeffT()
-            std::pair<bool, coeffT> continue_recursion(const std::vector<bool> child_is_leaf,
+            /// @return		to avoid recursion outside this return: std::pair<is_leaf,coeff> = true,coeffT()
+            std::pair<bool,coeffT> continue_recursion(const std::vector<bool> child_is_leaf,
                                                       const tensorT& coeffs, const keyT& key) const {
-                std::size_t i = 0;
+                std::size_t i=0;
                 for (KeyChildIterator<NDIM> kit(key); kit; ++kit, ++i) {
-                    keyT child = kit.key();
-                    bool is_leaf = child_is_leaf[i];
+                    keyT child=kit.key();
+                    bool is_leaf=child_is_leaf[i];
 
                     if (is_leaf) {
                         // insert the sum coeffs
-                        insert_op<T, NDIM> iop(result);
-                        iop(child, coeffT(copy(coeffs(result->child_patch(child))), result->get_tensor_args()), is_leaf);
+                        insert_op<T,NDIM> iop(result);
+                        iop(child,coeffT(copy(coeffs(result->child_patch(child))),result->get_tensor_args()),is_leaf);
                     } else {
-                        this_type child_op = this->make_child(child);
-                        noop<T, NDIM> no;
+                        this_type child_op=this->make_child(child);
+                        noop<T,NDIM> no;
                         // spawn activation where child is local
-                        ProcessID p = result->get_coeffs().owner(child);
+                        ProcessID p=result->get_coeffs().owner(child);
 
-                        void (implT::*ft)(const Vphi_op_NS<opT, LDIM>&, const noop<T, NDIM>&, const keyT&) const = &implT:: template forward_traverse< Vphi_op_NS<opT, LDIM>, noop<T, NDIM>>;
+                        void (implT::*ft)(const Vphi_op_NS<opT,LDIM>&, const noop<T,NDIM>&, const keyT&) const = &implT:: template forward_traverse< Vphi_op_NS<opT,LDIM>, noop<T,NDIM> >;
                         result->task(p, ft, child_op, no, child);
                     }
                 }
                 // return e sum coeffs; also return always is_leaf=true:
                 // the recursion is continued within this struct, not outside in traverse_tree!
-                return std::pair<bool, coeffT> (true, coeffT());
+                return std::pair<bool,coeffT> (true,coeffT());
             }
 
             tensorT eri_coeffs(const keyT& key) const {
@@ -4075,8 +4101,8 @@ template<size_t NDIM>
                     return eri->get_functor()->coeff(key).full_tensor();
                 } else {
                     tensorT val_eri(eri->cdata.vk);
-                    eri->fcube(key, *(eri->get_functor()), eri->cdata.quad_x, val_eri);
-                    return eri->values2coeffs(key, val_eri);
+                    eri->fcube(key,*(eri->get_functor()),eri->cdata.quad_x,val_eri);
+                    return eri->values2coeffs(key,val_eri);
                 }
             }
 
@@ -4092,90 +4118,91 @@ template<size_t NDIM>
                                                             const tensorT& ceri) const {
                 double error = 0.0;
                 Key<LDIM> key1, key2;
-                key.break_apart(key1, key2);
+                key.break_apart(key1,key2);
 
                 PROFILE_BLOCK(compute_error);
                 double dnorm_ket, snorm_ket;
                 if (have_ket()) {
-                    snorm_ket = iaket.coeff(key).normf();
-                    dnorm_ket = iaket.dnorm(key);
+                    snorm_ket=iaket.coeff(key).normf();
+                    dnorm_ket=iaket.dnorm(key);
                 } else {
-                    double s1 = iap1.coeff(key1).normf();
-                    double s2 = iap2.coeff(key2).normf();
-                    double d1 = iap1.dnorm(key1);
-                    double d2 = iap2.dnorm(key2);
-                    snorm_ket = s1 * s2;
-                    dnorm_ket = s1 * d2 + s2 * d1 + d1 * d2;
+                    double s1=iap1.coeff(key1).normf();
+                    double s2=iap2.coeff(key2).normf();
+                    double d1=iap1.dnorm(key1);
+                    double d2=iap2.dnorm(key2);
+                    snorm_ket=s1*s2;
+                    dnorm_ket=s1*d2 + s2*d1 + d1*d2;
                 }
 
                 if (have_v1()) {
-                    double snorm = iav1.coeff(key1).normf();
-                    double dnorm = iav1.dnorm(key1);
-                    error += snorm * dnorm_ket + dnorm * snorm_ket + dnorm * dnorm_ket;
+                    double snorm=iav1.coeff(key1).normf();
+                    double dnorm=iav1.dnorm(key1);
+                    error+=snorm*dnorm_ket + dnorm*snorm_ket + dnorm*dnorm_ket;
                 }
                 if (have_v2()) {
-                    double snorm = iav2.coeff(key2).normf();
-                    double dnorm = iav2.dnorm(key2);
-                    error += snorm * dnorm_ket + dnorm * snorm_ket + dnorm * dnorm_ket;
+                    double snorm=iav2.coeff(key2).normf();
+                    double dnorm=iav2.dnorm(key2);
+                    error+=snorm*dnorm_ket + dnorm*snorm_ket + dnorm*dnorm_ket;
                 }
                 if (have_eri()) {
-                    tensorT s_coeffs = ceri(result->cdata.s0);
-                    double snorm = s_coeffs.normf();
-                    tensorT d = copy(ceri);
-                    d(result->cdata.s0) = 0.0;
-                    double dnorm = d.normf();
-                    error += snorm * dnorm_ket + dnorm * snorm_ket + dnorm * dnorm_ket;
+                    tensorT s_coeffs=ceri(result->cdata.s0);
+                    double snorm=s_coeffs.normf();
+                    tensorT d=copy(ceri);
+                    d(result->cdata.s0)=0.0;
+                    double dnorm=d.normf();
+                    error+=snorm*dnorm_ket + dnorm*snorm_ket + dnorm*dnorm_ket;
                 }
 
-                bool no_potential = not ((have_v1() or have_v2() or have_eri()));
+                bool no_potential=not ((have_v1() or have_v2() or have_eri()));
                 if (no_potential) {
-                    error = dnorm_ket;
+                    error=dnorm_ket;
                 }
                 return error;
             }
 
             /// make the sum coeffs for key
-            std::pair<coeffT, double> make_sum_coeffs(const keyT& key) const {
+            std::pair<coeffT,double> make_sum_coeffs(const keyT& key) const {
                 PROFILE_BLOCK(make_sum_coeffs);
                 // break key into particles
                 Key<LDIM> key1, key2;
-                key.break_apart(key1, key2);
+                key.break_apart(key1,key2);
 
-        		// bool printme = (int(key.translation()[0]) == int(std::pow(key.level(), 2) / 2)) and
-                // (int(key.translation()[1]) == int(std::pow(key.level(), 2) / 2)) and
-                // (int(key.translation()[2]) == int(std::pow(key.level(), 2) / 2));
-                // printme = false;
+        		// bool printme=(int(key.translation()[0])==int(std::pow(key.level(),2)/2)) and
+        		// 		(int(key.translation()[1])==int(std::pow(key.level(),2)/2)) and
+			// 			(int(key.translation()[2])==int(std::pow(key.level(),2)/2));
+
+//        		printme=false;
 
                 // get/make all coefficients
                 const coeffT coeff_ket = (iaket.get_impl()) ? iaket.coeff(key)
-                                                            : outer(iap1.coeff(key1), iap2.coeff(key2), result->get_tensor_args());
+                                                            : outer(iap1.coeff(key1),iap2.coeff(key2),result->get_tensor_args());
                 const coeffT cpot1 = (have_v1()) ? iav1.coeff(key1) : coeffT();
                 const coeffT cpot2 = (have_v2()) ? iav2.coeff(key2) : coeffT();
                 const tensorT ceri = (have_eri()) ? eri_coeffs(key) : tensorT();
 
                 // compute first part of the total error
-                double refine_error = compute_error_from_inaccurate_refinement(key, ceri);
-                double error = refine_error;
+                double refine_error=compute_error_from_inaccurate_refinement(key,ceri);
+                double error=refine_error;
 
         		// prepare the multiplication
-        		pointwise_multiplier<LDIM> pm(key, coeff_ket);
+        		pointwise_multiplier<LDIM> pm(key,coeff_ket);
 
         		// perform the multiplication, compute tnorm part of the total error
-        		coeffT cresult(result->cdata.vk, result->get_tensor_args());
+        		coeffT cresult(result->cdata.vk,result->get_tensor_args());
         		if (have_v1()) {
-        			cresult += pm(key, cpot1.get_tensor(), 1);
-        			error += pm.error;
+        			cresult+=pm(key,cpot1.get_tensor(),1);
+        			error+=pm.error;
             	}
         		if (have_v2()) {
-        			cresult += pm(key, cpot2.get_tensor(), 2);
-        			error += pm.error;
+        			cresult+=pm(key,cpot2.get_tensor(),2);
+        			error+=pm.error;
         		}
 
                 if (have_eri()) {
                     tensorT result1=cresult.full_tensor_copy();
-                    result1 += pm(key, copy(ceri(result->cdata.s0)));
-                    cresult = coeffT(result1, result->get_tensor_args());
-                    error += pm.error;
+                    result1+=pm(key,copy(ceri(result->cdata.s0)));
+                    cresult=coeffT(result1,result->get_tensor_args());
+                    error+=pm.error;
                 } else {
                     cresult.reduce_rank(result->get_tensor_args().thresh);
                 }
@@ -4183,35 +4210,35 @@ template<size_t NDIM>
                     cresult=coeff_ket;
                 }
 
-                return std::make_pair(cresult, error);
+                return std::make_pair(cresult,error);
             }
 
             this_type make_child(const keyT& child) const {
 
                 // break key into particles
                 Key<LDIM> key1, key2;
-                child.break_apart(key1, key2);
+                child.break_apart(key1,key2);
 
-                return this_type(result, leaf_op, iaket.make_child(child),
-                                 iap1.make_child(key1), iap2.make_child(key2),
-                                 iav1.make_child(key1), iav2.make_child(key2), eri);
+                return this_type(result,leaf_op,iaket.make_child(child),
+                                 iap1.make_child(key1),iap2.make_child(key2),
+                                 iav1.make_child(key1),iav2.make_child(key2),eri);
             }
 
             Future<this_type> activate() const {
-                Future<ctT> iaket1 = iaket.activate();
-                Future<ctL> iap11 = iap1.activate();
-                Future<ctL> iap21 = iap2.activate();
-                Future<ctL> iav11 = iav1.activate();
-                Future<ctL> iav21 = iav2.activate();
+                Future<ctT> iaket1=iaket.activate();
+                Future<ctL> iap11=iap1.activate();
+                Future<ctL> iap21=iap2.activate();
+                Future<ctL> iav11=iav1.activate();
+                Future<ctL> iav21=iav2.activate();
                 return result->world.taskq.add(detail::wrap_mem_fn(*const_cast<this_type *> (this),
-                                                                   &this_type::forward_ctor), result, leaf_op,
-                                               iaket1, iap11, iap21, iav11, iav21, eri);
+                                                                   &this_type::forward_ctor),result,leaf_op,
+                                               iaket1,iap11,iap21,iav11,iav21,eri);
             }
 
             this_type forward_ctor(implT* result1, const opT& leaf_op, const ctT& iaket1,
                                    const ctL& iap11, const ctL& iap21, const ctL& iav11, const ctL& iav21,
                                    const implT* eri1) {
-                return this_type(result1, leaf_op, iaket1, iap11, iap21, iav11, iav21, eri1);
+                return this_type(result1,leaf_op,iaket1,iap11,iap21,iav11,iav21,eri1);
             }
 
             /// serialize this (needed for use in recursive_op)
@@ -4229,41 +4256,43 @@ template<size_t NDIM>
         /// @param[in]  fence   global fence
         template<typename opT>
         void make_Vphi(const opT& leaf_op, const bool fence=true) {
-            constexpr size_t LDIM = NDIM / 2;
-            MADNESS_CHECK_THROW(NDIM == LDIM * 2, "make_Vphi only works for even dimensions");
+
+            constexpr size_t LDIM=NDIM/2;
+            MADNESS_CHECK_THROW(NDIM==LDIM*2,"make_Vphi only works for even dimensions");
+
 
             // keep the functor available, but remove it from the result
             // result will return false upon is_on_demand(), which is necessary for the
             // CoeffTracker to track the parent coeffs correctly for error_leaf_op
-            std::shared_ptr< FunctionFunctorInterface<T, NDIM>> func2(this->get_functor());
+            std::shared_ptr< FunctionFunctorInterface<T,NDIM> > func2(this->get_functor());
             this->unset_functor();
 
-            CompositeFunctorInterface<T, NDIM, LDIM>* func=
-                    dynamic_cast<CompositeFunctorInterface<T, NDIM, LDIM>* >(&(*func2));
+            CompositeFunctorInterface<T,NDIM,LDIM>* func=
+                    dynamic_cast<CompositeFunctorInterface<T,NDIM,LDIM>* >(&(*func2));
             MADNESS_ASSERT(func);
 
             // make sure everything is in place if no fence is requested
             if (fence) func->make_redundant(true);          // no-op if already redundant
-            MADNESS_CHECK_THROW(func->check_redundant(), "make_Vphi requires redundant functions");
+            MADNESS_CHECK_THROW(func->check_redundant(),"make_Vphi requires redundant functions");
 
             // loop over all functions in the functor (either ket or particles)
             for (auto& ket : func->impl_ket_vector) {
-                FunctionImpl<T, NDIM>* eri=func->impl_eri.get();
-                FunctionImpl<T, LDIM>* v1=func->impl_m1.get();
-                FunctionImpl<T, LDIM>* v2=func->impl_m2.get();
-                FunctionImpl<T, LDIM>* p1=nullptr;
-                FunctionImpl<T, LDIM>* p2=nullptr;
-                make_Vphi_only(leaf_op, ket.get(), v1, v2, p1, p2, eri, false);
+                FunctionImpl<T,NDIM>* eri=func->impl_eri.get();
+                FunctionImpl<T,LDIM>* v1=func->impl_m1.get();
+                FunctionImpl<T,LDIM>* v2=func->impl_m2.get();
+                FunctionImpl<T,LDIM>* p1=nullptr;
+                FunctionImpl<T,LDIM>* p2=nullptr;
+                make_Vphi_only(leaf_op,ket.get(),v1,v2,p1,p2,eri,false);
             }
 
-            for (std::size_t i = 0; i < func->impl_p1_vector.size(); ++i) {
-                FunctionImpl<T, NDIM>* ket=nullptr;
-                FunctionImpl<T, NDIM>* eri=func->impl_eri.get();
-                FunctionImpl<T, LDIM>* v1=func->impl_m1.get();
-                FunctionImpl<T, LDIM>* v2=func->impl_m2.get();
-                FunctionImpl<T, LDIM>* p1=func->impl_p1_vector[i].get();
-                FunctionImpl<T, LDIM>* p2=func->impl_p2_vector[i].get();
-                make_Vphi_only(leaf_op, ket, v1, v2, p1, p2, eri, false);
+            for (std::size_t i=0; i<func->impl_p1_vector.size(); ++i) {
+                FunctionImpl<T,NDIM>* ket=nullptr;
+                FunctionImpl<T,NDIM>* eri=func->impl_eri.get();
+                FunctionImpl<T,LDIM>* v1=func->impl_m1.get();
+                FunctionImpl<T,LDIM>* v2=func->impl_m2.get();
+                FunctionImpl<T,LDIM>* p1=func->impl_p1_vector[i].get();
+                FunctionImpl<T,LDIM>* p2=func->impl_p2_vector[i].get();
+                make_Vphi_only(leaf_op,ket,v1,v2,p1,p2,eri,false);
             }
 
             // some post-processing:
@@ -4271,10 +4300,12 @@ template<size_t NDIM>
             // - the operation constructs sum coefficients on all scales -> sum down to get a well-defined tree-state
             if (fence) {
                 world.gop.fence();
-                flo_unary_op_node_inplace(do_consolidate_buffer(get_tensor_args()), true);
+                flo_unary_op_node_inplace(do_consolidate_buffer(get_tensor_args()),true);
                 sum_down(true);
                 set_tree_state(reconstructed);
             }
+
+
         }
 
         /// assemble the function V*phi using V and phi given from the functor
@@ -4285,33 +4316,35 @@ template<size_t NDIM>
         /// @param[in]  leaf_op  operator to decide if a given node is a leaf node
         /// @param[in]  fence   global fence
         template<typename opT, std::size_t LDIM>
-        void make_Vphi_only(const opT& leaf_op, FunctionImpl<T, NDIM>* ket,
-                            FunctionImpl<T, LDIM>* v1, FunctionImpl<T, LDIM>* v2,
-                            FunctionImpl<T, LDIM>* p1, FunctionImpl<T, LDIM>* p2,
-                            FunctionImpl<T, NDIM>* eri, 
+        void make_Vphi_only(const opT& leaf_op, FunctionImpl<T,NDIM>* ket,
+                            FunctionImpl<T,LDIM>* v1, FunctionImpl<T,LDIM>* v2,
+                            FunctionImpl<T,LDIM>* p1, FunctionImpl<T,LDIM>* p2,
+                            FunctionImpl<T,NDIM>* eri,
                             const bool fence=true) {
+
             // prepare the CoeffTracker
-            CoeffTracker<T, NDIM> iaket(ket);
-            CoeffTracker<T, LDIM> iap1(p1);
-            CoeffTracker<T, LDIM> iap2(p2);
-            CoeffTracker<T, LDIM> iav1(v1);
-            CoeffTracker<T, LDIM> iav2(v2);
+            CoeffTracker<T,NDIM> iaket(ket);
+            CoeffTracker<T,LDIM> iap1(p1);
+            CoeffTracker<T,LDIM> iap2(p2);
+            CoeffTracker<T,LDIM> iav1(v1);
+            CoeffTracker<T,LDIM> iav2(v2);
 
             // the operator making the coefficients
-            typedef Vphi_op_NS<opT, LDIM> coeff_opT;
-            coeff_opT coeff_op(this, leaf_op, iaket, iap1, iap2, iav1, iav2, eri);
+            typedef Vphi_op_NS<opT,LDIM> coeff_opT;
+            coeff_opT coeff_op(this,leaf_op,iaket,iap1,iap2,iav1,iav2,eri);
 
             // this operator simply inserts the coeffs into this' tree
-            typedef noop<T, NDIM> apply_opT;
+            typedef noop<T,NDIM> apply_opT;
             apply_opT apply_op;
 
             if (world.rank() == coeffs.owner(cdata.key0)) {
-                woT::task(world.rank(), &implT:: template forward_traverse<coeff_opT, apply_opT>,
+                woT::task(world.rank(), &implT:: template forward_traverse<coeff_opT,apply_opT>,
                           coeff_op, apply_op, cdata.key0);
             }
 
             set_tree_state(redundant_after_merge);
             if (fence) world.gop.fence();
+
         }
 
         /// Permute the dimensions of f according to map, result on this
@@ -4353,12 +4386,12 @@ template<size_t NDIM>
         struct do_compute_snorm_and_dnorm {
             typedef Range<typename dcT::iterator> rangeT;
 
-            const FunctionCommonData<T, NDIM>& cdata;
-            do_compute_snorm_and_dnorm(const FunctionCommonData<T, NDIM>& cdata) :
+            const FunctionCommonData<T,NDIM>& cdata;
+            do_compute_snorm_and_dnorm(const FunctionCommonData<T,NDIM>& cdata) :
                     cdata(cdata) {}
 
             bool operator()(typename rangeT::iterator& it) const {
-                auto& node = it->second;
+                auto& node=it->second;
                 node.recompute_snorm_and_dnorm(cdata);
                 return true;
             }
@@ -4409,7 +4442,7 @@ template<size_t NDIM>
         /// @param[in]  key key of level n
         /// @param[in]  v   vector of sum coefficients of level n+1
         /// @return     sum coefficients on level n in full tensor format
-        tensorT downsample(const keyT& key, const std::vector< Future<coeffT >>& v) const;
+        tensorT downsample(const keyT& key, const std::vector< Future<coeffT > >& v) const;
 
         /// upsample the sum coefficients of level 1 to sum coeffs on level n+1
 
@@ -4434,11 +4467,11 @@ template<size_t NDIM>
             // Must allow for someone already having autorefined the coeffs
             // and we get a write accessor just in case they are already executing
             typename dcT::accessor acc;
-            const auto found = coeffs.find(acc, key);
+            const auto found = coeffs.find(acc,key);
             MADNESS_CHECK(found);
             nodeT& node = acc->second;
             if (node.has_coeff() && key.level() < max_refine_level && op(this, key, node)) {
-                coeffT d(cdata.v2k, targs);
+                coeffT d(cdata.v2k,targs);
                 d(cdata.s0) += copy(node.coeff());
                 d = unfilter(d);
                 node.clear_coeff();
@@ -4447,8 +4480,8 @@ template<size_t NDIM>
                     const keyT& child = kit.key();
                     coeffT ss = copy(d(child_patch(child)));
                     ss.reduce_rank(targs.thresh);
-                    //                    coeffs.replace(child, nodeT(ss, -1.0, false).node_to_low_rank());
-                    coeffs.replace(child, nodeT(ss, -1.0, false));
+                    //                    coeffs.replace(child,nodeT(ss,-1.0,false).node_to_low_rank());
+                    coeffs.replace(child,nodeT(ss,-1.0,false));
                     // Note value -1.0 for norm tree to indicate result of refinement
                 }
             }
@@ -4479,7 +4512,8 @@ template<size_t NDIM>
 
         bool exists_and_is_leaf(const keyT& key) const;
 
-        void broaden_op(const keyT& key, const std::vector< Future <bool>>& v);
+
+        void broaden_op(const keyT& key, const std::vector< Future <bool> >& v);
 
         // For each local node sets value of norm tree, snorm and dnorm to 0.0
         void zero_norm_tree();
@@ -4501,7 +4535,7 @@ template<size_t NDIM>
         void change_tree_state(const TreeState finalstate, bool fence=true);
 
         // Invoked on node where key is local
-        // void reconstruct_op(const keyT& key, const tensorT& s);
+        //        void reconstruct_op(const keyT& key, const tensorT& s);
         void reconstruct_op(const keyT& key, const coeffT& s, const bool accumulate_NS=true);
 
         /// compress the wave function
@@ -4511,11 +4545,11 @@ template<size_t NDIM>
         /// @param[in] nonstandard	keep sum coeffs at all other levels, except leaves
         /// @param[in] keepleaves	keep sum coeffs (but no diff coeffs) at leaves
         /// @param[in] redundant    keep only sum coeffs at all levels, discard difference coeffs
-        // void compress(bool nonstandard, bool keepleaves, bool redundant, bool fence);
+//        void compress(bool nonstandard, bool keepleaves, bool redundant, bool fence);
         void compress(const TreeState newstate, bool fence);
 
         /// Invoked on node where key is local
-        Future<std::pair<coeffT, double>> compress_spawn(const keyT& key, bool nonstandard, bool keepleaves,
+        Future<std::pair<coeffT,double> > compress_spawn(const keyT& key, bool nonstandard, bool keepleaves,
         		bool redundant1);
 
         private:
@@ -4533,7 +4567,7 @@ template<size_t NDIM>
         /// compute for each FunctionNode the norm of the function inside that node
         void norm_tree(bool fence);
 
-        double norm_tree_op(const keyT& key, const std::vector< Future<double>>& v);
+        double norm_tree_op(const keyT& key, const std::vector< Future<double> >& v);
 
         Future<double> norm_tree_spawn(const keyT& key);
 
@@ -4545,7 +4579,7 @@ template<size_t NDIM>
         /// given the sum coefficients of all children, truncate or not
 
         /// @return     new sum coefficients (empty if internal, not empty, if new leaf); might delete its children
-        coeffT truncate_reconstructed_op(const keyT& key, const std::vector< Future<coeffT >>& v, const double tol);
+        coeffT truncate_reconstructed_op(const keyT& key, const std::vector< Future<coeffT > >& v, const double tol);
 
         /// calculate the wavelet coefficients using the sum coefficients of all child nodes
 
@@ -4555,7 +4589,7 @@ template<size_t NDIM>
         /// @param[in] nonstandard  keep the sum coefficients with the wavelet coefficients
         /// @param[in] redundant    keep only the sum coefficients, discard the wavelet coefficients
         /// @return 		the sum coefficients
-        std::pair<coeffT, double> compress_op(const keyT& key, const std::vector< Future<std::pair<coeffT, double>>>& v, bool nonstandard);
+        std::pair<coeffT,double> compress_op(const keyT& key, const std::vector< Future<std::pair<coeffT,double>> >& v, bool nonstandard);
 
 
         /// similar to compress_op, but insert only the sum coefficients in the tree
@@ -4564,7 +4598,7 @@ template<size_t NDIM>
         /// @param[in] key  this's key
         /// @param[in] v    sum coefficients of the child nodes
         /// @return         the sum coefficients
-        std::pair<coeffT, double> make_redundant_op(const keyT& key, const std::vector< Future<std::pair<coeffT, double>> >& v);
+        std::pair<coeffT,double> make_redundant_op(const keyT& key,const std::vector< Future<std::pair<coeffT,double> > >& v);
 
         /// Changes non-standard compressed form to standard compressed form
         void standard(bool fence);
@@ -4582,12 +4616,13 @@ template<size_t NDIM>
 
             //
             bool operator()(typename rangeT::iterator& it) const {
+
                 const keyT& key = it->first;
                 nodeT& node = it->second;
                 if (key.level()> 0 && node.has_coeff()) {
                     if (node.has_children()) {
                         // Zero out scaling coeffs
-                    	MADNESS_ASSERT(node.coeff().dim(0) == 2*impl->get_k());
+                    	MADNESS_ASSERT(node.coeff().dim(0)==2*impl->get_k());
                         node.coeff()(impl->cdata.s0)=0.0;
                         node.reduceRank(impl->targs.thresh);
                     } else {
@@ -4597,9 +4632,8 @@ template<size_t NDIM>
                 }
                 return true;
             }
-
             template <typename Archive> void serialize(const Archive& ar) {
-                MADNESS_EXCEPTION("no serialization of do_standard", 1);
+                MADNESS_EXCEPTION("no serialization of do_standard",1);
             }
         };
 
@@ -4607,17 +4641,16 @@ template<size_t NDIM>
         /// laziness
         template<size_t OPDIM>
         struct do_op_args {
-            Key<OPDIM> key, d;
+            Key<OPDIM> key,d;
             keyT dest;
             double tol, fac, cnorm;
 
             do_op_args() = default;
             do_op_args(const Key<OPDIM>& key, const Key<OPDIM>& d, const keyT& dest, double tol, double fac, double cnorm)
                 : key(key), d(d), dest(dest), tol(tol), fac(fac), cnorm(cnorm) {}
-
             template <class Archive>
             void serialize(Archive& ar) {
-                ar & archive::wrap_opaque(this, 1);
+                ar & archive::wrap_opaque(this,1);
             }
         };
 
@@ -4634,9 +4667,9 @@ template<size_t NDIM>
             // Screen here to reduce communication cost of negligible data
             // and also to ensure we don't needlessly widen the tree when
             // applying the operator
-            if (result.normf() > 0.3 * args.tol / args.fac) {
+            if (result.normf()> 0.3*args.tol/args.fac) {
                 coeffs.task(args.dest, &nodeT::accumulate2, result, coeffs, args.dest, TaskAttributes::hipri());
-                // woT::task(world.rank(), &implT::accumulate_timer, time, TaskAttributes::hipri());
+                //woT::task(world.rank(),&implT::accumulate_timer,time,TaskAttributes::hipri());
                 // UGLY BUT ADDED THE OPTIMIZATION BACK IN HERE EXPLICITLY/
                 if (args.dest == world.rank()) {
                     coeffs.send(args.dest, &nodeT::accumulate, result, coeffs, args.dest);
@@ -4659,26 +4692,26 @@ template<size_t NDIM>
                                 const TensorArgs& apply_targs) {
 
             tensorT result_full = op->apply(args.key, args.d, c, args.tol/args.fac/args.cnorm);
-            const double norm = result_full.normf();
+            const double norm=result_full.normf();
 
             // Screen here to reduce communication cost of negligible data
             // and also to ensure we don't needlessly widen the tree when
             // applying the operator
             // OPTIMIZATION NEEDED HERE ... CHANGING THIS TO TASK NOT SEND REMOVED
             // BUILTIN OPTIMIZATION TO SHORTCIRCUIT MSG IF DATA IS LOCAL
-            if (norm > 0.3 * args.tol / args.fac) {
+            if (norm > 0.3*args.tol/args.fac) {
 
                 small++;
-                // double cpu0 = cpu_time();
-                coeffT result = coeffT(result_full, apply_targs);
+                //double cpu0=cpu_time();
+                coeffT result=coeffT(result_full,apply_targs);
                 MADNESS_ASSERT(result.is_full_tensor() or result.is_svd_tensor());
-                // double cpu1 = cpu_time();
-                // timer_lr_result.accumulate(cpu1 - cpu0);
+                //double cpu1=cpu_time();
+                //timer_lr_result.accumulate(cpu1-cpu0);
 
                 coeffs.task(args.dest, &nodeT::accumulate, result, coeffs, args.dest, apply_targs,
                                                 TaskAttributes::hipri());
 
-                // woT::task(world.rank(), &implT::accumulate_timer, time, TaskAttributes::hipri());
+                //woT::task(world.rank(),&implT::accumulate_timer,time,TaskAttributes::hipri());
             }
             return norm;
         }
@@ -4697,25 +4730,26 @@ template<size_t NDIM>
                                 const TensorArgs& apply_targs) {
 
             coeffT result;
-            if (2 * OPDIM == NDIM) result = op->apply2_lowdim(args.key, args.d, coeff,
-                    args.tol / args.fac / args.cnorm, args.tol / args.fac);
-            if (OPDIM == NDIM) result = op->apply2(args.key, args.d, coeff,
-                    args.tol / args.fac / args.cnorm, args.tol / args.fac);
+            if (2*OPDIM==NDIM) result= op->apply2_lowdim(args.key, args.d, coeff,
+                    args.tol/args.fac/args.cnorm, args.tol/args.fac);
+            if (OPDIM==NDIM) result = op->apply2(args.key, args.d, coeff,
+                    args.tol/args.fac/args.cnorm, args.tol/args.fac);
 
-            const double result_norm = result.svd_normf();
+            const double result_norm=result.svd_normf();
 
-            if (result_norm > 0.3 * args.tol / args.fac) {
+            if (result_norm> 0.3*args.tol/args.fac) {
                 small++;
 
-                double cpu0 = cpu_time();
-                if (not result.is_of_tensortype(targs.tt)) result = result.convert(targs);
-                double cpu1 = cpu_time();
-                timer_lr_result.accumulate(cpu1 - cpu0);
+                double cpu0=cpu_time();
+                if (not result.is_of_tensortype(targs.tt)) result=result.convert(targs);
+                double cpu1=cpu_time();
+                timer_lr_result.accumulate(cpu1-cpu0);
 
                 // accumulate also expects result in SVD form
                 coeffs.task(args.dest, &nodeT::accumulate, result, coeffs, args.dest, apply_targs,
-                            TaskAttributes::hipri());
-                // woT::task(world.rank(), &implT::accumulate_timer, time, TaskAttributes::hipri());
+                                                TaskAttributes::hipri());
+//                woT::task(world.rank(),&implT::accumulate_timer,time,TaskAttributes::hipri());
+
             }
             return result_norm;
 
@@ -4723,7 +4757,7 @@ template<size_t NDIM>
 
         // volume of n-dimensional sphere of radius R
         double vol_nsphere(int n, double R) {
-            return std::pow(madness::constants::pi, n * 0.5) * std::pow(R, n) / std::tgamma(1 + 0.5 * n);
+            return std::pow(madness::constants::pi,n*0.5)*std::pow(R,n)/std::tgamma(1+0.5*n);
         }
         
 
@@ -4737,18 +4771,19 @@ template<size_t NDIM>
         void do_apply(const opT* op, const keyT& key, const Tensor<R>& c) {
             PROFILE_MEMBER_FUNC(FunctionImpl);
 
-            // working assumption here WAS that the operator is
-            // isotropic and montonically decreasing with distance
-            // ... however, now we are using derivative Gaussian
-            // expansions (and also non-cubic boxes) isotropic is
-            // violated. While not strictly monotonically decreasing,
-            // the derivative gaussian is still such that once it
-            // becomes negligible we are in the asymptotic region.
+	    // working assumption here WAS that the operator is
+	    // isotropic and montonically decreasing with distance
+	    // ... however, now we are using derivative Gaussian
+	    // expansions (and also non-cubic boxes) isotropic is
+	    // violated. While not strictly monotonically decreasing,
+	    // the derivative gaussian is still such that once it
+	    // becomes negligible we are in the asymptotic region.
 
             typedef typename opT::keyT opkeyT;
-            static const size_t opdim = opT::opdim;
-            const opkeyT source = op->get_source_key(key);
+            static const size_t opdim=opT::opdim;
+            const opkeyT source=op->get_source_key(key);
 
+            
             // Tuning here is based on observation that with
             // sufficiently high-order wavelet relative to the
             // precision, that only nearest neighbor boxes contribute,
@@ -4765,36 +4800,36 @@ template<size_t NDIM>
             // tol/fac
 
             // radius of shell (nearest neighbor is diameter of 3 boxes, so radius=1.5)
-            double radius = 1.5 + 0.33 * std::max(0.0, 2 - std::log10(thresh) - k); // 0.33 was 0.5
+            double radius = 1.5 + 0.33*std::max(0.0,2-std::log10(thresh)-k); // 0.33 was 0.5
             double fac = vol_nsphere(NDIM, radius);
-            // previously fac = 10.0 selected empirically constrained by qmprop
+            //previously fac=10.0 selected empirically constrained by qmprop
 
             double cnorm = c.normf();
 
             const std::vector<opkeyT>& disp = op->get_disp(key.level()); // list of displacements sorted in orer of increasing distance
-            const std::vector<bool> is_periodic(NDIM, false); // Periodic sum is already done when making rnlp
-            int nvalid = 1;       // Counts #valid at each distance
-            int nused = 1;	// Counts #used at each distance
-	        uint64_t distsq = 99999999999999;
+            const std::vector<bool> is_periodic(NDIM,false); // Periodic sum is already done when making rnlp
+            int nvalid=1;       // Counts #valid at each distance
+            int nused=1;	// Counts #used at each distance
+	    uint64_t distsq = 99999999999999;
             for (typename std::vector<opkeyT>::const_iterator it=disp.begin(); it != disp.end(); ++it) {
-	            keyT d;
+	        keyT d;
                 Key<NDIM-opdim> nullkey(key.level());
-                if (op->particle() == 1) d=it->merge_with(nullkey);
-                if (op->particle() == 2) d=nullkey.merge_with(*it);
+                if (op->particle()==1) d=it->merge_with(nullkey);
+                if (op->particle()==2) d=nullkey.merge_with(*it);
 
-                uint64_t dsq = d.distsq();
-                if (dsq != distsq) { // Moved to next shell of neighbors
-                    if (nvalid > 0 && nused == 0 && dsq > 1) {
-                        // Have at least done the input box and all first
-                        // nearest neighbors, and for all of the last set
-                        // of neighbors had no contribution.  Thus,
-                        // assuming monotonic decrease, we are done.
-                        break;
-                    }
-                    nused = 0;
+		uint64_t dsq = d.distsq();
+		if (dsq != distsq) { // Moved to next shell of neighbors
+		    if (nvalid > 0 && nused == 0 && dsq > 1) {
+		        // Have at least done the input box and all first
+		        // nearest neighbors, and for all of the last set
+		        // of neighbors had no contribution.  Thus,
+		        // assuming monotonic decrease, we are done.
+		        break;
+		    }
+		    nused = 0;
                     nvalid = 0;
-                    distsq = dsq;
-                }
+		    distsq = dsq;
+		} 
 
                 keyT dest = neighbor(key, d, is_periodic);
                 if (dest.is_valid()) {
@@ -4802,14 +4837,14 @@ template<size_t NDIM>
                     double opnorm = op->norm(key.level(), *it, source);
                     double tol = truncate_tol(thresh, key);
 
-                    if (cnorm * opnorm > tol / fac) {
+                    if (cnorm*opnorm> tol/fac) {
                         nused++;
-                        tensorT result = op->apply(source, *it, c, tol / fac / cnorm);
-                        if (result.normf() > 0.3 * tol / fac) {
-                            if (coeffs.is_local(dest))
-                                coeffs.send(dest, &nodeT::accumulate2, result, coeffs, dest);
-                            else
-                                coeffs.task(dest, &nodeT::accumulate2, result, coeffs, dest);
+		        tensorT result = op->apply(source, *it, c, tol/fac/cnorm);
+			if (result.normf() > 0.3*tol/fac) {
+			  if (coeffs.is_local(dest))
+			      coeffs.send(dest, &nodeT::accumulate2, result, coeffs, dest);
+			  else
+  			      coeffs.task(dest, &nodeT::accumulate2, result, coeffs, dest);
                         }
                     }
                 }
@@ -4819,19 +4854,19 @@ template<size_t NDIM>
 
         /// apply an operator on f to return this
         template <typename opT, typename R>
-        void apply(opT& op, const FunctionImpl<R, NDIM>& f, bool fence) {
+        void apply(opT& op, const FunctionImpl<R,NDIM>& f, bool fence) {
             PROFILE_MEMBER_FUNC(FunctionImpl);
             MADNESS_ASSERT(!op.modified());
             typename dcT::const_iterator end = f.coeffs.end();
-            for (typename dcT::const_iterator it = f.coeffs.begin(); it != end; ++it) {
+            for (typename dcT::const_iterator it=f.coeffs.begin(); it!=end; ++it) {
                 // looping through all the coefficients in the source
                 const keyT& key = it->first;
-                const FunctionNode<R, NDIM>& node = it->second;
+                const FunctionNode<R,NDIM>& node = it->second;
                 if (node.has_coeff()) {
                     if (node.coeff().dim(0) != k || op.doleaves) {
                         ProcessID p = FunctionDefaults<NDIM>::get_apply_randomize() ? world.random_proc() : coeffs.owner(key);
-                        // woT::task(p, &implT:: template do_apply<opT, R>, &op, key, node.coeff()); //.full_tensor_copy() ????? why copy ????
-                        woT::task(p, &implT:: template do_apply<opT, R>, &op, key, node.coeff().reconstruct_tensor());
+//                        woT::task(p, &implT:: template do_apply<opT,R>, &op, key, node.coeff()); //.full_tensor_copy() ????? why copy ????
+                        woT::task(p, &implT:: template do_apply<opT,R>, &op, key, node.coeff().reconstruct_tensor());
                     }
                 }
             }
@@ -4839,9 +4874,10 @@ template<size_t NDIM>
                 world.gop.fence();
 
             set_tree_state(nonstandard_after_apply);
-            // this->compressed = true;
-            // this->nonstandard = true;
-            // this->redundant = false;
+//            this->compressed=true;
+//            this->nonstandard=true;
+//            this->redundant=false;
+
         }
 
 
@@ -4864,49 +4900,49 @@ template<size_t NDIM>
             // screening: contains all displacement keys that had small result norms
             std::list<opkeyT> blacklist;
 
-            static const size_t opdim = opT::opdim;
+            static const size_t opdim=opT::opdim;
             Key<NDIM-opdim> nullkey(key.level());
 
             // source is that part of key that corresponds to those dimensions being processed
-            const opkeyT source = op->get_source_key(key);
+            const opkeyT source=op->get_source_key(key);
 
             const double tol = truncate_tol(thresh, key);
 
             // fac is the root of the number of contributing neighbors (1st shell)
-            double fac = std::pow(3, NDIM*0.5);
+            double fac=std::pow(3,NDIM*0.5);
             double cnorm = coeff.normf();
 
             // for accumulation: keep slightly tighter TensorArgs
             TensorArgs apply_targs(targs);
-            apply_targs.thresh = tol / fac * 0.03;
+            apply_targs.thresh=tol/fac*0.03;
 
-            double maxnorm = 0.0;
+            double maxnorm=0.0;
 
             // for the kernel it may be more efficient to do the convolution in full rank
             tensorT coeff_full;
             // for partial application (exchange operator) it's more efficient to
             // do SVD tensors instead of tensortrains, because addition in apply
             // can be done in full form for the specific particle
-            coeffT coeff_SVD = coeff.convert(TensorArgs(-1.0, TT_2D));
+            coeffT coeff_SVD=coeff.convert(TensorArgs(-1.0,TT_2D));
 #ifdef HAVE_GENTENSOR
-            coeff_SVD.get_svdtensor().orthonormalize(tol * GenTensor<T>::fac_reduce());
+            coeff_SVD.get_svdtensor().orthonormalize(tol*GenTensor<T>::fac_reduce());
 #endif
 
             const std::vector<opkeyT>& disp = op->get_disp(key.level());
-            const std::vector<bool> is_periodic(NDIM, false); // Periodic sum is already done when making rnlp
+            const std::vector<bool> is_periodic(NDIM,false); // Periodic sum is already done when making rnlp
 
-            for (typename std::vector<opkeyT>::const_iterator it = disp.begin(); it != disp.end(); ++it) {
+            for (typename std::vector<opkeyT>::const_iterator it=disp.begin(); it != disp.end(); ++it) {
                 const opkeyT& d = *it;
 
-                const int shell = d.distsq();
-                if (do_kernel and (shell > 0)) break;
-                if ((not do_kernel) and (shell == 0)) continue;
+                const int shell=d.distsq();
+                if (do_kernel and (shell>0)) break;
+                if ((not do_kernel) and (shell==0)) continue;
 
                 keyT disp1;
-                if (op->particle() == 1) disp1 = it->merge_with(nullkey);
-                else if (op->particle() == 2) disp1 = nullkey.merge_with(*it);
+                if (op->particle()==1) disp1=it->merge_with(nullkey);
+                else if (op->particle()==2) disp1=nullkey.merge_with(*it);
                 else {
-                    MADNESS_EXCEPTION("confused particle in operato??", 1);
+                    MADNESS_EXCEPTION("confused particle in operato??",1);
                 }
 
                 keyT dest = neighbor(key, disp1, is_periodic);
@@ -4916,66 +4952,69 @@ template<size_t NDIM>
                 // directed screening
                 // working assumption here is that the operator is isotropic and
                 // monotonically decreasing with distance
-                bool screened = false;
+                bool screened=false;
                 typename std::list<opkeyT>::const_iterator it2;
-                for (it2 = blacklist.begin(); it2 != blacklist.end(); it2++) {
+                for (it2=blacklist.begin(); it2!=blacklist.end(); it2++) {
                     if (d.is_farther_out_than(*it2)) {
-                        screened = true;
+                        screened=true;
                         break;
                     }
                 }
                 if (not screened) {
 
                     double opnorm = op->norm(key.level(), d, source);
-                    double norm = 0.0;
+                    double norm=0.0;
 
-                    if (cnorm * opnorm > tol / fac) {
+                    if (cnorm*opnorm> tol/fac) {
 
-                        double cost_ratio = op->estimate_costs(source, d, coeff_SVD, tol / fac / cnorm, tol / fac);
-                        // cost_ratio = 1.5; // force low rank
-                        // cost_ratio = 0.5; // force full rank
+                        double cost_ratio=op->estimate_costs(source, d, coeff_SVD, tol/fac/cnorm, tol/fac);
+                        //                        cost_ratio=1.5;     // force low rank
+                        //                        cost_ratio=0.5;     // force full rank
 
-                        if (cost_ratio > 0.0) {
+                        if (cost_ratio>0.0) {
 
                             do_op_args<opdim> args(source, d, dest, tol, fac, cnorm);
-                            norm = 0.0;
-                            if (cost_ratio < 1.0) {
-                                if (not coeff_full.has_data()) coeff_full = coeff.full_tensor_copy();
-                                norm = do_apply_kernel2(op, coeff_full, args, apply_targs);
+                            norm=0.0;
+                            if (cost_ratio<1.0) {
+                                if (not coeff_full.has_data()) coeff_full=coeff.full_tensor_copy();
+                                norm=do_apply_kernel2(op, coeff_full,args,apply_targs);
                             } else {
-                                if (2 * opdim == NDIM) {  // apply operator on one particle only
-                                    norm = do_apply_kernel3(op, coeff_SVD, args, apply_targs);
+                                if (2*opdim==NDIM) {    // apply operator on one particle only
+                                    norm=do_apply_kernel3(op,coeff_SVD,args,apply_targs);
                                 } else {
-                                    norm = do_apply_kernel3(op, coeff, args, apply_targs);
+                                    norm=do_apply_kernel3(op,coeff,args,apply_targs);
                                 }
                             }
-                            maxnorm = std::max(norm, maxnorm);
+                            maxnorm=std::max(norm,maxnorm);
                         }
+
                     } else if (shell >= 12) {
                         break; // Assumes monotonic decay beyond nearest neighbor
                     }
-                    if (norm < 0.3 * tol / fac) blacklist.push_back(d);
+                    if (norm<0.3*tol/fac) blacklist.push_back(d);
                 }
             }
             return maxnorm;
         }
 
+
         /// similar to apply, but for low rank coeffs
         template <typename opT, typename R>
-        void apply_source_driven(opT& op, const FunctionImpl<R, NDIM>& f, bool fence) {
+        void apply_source_driven(opT& op, const FunctionImpl<R,NDIM>& f, bool fence) {
             PROFILE_MEMBER_FUNC(FunctionImpl);
 
             MADNESS_ASSERT(not op.modified());
             // looping through all the coefficients of the source f
             typename dcT::const_iterator end = f.get_coeffs().end();
-            for (typename dcT::const_iterator it = f.get_coeffs().begin(); it != end; ++it) {
+            for (typename dcT::const_iterator it=f.get_coeffs().begin(); it!=end; ++it) {
+
                 const keyT& key = it->first;
                 const coeffT& coeff = it->second.coeff();
 
-                if (coeff.has_data() and (coeff.rank() != 0)) {
+                if (coeff.has_data() and (coeff.rank()!=0)) {
                     ProcessID p = FunctionDefaults<NDIM>::get_apply_randomize() ? world.random_proc() : coeffs.owner(key);
-                    woT::task(p, &implT:: template do_apply_directed_screening<opT, R>, &op, key, coeff, true);
-                    woT::task(p, &implT:: template do_apply_directed_screening<opT, R>, &op, key, coeff, false);
+                    woT::task(p, &implT:: template do_apply_directed_screening<opT,R>, &op, key, coeff, true);
+                    woT::task(p, &implT:: template do_apply_directed_screening<opT,R>, &op, key, coeff, false);
                 }
             }
             if (fence) world.gop.fence();
@@ -5002,25 +5041,25 @@ template<size_t NDIM>
         /// @param[in]	fimpl    the funcimpl of the function of particle 1
         /// @param[in]	gimpl    the funcimpl of the function of particle 2
         template<typename opT, std::size_t LDIM>
-        void recursive_apply(opT& apply_op, const FunctionImpl<T, LDIM>* fimpl,
-                             const FunctionImpl<T, LDIM>* gimpl, const bool fence) {
+        void recursive_apply(opT& apply_op, const FunctionImpl<T,LDIM>* fimpl,
+                             const FunctionImpl<T,LDIM>* gimpl, const bool fence) {
 
             //print("IN RECUR2");
-            const keyT& key0 = cdata.key0;
+            const keyT& key0=cdata.key0;
 
             if (world.rank() == coeffs.owner(key0)) {
 
-                CoeffTracker<T, LDIM> ff(fimpl);
-                CoeffTracker<T, LDIM> gg(gimpl);
+                CoeffTracker<T,LDIM> ff(fimpl);
+                CoeffTracker<T,LDIM> gg(gimpl);
 
-                typedef recursive_apply_op<opT, LDIM> coeff_opT;
-                coeff_opT coeff_op(this, ff, gg, &apply_op);
+                typedef recursive_apply_op<opT,LDIM> coeff_opT;
+                coeff_opT coeff_op(this,ff,gg,&apply_op);
 
-                typedef noop<T, NDIM> apply_opT;
+                typedef noop<T,NDIM> apply_opT;
                 apply_opT apply_op;
 
-                ProcessID p = coeffs.owner(key0);
-                woT::task(p, &implT:: template forward_traverse<coeff_opT, apply_opT>, coeff_op, apply_op, key0);
+                ProcessID p= coeffs.owner(key0);
+                woT::task(p, &implT:: template forward_traverse<coeff_opT,apply_opT>, coeff_op, apply_op, key0);
 
             }
             if (fence) world.gop.fence();
@@ -5030,22 +5069,22 @@ template<size_t NDIM>
         /// recursive part of recursive_apply
         template<typename opT, std::size_t LDIM>
         struct recursive_apply_op {
-            bool randomize() const { return true; }
+            bool randomize() const {return true;}
 
-            typedef recursive_apply_op<opT, LDIM> this_type;
+            typedef recursive_apply_op<opT,LDIM> this_type;
 
             implT* result;
-            CoeffTracker<T, LDIM> iaf;
-            CoeffTracker<T, LDIM> iag;
+            CoeffTracker<T,LDIM> iaf;
+            CoeffTracker<T,LDIM> iag;
             opT* apply_op;
 
             // ctor
             recursive_apply_op() = default;
             recursive_apply_op(implT* result,
-                               const CoeffTracker<T, LDIM>& iaf, const CoeffTracker<T, LDIM>& iag,
+                               const CoeffTracker<T,LDIM>& iaf, const CoeffTracker<T,LDIM>& iag,
                                const opT* apply_op) : result(result), iaf(iaf), iag(iag), apply_op(apply_op)
             {
-                MADNESS_ASSERT(LDIM + LDIM == NDIM);
+                MADNESS_ASSERT(LDIM+LDIM==NDIM);
             }
             recursive_apply_op(const recursive_apply_op& other) : result(other.result), iaf(other.iaf),
                                                                   iag(other.iag), apply_op(other.apply_op) {}
@@ -5053,73 +5092,75 @@ template<size_t NDIM>
 
             /// make the NS-coefficients and send off the application of the operator
 
-            /// @return		a Future<bool, coeffT>(is_leaf, coeffT())
-            std::pair<bool, coeffT> operator()(const Key<NDIM>& key) const {
-                // World& world = result->world;
+            /// @return		a Future<bool,coeffT>(is_leaf,coeffT())
+            std::pair<bool,coeffT> operator()(const Key<NDIM>& key) const {
+
+                //            	World& world=result->world;
                 // break key into particles (these are the child keys, with datum1/2 come the parent keys)
-                Key<LDIM> key1, key2;
-                key.break_apart(key1, key2);
+                Key<LDIM> key1,key2;
+                key.break_apart(key1,key2);
 
                 // the lo-dim functions should be in full tensor form
-                const tensorT fcoeff = iaf.coeff(key1).full_tensor();
-                const tensorT gcoeff = iag.coeff(key2).full_tensor();
+                const tensorT fcoeff=iaf.coeff(key1).full_tensor();
+                const tensorT gcoeff=iag.coeff(key2).full_tensor();
 
                 // would this be a leaf node? If so, then its sum coeffs have already been
                 // processed by the parent node's wavelet coeffs. Therefore we won't
                 // process it any more.
-                hartree_leaf_op<T, NDIM> leaf_op(result, result->get_k());
-                bool is_leaf = leaf_op(key, fcoeff, gcoeff);
+                hartree_leaf_op<T,NDIM> leaf_op(result,result->get_k());
+                bool is_leaf=leaf_op(key,fcoeff,gcoeff);
 
                 if (not is_leaf) {
                     // new coeffs are simply the hartree/kronecker/outer product --
-                    const std::vector<Slice>& s0 = iaf.get_impl()->cdata.s0;
+                    const std::vector<Slice>& s0=iaf.get_impl()->cdata.s0;
                     const coeffT coeff = (apply_op->modified())
-                        ? outer(copy(fcoeff(s0)), copy(gcoeff(s0)), result->targs)
-                        : outer(fcoeff, gcoeff, result->targs);
+                        ? outer(copy(fcoeff(s0)),copy(gcoeff(s0)),result->targs)
+                        : outer(fcoeff,gcoeff,result->targs);
 
                     // now send off the application
                     tensorT coeff_full;
-                    ProcessID p = result->world.rank();
-                    double norm0 = result->do_apply_directed_screening<opT, T>(apply_op, key, coeff, true);
+                    ProcessID p=result->world.rank();
+                    double norm0=result->do_apply_directed_screening<opT,T>(apply_op, key, coeff, true);
 
-                    result->task(p, &implT:: template do_apply_directed_screening<opT, T>,
-                                 apply_op, key, coeff, false);
+                    result->task(p,&implT:: template do_apply_directed_screening<opT,T>,
+                                 apply_op,key,coeff,false);
 
-                    return finalize(norm0, key, coeff);
+                    return finalize(norm0,key,coeff);
 
                 } else {
-                    return std::pair<bool, coeffT> (is_leaf, coeffT());
+                    return std::pair<bool,coeffT> (is_leaf,coeffT());
                 }
             }
 
             /// sole purpose is to wait for the kernel norm, wrap it and send it back to caller
-            std::pair<bool, coeffT> finalize(const double kernel_norm, const keyT& key,
+            std::pair<bool,coeffT> finalize(const double kernel_norm, const keyT& key,
                                             const coeffT& coeff) const {
-            	const double thresh = result->get_thresh() * 0.1;
-            	bool is_leaf = (kernel_norm<result->truncate_tol(thresh, key));
-            	if (key.level() < 2) is_leaf = false;
-            	return std::pair<bool, coeffT> (is_leaf, coeff);
+            	const double thresh=result->get_thresh()*0.1;
+            	bool is_leaf=(kernel_norm<result->truncate_tol(thresh,key));
+            	if (key.level()<2) is_leaf=false;
+            	return std::pair<bool,coeffT> (is_leaf,coeff);
             }
 
 
             this_type make_child(const keyT& child) const {
+
                 // break key into particles
                 Key<LDIM> key1, key2;
-                child.break_apart(key1, key2);
+                child.break_apart(key1,key2);
 
-                return this_type(result, iaf.make_child(key1), iag.make_child(key2), apply_op);
+                return this_type(result,iaf.make_child(key1),iag.make_child(key2),apply_op);
             }
 
             Future<this_type> activate() const {
-            	Future<CoeffTracker<T, LDIM>> f1 = iaf.activate();
-            	Future<CoeffTracker<T, LDIM>> g1 = iag.activate();
+            	Future<CoeffTracker<T,LDIM> > f1=iaf.activate();
+            	Future<CoeffTracker<T,LDIM> > g1=iag.activate();
                 return result->world.taskq.add(detail::wrap_mem_fn(*const_cast<this_type *> (this),
-                                               &this_type::forward_ctor), result, f1, g1, apply_op);
+                                               &this_type::forward_ctor),result,f1,g1,apply_op);
             }
 
-            this_type forward_ctor(implT* r, const CoeffTracker<T, LDIM>& f1, const CoeffTracker<T, LDIM>& g1,
+            this_type forward_ctor(implT* r, const CoeffTracker<T,LDIM>& f1, const CoeffTracker<T,LDIM>& g1,
                                    const opT* apply_op1) {
-            	return this_type(r, f1, g1, apply_op1);
+            	return this_type(r,f1,g1,apply_op1);
             }
 
             template <typename Archive> void serialize(const Archive& ar) {
@@ -5138,17 +5179,17 @@ template<size_t NDIM>
 
             print("IN RECUR1");
 
-            const keyT& key0 = cdata.key0;
+            const keyT& key0=cdata.key0;
 
             if (world.rank() == coeffs.owner(key0)) {
 
                 typedef recursive_apply_op2<opT> coeff_opT;
-                coeff_opT coeff_op(this, fimpl, &apply_op);
+                coeff_opT coeff_op(this,fimpl,&apply_op);
 
-                typedef noop<T, NDIM> apply_opT;
+                typedef noop<T,NDIM> apply_opT;
                 apply_opT apply_op;
 
-                woT::task(world.rank(), &implT:: template forward_traverse<coeff_opT, apply_opT>,
+                woT::task(world.rank(), &implT:: template forward_traverse<coeff_opT,apply_opT>,
                           coeff_op, apply_op, cdata.key0);
 
             }
@@ -5159,11 +5200,11 @@ template<size_t NDIM>
         /// recursive part of recursive_apply
         template<typename opT>
         struct recursive_apply_op2 {
-            bool randomize() const { return true; }
+            bool randomize() const {return true;}
 
             typedef recursive_apply_op2<opT> this_type;
-            typedef CoeffTracker<T, NDIM> ctT;
-            typedef std::pair<bool, coeffT> argT;
+            typedef CoeffTracker<T,NDIM> ctT;
+            typedef std::pair<bool,coeffT> argT;
 
             mutable implT* result;
             ctT iaf;			/// need this for randomization
@@ -5182,54 +5223,59 @@ template<size_t NDIM>
 
             /// the first (core) neighbor (ie. the box itself) is processed
             /// immediately, all other ones are shoved into the taskq
-            /// @return		a pair<bool, coeffT>(is_leaf, coeffT())
+            /// @return		a pair<bool,coeffT>(is_leaf,coeffT())
             argT operator()(const Key<NDIM>& key) const {
 
-            	const coeffT& coeff = iaf.coeff();
+            	const coeffT& coeff=iaf.coeff();
 
                 if (coeff.has_data()) {
+
                     // now send off the application for all neighbor boxes
-                    ProcessID p = result->world.rank();
-                    result->task(p, &implT:: template do_apply_directed_screening<opT, T>,
+                    ProcessID p=result->world.rank();
+                    result->task(p,&implT:: template do_apply_directed_screening<opT,T>,
                                  apply_op, key, coeff, false);
 
                     // process the core box
-                    double norm0 = result->do_apply_directed_screening<opT, T>(apply_op, key, coeff, true);
+                    double norm0=result->do_apply_directed_screening<opT,T>(apply_op,key,coeff,true);
 
-                    if (iaf.is_leaf()) return argT(true, coeff);
-                    return finalize(norm0, key, coeff, result);
+                    if (iaf.is_leaf()) return argT(true,coeff);
+                    return finalize(norm0,key,coeff,result);
+
                 } else {
-                    const bool is_leaf = true;
-                    return argT(is_leaf, coeffT());
+                    const bool is_leaf=true;
+                    return argT(is_leaf,coeffT());
                 }
             }
 
             /// sole purpose is to wait for the kernel norm, wrap it and send it back to caller
             argT finalize(const double kernel_norm, const keyT& key,
                           const coeffT& coeff, const implT* r) const {
-            	const double thresh = r->get_thresh()*0.1;
-            	bool is_leaf = (kernel_norm<r->truncate_tol(thresh, key));
-            	if (key.level() < 2) is_leaf = false;
-            	return argT(is_leaf, coeff);
+            	const double thresh=r->get_thresh()*0.1;
+            	bool is_leaf=(kernel_norm<r->truncate_tol(thresh,key));
+            	if (key.level()<2) is_leaf=false;
+            	return argT(is_leaf,coeff);
             }
 
+
             this_type make_child(const keyT& child) const {
-                return this_type(result, iaf.make_child(child), apply_op);
+                return this_type(result,iaf.make_child(child),apply_op);
             }
 
             /// retrieve the coefficients (parent coeffs might be remote)
             Future<this_type> activate() const {
-            	Future<ctT> f1 = iaf.activate();
-                // Future<ctL> g1=g.activate();
-                // return h->world.taskq.add(detail::wrap_mem_fn(*const_cast<this_type *> (this),
-                //                           &this_type::forward_ctor), h, f1, g1, particle);
+            	Future<ctT> f1=iaf.activate();
+
+//                Future<ctL> g1=g.activate();
+//                return h->world.taskq.add(detail::wrap_mem_fn(*const_cast<this_type *> (this),
+//                                          &this_type::forward_ctor),h,f1,g1,particle);
+
                 return result->world.taskq.add(detail::wrap_mem_fn(*const_cast<this_type *> (this),
-                                               &this_type::forward_ctor), result, f1, apply_op);
+                                               &this_type::forward_ctor),result,f1,apply_op);
             }
 
             /// taskq-compatible ctor
             this_type forward_ctor(implT* result1, const ctT& iaf1, const opT* apply_op1) {
-            	return this_type(result1, iaf1, apply_op1);
+            	return this_type(result1,iaf1,apply_op1);
             }
 
             template <typename Archive> void serialize(const Archive& ar) {
@@ -5245,29 +5291,30 @@ template<size_t NDIM>
         double err_box(const keyT& key, const nodeT& node, const opT& func,
                        int npt, const Tensor<double>& qx, const Tensor<double>& quad_phit,
                        const Tensor<double>& quad_phiw) const {
+
             std::vector<long> vq(NDIM);
-            for (std::size_t i = 0; i < NDIM; ++i)
+            for (std::size_t i=0; i<NDIM; ++i)
                 vq[i] = npt;
-            tensorT fval(vq, false), work(vq, false), result(vq, false);
+            tensorT fval(vq,false), work(vq,false), result(vq,false);
 
             // Compute the "exact" function in this volume at npt points
             // where npt is usually this->npt+1.
             fcube(key, func, qx, fval);
 
             // Transform into the scaling function basis of order npt
-            double scale = pow(0.5, 0.5 * NDIM * key.level()) * sqrt(FunctionDefaults<NDIM>::get_cell_volume());
-            fval = fast_transform(fval, quad_phiw, result, work).scale(scale);
+            double scale = pow(0.5,0.5*NDIM*key.level())*sqrt(FunctionDefaults<NDIM>::get_cell_volume());
+            fval = fast_transform(fval,quad_phiw,result,work).scale(scale);
 
             // Subtract to get the error ... the original coeffs are in the order k
             // basis but we just computed the coeffs in the order npt(=k+1) basis
             // so we can either use slices or an iterator macro.
             const tensorT coeff = node.coeff().full_tensor_copy();
-            ITERATOR(coeff, fval(IND) -= coeff(IND););
+            ITERATOR(coeff,fval(IND)-=coeff(IND););
             // flo note: we do want to keep a full tensor here!
 
             // Compute the norm of what remains
             double err = fval.normf();
-            return err * err;
+            return err*err;
         }
 
         template <typename opT>
@@ -5298,7 +5345,7 @@ template<size_t NDIM>
             }
 
             double operator()(double a, double b) const {
-                return a + b;
+                return a+b;
             }
 
             template <typename Archive>
@@ -5314,15 +5361,15 @@ template<size_t NDIM>
             // Make quadrature rule of higher order
             const int npt = cdata.npt + 1;
             Tensor<double> qx, qw, quad_phi, quad_phiw, quad_phit;
-            FunctionCommonData<T, NDIM>::_init_quadrature(k + 1, npt, qx, qw, quad_phi, quad_phiw, quad_phit);
+            FunctionCommonData<T,NDIM>::_init_quadrature(k+1, npt, qx, qw, quad_phi, quad_phiw, quad_phit);
 
             typedef Range<typename dcT::const_iterator> rangeT;
             rangeT range(coeffs.begin(), coeffs.end());
-            return world.taskq.reduce<double, rangeT, do_err_box<opT>>(range,
+            return world.taskq.reduce< double,rangeT,do_err_box<opT> >(range,
                                                                        do_err_box<opT>(this, &func, npt, qx, quad_phit, quad_phiw));
         }
 
-        /// Returns \c int(f(x), x) in local volume
+        /// Returns \c int(f(x),x) in local volume
         T trace_local() const;
 
         struct do_norm2sq_local {
@@ -5353,23 +5400,23 @@ template<size_t NDIM>
         /// compute the inner product of this range with other
         template<typename R>
         struct do_inner_local {
-            const FunctionImpl<R, NDIM>* other;
+            const FunctionImpl<R,NDIM>* other;
             bool leaves_only;
-            typedef TENSOR_RESULT_TYPE(T, R) resultT;
+            typedef TENSOR_RESULT_TYPE(T,R) resultT;
 
-            do_inner_local(const FunctionImpl<R, NDIM>* other, const bool leaves_only)
+            do_inner_local(const FunctionImpl<R,NDIM>* other, const bool leaves_only)
             	: other(other), leaves_only(leaves_only) {}
             resultT operator()(typename dcT::const_iterator& it) const {
 
-            	TENSOR_RESULT_TYPE(T, R) sum = 0.0;
-            	const keyT& key = it->first;
+            	TENSOR_RESULT_TYPE(T,R) sum=0.0;
+            	const keyT& key=it->first;
                 const nodeT& fnode = it->second;
                 if (fnode.has_coeff()) {
                     if (other->coeffs.probe(it->first)) {
-                        const FunctionNode<R, NDIM>& gnode = other->coeffs.find(key).get()->second;
+                        const FunctionNode<R,NDIM>& gnode = other->coeffs.find(key).get()->second;
                         if (gnode.has_coeff()) {
                             if (gnode.coeff().dim(0) != fnode.coeff().dim(0)) {
-                                madness::print("INNER", it->first, gnode.coeff().dim(0), fnode.coeff().dim(0));
+                                madness::print("INNER", it->first, gnode.coeff().dim(0),fnode.coeff().dim(0));
                                 MADNESS_EXCEPTION("functions have different k or compress/reconstruct error", 0);
                             }
                             if (leaves_only) {
@@ -5398,112 +5445,113 @@ template<size_t NDIM>
 
         /// handles compressed and redundant form
         template <typename R>
-        TENSOR_RESULT_TYPE(T, R) inner_local(const FunctionImpl<R, NDIM>& g) const {
+        TENSOR_RESULT_TYPE(T,R) inner_local(const FunctionImpl<R,NDIM>& g) const {
             PROFILE_MEMBER_FUNC(FunctionImpl);
             typedef Range<typename dcT::const_iterator> rangeT;
-            typedef TENSOR_RESULT_TYPE(T, R) resultT;
+            typedef TENSOR_RESULT_TYPE(T,R) resultT;
 
             // make sure the states of the trees are consistent
-            MADNESS_ASSERT(this->is_redundant() == g.is_redundant());
-            bool leaves_only = (this->is_redundant());
-            return world.taskq.reduce<resultT, rangeT, do_inner_local<R>>
-                (rangeT(coeffs.begin(), coeffs.end()), do_inner_local<R>(&g, leaves_only));
+            MADNESS_ASSERT(this->is_redundant()==g.is_redundant());
+            bool leaves_only=(this->is_redundant());
+            return world.taskq.reduce<resultT,rangeT,do_inner_local<R> >
+                (rangeT(coeffs.begin(),coeffs.end()),do_inner_local<R>(&g, leaves_only));
         }
 
 
         /// compute the inner product of this range with other
         template<typename R>
         struct do_inner_local_on_demand {
-            const FunctionImpl<T, NDIM>* bra;
-            const FunctionImpl<R, NDIM>* ket;
+            const FunctionImpl<T,NDIM>* bra;
+            const FunctionImpl<R,NDIM>* ket;
             bool leaves_only=true;
-            typedef TENSOR_RESULT_TYPE(T, R) resultT;
+            typedef TENSOR_RESULT_TYPE(T,R) resultT;
 
-            do_inner_local_on_demand(const FunctionImpl<T, NDIM>* bra, const FunctionImpl<R, NDIM>* ket,
+            do_inner_local_on_demand(const FunctionImpl<T,NDIM>* bra, const FunctionImpl<R,NDIM>* ket,
                                      const bool leaves_only=true)
                     : bra(bra), ket(ket), leaves_only(leaves_only) {}
             resultT operator()(typename dcT::const_iterator& it) const {
-                constexpr std::size_t LDIM=std::max(NDIM/2, std::size_t(1));
 
-                const keyT& key = it->first;
+                constexpr std::size_t LDIM=std::max(NDIM/2,std::size_t(1));
+
+                const keyT& key=it->first;
                 const nodeT& fnode = it->second;
                 if (not fnode.has_coeff()) return resultT(0.0); // probably internal nodes
 
                 // assuming all boxes (esp the low-dim ones) are local, i.e. the functions are replicated
                 auto find_valid_parent = [](auto& key, auto& impl, auto&& find_valid_parent) {
-                    MADNESS_CHECK(impl->get_coeffs().owner(key) == impl->world.rank()); // make sure everything is local!
+                    MADNESS_CHECK(impl->get_coeffs().owner(key)==impl->world.rank()); // make sure everything is local!
                     if (impl->get_coeffs().probe(key)) return key;
-                    auto parentkey = key.parent();
+                    auto parentkey=key.parent();
                     return find_valid_parent(parentkey, impl, find_valid_parent);
                 };
 
                 // returns coefficients, empty if no functor present
                 auto get_coeff = [&find_valid_parent](const auto& key, const auto& v_impl) {
-                    if ((v_impl.size() > 0) and v_impl.front().get()) {
-                        auto impl = v_impl.front();
+                    if ((v_impl.size()>0) and v_impl.front().get()) {
+                        auto impl=v_impl.front();
 
-                        // bool have_impl=impl.get();
-                        // if (have_impl) {
+//                    bool have_impl=impl.get();
+//                    if (have_impl) {
                         auto parentkey = find_valid_parent(key, impl, find_valid_parent);
                         MADNESS_CHECK(impl->get_coeffs().probe(parentkey));
                         typename decltype(impl->coeffs)::accessor acc;
-                        impl->get_coeffs().find(acc, parentkey);
-                        auto parentcoeff = acc->second.coeff();
+                        impl->get_coeffs().find(acc,parentkey);
+                        auto parentcoeff=acc->second.coeff();
                         auto coeff=impl->parent_to_child(parentcoeff, parentkey, key);
                         return coeff;
                     } else {
                         // get type of vector elements
                         typedef typename std::decay_t<decltype(v_impl)>::value_type::element_type::typeT S;
-                        // typedef typename std::decay_t<decltype(v_impl)>::value_type S;
+//                        typedef typename std::decay_t<decltype(v_impl)>::value_type S;
                         return GenTensor<S>();
-                        // return GenTensor<typename std::decay_t<decltype(*impl)>::typeT>();
+//                        return GenTensor<typename std::decay_t<decltype(*impl)>::typeT>();
                     }
                 };
 
                 auto make_vector = [](auto& arg) {
-                    return std::vector<std::decay_t<decltype(arg)>>(1, arg);
+                    return std::vector<std::decay_t<decltype(arg)>>(1,arg);
                 };
 
 
-                Key<LDIM> key1, key2;
-                key.break_apart(key1, key2);
+                Key<LDIM> key1,key2;
+                key.break_apart(key1,key2);
 
-                auto func = dynamic_cast<CompositeFunctorInterface<R, NDIM, LDIM>*>(ket->functor.get());
+                auto func=dynamic_cast<CompositeFunctorInterface<R,NDIM,LDIM>* >(ket->functor.get());
                 MADNESS_ASSERT(func);
 
-                MADNESS_CHECK_THROW(func->impl_ket_vector.size() == 0 or func->impl_ket_vector.size() == 1,
+                MADNESS_CHECK_THROW(func->impl_ket_vector.size()==0 or func->impl_ket_vector.size()==1,
                                     "only one ket function supported in inner_on_demand");
-                MADNESS_CHECK_THROW(func->impl_p1_vector.size() == 0 or func->impl_p1_vector.size() == 1,
+                MADNESS_CHECK_THROW(func->impl_p1_vector.size()==0 or func->impl_p1_vector.size()==1,
                                     "only one p1 function supported in inner_on_demand");
-                MADNESS_CHECK_THROW(func->impl_p2_vector.size() == 0 or func->impl_p2_vector.size() == 1,
+                MADNESS_CHECK_THROW(func->impl_p2_vector.size()==0 or func->impl_p2_vector.size()==1,
                                     "only one p2 function supported in inner_on_demand");
-                auto coeff_bra = fnode.coeff();
-                auto coeff_ket = get_coeff(key, func->impl_ket_vector);
-                auto coeff_v1 = get_coeff(key1, make_vector(func->impl_m1));
-                auto coeff_v2 = get_coeff(key2, make_vector(func->impl_m2));
-                auto coeff_p1 = get_coeff(key1, func->impl_p1_vector);
-                auto coeff_p2 = get_coeff(key2, func->impl_p2_vector);
+                auto coeff_bra=fnode.coeff();
+                auto coeff_ket=get_coeff(key,func->impl_ket_vector);
+                auto coeff_v1=get_coeff(key1,make_vector(func->impl_m1));
+                auto coeff_v2=get_coeff(key2,make_vector(func->impl_m2));
+                auto coeff_p1=get_coeff(key1,func->impl_p1_vector);
+                auto coeff_p2=get_coeff(key2,func->impl_p2_vector);
 
-                // construct |ket(1, 2)> or |p(1)p(2)> or |p(1)p(2) ket(1, 2)>
-                double error = 0.0;
+                // construct |ket(1,2)> or |p(1)p(2)> or |p(1)p(2) ket(1,2)>
+                double error=0.0;
                 if (coeff_ket.has_data() and coeff_p1.has_data()) {
-                    pointwise_multiplier<LDIM> pm(key, coeff_ket);
-                    coeff_ket = pm(key, outer(coeff_p1, coeff_p2, TensorArgs(TT_FULL, -1.0)).full_tensor());
-                    error += pm.error;
+                    pointwise_multiplier<LDIM> pm(key,coeff_ket);
+                    coeff_ket=pm(key,outer(coeff_p1,coeff_p2,TensorArgs(TT_FULL,-1.0)).full_tensor());
+                    error+=pm.error;
                 } else if (coeff_ket.has_data() or coeff_p1.has_data()) {
-                    coeff_ket = (coeff_ket.has_data()) ? coeff_ket : outer(coeff_p1, coeff_p2);
+                    coeff_ket = (coeff_ket.has_data()) ? coeff_ket : outer(coeff_p1,coeff_p2);
                 } else { // not ket and no p1p2
-                    MADNESS_EXCEPTION("confused ket/p1p2 in do_inner_local_on_demand", 1);
+                    MADNESS_EXCEPTION("confused ket/p1p2 in do_inner_local_on_demand",1);
                 }
 
-                // construct (v(1) + v(2)) |ket(1, 2)>
+                // construct (v(1) + v(2)) |ket(1,2)>
                 coeffT v1v2ket;
                 if (coeff_v1.has_data()) {
-                    pointwise_multiplier<LDIM> pm(key, coeff_ket);
-                    v1v2ket = pm(key, coeff_v1.full_tensor(), 1);
-                    error += pm.error;
-                    v1v2ket += pm(key, coeff_v2.full_tensor(), 2);
-                    error += pm.error;
+                    pointwise_multiplier<LDIM> pm(key,coeff_ket);
+                    v1v2ket = pm(key,coeff_v1.full_tensor(), 1);
+                    error+=pm.error;
+                    v1v2ket+= pm(key,coeff_v2.full_tensor(), 2);
+                    error+=pm.error;
                 } else {
                     v1v2ket = coeff_ket;
                 }
@@ -5511,21 +5559,21 @@ template<size_t NDIM>
                 resultT result;
                 if (func->impl_eri) {         // project bra*ket onto eri, avoid multiplication with eri
                     MADNESS_CHECK(func->impl_eri->get_functor()->provides_coeff());
-                    coeffT coeff_eri = func->impl_eri->get_functor()->coeff(key).full_tensor();
-                    pointwise_multiplier<LDIM> pm(key, v1v2ket);
-                    tensorT braket = pm(key, coeff_bra.full_tensor_copy().conj());
-                    error += pm.error;
-                    if (error > 1.e-3) print("error in key", key, error);
-                    result = coeff_eri.full_tensor().trace(braket);
+                    coeffT coeff_eri=func->impl_eri->get_functor()->coeff(key).full_tensor();
+                    pointwise_multiplier<LDIM> pm(key,v1v2ket);
+                    tensorT braket=pm(key,coeff_bra.full_tensor_copy().conj());
+                    error+=pm.error;
+                    if (error>1.e-3) print("error in key",key,error);
+                    result=coeff_eri.full_tensor().trace(braket);
 
                 } else {                            // no eri, project ket onto bra
-                    result = coeff_bra.full_tensor_copy().trace_conj(v1v2ket.full_tensor_copy());
+                    result=coeff_bra.full_tensor_copy().trace_conj(v1v2ket.full_tensor_copy());
                 }
                 return result;
             }
 
             resultT operator()(resultT a, resultT b) const {
-                return (a + b);
+                return (a+b);
             }
 
             template <typename Archive> void serialize(const Archive& ar) {
@@ -5537,7 +5585,7 @@ template<size_t NDIM>
 
         /// the leaf boxes of this' MRA tree defines the inner product
         template <typename R>
-        TENSOR_RESULT_TYPE(T, R) inner_local_on_demand(const FunctionImpl<R, NDIM>& gimpl) const {
+        TENSOR_RESULT_TYPE(T,R) inner_local_on_demand(const FunctionImpl<R,NDIM>& gimpl) const {
             PROFILE_MEMBER_FUNC(FunctionImpl);
             MADNESS_CHECK(this->is_reconstructed());
 
@@ -5548,7 +5596,7 @@ template<size_t NDIM>
         }
 
         /// Type of the entry in the map returned by make_key_vec_map
-        typedef std::vector< std::pair<int, const coeffT*>> mapvecT;
+        typedef std::vector< std::pair<int,const coeffT*> > mapvecT;
 
         /// Type of the map returned by make_key_vec_map
         typedef ConcurrentHashMap< keyT, mapvecT > mapT;
@@ -5556,13 +5604,13 @@ template<size_t NDIM>
         /// Adds keys to union of local keys with specified index
         void add_keys_to_map(mapT* map, int index) const {
             typename dcT::const_iterator end = coeffs.end();
-            for (typename dcT::const_iterator it = coeffs.begin(); it != end; ++it) {
+            for (typename dcT::const_iterator it=coeffs.begin(); it!=end; ++it) {
                 typename mapT::accessor acc;
                 const keyT& key = it->first;
-                const FunctionNode<T, NDIM>& node = it->second;
+                const FunctionNode<T,NDIM>& node = it->second;
                 if (node.has_coeff()) {
-                    [[maybe_unused]] auto inserted = map->insert(acc, key);
-                    acc->second.push_back(std::make_pair(index, &(node.coeff())));
+                    [[maybe_unused]] auto inserted = map->insert(acc,key);
+                    acc->second.push_back(std::make_pair(index,&(node.coeff())));
                 }
             }
         }
@@ -5572,12 +5620,12 @@ template<size_t NDIM>
         /// Local concurrency and synchronization only; no communication
         static
         mapT
-        make_key_vec_map(const std::vector<const FunctionImpl<T, NDIM>*>& v) {
+        make_key_vec_map(const std::vector<const FunctionImpl<T,NDIM>*>& v) {
             mapT map(100000);
             // This loop must be parallelized
-            for (unsigned int i = 0; i < v.size(); i++) {
-                // v[i]->add_keys_to_map(&map, i);
-                v[i]->world.taskq.add(*(v[i]), &FunctionImpl<T, NDIM>::add_keys_to_map, &map, int(i));
+            for (unsigned int i=0; i<v.size(); i++) {
+                //v[i]->add_keys_to_map(&map,i);
+                v[i]->world.taskq.add(*(v[i]), &FunctionImpl<T,NDIM>::add_keys_to_map, &map, int(i));
             }
             if (v.size()) v[0]->world.taskq.fence();
             return map;
@@ -5590,29 +5638,29 @@ template<size_t NDIM>
                                     const typename mapT::iterator lend,
                                     typename FunctionImpl<R, NDIM>::mapT* rmap_ptr,
                                     const bool sym,
-                                    Tensor<TENSOR_RESULT_TYPE(T, R)>* result_ptr,
+                                    Tensor< TENSOR_RESULT_TYPE(T,R) >* result_ptr,
                                     Mutex* mutex) {
-            Tensor<TENSOR_RESULT_TYPE(T, R)>& result = *result_ptr;
-            Tensor<TENSOR_RESULT_TYPE(T, R)> r(result.dim(0), result.dim(1));
-            for (typename mapT::iterator lit = lstart; lit != lend; ++lit) {
+            Tensor< TENSOR_RESULT_TYPE(T,R) >& result = *result_ptr;
+            Tensor< TENSOR_RESULT_TYPE(T,R) > r(result.dim(0),result.dim(1));
+            for (typename mapT::iterator lit=lstart; lit!=lend; ++lit) {
                 const keyT& key = lit->first;
-                typename FunctionImpl<R, NDIM>::mapT::iterator rit = rmap_ptr->find(key);
+                typename FunctionImpl<R,NDIM>::mapT::iterator rit=rmap_ptr->find(key);
                 if (rit != rmap_ptr->end()) {
                     const mapvecT& leftv = lit->second;
-                    const typename FunctionImpl<R, NDIM>::mapvecT& rightv = rit->second;
+                    const typename FunctionImpl<R,NDIM>::mapvecT& rightv =rit->second;
                     const int nleft = leftv.size();
-                    const int nright = rightv.size();
+                    const int nright= rightv.size();
 
-                    for (int iv = 0; iv<nleft; iv++) {
+                    for (int iv = 0; iv < nleft; iv++) {
                         const int i = leftv[iv].first;
                         const GenTensor<T>* iptr = leftv[iv].second;
 
-                        for (int jv = 0; jv<nright; jv++) {
+                        for (int jv=0; jv<nright; jv++) {
                             const int j = rightv[jv].first;
                             const GenTensor<R>* jptr = rightv[jv].second;
 
                             if (!sym || (sym && i <= j))
-                                r(i, j) += iptr->trace_conj(*jptr);
+                                r(i, j) += iptr->trace(*jptr);
                         }
                     }
                 }
@@ -5627,34 +5675,33 @@ template<size_t NDIM>
                                    const typename mapT::iterator lend,
                                    typename FunctionImpl<R, NDIM>::mapT* rmap_ptr,
                                    const bool sym,
-                                   Tensor<TENSOR_RESULT_TYPE(T, R)>* result_ptr,
+                                   Tensor< TENSOR_RESULT_TYPE(T,R) >* result_ptr,
                                    Mutex* mutex) {
-           Tensor<TENSOR_RESULT_TYPE(T, R)>& result = *result_ptr;
-           // Tensor<TENSOR_RESULT_TYPE(T, R)> r(result.dim(0), result.dim(1));
-           for (typename mapT::iterator lit = lstart; lit != lend; ++lit) {
+           Tensor< TENSOR_RESULT_TYPE(T,R) >& result = *result_ptr;
+           //Tensor< TENSOR_RESULT_TYPE(T,R) > r(result.dim(0),result.dim(1));
+           for (typename mapT::iterator lit=lstart; lit!=lend; ++lit) {
                const keyT& key = lit->first;
-               typename FunctionImpl<R, NDIM>::mapT::iterator rit = rmap_ptr->find(key);
+               typename FunctionImpl<R,NDIM>::mapT::iterator rit=rmap_ptr->find(key);
                if (rit != rmap_ptr->end()) {
                    const mapvecT& leftv = lit->second;
-                   const typename FunctionImpl<R, NDIM>::mapvecT& rightv = rit->second;
+                   const typename FunctionImpl<R,NDIM>::mapvecT& rightv =rit->second;
                    const size_t nleft = leftv.size();
                    const size_t nright= rightv.size();
 
                    unsigned int size = leftv[0].second->size();
                    Tensor<T> Left(nleft, size);
                    Tensor<R> Right(nright, size);
-                   Tensor<TENSOR_RESULT_TYPE(T, R)> r(nleft, nright);
-                   for(unsigned int iv = 0; iv < nleft; ++iv) Left(iv, _) = *(leftv[iv].second);
-                   for(unsigned int jv = 0; jv < nright; ++jv) Right(jv, _) = *(rightv[jv].second);
+                   Tensor< TENSOR_RESULT_TYPE(T,R)> r(nleft, nright);
+                   for(unsigned int iv = 0; iv < nleft; ++iv) Left(iv,_) = *(leftv[iv].second);
+                   for(unsigned int jv = 0; jv < nright; ++jv) Right(jv,_) = *(rightv[jv].second);
                    // call mxmT from mxm.h in tensor
-                   if(TensorTypeData<T>::iscomplex) Left = Left.conj();  // Should handle complex case and leave real case alone
                    mxmT(nleft, nright, size, r.ptr(), Left.ptr(), Right.ptr());
                    mutex->lock();
                    for(unsigned int iv = 0; iv < nleft; ++iv) {
                        const int i = leftv[iv].first;
                        for(unsigned int jv = 0; jv < nright; ++jv) {
                          const int j = rightv[jv].first;
-                         if (!sym || (sym && i <= j)) result(i, j) += r(iv, jv);
+                         if (!sym || (sym && i<=j)) result(i,j) += r(iv,jv);
                        }
                    }
                    mutex->unlock();
@@ -5751,9 +5798,9 @@ template<size_t NDIM>
         }
 
         template <typename R>
-        static Tensor<TENSOR_RESULT_TYPE(T, R)>
-        inner_local(const std::vector<const FunctionImpl<T, NDIM>*>& left,
-                    const std::vector<const FunctionImpl<R, NDIM>*>& right,
+        static Tensor< TENSOR_RESULT_TYPE(T,R) >
+        inner_local(const std::vector<const FunctionImpl<T,NDIM>*>& left,
+                    const std::vector<const FunctionImpl<R,NDIM>*>& right,
                     bool sym) {
 
             // This is basically a sparse matrix^T * matrix product
@@ -5776,26 +5823,79 @@ template<size_t NDIM>
                 rmap_ptr = &rmap;
             }
 
-            size_t chunk = (lmap.size() - 1) / (3 * 4 * 5) + 1;
+            size_t chunk = (lmap.size()-1)/(3*4*5)+1;
 
-            Tensor<TENSOR_RESULT_TYPE(T, R)> r(left.size(), right.size());
+            Tensor< TENSOR_RESULT_TYPE(T,R) > r(left.size(), right.size());
             Mutex mutex;
 
             typename mapT::iterator lstart = lmap.begin();
             while (lstart != lmap.end()) {
                 typename mapT::iterator lend = lstart;
-                advance(lend, chunk);
-                left[0]->world.taskq.add(&FunctionImpl<T, NDIM>::do_inner_localX<R>, lstart, lend, rmap_ptr, sym, &r, &mutex);
+                advance(lend,chunk);
+                left[0]->world.taskq.add(&FunctionImpl<T,NDIM>::do_inner_localX<R>, lstart, lend, rmap_ptr, sym, &r, &mutex);
                 lstart = lend;
             }
             left[0]->world.taskq.fence();
 
             if (sym) {
-                for (long i = 0; i < r.dim(0); i++) {
-                    for (long j = 0; j < i; j++) {
-                        TENSOR_RESULT_TYPE(T, R) sum = r(i, j) + conj(r(j, i));
-                        r(i, j) = sum;
-                        r(j, i) = conj(sum);
+                for (long i=0; i<r.dim(0); i++) {
+                    for (long j=0; j<i; j++) {
+                        TENSOR_RESULT_TYPE(T,R) sum = r(i,j)+conj(r(j,i));
+                        r(i,j) = sum;
+                        r(j,i) = conj(sum);
+                    }
+                }
+            }
+            return r;
+        }
+
+        template <typename R>
+        static Tensor<TENSOR_RESULT_TYPE(T, R)>
+        dot_local(const std::vector<const FunctionImpl<T, NDIM>*>& left,
+                  const std::vector<const FunctionImpl<R, NDIM>*>& right,
+                  bool sym) {
+
+            // This is basically a sparse matrix * matrix product
+            // Rij = sum(k) Aik * Bkj
+            // where i and j index functions and k index the wavelet coeffs
+            // eventually the goal is this structure (don't have jtile yet)
+            //
+            // do in parallel tiles of k (tensors of coeffs)
+            //    do tiles of j
+            //       do i
+            //          do j in jtile
+            //             do k in ktile
+            //                Rij += Aik*Bkj
+
+            mapT lmap = make_key_vec_map(left);
+            typename FunctionImpl<R, NDIM>::mapT rmap;
+            auto* rmap_ptr = (typename FunctionImpl<R, NDIM>::mapT*)(&lmap);
+            if ((std::vector<const FunctionImpl<R, NDIM>*>*)(&left) != &right) {
+                rmap = FunctionImpl<R, NDIM>::make_key_vec_map(right);
+                rmap_ptr = &rmap;
+            }
+
+            size_t chunk = (lmap.size()-1)/(3*4*5)+1;
+
+            Tensor< TENSOR_RESULT_TYPE(T,R) > r(left.size(), right.size());
+            Mutex mutex;
+
+            typename mapT::iterator lstart=lmap.begin();
+            while (lstart != lmap.end()) {
+                typename mapT::iterator lend = lstart;
+                advance(lend, chunk);
+                left[0]->world.taskq.add(&FunctionImpl<T, NDIM>::do_dot_localX<R>, lstart, lend, rmap_ptr, sym, &r, &mutex);
+                lstart = lend;
+            }
+            left[0]->world.taskq.fence();
+
+            // sym is for hermiticity
+            if (sym) {
+                for (long i=0; i<r.dim(0); i++) {
+                    for (long j=0; j<i; j++) {
+                        TENSOR_RESULT_TYPE(T,R) sum = r(i,j)+conj(r(j,i));
+                        r(i,j) = sum;
+                        r(j,i) = conj(sum);
                     }
                 }
             }
@@ -5865,48 +5965,48 @@ template<size_t NDIM>
 
         /// invoked by result
 
-        /// contract 2 functions f(x, z) = \int g(x, y) * h(y, z) dy
+        /// contract 2 functions f(x,z) = \int g(x,y) * h(y,z) dy
         /// @tparam CDIM: the dimension of the contraction variable (y)
-        /// @tparam NDIM: the dimension of the result (x, z)
-        /// @tparam LDIM: the dimension of g(x, y)
-        /// @tparam KDIM: the dimension of h(y, z)
+        /// @tparam NDIM: the dimension of the result (x,z)
+        /// @tparam LDIM: the dimension of g(x,y)
+        /// @tparam KDIM: the dimension of h(y,z)
         template<typename Q, std::size_t LDIM, typename R, std::size_t KDIM,
                 std::size_t CDIM = (KDIM + LDIM - NDIM) / 2>
         void partial_inner(const FunctionImpl<Q, LDIM>& g, const FunctionImpl<R, KDIM>& h,
                            const std::array<int, CDIM> v1, const std::array<int, CDIM> v2) {
 
             typedef std::multimap<Key<NDIM>, std::list<Key<CDIM>>> contractionmapT;
-            // double wall_get_lists = 0.0;
-            // double wall_recur = 0.0;
-            // double wall_contract = 0.0;
-            std::size_t nmax = FunctionDefaults<CDIM>::get_max_refine_level();
-            const double thresh = FunctionDefaults<NDIM>::get_thresh();
+            //double wall_get_lists=0.0;
+            //double wall_recur=0.0;
+            //double wall_contract=0.0;
+            std::size_t nmax=FunctionDefaults<CDIM>::get_max_refine_level();
+            const double thresh=FunctionDefaults<NDIM>::get_thresh();
 
             // auto print_map = [](const auto& map) {
-                // for (const auto& kv : map) print(kv.first, "--", kv.second);
+                // for (const auto& kv : map) print(kv.first,"--",kv.second);
             // };
             // logical constness, not bitwise constness
-            auto& g_nc=const_cast<FunctionImpl<Q, LDIM>&>(g);
-            auto& h_nc=const_cast<FunctionImpl<R, KDIM>&>(h);
+            FunctionImpl<Q,LDIM>& g_nc=const_cast<FunctionImpl<Q,LDIM>&>(g);
+            FunctionImpl<R,KDIM>& h_nc=const_cast<FunctionImpl<R,KDIM>&>(h);
 
             std::list<contractionmapT> all_contraction_maps;
-            for (std::size_t n = 0; n < nmax; ++n) {
+            for (std::size_t n=0; n<nmax; ++n) {
 
                 // list of nodes with d coefficients (and their parents)
-	            // double wall0 = wall_time();
+	      //double wall0 = wall_time();
                 auto [g_ijlist, g_jlist] = g.get_contraction_node_lists(n, v1);
                 auto [h_ijlist, h_jlist] = h.get_contraction_node_lists(n, v2);
                 if ((g_ijlist.size() == 0) and (h_ijlist.size() == 0)) break;
-                // double wall1 = wall_time();
-                // wall_get_lists += (wall1 - wall0);
-                // wall0 = wall1;
-                // print("g_jlist");
-                // for (const auto& kv : g_jlist) print(kv.first, kv.second);
-                // print("h_jlist");
-                // for (const auto& kv : h_jlist) print(kv.first, kv.second);
+                //double wall1 = wall_time();
+                //wall_get_lists += (wall1 - wall0);
+                //wall0 = wall1;
+//                print("g_jlist");
+//                for (const auto& kv : g_jlist) print(kv.first,kv.second);
+//                print("h_jlist");
+//                for (const auto& kv : h_jlist) print(kv.first,kv.second);
 
                 // next lines will insert s nodes into g and h -> possible race condition!
-                bool this_first = true;  // are the remaining indices of g before those of g: f(x, z) = g(x, y) h(y, z)
+                bool this_first = true;  // are the remaining indices of g before those of g: f(x,z) = g(x,y) h(y,z)
                 // CDIM, NDIM, KDIM
                 contractionmapT contraction_map = g_nc.recur_down_for_contraction_map(
                         g_nc.key0(), g_nc.get_coeffs().find(g_nc.key0()).get()->second, v1, v2,
@@ -5914,7 +6014,7 @@ template<size_t NDIM>
 
                 this_first = false;
                 // CDIM, NDIM, LDIM
-                auto hnode0 = h_nc.get_coeffs().find(h_nc.key0()).get()->second;
+                auto hnode0=h_nc.get_coeffs().find(h_nc.key0()).get()->second;
                 contractionmapT contraction_map1 = h_nc.recur_down_for_contraction_map(
                         h_nc.key0(), hnode0, v2, v1,
                         g_ijlist, g_jlist, this_first, thresh);
@@ -5933,39 +6033,39 @@ template<size_t NDIM>
                     }
                     it = it_end;
                 }
-                // print("thresh               ", thresh);
-                // print("contraction list size", contraction_map.size());
+//                print("thresh               ",thresh);
+//                print("contraction list size",contraction_map.size());
 
                 // remove all double entries
                 for (auto& elem: contraction_map) {
                     elem.second.sort();
                     elem.second.unique();
                 }
-                // wall1 = wall_time();
-                // wall_recur += (wall1 - wall0);
-                // if (n == 2) {
-                //     print("contraction map for n=", n);
-                //     print_map(contraction_map);
-                // }
+                //wall1 = wall_time();
+                //wall_recur += (wall1 - wall0);
+//                if (n==2) {
+//                    print("contraction map for n=", n);
+//                    print_map(contraction_map);
+//                }
                 all_contraction_maps.push_back(contraction_map);
 
-                long mapsize = contraction_map.size();
-                if (mapsize == 0) break;
+                long mapsize=contraction_map.size();
+                if (mapsize==0) break;
             }
 
 
             // finally do the contraction
             for (const auto& contraction_map : all_contraction_maps) {
                 for (const auto& key_list : contraction_map) {
-                    const Key<NDIM>& key = key_list.first;
-                    const std::list<Key<CDIM>>& list = key_list.second;
-                    woT::task(coeffs.owner(key), &implT:: template partial_inner_contract<Q, LDIM, R, KDIM>,
-                              &g, &h, v1, v2, key, list);
+                    const Key<NDIM>& key=key_list.first;
+                    const std::list<Key<CDIM>>& list=key_list.second;
+                    woT::task(coeffs.owner(key), &implT:: template partial_inner_contract<Q,LDIM,R,KDIM>,
+                              &g,&h,v1,v2,key,list);
                 }
             }
         }
 
-        /// for contraction two functions f(x, z) = \int g(x, y) h(y, z) dy
+        /// for contraction two functions f(x,z) = \int g(x,y) h(y,z) dy
 
         /// find all nodes with d coefficients and return a list of complete keys and of
         /// keys holding only the y dimension, also the maximum norm of all d for the j dimension
@@ -5973,37 +6073,37 @@ template<size_t NDIM>
         /// @param[in]  v   array holding the indices of the integration variable
         /// @return     ijlist: list of all nodes with d coeffs; jlist: j-part of ij list only
         template<std::size_t CDIM>
-        std::tuple<std::set<Key<NDIM>>, std::map<Key<CDIM>, double>>
+        std::tuple<std::set<Key<NDIM>>, std::map<Key<CDIM>,double>>
         get_contraction_node_lists(const std::size_t n, const std::array<int, CDIM>& v) const {
 
-            const auto& cdata = get_cdata();
+            const auto& cdata=get_cdata();
             auto has_d_coeffs = [&cdata](const coeffT& coeff) {
                 if (coeff.has_no_data()) return false;
-                return (coeff.dim(0) == 2*cdata.k);
+                return (coeff.dim(0)==2*cdata.k);
             };
 
             // keys to be contracted in g
             std::set<Key<NDIM>> ij_list;           // full key
-            std::map<Key<CDIM>, double> j_list;      // only that dimension that will be contracted
+            std::map<Key<CDIM>,double> j_list;      // only that dimension that will be contracted
 
-            for (auto it=get_coeffs().begin(); it != get_coeffs().end(); ++it) {
-                const Key<NDIM>& key = it->first;
-                const FunctionNode<T, NDIM>& node = it->second;
-                if ((key.level() == n) and (has_d_coeffs(node.coeff()))) {
+            for (auto it=get_coeffs().begin(); it!=get_coeffs().end(); ++it) {
+                const Key<NDIM>& key=it->first;
+                const FunctionNode<T,NDIM>& node=it->second;
+                if ((key.level()==n) and (has_d_coeffs(node.coeff()))) {
                     ij_list.insert(key);
-                    Vector<Translation, CDIM> j_trans;
-                    for (std::size_t i = 0; i < CDIM; ++i) j_trans[i] = key.translation()[v[i]];
-                    Key<CDIM> jkey(n, j_trans);
-                    const double max_d_norm = j_list[jkey];
-                    j_list.insert_or_assign(jkey, std::max(max_d_norm, node.get_dnorm()));
-                    Key<CDIM> parent_jkey = jkey.parent();
-                    while (j_list.count(parent_jkey) == 0) {
-                        j_list.insert({parent_jkey, 1.0});
-                        parent_jkey = parent_jkey.parent();
+                    Vector<Translation,CDIM> j_trans;
+                    for (std::size_t i=0; i<CDIM; ++i) j_trans[i]=key.translation()[v[i]];
+                    Key<CDIM> jkey(n,j_trans);
+                    const double max_d_norm=j_list[jkey];
+                    j_list.insert_or_assign(jkey,std::max(max_d_norm,node.get_dnorm()));
+                    Key<CDIM> parent_jkey=jkey.parent();
+                    while (j_list.count(parent_jkey)==0) {
+                        j_list.insert({parent_jkey,1.0});
+                        parent_jkey=parent_jkey.parent();
                     }
                 }
             }
-            return std::make_tuple(ij_list, j_list);
+            return std::make_tuple(ij_list,j_list);
         }
 
         /// make a map of all nodes that will contribute to a partial inner product
@@ -6029,10 +6129,10 @@ template<size_t NDIM>
         template<std::size_t CDIM, std::size_t ODIM, std::size_t FDIM=NDIM+ODIM-2*CDIM>
         std::multimap<Key<FDIM>, std::list<Key<CDIM>>> recur_down_for_contraction_map(
                 const keyT& key, const nodeT& node,
-                const std::array<int, CDIM>& v_this,
-                const std::array<int, CDIM>& v_other,
+                const std::array<int,CDIM>& v_this,
+                const std::array<int,CDIM>& v_other,
                 const std::set<Key<ODIM>>& ij_other_list,
-                const std::map<Key<CDIM>, double>& j_other_list,
+                const std::map<Key<CDIM>,double>& j_other_list,
                 bool this_first, const double thresh) {
 
             std::multimap<Key<FDIM>, std::list<Key<CDIM>>> contraction_map;
@@ -6042,82 +6142,84 @@ template<size_t NDIM>
 
             // continue recursion if this node may be contracted with the j column
             // extract relevant node translations from this node
-            const auto j_this_key = key.extract_key(v_this);
+            const auto j_this_key=key.extract_key(v_this);
 
-            // print("\nkey, j_this_key", key, j_this_key);
-            const double max_d_norm = j_other_list.find(j_this_key)->second;
-            const bool sd_norm_product_large = node.get_snorm() * max_d_norm > truncate_tol(thresh, key);
-            // print("sd_product_norm", node.get_snorm() * max_d_norm, thresh);
+//            print("\nkey, j_this_key", key, j_this_key);
+            const double max_d_norm=j_other_list.find(j_this_key)->second;
+            const bool sd_norm_product_large = node.get_snorm() * max_d_norm > truncate_tol(thresh,key);
+//            print("sd_product_norm",node.get_snorm() * max_d_norm, thresh);
 
             // end recursion if we have reached the final scale n
             // with which nodes from other will this node be contracted?
-            bool final_scale = key.level() == ij_other_list.begin()->level();
+            bool final_scale=key.level()==ij_other_list.begin()->level();
             if (final_scale and sd_norm_product_large) {
                 for (auto& other_key : ij_other_list) {
-                    const auto j_other_key = other_key.extract_key(v_other);
+                    const auto j_other_key=other_key.extract_key(v_other);
                     if (j_this_key != j_other_key) continue;
-                    auto i_key = key.extract_complement_key(v_this);
-                    auto k_key = other_key.extract_complement_key(v_other);
-                    // print("key, ij_other_key", key, other_key);
-                    // print("i, k, j key", i_key, k_key, j_this_key);
-                    Key<FDIM> ik_key = (this_first) ? i_key.merge_with(k_key) : k_key.merge_with(i_key);
-                    // print("ik_key", ik_key);
-                    // MADNESS_CHECK(contraction_map.count(ik_key) == 0);
-                    contraction_map.insert(std::make_pair(ik_key, std::list<Key<CDIM>>{j_this_key}));
+                    auto i_key=key.extract_complement_key(v_this);
+                    auto k_key=other_key.extract_complement_key(v_other);
+//                    print("key, ij_other_key",key,other_key);
+//                    print("i, k, j key",i_key, k_key, j_this_key);
+                    Key<FDIM> ik_key=(this_first) ? i_key.merge_with(k_key) : k_key.merge_with(i_key);
+//                    print("ik_key",ik_key);
+//                    MADNESS_CHECK(contraction_map.count(ik_key)==0);
+                    contraction_map.insert(std::make_pair(ik_key,std::list<Key<CDIM>>{j_this_key}));
                 }
                 return contraction_map;
             }
 
-            bool continue_recursion = (j_other_list.count(j_this_key) == 1);
+            bool continue_recursion = (j_other_list.count(j_this_key)==1);
             if (not continue_recursion) return contraction_map;
+
 
             // continue recursion if norms are large
             continue_recursion = (node.has_children() or sd_norm_product_large);
 
             if (continue_recursion) {
                 // in case we need to compute children's coefficients: unfilter only once
-                bool compute_child_s_coeffs = true;
+                bool compute_child_s_coeffs=true;
                 coeffT d = node.coeff();
-                // print("continuing recursion from key", key);
+//                print("continuing recursion from key",key);
 
                 for (KeyChildIterator<NDIM> kit(key); kit; ++kit) {
-                    keyT child = kit.key();
+                    keyT child=kit.key();
                     typename dcT::accessor acc;
 
                     // make child's s coeffs if it doesn't exist or if is has no s coeffs
-                    bool childnode_exists = get_coeffs().find(acc, child);
-                    bool need_s_coeffs = childnode_exists ? (acc->second.get_snorm() <= 0.0) : true;
+                    bool childnode_exists=get_coeffs().find(acc,child);
+                    bool need_s_coeffs= childnode_exists ? (acc->second.get_snorm()<=0.0) : true;
 
                     coeffT child_s_coeffs;
                     if (need_s_coeffs and compute_child_s_coeffs) {
-                        if (d.dim(0) == cdata.vk[0]) {        // s coeffs only in this node
-                            coeffT d1(cdata.v2k, get_tensor_args());
-                            d1(cdata.s0) += d;
-                            d = d1;
+                        if (d.dim(0)==cdata.vk[0]) {        // s coeffs only in this node
+                            coeffT d1(cdata.v2k,get_tensor_args());
+                            d1(cdata.s0)+=d;
+                            d=d1;
                         }
                         d = unfilter(d);
-                        child_s_coeffs = copy(d(child_patch(child)));
+                        child_s_coeffs=copy(d(child_patch(child)));
                         child_s_coeffs.reduce_rank(thresh);
-                        compute_child_s_coeffs = false;
+                        compute_child_s_coeffs=false;
                     }
 
                     if (not childnode_exists) {
-                        get_coeffs().replace(child, nodeT(child_s_coeffs, false));
-                        get_coeffs().find(acc, child);
+                        get_coeffs().replace(child,nodeT(child_s_coeffs,false));
+                        get_coeffs().find(acc,child);
                     } else if (childnode_exists and need_s_coeffs) {
-                        acc->second.coeff() = child_s_coeffs;
+                        acc->second.coeff()=child_s_coeffs;
                     }
-                    bool exists = get_coeffs().find(acc, child);
+                    bool exists= get_coeffs().find(acc,child);
                     MADNESS_CHECK(exists);
                     nodeT& childnode = acc->second;
                     if (need_s_coeffs) childnode.recompute_snorm_and_dnorm(get_cdata());
-                    // print("recurring down to", child);
-                    contraction_map.merge(recur_down_for_contraction_map(child, childnode, v_this, v_other,
+//                    print("recurring down to",child);
+                    contraction_map.merge(recur_down_for_contraction_map(child,childnode, v_this, v_other,
                                                                          ij_other_list, j_other_list, this_first, thresh));
-                    // print("contraction_map.size()", contraction_map.size());
+//                    print("contraction_map.size()",contraction_map.size());
                 }
 
             }
+
             return contraction_map;
         }
 
@@ -6135,6 +6237,7 @@ template<size_t NDIM>
         void partial_inner_contract(const FunctionImpl<Q, LDIM>* g, const FunctionImpl<R, KDIM>* h,
                                const std::array<int, CDIM> v1, const std::array<int, CDIM> v2,
                                const Key<NDIM>& key, const std::list<Key<CDIM>>& j_key_list) {
+
             Key<LDIM - CDIM> i_key;
             Key<KDIM - CDIM> k_key;
             key.break_apart(i_key, k_key);
@@ -6184,7 +6287,7 @@ template<size_t NDIM>
                     hcoeff1 = hcoeff;
                 }
 
-                // offset: 0 for full tensor, 1 for svd representation with rand being the first dimension (r, d1, d2, d3) -> (r, d1*d2*d3)
+                // offset: 0 for full tensor, 1 for svd representation with rand being the first dimension (r,d1,d2,d3) -> (r,d1*d2*d3)
                 auto fuse = [](Tensor<T> tensor, const std::array<int, CDIM>& v, int offset) {
                     for (std::size_t i = 0; i < CDIM - 1; ++i) {
                         MADNESS_CHECK((v[i] + 1) == v[i + 1]); // make sure v is contiguous and ascending
@@ -6193,22 +6296,22 @@ template<size_t NDIM>
                     return tensor;
                 };
 
-                // use case: partial_projection of 2-electron functions in svd representation  f(1) = \int g(2) h(1, 2) d2
+                // use case: partial_projection of 2-electron functions in svd representation  f(1) = \int g(2) h(1,2) d2
                 // c_i = \sum_j a_j b_ij = \sum_jr a_j b_rj b'_rj
                 //                       = \sum_jr ( a_j b_rj) b'_rj )
                 auto contract2 = [](const auto& svdcoeff, const auto& tensor, const int particle) {
 #if HAVE_GENTENSOR
-                    const int spectator_particle = (particle + 1) % 2;
+                    const int spectator_particle=(particle+1)%2;
                     Tensor<Q> gtensor = svdcoeff.get_svdtensor().make_vector_with_weights(particle);
-                    gtensor=gtensor.reshape(svdcoeff.rank(), gtensor.size() / svdcoeff.rank());
-                    MADNESS_CHECK(gtensor.ndim() == 2);
+                    gtensor=gtensor.reshape(svdcoeff.rank(),gtensor.size()/svdcoeff.rank());
+                    MADNESS_CHECK(gtensor.ndim()==2);
                     Tensor<Q> gtensor_other = svdcoeff.get_svdtensor().ref_vector(spectator_particle);
-                    Tensor<T> tmp1 = inner(gtensor, tensor.flat(), 1, 0);          // tmp1(r) = sum_j a'_(r, j) b(j)
-                    MADNESS_CHECK(tmp1.ndim() == 1);
-                    Tensor<T> tmp2 = inner(gtensor_other, tmp1, 0, 0);          // tmp2(i) = sum_r a_(r, i) tmp1(r)
+                    Tensor<T> tmp1=inner(gtensor,tensor.flat(),1,0);          // tmp1(r) = sum_j a'_(r,j) b(j)
+                    MADNESS_CHECK(tmp1.ndim()==1);
+                    Tensor<T> tmp2=inner(gtensor_other,tmp1,0,0);          // tmp2(i) = sum_r a_(r,i) tmp1(r)
                     return tmp2;
 #else
-                    MADNESS_EXCEPTION("no partial_inner using svd without GenTensor", 1);
+                    MADNESS_EXCEPTION("no partial_inner using svd without GenTensor",1);
                     return Tensor<T>();
 #endif
                 };
@@ -6229,76 +6332,74 @@ template<size_t NDIM>
                 }
 
 
-                // use case: 2-electron functions in svd representation  f(1, 3) = \int g(1, 2) h(2, 3) d2
+                // use case: 2-electron functions in svd representation  f(1,3) = \int g(1,2) h(2,3) d2
                 // c_ik = \sum_j a_ij b_jk = \sum_jrr' a_ri a'_rj b_r'j b_r'k
                 //                         = \sum_jrr' ( a_ri (a'_rj b_r'j) )  b_r'k
                 //                         = \sum_jrr' c_r'i  b_r'k
                 else if (gcoeff.is_svd_tensor() and hcoeff.is_svd_tensor() and result_coeff.is_svd_tensor()) {
-                    MADNESS_CHECK(v1[0] == 0 or v1[CDIM - 1] == LDIM - 1);
-                    MADNESS_CHECK(v2[0] == 0 or v2[CDIM - 1] == KDIM - 1);
-                    int gparticle = v1[0] == 0 ? 0 : 1;  // which particle to integrate over
-                    int hparticle = v2[0] == 0 ? 0 : 1;  // which particle to integrate over
+                    MADNESS_CHECK(v1[0]==0 or v1[CDIM-1]==LDIM-1);
+                    MADNESS_CHECK(v2[0]==0 or v2[CDIM-1]==KDIM-1);
+                    int gparticle=  v1[0]==0 ? 0 : 1;       // which particle to integrate over
+                    int hparticle=  v2[0]==0 ? 0 : 1;       // which particle to integrate over
                     // merge multiple contraction dimensions into one
                     Tensor<Q> gtensor = gcoeff1.get_svdtensor().flat_vector_with_weights(gparticle);
-                    Tensor<Q> gtensor_other = gcoeff1.get_svdtensor().flat_vector((gparticle + 1) % 2);
+                    Tensor<Q> gtensor_other = gcoeff1.get_svdtensor().flat_vector((gparticle+1)%2);
                     Tensor<R> htensor = hcoeff1.get_svdtensor().flat_vector_with_weights(hparticle);
-                    Tensor<R> htensor_other = hcoeff1.get_svdtensor().flat_vector((hparticle + 1) % 2);
-                    Tensor<T> tmp1 = inner(gtensor, htensor, 1, 1);      // tmp1(r, r') = sum_j b(r, j) a(r', j)
-                    Tensor<T> tmp2 = inner(tmp1, gtensor_other, 0, 0);   // tmp2(r', i) = sum_r tmp1(r, r') a(r, i)
+                    Tensor<R> htensor_other = hcoeff1.get_svdtensor().flat_vector((hparticle+1)%2);
+                    Tensor<T> tmp1=inner(gtensor,htensor,1,1);      // tmp1(r,r') = sum_j b(r,j) a(r',j)
+                    Tensor<T> tmp2=inner(tmp1,gtensor_other,0,0);   // tmp2(r',i) = sum_r tmp1(r,r') a(r,i)
                     Tensor< typename Tensor<T>::scalar_type > w(tmp2.dim(0));
-                    MADNESS_CHECK(tmp2.dim(0) == htensor_other.dim(0));
+                    MADNESS_CHECK(tmp2.dim(0)==htensor_other.dim(0));
                     w=1.0;
                     coeffT result_tmp(get_cdata().v2k, get_tensor_type());
-                    result_tmp.get_svdtensor().set_vectors_and_weights(w, tmp2, htensor_other);
+                    result_tmp.get_svdtensor().set_vectors_and_weights(w,tmp2,htensor_other);
                     if (key.level() > 0) {
                         GenTensor<Q> gcoeff2 = copy(gcoeff1(g->get_cdata().s0));
                         GenTensor<R> hcoeff2 = copy(hcoeff1(h->get_cdata().s0));
                         Tensor<Q> gtensor = gcoeff2.get_svdtensor().flat_vector_with_weights(gparticle);
-                        Tensor<Q> gtensor_other = gcoeff2.get_svdtensor().flat_vector((gparticle + 1) % 2);
+                        Tensor<Q> gtensor_other = gcoeff2.get_svdtensor().flat_vector((gparticle+1)%2);
                         Tensor<R> htensor = hcoeff2.get_svdtensor().flat_vector_with_weights(hparticle);
-                        Tensor<R> htensor_other = hcoeff2.get_svdtensor().flat_vector((hparticle + 1) % 2);
-                        Tensor<T> tmp1 = inner(gtensor, htensor, 1, 1);      // tmp1(r, r') = sum_j b(r, j) a(r', j)
-                        Tensor<T> tmp2 = inner(tmp1, gtensor_other, 0, 0);   // tmp2(r', i) = sum_r tmp1(r, r') a(r, i)
+                        Tensor<R> htensor_other = hcoeff2.get_svdtensor().flat_vector((hparticle+1)%2);
+                        Tensor<T> tmp1=inner(gtensor,htensor,1,1);      // tmp1(r,r') = sum_j b(r,j) a(r',j)
+                        Tensor<T> tmp2=inner(tmp1,gtensor_other,0,0);   // tmp2(r',i) = sum_r tmp1(r,r') a(r,i)
                         Tensor< typename Tensor<T>::scalar_type > w(tmp2.dim(0));
-                        MADNESS_CHECK(tmp2.dim(0) == htensor_other.dim(0));
-                        w = 1.0;
+                        MADNESS_CHECK(tmp2.dim(0)==htensor_other.dim(0));
+                        w=1.0;
                         coeffT result_coeff1(get_cdata().vk, get_tensor_type());
-                        result_coeff1.get_svdtensor().set_vectors_and_weights(w, tmp2, htensor_other);
-                        result_tmp(get_cdata().s0) -= result_coeff1;
+                        result_coeff1.get_svdtensor().set_vectors_and_weights(w,tmp2,htensor_other);
+                        result_tmp(get_cdata().s0)-=result_coeff1;
                     }
-                    result_coeff += result_tmp;
+                    result_coeff+=result_tmp;
                 }
 
-                // use case: partial_projection of 2-electron functions in svd representation  f(1) = \int g(2) h(1, 2) d2
+                // use case: partial_projection of 2-electron functions in svd representation  f(1) = \int g(2) h(1,2) d2
                 // c_i = \sum_j a_j b_ij = \sum_jr a_j b_rj b'_rj
                 //                       = \sum_jr ( a_j b_rj) b'_rj )
                 else if (gcoeff.is_full_tensor() and hcoeff.is_svd_tensor() and result_coeff.is_full_tensor()) {
-                    MADNESS_CHECK(v1[0] == 0 and v1[CDIM-1] == LDIM-1);
-                    MADNESS_CHECK(v2[0] == 0 or v2[CDIM-1] == KDIM-1);
-                    MADNESS_CHECK(LDIM == CDIM);
-                    int hparticle = v2[0] == 0 ? 0 : 1;       // which particle to integrate over
+                    MADNESS_CHECK(v1[0]==0 and v1[CDIM-1]==LDIM-1);
+                    MADNESS_CHECK(v2[0]==0 or v2[CDIM-1]==KDIM-1);
+                    MADNESS_CHECK(LDIM==CDIM);
+                    int hparticle=  v2[0]==0 ? 0 : 1;       // which particle to integrate over
 
-                    Tensor<T> r = contract2(hcoeff1, gcoeff1.full_tensor(), hparticle);
-                    if (key.level() > 0)
-                        r(get_cdata().s0) -= contract2(copy(hcoeff1(h->get_cdata().s0)), copy(gcoeff.full_tensor()(g->get_cdata().s0)), hparticle);
-                    result_coeff.full_tensor() += r;
+                    Tensor<T> r=contract2(hcoeff1,gcoeff1.full_tensor(),hparticle);
+                    if (key.level()>0) r(get_cdata().s0)-=contract2(copy(hcoeff1(h->get_cdata().s0)),copy(gcoeff.full_tensor()(g->get_cdata().s0)),hparticle);
+                    result_coeff.full_tensor()+=r;
                 }
-                // use case: partial_projection of 2-electron functions in svd representation  f(1) = \int g(1, 2) h(2) d2
+                // use case: partial_projection of 2-electron functions in svd representation  f(1) = \int g(1,2) h(2) d2
                 // c_i = \sum_j a_ij b_j = \sum_jr a_ri a'_rj b_j
                 //                       = \sum_jr ( a_ri (a'_rj b_j) )
                 else if (gcoeff.is_svd_tensor() and hcoeff.is_full_tensor() and result_coeff.is_full_tensor()) {
-                    MADNESS_CHECK(v1[0] == 0 or v1[CDIM-1] == LDIM-1);
-                    MADNESS_CHECK(v2[0] == 0 and v2[CDIM-1] == KDIM-1);
-                    MADNESS_CHECK(KDIM == CDIM);
-                    int gparticle=  v1[0] == 0 ? 0 : 1;       // which particle to integrate over
+                    MADNESS_CHECK(v1[0]==0 or v1[CDIM-1]==LDIM-1);
+                    MADNESS_CHECK(v2[0]==0 and v2[CDIM-1]==KDIM-1);
+                    MADNESS_CHECK(KDIM==CDIM);
+                    int gparticle=  v1[0]==0 ? 0 : 1;       // which particle to integrate over
 
-                    Tensor<T> r=contract2(gcoeff1, hcoeff1.full_tensor(), gparticle);
-                    if (key.level() > 0)
-                        r(get_cdata().s0) -= contract2(copy(gcoeff1(g->get_cdata().s0)), copy(hcoeff.full_tensor()(h->get_cdata().s0)), gparticle);
+                    Tensor<T> r=contract2(gcoeff1,hcoeff1.full_tensor(),gparticle);
+                    if (key.level()>0) r(get_cdata().s0)-=contract2(copy(gcoeff1(g->get_cdata().s0)),copy(hcoeff.full_tensor()(h->get_cdata().s0)),gparticle);
                     result_coeff.full_tensor()+=r;
 
                 } else {
-                    MADNESS_EXCEPTION("unknown case in partial_inner_contract", 1);
+                    MADNESS_EXCEPTION("unknown case in partial_inner_contract",1);
                 }
             }
 
@@ -6317,7 +6418,7 @@ template<size_t NDIM>
         /// @param[in] c Tensor of coefficients for the function at the function node given by key
         /// @param[in] f Reference to FunctionFunctorInterface. This is the externally provided function
         /// @return Returns the inner product over the domain of a single function node, no guarantee of accuracy.
-        T inner_ext_node(keyT key, tensorT c, const std::shared_ptr< FunctionFunctorInterface<T, NDIM>> f) const {
+        T inner_ext_node(keyT key, tensorT c, const std::shared_ptr< FunctionFunctorInterface<T,NDIM> > f) const {
             tensorT fvals = tensorT(this->cdata.vk);
             // Compute the value of the external function at the quadrature points.
             fcube(key, *(f), cdata.quad_x, fvals);
@@ -6334,7 +6435,7 @@ template<size_t NDIM>
         /// @param[in] leaf_refine boolean switch to turn on/off refinement past leaf nodes
         /// @param[in] old_inner the inner product on the parent function node
         /// @return Returns the inner product over the domain of a single function, checks for convergence.
-        T inner_ext_recursive(keyT key, tensorT c, const std::shared_ptr< FunctionFunctorInterface<T, NDIM>> f, const bool leaf_refine, T old_inner=T(0)) const {
+        T inner_ext_recursive(keyT key, tensorT c, const std::shared_ptr< FunctionFunctorInterface<T,NDIM> > f, const bool leaf_refine, T old_inner=T(0)) const {
             int i = 0;
             tensorT c_child, inner_child;
             T new_inner, result = 0.0;
@@ -6406,12 +6507,12 @@ template<size_t NDIM>
         }
 
         struct do_inner_ext_local_ffi {
-            const std::shared_ptr< FunctionFunctorInterface<T, NDIM>> fref;
+            const std::shared_ptr< FunctionFunctorInterface<T, NDIM> > fref;
             const implT * impl;
             const bool leaf_refine;
             const bool do_leaves;   ///< start with leaf nodes instead of initial_level
 
-            do_inner_ext_local_ffi(const std::shared_ptr< FunctionFunctorInterface<T, NDIM>> f,
+            do_inner_ext_local_ffi(const std::shared_ptr< FunctionFunctorInterface<T,NDIM> > f,
                     const implT * impl, const bool leaf_refine, const bool do_leaves)
                     : fref(f), impl(impl), leaf_refine(leaf_refine), do_leaves(do_leaves) {};
 
@@ -6440,10 +6541,10 @@ template<size_t NDIM>
         /// @param[in] f Reference to FunctionFunctorInterface. This is the externally provided function
         /// @param[in] leaf_refine boolean switch to turn on/off refinement past leaf nodes
         /// @return Returns local part of the inner product, i.e. over the domain of all function nodes on this compute node.
-        T inner_ext_local(const std::shared_ptr< FunctionFunctorInterface<T, NDIM>> f, const bool leaf_refine) const {
+        T inner_ext_local(const std::shared_ptr< FunctionFunctorInterface<T,NDIM> > f, const bool leaf_refine) const {
             typedef Range<typename dcT::const_iterator> rangeT;
 
-            return world.taskq.reduce<T, rangeT, do_inner_ext_local_ffi>(rangeT(coeffs.begin(), coeffs.end()),
+            return world.taskq.reduce<T, rangeT, do_inner_ext_local_ffi>(rangeT(coeffs.begin(),coeffs.end()),
                     do_inner_ext_local_ffi(f, this, leaf_refine, false));
         }
 
@@ -6451,10 +6552,10 @@ template<size_t NDIM>
         /// @param[in] f Reference to FunctionFunctorInterface. This is the externally provided function
         /// @param[in] leaf_refine boolean switch to turn on/off refinement past leaf nodes
         /// @return Returns local part of the inner product, i.e. over the domain of all function nodes on this compute node.
-        T inner_adaptive_local(const std::shared_ptr< FunctionFunctorInterface<T, NDIM>> f, const bool leaf_refine) const {
+        T inner_adaptive_local(const std::shared_ptr< FunctionFunctorInterface<T,NDIM> > f, const bool leaf_refine) const {
             typedef Range<typename dcT::const_iterator> rangeT;
 
-            return world.taskq.reduce<T, rangeT, do_inner_ext_local_ffi>(rangeT(coeffs.begin(), coeffs.end()),
+            return world.taskq.reduce<T, rangeT, do_inner_ext_local_ffi>(rangeT(coeffs.begin(),coeffs.end()),
                     do_inner_ext_local_ffi(f, this, leaf_refine, true));
         }
 
@@ -6466,12 +6567,12 @@ template<size_t NDIM>
         /// @param[in] old_inner the inner product on the parent function node
         /// @return Returns the inner product over the domain of a single function, checks for convergence.
         T inner_adaptive_recursive(keyT key, const tensorT& c,
-                const std::shared_ptr< FunctionFunctorInterface<T, NDIM>> f,
+                const std::shared_ptr< FunctionFunctorInterface<T,NDIM> > f,
                 const bool leaf_refine, T old_inner=T(0)) const {
 
             // the inner product in the current node
             old_inner = inner_ext_node(key, c, f);
-            T result = 0.0;
+            T result=0.0;
 
             // the inner product in the child nodes
 
@@ -6486,11 +6587,11 @@ template<size_t NDIM>
             for (KeyChildIterator<NDIM> it(key); it; ++it) {
                 const keyT& child = it.key();
                 tensorT cc = tensorT(c_child(child_patch(child)));
-                new_inner += inner_ext_node(child, cc, f);
+                new_inner+= inner_ext_node(child, cc, f);
             }
 
             // continue recursion if needed
-            const double tol = truncate_tol(thresh, key);
+            const double tol=truncate_tol(thresh,key);
             if (leaf_refine and (std::abs(new_inner - old_inner) > tol)) {
                 for (KeyChildIterator<NDIM> it(key); it; ++it) {
                     const keyT& child = it.key();
@@ -6542,10 +6643,10 @@ template<size_t NDIM>
         /// @param[in] tol convergence tolerance...when the norm of the gaxpy's
         ///            difference coefficients is less than tol, we are done.
         template <typename L>
-        void gaxpy_ext_recursive(const keyT& key, const FunctionImpl<L, NDIM>* left,
+        void gaxpy_ext_recursive(const keyT& key, const FunctionImpl<L,NDIM>* left,
                                  Tensor<L> lcin, tensorT c, T (*f)(const coordT&),
                                  T alpha, T beta, double tol, bool below_leaf) {
-            typedef typename FunctionImpl<L, NDIM>::dcT::const_iterator literT;
+            typedef typename FunctionImpl<L,NDIM>::dcT::const_iterator literT;
 
             // If we haven't yet reached the leaf level, check whether the
             // current key is a leaf node of left. If so, set below_leaf to true
@@ -6558,7 +6659,7 @@ template<size_t NDIM>
                     this->coeffs.replace(key, nodeT(coeffT(), true));
                     for (KeyChildIterator<NDIM> it(key); it; ++it) {
                         const keyT& child = it.key();
-                        woT::task(left->coeffs.owner(child), &implT:: template gaxpy_ext_recursive<L>, 
+                        woT::task(left->coeffs.owner(child), &implT:: template gaxpy_ext_recursive<L>,
                                   child, left, Tensor<L>(), tensorT(), f, alpha, beta, tol, below_leaf);
                     }
                     return;
@@ -6612,8 +6713,8 @@ template<size_t NDIM>
 
             // Small d.normf means we've reached a good level of resolution
             // Store the coefficients and return.
-            if (dnorm <= truncate_tol(tol, key)) {
-                this->coeffs.replace(key, nodeT(coeffT(c, targs), false));
+            if (dnorm <= truncate_tol(tol,key)) {
+                this->coeffs.replace(key, nodeT(coeffT(c,targs), false));
             } else {
                 // Otherwise, make this a parent node and recur down
                 this->coeffs.replace(key, nodeT(coeffT(), true)); // Interior node
@@ -6629,14 +6730,14 @@ template<size_t NDIM>
         }
 
         template <typename L>
-        void gaxpy_ext(const FunctionImpl<L, NDIM>* left, T (*f)(const coordT&), T alpha, T beta, double tol, bool fence) {
+        void gaxpy_ext(const FunctionImpl<L,NDIM>* left, T (*f)(const coordT&), T alpha, T beta, double tol, bool fence) {
             if (world.rank() == coeffs.owner(cdata.key0))
                 gaxpy_ext_recursive<L> (cdata.key0, left, Tensor<L>(), tensorT(), f, alpha, beta, tol, false);
             if (fence)
                 world.gop.fence();
         }
 
-        /// project the low-dim function g on the hi-dim function f: result(x) = <this(x, y) | g(y)>
+        /// project the low-dim function g on the hi-dim function f: result(x) = <this(x,y) | g(y)>
 
         /// invoked by the hi-dim function, a function of NDIM+LDIM
 
@@ -6645,35 +6746,39 @@ template<size_t NDIM>
         /// @param[in]  gimpl  	lo-dim function of LDIM
         /// @param[in]  dim over which dimensions to be integrated: 0..LDIM or LDIM..LDIM+NDIM-1
         template<size_t LDIM>
-        void project_out(FunctionImpl<T, NDIM-LDIM>* result, const FunctionImpl<T, LDIM>* gimpl,
+        void project_out(FunctionImpl<T,NDIM-LDIM>* result, const FunctionImpl<T,LDIM>* gimpl,
                          const int dim, const bool fence) {
-            const keyT& key0 = cdata.key0;
+
+            const keyT& key0=cdata.key0;
 
             if (world.rank() == coeffs.owner(key0)) {
+
                 // coeff_op will accumulate the result
                 typedef project_out_op<LDIM> coeff_opT;
-                coeff_opT coeff_op(this, result, CoeffTracker<T, LDIM>(gimpl), dim);
+                coeff_opT coeff_op(this,result,CoeffTracker<T,LDIM>(gimpl),dim);
 
                 // don't do anything on this -- coeff_op will accumulate into result
-                typedef noop<T, NDIM> apply_opT;
+                typedef noop<T,NDIM> apply_opT;
                 apply_opT apply_op;
 
-                woT::task(world.rank(), &implT:: template forward_traverse<coeff_opT, apply_opT>,
+                woT::task(world.rank(), &implT:: template forward_traverse<coeff_opT,apply_opT>,
                           coeff_op, apply_op, cdata.key0);
+
             }
             if (fence) world.gop.fence();
+
         }
 
 
-        /// project the low-dim function g on the hi-dim function f: result(x) = <f(x, y) | g(y)>
+        /// project the low-dim function g on the hi-dim function f: result(x) = <f(x,y) | g(y)>
         template<size_t LDIM>
         struct project_out_op {
-            bool randomize() const { return false; }
+            bool randomize() const {return false;}
 
             typedef project_out_op<LDIM> this_type;
-            typedef CoeffTracker<T, LDIM> ctL;
-            typedef FunctionImpl<T, NDIM-LDIM> implL1;
-            typedef std::pair<bool, coeffT> argT;
+            typedef CoeffTracker<T,LDIM> ctL;
+            typedef FunctionImpl<T,NDIM-LDIM> implL1;
+            typedef std::pair<bool,coeffT> argT;
 
             const implT* fimpl;		///< the hi dim function f
             mutable implL1* result;	///< the low dim result function
@@ -6691,42 +6796,42 @@ template<size_t NDIM>
             /// do the actual contraction
             Future<argT> operator()(const Key<NDIM>& key) const {
 
-            	Key<LDIM> key1, key2, dest;
-            	key.break_apart(key1, key2);
+            	Key<LDIM> key1,key2,dest;
+            	key.break_apart(key1,key2);
 
             	// make the right coefficients
                 coeffT gcoeff;
-                if (dim == 0) {
-                    gcoeff = iag.get_impl()->parent_to_child(iag.coeff(), iag.key(), key1);
-                    dest = key2;
+                if (dim==0) {
+                    gcoeff=iag.get_impl()->parent_to_child(iag.coeff(),iag.key(),key1);
+                    dest=key2;
                 }
-                if (dim == 1) {
-                    gcoeff = iag.get_impl()->parent_to_child(iag.coeff(), iag.key(), key2);
-                    dest = key1;
+                if (dim==1) {
+                    gcoeff=iag.get_impl()->parent_to_child(iag.coeff(),iag.key(),key2);
+                    dest=key1;
                 }
 
                 MADNESS_ASSERT(fimpl->get_coeffs().probe(key));		// must be local!
-                const nodeT& fnode = fimpl->get_coeffs().find(key).get()->second;
-                const coeffT& fcoeff = fnode.coeff();
+                const nodeT& fnode=fimpl->get_coeffs().find(key).get()->second;
+                const coeffT& fcoeff=fnode.coeff();
 
                 // fast return if possible
                 if (fcoeff.has_no_data() or gcoeff.has_no_data())
-                    return Future<argT> (argT(fnode.is_leaf(), coeffT()));;
+                    return Future<argT> (argT(fnode.is_leaf(),coeffT()));;
 
                 MADNESS_CHECK(gcoeff.is_full_tensor());
                 tensorT final(result->cdata.vk);
-                const int k = fcoeff.dim(0);
-                const int k_ldim = std::pow(k, LDIM);
+                const int k=fcoeff.dim(0);
+                const int k_ldim=std::pow(k,LDIM);
                 std::vector<long> shape(LDIM, k);
 
                 if (fcoeff.is_full_tensor()) {
                     //  result_i = \sum_j g_j f_ji
                     const tensorT gtensor = gcoeff.full_tensor().reshape(k_ldim);
-                    const tensorT ftensor = fcoeff.full_tensor().reshape(k_ldim, k_ldim);
-                    final=inner(gtensor, ftensor, 0, dim).reshape(shape);
+                    const tensorT ftensor = fcoeff.full_tensor().reshape(k_ldim,k_ldim);
+                    final=inner(gtensor,ftensor,0,dim).reshape(shape);
 
                 } else if (fcoeff.is_svd_tensor()) {
-                    if (fcoeff.rank() > 0) {
+                    if (fcoeff.rank()>0) {
 
                         //  result_i = \sum_jr g_j a_rj w_r b_ri
                         const int otherdim = (dim + 1) % 2;
@@ -6741,43 +6846,45 @@ template<size_t NDIM>
                         for (int r = 0; r < fcoeff.rank(); ++r) final += weights(r) * btensor(r, _);
                         final = final.reshape(shape);
                     }
+
                 } else {
-                    MADNESS_EXCEPTION("unsupported tensor type in project_out_op", 1);
+                    MADNESS_EXCEPTION("unsupported tensor type in project_out_op",1);
                 }
 
                 // accumulate the result
-                result->coeffs.task(dest, &FunctionNode<T, LDIM>::accumulate2, final, result->coeffs, dest, TaskAttributes::hipri());
+                result->coeffs.task(dest, &FunctionNode<T,LDIM>::accumulate2, final, result->coeffs, dest, TaskAttributes::hipri());
 
-                return Future<argT> (argT(fnode.is_leaf(), coeffT()));
+                return Future<argT> (argT(fnode.is_leaf(),coeffT()));
             }
 
             this_type make_child(const keyT& child) const {
-            	Key<LDIM> key1, key2;
-            	child.break_apart(key1, key2);
-            	const Key<LDIM> gkey = (dim == 0) ? key1 : key2;
+            	Key<LDIM> key1,key2;
+            	child.break_apart(key1,key2);
+            	const Key<LDIM> gkey = (dim==0) ? key1 : key2;
 
-                return this_type(fimpl, result, iag.make_child(gkey), dim);
+                return this_type(fimpl,result,iag.make_child(gkey),dim);
             }
 
             /// retrieve the coefficients (parent coeffs might be remote)
             Future<this_type> activate() const {
-            	Future<ctL> g1 = iag.activate();
+            	Future<ctL> g1=iag.activate();
                 return result->world.taskq.add(detail::wrap_mem_fn(*const_cast<this_type *> (this),
-                                               &this_type::forward_ctor), fimpl, result, g1, dim);
+                                               &this_type::forward_ctor),fimpl,result,g1,dim);
             }
 
             /// taskq-compatible ctor
             this_type forward_ctor(const implT* fimpl1, implL1* result1, const ctL& iag1, const int dim1) {
-            	return this_type(fimpl1, result1, iag1, dim1);
+            	return this_type(fimpl1,result1,iag1,dim1);
             }
 
             template <typename Archive> void serialize(const Archive& ar) {
                 ar & result & iag & fimpl & dim;
             }
+
         };
 
 
-        /// project the low-dim function g on the hi-dim function f: this(x) = <f(x, y) | g(y)>
+        /// project the low-dim function g on the hi-dim function f: this(x) = <f(x,y) | g(y)>
 
         /// invoked by result, a function of NDIM
 
@@ -6785,50 +6892,52 @@ template<size_t NDIM>
         /// @param[in]  g   lo-dim function of LDIM
         /// @param[in]  dim over which dimensions to be integrated: 0..LDIM or LDIM..LDIM+NDIM-1
         template<size_t LDIM>
-        void project_out2(const FunctionImpl<T, LDIM + NDIM>* f, const FunctionImpl<T, LDIM>* g, const int dim) {
-            typedef std::pair< keyT, coeffT > pairT;
-            typedef typename FunctionImpl<T, NDIM+LDIM>::dcT::const_iterator fiterator;
+        void project_out2(const FunctionImpl<T,LDIM+NDIM>* f, const FunctionImpl<T,LDIM>* g, const int dim) {
+
+            typedef std::pair< keyT,coeffT > pairT;
+            typedef typename FunctionImpl<T,NDIM+LDIM>::dcT::const_iterator fiterator;
 
             // loop over all nodes of hi-dim f, compute the inner products with all
             // appropriate nodes of g, and accumulate in result
             fiterator end = f->get_coeffs().end();
-            for (fiterator it = f->get_coeffs().begin(); it != end; ++it) {
-                const Key<LDIM+NDIM> key = it->first;
-                const FunctionNode<T, LDIM + NDIM> fnode = it->second;
-                const coeffT& fcoeff = fnode.coeff();
+            for (fiterator it=f->get_coeffs().begin(); it!=end; ++it) {
+                const Key<LDIM+NDIM> key=it->first;
+                const FunctionNode<T,LDIM+NDIM> fnode=it->second;
+                const coeffT& fcoeff=fnode.coeff();
 
                 if (fnode.is_leaf() and fcoeff.has_data()) {
 
                     // break key into particle: over key1 will be summed, over key2 will be
                     // accumulated, or vice versa, depending on dim
-                    if (dim == 0) {
+                    if (dim==0) {
                         Key<NDIM> key1;
                         Key<LDIM> key2;
-                        key.break_apart(key1, key2);
+                        key.break_apart(key1,key2);
 
                         Future<pairT> result;
-                        // sock_it_to_me(key1, result.remote_ref(world));
+                        //                        sock_it_to_me(key1, result.remote_ref(world));
                         g->task(coeffs.owner(key1), &implT::sock_it_to_me, key1, result.remote_ref(world), TaskAttributes::hipri());
-                        woT::task(world.rank(), &implT:: template do_project_out<LDIM>, fcoeff, result, key1, key2, dim);
+                        woT::task(world.rank(),&implT:: template do_project_out<LDIM>,fcoeff,result,key1,key2,dim);
 
-                    } else if (dim == 1) {
+                    } else if (dim==1) {
                         Key<LDIM> key1;
                         Key<NDIM> key2;
-                        key.break_apart(key1, key2);
+                        key.break_apart(key1,key2);
 
                         Future<pairT> result;
-                        // sock_it_to_me(key2, result.remote_ref(world));
+                        //                        sock_it_to_me(key2, result.remote_ref(world));
                         g->task(coeffs.owner(key2), &implT::sock_it_to_me, key2, result.remote_ref(world), TaskAttributes::hipri());
-                        woT::task(world.rank(), &implT:: template do_project_out<LDIM>, fcoeff, result, key2, key1, dim);
+                        woT::task(world.rank(),&implT:: template do_project_out<LDIM>,fcoeff,result,key2,key1,dim);
+
                     } else {
-                        MADNESS_EXCEPTION("confused dim in project_out", 1);
+                        MADNESS_EXCEPTION("confused dim in project_out",1);
                     }
                 }
             }
             set_tree_state(redundant);
-            // this->compressed=false;
-            // this->nonstandard=false;
-            // this->redundant=true;
+//            this->compressed=false;
+//            this->nonstandard=false;
+//            this->redundant=true;
         }
 
 
@@ -6841,36 +6950,40 @@ template<size_t NDIM>
         /// @param[in]  dest    destination node for the result
         /// @param[in]  dim     which dimensions should be contracted: 0..LDIM-1 or LDIM..NDIM+LDIM-1
         template<size_t LDIM>
-        void do_project_out(const coeffT& fcoeff, const std::pair<keyT, coeffT> gpair, const keyT& gkey,
+        void do_project_out(const coeffT& fcoeff, const std::pair<keyT,coeffT> gpair, const keyT& gkey,
                             const Key<NDIM>& dest, const int dim) const {
-            const coeffT gcoeff = parent_to_child(gpair.second, gpair.first, gkey);
+
+            const coeffT gcoeff=parent_to_child(gpair.second,gpair.first,gkey);
 
             // fast return if possible
             if (fcoeff.has_no_data() or gcoeff.has_no_data()) return;
 
             // let's specialize for the time being on SVD tensors for f and full tensors of half dim for g
-            MADNESS_ASSERT(gcoeff.tensor_type() == TT_FULL);
-            MADNESS_ASSERT(fcoeff.tensor_type() == TT_2D);
+            MADNESS_ASSERT(gcoeff.tensor_type()==TT_FULL);
+            MADNESS_ASSERT(fcoeff.tensor_type()==TT_2D);
             const tensorT gtensor=gcoeff.full_tensor();
             tensorT result(cdata.vk);
 
-            const int otherdim = (dim + 1) % 2;
+            const int otherdim=(dim+1)%2;
             const int k=fcoeff.dim(0);
-            std::vector<Slice> s(fcoeff.config().dim_per_vector()+1, _);
+            std::vector<Slice> s(fcoeff.config().dim_per_vector()+1,_);
 
             // do the actual contraction
-            for (int r = 0; r < fcoeff.rank(); ++r) {
-                s[0] = Slice(r, r);
-                const tensorT contracted_tensor = fcoeff.config().ref_vector(dim)(s).reshape(k, k, k);
-                const tensorT other_tensor = fcoeff.config().ref_vector(otherdim)(s).reshape(k, k, k);
-                const double ovlp = gtensor.trace_conj(contracted_tensor);
-                const double fac = ovlp * fcoeff.config().weights(r);
-                result += fac * other_tensor;
+            for (int r=0; r<fcoeff.rank(); ++r) {
+                s[0]=Slice(r,r);
+                const tensorT contracted_tensor=fcoeff.config().ref_vector(dim)(s).reshape(k,k,k);
+                const tensorT other_tensor=fcoeff.config().ref_vector(otherdim)(s).reshape(k,k,k);
+                const double ovlp= gtensor.trace_conj(contracted_tensor);
+                const double fac=ovlp * fcoeff.config().weights(r);
+                result+=fac*other_tensor;
             }
 
             // accumulate the result
             coeffs.task(dest, &nodeT::accumulate2, result, coeffs, dest, TaskAttributes::hipri());
         }
+
+
+
 
         /// Returns the maximum local depth of the tree ... no communications.
         std::size_t max_local_depth() const;
@@ -6908,19 +7021,19 @@ template<size_t NDIM>
 
         /// Out-of-place scale by a constant
         template <typename Q, typename F>
-        void scale_oop(const Q q, const FunctionImpl<F, NDIM>& f, bool fence) {
-            typedef typename FunctionImpl<F, NDIM>::nodeT fnodeT;
-            typedef typename FunctionImpl<F, NDIM>::dcT fdcT;
+        void scale_oop(const Q q, const FunctionImpl<F,NDIM>& f, bool fence) {
+            typedef typename FunctionImpl<F,NDIM>::nodeT fnodeT;
+            typedef typename FunctionImpl<F,NDIM>::dcT fdcT;
             typename fdcT::const_iterator end = f.coeffs.end();
-            for (typename fdcT::const_iterator it = f.coeffs.begin(); it != end; ++it) {
+            for (typename fdcT::const_iterator it=f.coeffs.begin(); it!=end; ++it) {
                 const keyT& key = it->first;
                 const fnodeT& node = it->second;
 
                 if (node.has_coeff()) {
-                    coeffs.replace(key, nodeT(node.coeff()*q, node.has_children()));
+                    coeffs.replace(key,nodeT(node.coeff()*q,node.has_children()));
                 }
                 else {
-                    coeffs.replace(key, nodeT(coeffT(), node.has_children()));
+                    coeffs.replace(key,nodeT(coeffT(),node.has_children()));
                 }
             }
             if (fence)
@@ -6931,7 +7044,7 @@ template<size_t NDIM>
 
         /// \param[in] impl pointer to a FunctionImpl
         /// \return The hash.
-        inline friend hashT hash_value(const FunctionImpl<T, NDIM>* pimpl) {
+        inline friend hashT hash_value(const FunctionImpl<T,NDIM>* pimpl) {
             hashT seed = hash_value(pimpl->id().get_world_id());
             detail::combine_hash(seed, hash_value(pimpl->id().get_obj_id()));
             return seed;
@@ -6941,104 +7054,104 @@ template<size_t NDIM>
 
         /// \param[in] impl pointer to a FunctionImpl
         /// \return The hash.
-        inline friend hashT hash_value(const std::shared_ptr<FunctionImpl<T, NDIM>> impl) {
+        inline friend hashT hash_value(const std::shared_ptr<FunctionImpl<T,NDIM>> impl) {
             return hash_value(impl.get());
         }
     };
 
     namespace archive {
         template <class Archive, class T, std::size_t NDIM>
-        struct ArchiveLoadImpl<Archive, const FunctionImpl<T, NDIM>*> {
-            static void load(const Archive& ar, const FunctionImpl<T, NDIM>*& ptr) {
-                bool exists = false;
+        struct ArchiveLoadImpl<Archive,const FunctionImpl<T,NDIM>*> {
+            static void load(const Archive& ar, const FunctionImpl<T,NDIM>*& ptr) {
+                bool exists=false;
                 ar & exists;
                 if (exists) {
                     uniqueidT id;
                     ar & id;
                     World* world = World::world_from_id(id.get_world_id());
                     MADNESS_ASSERT(world);
-                    auto ptr_opt = world->ptr_from_id< WorldObject< FunctionImpl<T, NDIM>> >(id);
+                    auto ptr_opt = world->ptr_from_id< WorldObject< FunctionImpl<T,NDIM> > >(id);
                     if (!ptr_opt)
-                      MADNESS_EXCEPTION("FunctionImpl: remote operation attempting to use a locally uninitialized object", 0);
-                    ptr = static_cast< const FunctionImpl<T, NDIM>*>(*ptr_opt);
+                      MADNESS_EXCEPTION("FunctionImpl: remote operation attempting to use a locally uninitialized object",0);
+                    ptr = static_cast< const FunctionImpl<T,NDIM>*>(*ptr_opt);
                     if (!ptr)
-                        MADNESS_EXCEPTION("FunctionImpl: remote operation attempting to use an unregistered object", 0);
+                        MADNESS_EXCEPTION("FunctionImpl: remote operation attempting to use an unregistered object",0);
                 } else {
-                    ptr = nullptr;
+                    ptr=nullptr;
                 }
             }
         };
 
         template <class Archive, class T, std::size_t NDIM>
-        struct ArchiveStoreImpl<Archive, const FunctionImpl<T, NDIM>*> {
-            static void store(const Archive& ar, const FunctionImpl<T, NDIM>*const& ptr) {
-                bool exists = (ptr) ? true : false;
+        struct ArchiveStoreImpl<Archive,const FunctionImpl<T,NDIM>*> {
+            static void store(const Archive& ar, const FunctionImpl<T,NDIM>*const& ptr) {
+                bool exists=(ptr) ? true : false;
                 ar & exists;
                 if (exists) ar & ptr->id();
             }
         };
 
         template <class Archive, class T, std::size_t NDIM>
-        struct ArchiveLoadImpl<Archive, FunctionImpl<T, NDIM>*> {
-            static void load(const Archive& ar, FunctionImpl<T, NDIM>*& ptr) {
-                bool exists = false;
+        struct ArchiveLoadImpl<Archive, FunctionImpl<T,NDIM>*> {
+            static void load(const Archive& ar, FunctionImpl<T,NDIM>*& ptr) {
+                bool exists=false;
                 ar & exists;
                 if (exists) {
                     uniqueidT id;
                     ar & id;
                     World* world = World::world_from_id(id.get_world_id());
                     MADNESS_ASSERT(world);
-                    auto ptr_opt = world->ptr_from_id< WorldObject< FunctionImpl<T, NDIM>> >(id);
+                    auto ptr_opt = world->ptr_from_id< WorldObject< FunctionImpl<T,NDIM> > >(id);
                     if (!ptr_opt)
-                      MADNESS_EXCEPTION("FunctionImpl: remote operation attempting to use a locally uninitialized object", 0);
-                    ptr = static_cast< FunctionImpl<T, NDIM>*>(*ptr_opt);
+                      MADNESS_EXCEPTION("FunctionImpl: remote operation attempting to use a locally uninitialized object",0);
+                    ptr = static_cast< FunctionImpl<T,NDIM>*>(*ptr_opt);
                     if (!ptr)
-                      MADNESS_EXCEPTION("FunctionImpl: remote operation attempting to use an unregistered object", 0);
+                      MADNESS_EXCEPTION("FunctionImpl: remote operation attempting to use an unregistered object",0);
                 } else {
-                    ptr = nullptr;
+                    ptr=nullptr;
                 }
             }
         };
 
         template <class Archive, class T, std::size_t NDIM>
-        struct ArchiveStoreImpl<Archive, FunctionImpl<T, NDIM>*> {
-            static void store(const Archive& ar, FunctionImpl<T, NDIM>*const& ptr) {
-                bool exists = (ptr) ? true : false;
+        struct ArchiveStoreImpl<Archive, FunctionImpl<T,NDIM>*> {
+            static void store(const Archive& ar, FunctionImpl<T,NDIM>*const& ptr) {
+                bool exists=(ptr) ? true : false;
                 ar & exists;
                 if (exists) ar & ptr->id();
-                // ar & ptr->id();
+                //                ar & ptr->id();
             }
         };
 
         template <class Archive, class T, std::size_t NDIM>
-        struct ArchiveLoadImpl<Archive, std::shared_ptr<const FunctionImpl<T, NDIM>> > {
-            static void load(const Archive& ar, std::shared_ptr<const FunctionImpl<T, NDIM>>& ptr) {
-                const FunctionImpl<T, NDIM>* f = nullptr;
-                ArchiveLoadImpl<Archive, const FunctionImpl<T, NDIM>*>::load(ar, f);
-                ptr.reset(f, [] (const FunctionImpl<T, NDIM> *p_) -> void {});
+        struct ArchiveLoadImpl<Archive, std::shared_ptr<const FunctionImpl<T,NDIM> > > {
+            static void load(const Archive& ar, std::shared_ptr<const FunctionImpl<T,NDIM> >& ptr) {
+                const FunctionImpl<T,NDIM>* f = nullptr;
+                ArchiveLoadImpl<Archive, const FunctionImpl<T,NDIM>*>::load(ar, f);
+                ptr.reset(f, [] (const FunctionImpl<T,NDIM> *p_) -> void {});
             }
         };
 
         template <class Archive, class T, std::size_t NDIM>
-        struct ArchiveStoreImpl<Archive, std::shared_ptr<const FunctionImpl<T, NDIM>> > {
-            static void store(const Archive& ar, const std::shared_ptr<const FunctionImpl<T, NDIM>>& ptr) {
-                ArchiveStoreImpl<Archive, const FunctionImpl<T, NDIM>*>::store(ar, ptr.get());
+        struct ArchiveStoreImpl<Archive, std::shared_ptr<const FunctionImpl<T,NDIM> > > {
+            static void store(const Archive& ar, const std::shared_ptr<const FunctionImpl<T,NDIM> >& ptr) {
+                ArchiveStoreImpl<Archive, const FunctionImpl<T,NDIM>*>::store(ar, ptr.get());
             }
         };
 
         template <class Archive, class T, std::size_t NDIM>
-        struct ArchiveLoadImpl<Archive, std::shared_ptr<FunctionImpl<T, NDIM>> > {
-            static void load(const Archive& ar, std::shared_ptr<FunctionImpl<T, NDIM>>& ptr) {
-                FunctionImpl<T, NDIM>* f = nullptr;
-                ArchiveLoadImpl<Archive, FunctionImpl<T, NDIM>*>::load(ar, f);
-                ptr.reset(f, [] (FunctionImpl<T, NDIM> *p_) -> void {});
+        struct ArchiveLoadImpl<Archive, std::shared_ptr<FunctionImpl<T,NDIM> > > {
+            static void load(const Archive& ar, std::shared_ptr<FunctionImpl<T,NDIM> >& ptr) {
+                FunctionImpl<T,NDIM>* f = nullptr;
+                ArchiveLoadImpl<Archive, FunctionImpl<T,NDIM>*>::load(ar, f);
+                ptr.reset(f, [] (FunctionImpl<T,NDIM> *p_) -> void {});
             }
         };
 
         template <class Archive, class T, std::size_t NDIM>
-        struct ArchiveStoreImpl<Archive, std::shared_ptr<FunctionImpl<T, NDIM>> > {
-            static void store(const Archive& ar, const std::shared_ptr<FunctionImpl<T, NDIM>>& ptr) {
-                ArchiveStoreImpl<Archive, FunctionImpl<T, NDIM>*>::store(ar, ptr.get());
+        struct ArchiveStoreImpl<Archive, std::shared_ptr<FunctionImpl<T,NDIM> > > {
+            static void store(const Archive& ar, const std::shared_ptr<FunctionImpl<T,NDIM> >& ptr) {
+                ArchiveStoreImpl<Archive, FunctionImpl<T,NDIM>*>::store(ar, ptr.get());
             }
         };
     }

--- a/src/madness/mra/funcimpl.h
+++ b/src/madness/mra/funcimpl.h
@@ -1,7 +1,7 @@
 /*
   This file is part of MADNESS.
 
-  Copyright (C) 2007,2010 Oak Ridge National Laboratory
+  Copyright (C) 2007, 2010 Oak Ridge National Laboratory
 
   This program is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -130,15 +130,15 @@ namespace madness {
         // be no need to set as volatile since the container internally
         // stores the entire entry as volatile
 
-        coeffT _coeffs; ///< The coefficients, if any
-        double _norm_tree; ///< After norm_tree will contain norm of coefficients summed up tree
-        bool _has_children; ///< True if there are children
-        coeffT buffer; ///< The coefficients, if any
-        double dnorm=-1.0;	///< norm of the d coefficients, also defined if there are no d coefficients
-        double snorm=-1.0;	///< norm of the s coefficients
+        coeffT _coeffs;       ///< The coefficients, if any
+        double _norm_tree;    ///< After norm_tree will contain norm of coefficients summed up tree
+        bool _has_children;   ///< True if there are children
+        coeffT buffer;        ///< The coefficients, if any
+        double dnorm = -1.0;  ///< norm of the d coefficients, also defined if there are no d coefficients
+        double snorm = -1.0;  ///< norm of the s coefficients
 
     public:
-        typedef WorldContainer<Key<NDIM> , FunctionNode<T, NDIM> > dcT; ///< Type of container holding the nodes
+        typedef WorldContainer<Key<NDIM> , FunctionNode<T, NDIM>> dcT; ///< Type of container holding the nodes
         /// Default constructor makes node without coeff or children
         FunctionNode() :
             _coeffs(), _norm_tree(1e300), _has_children(false) {
@@ -161,7 +161,7 @@ namespace madness {
 
         explicit
         FunctionNode(const coeffT& coeff, double norm_tree, double snorm, double dnorm, bool has_children) :
-	  _coeffs(coeff), _norm_tree(norm_tree), _has_children(has_children), dnorm(dnorm), snorm(snorm) {
+	        _coeffs(coeff), _norm_tree(norm_tree), _has_children(has_children), dnorm(dnorm), snorm(snorm) {
         }
 
         FunctionNode(const FunctionNode<T, NDIM>& other) {
@@ -186,41 +186,35 @@ namespace madness {
         /// Choose to not overload copy and type conversion operators
         /// so there are no automatic type conversions.
         template<typename Q>
-        FunctionNode<Q, NDIM>
-        convert() const {
-            return FunctionNode<Q, NDIM> (madness::convert<Q,T>(coeff()), _norm_tree, snorm, dnorm, _has_children);
+        FunctionNode<Q, NDIM> convert() const {
+            return FunctionNode<Q, NDIM> (madness::convert<Q, T>(coeff()), _norm_tree, snorm, dnorm, _has_children);
         }
 
         /// Returns true if there are coefficients in this node
-        bool
-        has_coeff() const {
+        bool has_coeff() const {
             return _coeffs.has_data();
         }
 
 
         /// Returns true if this node has children
-        bool
-        has_children() const {
+        bool has_children() const {
             return _has_children;
         }
 
         /// Returns true if this does not have children
-        bool
-        is_leaf() const {
+        bool is_leaf() const {
             return !_has_children;
         }
 
         /// Returns true if this node is invalid (no coeffs and no children)
-        bool
-        is_invalid() const {
+        bool is_invalid() const {
             return !(has_coeff() || has_children());
         }
 
         /// Returns a non-const reference to the tensor containing the coeffs
 
         /// Returns an empty tensor if there are no coefficients.
-        coeffT&
-        coeff() {
+        coeffT& coeff() {
             MADNESS_ASSERT(_coeffs.ndim() == -1 || (_coeffs.dim(0) <= 2
                                                     * MAXK && _coeffs.dim(0) >= 0));
             return const_cast<coeffT&>(_coeffs);
@@ -229,8 +223,7 @@ namespace madness {
         /// Returns a const reference to the tensor containing the coeffs
 
         /// Returns an empty tensor if there are no coefficeints.
-        const coeffT&
-        coeff() const {
+        const coeffT& coeff() const {
             return const_cast<const coeffT&>(_coeffs);
         }
 
@@ -252,10 +245,10 @@ namespace madness {
         }
 
         /// Sets \c has_children attribute to true recurring up to ensure connected
-        void set_has_children_recursive(const typename FunctionNode<T,NDIM>::dcT& c,const Key<NDIM>& key) {
+        void set_has_children_recursive(const typename FunctionNode<T, NDIM>::dcT& c, const Key<NDIM>& key) {
             //madness::print("   set_chi_recu: ", key, *this);
             //PROFILE_MEMBER_FUNC(FunctionNode); // Too fine grain for routine profiling
-            if (!(has_children() || has_coeff() || key.level()==0)) {
+            if (!(has_children() || has_coeff() || key.level() == 0)) {
                 // If node already knows it has children or it has
                 // coefficients then it must already be connected to
                 // its parent.  If not, the node was probably just
@@ -265,9 +258,9 @@ namespace madness {
                 // Task on next line used to be TaskAttributes::hipri()) ... but deferring execution of this
                 // makes sense since it is not urgent and lazy connection will likely mean that less forwarding
                 // will happen since the upper level task will have already made the connection.
-                const_cast<dcT&>(c).task(parent, &FunctionNode<T,NDIM>::set_has_children_recursive, c, parent);
-                //const_cast<dcT&>(c).send(parent, &FunctionNode<T,NDIM>::set_has_children_recursive, c, parent);
-                //madness::print("   set_chi_recu: forwarding",key,parent);
+                const_cast<dcT&>(c).task(parent, &FunctionNode<T, NDIM>::set_has_children_recursive, c, parent);
+                //const_cast<dcT&>(c).send(parent, &FunctionNode<T, NDIM>::set_has_children_recursive, c, parent);
+                //madness::print("   set_chi_recu: forwarding", key, parent);
             }
             _has_children = true;
         }
@@ -280,16 +273,16 @@ namespace madness {
         /// Takes a \em shallow copy of the coeff --- same as \c this->coeff()=coeff
         void set_coeff(const coeffT& coeffs) {
             coeff() = coeffs;
-            if ((_coeffs.has_data()) and ((_coeffs.dim(0) < 0) || (_coeffs.dim(0)>2*MAXK))) {
+            if ((_coeffs.has_data()) and ((_coeffs.dim(0) < 0) || (_coeffs.dim(0) > 2 * MAXK))) {
                 print("set_coeff: may have a problem");
-                print("set_coeff: coeff.dim[0] =", coeffs.dim(0), ", 2* MAXK =", 2*MAXK);
+                print("set_coeff: coeff.dim[0] =", coeffs.dim(0), ", 2* MAXK =", 2 * MAXK);
             }
-            MADNESS_ASSERT(coeffs.dim(0)<=2*MAXK && coeffs.dim(0)>=0);
+            MADNESS_ASSERT(coeffs.dim(0) <= 2 * MAXK && coeffs.dim(0) >= 0);
         }
 
         /// Clears the coefficients (has_coeff() will subsequently return false)
         void clear_coeff() {
-            coeff()=coeffT();
+            coeff() = coeffT();
         }
 
         /// Scale the coefficients of this node
@@ -328,7 +321,7 @@ namespace madness {
             return snorm;
         }
 
-        void recompute_snorm_and_dnorm(const FunctionCommonData<T,NDIM>& cdata) {
+        void recompute_snorm_and_dnorm(const FunctionCommonData<T, NDIM>& cdata) {
             snorm = 0.0;
             dnorm = 0.0;
             if (coeff().size() == 0) { ;
@@ -358,64 +351,64 @@ namespace madness {
         /// This/other may not have coefficients.  Has_children will be
         /// true in the result if either this/other have children.
         template <typename Q, typename R>
-        void gaxpy_inplace(const T& alpha, const FunctionNode<Q,NDIM>& other, const R& beta) {
+        void gaxpy_inplace(const T& alpha, const FunctionNode<Q, NDIM>& other, const R& beta) {
             //PROFILE_MEMBER_FUNC(FuncNode);  // Too fine grain for routine profiling
             if (other.has_children())
                 _has_children = true;
             if (has_coeff()) {
                 if (other.has_coeff()) {
-                    coeff().gaxpy(alpha,other.coeff(),beta);
+                    coeff().gaxpy(alpha, other.coeff(), beta);
                 }
                 else {
                     coeff().scale(alpha);
                 }
             }
             else if (other.has_coeff()) {
-                coeff() = other.coeff()*beta; //? Is this the correct type conversion?
+                coeff() = other.coeff() * beta; //? Is this the correct type conversion?
             }
         }
 
         /// Accumulate inplace and if necessary connect node to parent
-        void accumulate2(const tensorT& t, const typename FunctionNode<T,NDIM>::dcT& c,
+        void accumulate2(const tensorT& t, const typename FunctionNode<T, NDIM>::dcT& c,
                            const Key<NDIM>& key) {
-	  // double cpu0=cpu_time();
+	        // double cpu0 = cpu_time();
             if (has_coeff()) {
             	MADNESS_ASSERT(coeff().is_full_tensor());
-                //            	if (coeff().type==TT_FULL) {
-                coeff() += coeffT(t,-1.0,TT_FULL);
-                //            	} else {
-                //            		tensorT cc=coeff().full_tensor_copy();;
-                //            		cc += t;
-                //            		coeff()=coeffT(cc,args);
-                //            	}
+                // if (coeff().type == TT_FULL) {
+                coeff() += coeffT(t, -1.0, TT_FULL);
+                // } else {
+                //     tensorT cc=coeff().full_tensor_copy();
+                //     cc += t;
+                //     coeff()=coeffT(cc, args);
+                // }
             }
             else {
                 // No coeff and no children means the node is newly
                 // created for this operation and therefore we must
                 // tell its parent that it exists.
-            	coeff() = coeffT(t,-1.0,TT_FULL);
-                //                coeff() = copy(t);
-                //                coeff() = coeffT(t,args);
+            	coeff() = coeffT(t, -1.0, TT_FULL);
+                // coeff() = copy(t);
+                // coeff() = coeffT(t, args);
                 if ((!_has_children) && key.level()> 0) {
                     Key<NDIM> parent = key.parent();
-		    if (c.is_local(parent))
-			const_cast<dcT&>(c).send(parent, &FunctionNode<T,NDIM>::set_has_children_recursive, c, parent);
-		    else
-		      const_cast<dcT&>(c).task(parent, &FunctionNode<T,NDIM>::set_has_children_recursive, c, parent);
+                    if (c.is_local(parent))
+                        const_cast<dcT&>(c).send(parent, &FunctionNode<T, NDIM>::set_has_children_recursive, c, parent);
+                    else
+                        const_cast<dcT&>(c).task(parent, &FunctionNode<T, NDIM>::set_has_children_recursive, c, parent);
                 }
             }
-            //double cpu1=cpu_time();
+            // double cpu1 = cpu_time();
         }
 
 
         /// Accumulate inplace and if necessary connect node to parent
-        void accumulate(const coeffT& t, const typename FunctionNode<T,NDIM>::dcT& c,
+        void accumulate(const coeffT& t, const typename FunctionNode<T, NDIM>::dcT& c,
                           const Key<NDIM>& key, const TensorArgs& args) {
             if (has_coeff()) {
-                coeff().add_SVD(t,args.thresh);
+                coeff().add_SVD(t, args.thresh);
                 if (buffer.rank()<coeff().rank()) {
                     if (buffer.has_data()) {
-                        buffer.add_SVD(coeff(),args.thresh);
+                        buffer.add_SVD(coeff(), args.thresh);
                     } else {
                         buffer=copy(coeff());
                     }
@@ -430,23 +423,23 @@ namespace madness {
                 if ((!_has_children) && key.level()> 0) {
                     Key<NDIM> parent = key.parent();
 		    if (c.is_local(parent)) 
-		      const_cast<dcT&>(c).send(parent, &FunctionNode<T,NDIM>::set_has_children_recursive, c, parent);
+		      const_cast<dcT&>(c).send(parent, &FunctionNode<T, NDIM>::set_has_children_recursive, c, parent);
 		    else
-		      const_cast<dcT&>(c).task(parent, &FunctionNode<T,NDIM>::set_has_children_recursive, c, parent);
+		      const_cast<dcT&>(c).task(parent, &FunctionNode<T, NDIM>::set_has_children_recursive, c, parent);
                 }
             }
         }
 
         void consolidate_buffer(const TensorArgs& args) {
             if ((coeff().has_data()) and (buffer.has_data())) {
-                coeff().add_SVD(buffer,args.thresh);
+                coeff().add_SVD(buffer, args.thresh);
             } else if (buffer.has_data()) {
-                coeff()=buffer;
+                coeff() = buffer;
             }
-            buffer=coeffT();
+            buffer = coeffT();
         }
 
-        T trace_conj(const FunctionNode<T,NDIM>& rhs) const {
+        T trace_conj(const FunctionNode<T, NDIM>& rhs) const {
             return this->_coeffs.trace_conj((rhs._coeffs));
         }
 
@@ -455,30 +448,30 @@ namespace madness {
             ar & coeff() & _has_children & _norm_tree & dnorm & snorm;
         }
 
-        /// like operator<<(ostream&, const FunctionNode<T,NDIM>&) but
+        /// like operator<<(ostream&, const FunctionNode<T, NDIM>&) but
         /// produces a sequence JSON-formatted key-value pairs
         /// @warning enclose the output in curly braces to make
         /// a valid JSON object
         void print_json(std::ostream& s) const {
             s << "\"has_coeff\":" << this->has_coeff()
-              << ",\"has_children\":" << this->has_children() << ",\"norm\":";
+              << ", \"has_children\":" << this->has_children() << ", \"norm\":";
             double norm = this->has_coeff() ? this->coeff().normf() : 0.0;
             if (norm < 1e-12)
                 norm = 0.0;
             double nt = this->get_norm_tree();
             if (nt == 1e300)
                 nt = 0.0;
-            s << norm << ",\"norm_tree\":" << nt << ",\"snorm\":"
-              << this->get_snorm() << ",\"dnorm\":" << this->get_dnorm()
-              << ",\"rank\":" << this->coeff().rank();
+            s << norm << ", \"norm_tree\":" << nt << ", \"snorm\":"
+              << this->get_snorm() << ", \"dnorm\":" << this->get_dnorm()
+              << ", \"rank\":" << this->coeff().rank();
             if (this->coeff().is_assigned())
-                s << ",\"dim\":" << this->coeff().dim(0);
+                s << ", \"dim\":" << this->coeff().dim(0);
         }
 
     };
 
     template <typename T, std::size_t NDIM>
-    std::ostream& operator<<(std::ostream& s, const FunctionNode<T,NDIM>& node) {
+    std::ostream& operator<<(std::ostream& s, const FunctionNode<T, NDIM>& node) {
         s << "(has_coeff=" << node.has_coeff() << ", has_children=" << node.has_children() << ", norm=";
         double norm = node.has_coeff() ? node.coeff().normf() : 0.0;
         if (norm < 1e-12)
@@ -495,20 +488,20 @@ namespace madness {
     template<typename T, size_t NDIM>
     struct hartree_leaf_op {
 
-        typedef FunctionImpl<T,NDIM> implT;
-        const FunctionImpl<T,NDIM>* f;
+        typedef FunctionImpl<T, NDIM> implT;
+        const FunctionImpl<T, NDIM>* f;
         long k;
-        bool do_error_leaf_op() const {return false;}
+        bool do_error_leaf_op() const { return false; }
 
         hartree_leaf_op() {}
         hartree_leaf_op(const implT* f, const long& k) : f(f), k(k) {}
 
         /// no pre-determination
-        bool operator()(const Key<NDIM>& key) const {return false;}
+        bool operator()(const Key<NDIM>& key) const { return false; }
 
         /// no post-determination
         bool operator()(const Key<NDIM>& key, const GenTensor<T>& coeff) const {
-            MADNESS_EXCEPTION("no post-determination in hartree_leaf_op",1);
+            MADNESS_EXCEPTION("no post-determination in hartree_leaf_op", 1);
             return true;
         }
 
@@ -519,36 +512,37 @@ namespace madness {
         /// @param[in]  gcoeff coefficients of g of its appropriate key in NS form
         bool operator()(const Key<NDIM>& key, const Tensor<T>& fcoeff, const Tensor<T>& gcoeff) const {
 
-            if (key.level()<2) return false;
-            Slice s = Slice(0,k-1);
-            std::vector<Slice> s0(NDIM/2,s);
+            if (key.level() < 2) return false;
+            Slice s = Slice(0, k - 1);
+            std::vector<Slice> s0(NDIM / 2, s);
 
-            const double tol=f->get_thresh();
-            const double thresh=f->truncate_tol(tol, key)*0.3;      // custom factor to "ensure" accuracy
+            const double tol = f->get_thresh();
+            const double thresh = f->truncate_tol(tol, key) * 0.3;      // custom factor to "ensure" accuracy
             // include the wavelets in the norm, makes it much more accurate
-            const double fnorm=fcoeff.normf();
-            const double gnorm=gcoeff.normf();
+            const double fnorm = fcoeff.normf();
+            const double gnorm = gcoeff.normf();
 
             // if the final norm is small, perform the hartree product and return
-            const double norm=fnorm*gnorm;  // computing the outer product
+            const double norm = fnorm * gnorm;  // computing the outer product
             if (norm < thresh) return true;
 
             // norm of the scaling function coefficients
-            const double sfnorm=fcoeff(s0).normf();
-            const double sgnorm=gcoeff(s0).normf();
+            const double sfnorm = fcoeff(s0).normf();
+            const double sgnorm = gcoeff(s0).normf();
 
             // get the error of both functions and of the pair function;
             // need the abs for numerics: sfnorm might be equal fnorm.
-            const double ferror=sqrt(std::abs(fnorm*fnorm-sfnorm*sfnorm));
-            const double gerror=sqrt(std::abs(gnorm*gnorm-sgnorm*sgnorm));
+            const double ferror = sqrt(std::abs(fnorm * fnorm - sfnorm * sfnorm));
+            const double gerror = sqrt(std::abs(gnorm * gnorm - sgnorm * sgnorm));
 
             // if the expected error is small, perform the hartree product and return
-            const double error=fnorm*gerror + ferror*gnorm + ferror*gerror;
-            //            const double error=sqrt(fnorm*fnorm*gnorm*gnorm - sfnorm*sfnorm*sgnorm*sgnorm);
+            const double error = fnorm * gerror + ferror * gnorm + ferror * gerror;
+            // const double error = sqrt(fnorm * fnorm * gnorm * gnorm - sfnorm * sfnorm * sgnorm * sgnorm);
 
             if (error < thresh) return true;
             return false;
         }
+
         template <typename Archive> void serialize (Archive& ar) {
             ar & f & k;
         }
@@ -558,45 +552,44 @@ namespace madness {
     /// coefficients will be small
     template<typename T, size_t NDIM, typename opT>
     struct op_leaf_op {
-        typedef FunctionImpl<T,NDIM> implT;
+        typedef FunctionImpl<T, NDIM> implT;
 
         const opT* op;    ///< the convolution operator
         const implT* f;   ///< the source or result function, needed for truncate_tol
-        bool do_error_leaf_op() const {return true;}
+        bool do_error_leaf_op() const { return true; }
 
         op_leaf_op() {}
         op_leaf_op(const opT* op, const implT* f) : op(op), f(f) {}
 
         /// pre-determination: we can't know if this will be a leaf node before we got the final coeffs
-        bool operator()(const Key<NDIM>& key) const {return true;}
+        bool operator()(const Key<NDIM>& key) const { return true; }
 
         /// post-determination: return true if operator and coefficient norms are small
         bool operator()(const Key<NDIM>& key, const GenTensor<T>& coeff) const {
-            if (key.level()<2) return false;
-            const double cnorm=coeff.normf();
-            return this->operator()(key,cnorm);
+            if (key.level() < 2) return false;
+            const double cnorm = coeff.normf();
+            return this->operator()(key, cnorm);
         }
 
         /// post-determination: return true if operator and coefficient norms are small
         bool operator()(const Key<NDIM>& key, const double& cnorm) const {
-            if (key.level()<2) return false;
+            if (key.level() < 2) return false;
 
             typedef Key<opT::opdim> opkeyT;
-            const opkeyT source=op->get_source_key(key);
+            const opkeyT source = op->get_source_key(key);
 
-            const double thresh=f->truncate_tol(f->get_thresh(),key);
+            const double thresh = f->truncate_tol(f->get_thresh(), key);
             const std::vector<opkeyT>& disp = op->get_disp(key.level());
             const opkeyT& d = *disp.begin();         // use the zero-displacement for screening
             const double opnorm = op->norm(key.level(), d, source);
-            const double norm=opnorm*cnorm;
-            return norm<thresh;
+            const double norm = opnorm * cnorm;
+            return norm < thresh;
 
         }
 
         template <typename Archive> void serialize (Archive& ar) {
             ar & op & f;
         }
-
     };
 
 
@@ -605,24 +598,24 @@ namespace madness {
     template<typename T, size_t NDIM, size_t LDIM, typename opT>
     struct hartree_convolute_leaf_op {
 
-        typedef FunctionImpl<T,NDIM> implT;
-        typedef FunctionImpl<T,LDIM> implL;
+        typedef FunctionImpl<T, NDIM> implT;
+        typedef FunctionImpl<T, LDIM> implL;
 
-        const FunctionImpl<T,NDIM>* f;
+        const FunctionImpl<T, NDIM>* f;
         const implL* g;     // for use of its cdata only
         const opT* op;
-        bool do_error_leaf_op() const {return false;}
+        bool do_error_leaf_op() const { return false; }
 
         hartree_convolute_leaf_op() {}
         hartree_convolute_leaf_op(const implT* f, const implL* g, const opT* op)
             : f(f), g(g), op(op) {}
 
         /// no pre-determination
-        bool operator()(const Key<NDIM>& key) const {return true;}
+        bool operator()(const Key<NDIM>& key) const { return true; }
 
         /// no post-determination
         bool operator()(const Key<NDIM>& key, const GenTensor<T>& coeff) const {
-            MADNESS_EXCEPTION("no post-determination in hartree_convolute_leaf_op",1);
+            MADNESS_EXCEPTION("no post-determination in hartree_convolute_leaf_op", 1);
             return true;
         }
 
@@ -634,39 +627,40 @@ namespace madness {
         bool operator()(const Key<NDIM>& key, const Tensor<T>& fcoeff, const Tensor<T>& gcoeff) const {
             //        bool operator()(const Key<NDIM>& key, const GenTensor<T>& coeff) const {
 
-            if (key.level()<2) return false;
+            if (key.level() < 2) return false;
 
-            const double tol=f->get_thresh();
-            const double thresh=f->truncate_tol(tol, key);
+            const double tol = f->get_thresh();
+            const double thresh = f->truncate_tol(tol, key);
             // include the wavelets in the norm, makes it much more accurate
-            const double fnorm=fcoeff.normf();
-            const double gnorm=gcoeff.normf();
+            const double fnorm = fcoeff.normf();
+            const double gnorm = gcoeff.normf();
 
             // norm of the scaling function coefficients
-            const double sfnorm=fcoeff(g->get_cdata().s0).normf();
-            const double sgnorm=gcoeff(g->get_cdata().s0).normf();
+            const double sfnorm = fcoeff(g->get_cdata().s0).normf();
+            const double sgnorm = gcoeff(g->get_cdata().s0).normf();
 
             // if the final norm is small, perform the hartree product and return
-            const double norm=fnorm*gnorm;  // computing the outer product
+            const double norm = fnorm * gnorm;  // computing the outer product
             if (norm < thresh) return true;
 
             // get the error of both functions and of the pair function
-            const double ferror=sqrt(fnorm*fnorm-sfnorm*sfnorm);
-            const double gerror=sqrt(gnorm*gnorm-sgnorm*sgnorm);
+            const double ferror = sqrt(fnorm * fnorm - sfnorm * sfnorm);
+            const double gerror = sqrt(gnorm * gnorm - sgnorm * sgnorm);
 
             // if the expected error is small, perform the hartree product and return
-            const double error=fnorm*gerror + ferror*gnorm + ferror*gerror;
+            const double error = fnorm * gerror + ferror * gnorm + ferror * gerror;
             if (error < thresh) return true;
 
             // now check if the norm of this and the norm of the operator are significant
-            const std::vector<Key<NDIM> >& disp = op->get_disp(key.level());
-            const Key<NDIM>& d = *disp.begin();         // use the zero-displacement for screening
+            const std::vector<Key<NDIM>>& disp = op->get_disp(key.level());
+            const Key<NDIM>& d = *disp.begin();  // use the zero-displacement for screening
             const double opnorm = op->norm(key.level(), d, key);
-            const double final_norm=opnorm*sfnorm*sgnorm;
+            const double final_norm = opnorm * sfnorm * sgnorm;
             if (final_norm < thresh) return true;
 
             return false;
         }
+
         template <typename Archive> void serialize (Archive& ar) {
             ar & f & op;
         }
@@ -676,20 +670,19 @@ namespace madness {
     struct noop {
     	void operator()(const Key<NDIM>& key, const GenTensor<T>& coeff, const bool& is_leaf) const {}
         bool operator()(const Key<NDIM>& key, const GenTensor<T>& fcoeff, const GenTensor<T>& gcoeff) const {
-            MADNESS_EXCEPTION("in noop::operator()",1);
+            MADNESS_EXCEPTION("in noop::operator()", 1);
             return true;
         }
         template <typename Archive> void serialize (Archive& ar) {}
-
     };
 
     /// insert/replaces the coefficients into the function
     template<typename T, std::size_t NDIM>
     struct insert_op {
-    	typedef FunctionImpl<T,NDIM> implT;
+    	typedef FunctionImpl<T, NDIM> implT;
     	typedef Key<NDIM> keyT;
     	typedef GenTensor<T> coeffT;
-    	typedef FunctionNode<T,NDIM> nodeT;
+    	typedef FunctionNode<T, NDIM> nodeT;
 
     	implT* impl;
     	insert_op() : impl() {}
@@ -697,8 +690,9 @@ namespace madness {
     	insert_op(const insert_op& other) : impl(other.impl) {}
     	void operator()(const keyT& key, const coeffT& coeff, const bool& is_leaf) const {
     		MADNESS_ASSERT(impl->get_coeffs().is_local(key));
-            impl->get_coeffs().replace(key,nodeT(coeff,not is_leaf));
+            impl->get_coeffs().replace(key, nodeT(coeff, not is_leaf));
     	}
+
         template <typename Archive> void serialize (Archive& ar) {
             ar & impl;
         }
@@ -711,20 +705,20 @@ namespace madness {
     template<typename T, std::size_t NDIM>
     struct accumulate_op {
         typedef GenTensor<T> coeffT;
-        typedef FunctionNode<T,NDIM> nodeT;
+        typedef FunctionNode<T, NDIM> nodeT;
 
-        FunctionImpl<T,NDIM>* impl;
+        FunctionImpl<T, NDIM>* impl;
         accumulate_op() = default;
-        accumulate_op(FunctionImpl<T,NDIM>* f) : impl(f) {}
+        accumulate_op(FunctionImpl<T, NDIM>* f) : impl(f) {}
         accumulate_op(const accumulate_op& other) = default;
         void operator()(const Key<NDIM>& key, const coeffT& coeff, const bool& is_leaf) const {
             if (coeff.has_data())
                 impl->get_coeffs().task(key, &nodeT::accumulate, coeff, impl->get_coeffs(), key, impl->get_tensor_args());
         }
+
         template <typename Archive> void serialize (Archive& ar) {
             ar & impl;
         }
-
     };
 
 
@@ -732,10 +726,10 @@ template<size_t NDIM>
     struct true_op {
 
     	template<typename T>
-        bool operator()(const Key<NDIM>& key, const T& t) const {return true;}
+        bool operator()(const Key<NDIM>& key, const T& t) const { return true; }
 
     	template<typename T, typename R>
-        bool operator()(const Key<NDIM>& key, const T& t, const R& r) const {return true;}
+        bool operator()(const Key<NDIM>& key, const T& t, const R& r) const { return true; }
         template <typename Archive> void serialize (Archive& ar) {}
 
     };
@@ -746,12 +740,13 @@ template<size_t NDIM>
         typedef GenTensor<T> coeffT;
         coeffT _coeffs;
         bool _has_children;
-        double dnorm=-1.0;
+        double dnorm = -1.0;
+
         ShallowNode() : _coeffs(), _has_children(false) {}
-        ShallowNode(const FunctionNode<T,NDIM>& node)
+        ShallowNode(const FunctionNode<T, NDIM>& node)
             : _coeffs(node.coeff()), _has_children(node.has_children()),
 			  dnorm(node.get_dnorm()) {}
-        ShallowNode(const ShallowNode<T,NDIM>& node)
+        ShallowNode(const ShallowNode<T, NDIM>& node)
             : _coeffs(node.coeff()), _has_children(node._has_children),
 			  dnorm(node.dnorm) {}
 
@@ -786,10 +781,10 @@ template<size_t NDIM>
     template<typename T, size_t NDIM>
     class CoeffTracker {
 
-    	typedef FunctionImpl<T,NDIM> implT;
+    	typedef FunctionImpl<T, NDIM> implT;
     	typedef Key<NDIM> keyT;
     	typedef GenTensor<T> coeffT;
-        typedef std::pair<Key<NDIM>,ShallowNode<T,NDIM> > datumT;
+        typedef std::pair<Key<NDIM>, ShallowNode<T, NDIM>> datumT;
         enum LeafStatus {no, yes, unknown};
 
         /// the funcimpl that has the coeffs
@@ -801,7 +796,7 @@ template<size_t NDIM>
     	/// the coefficients belonging to key
     	coeffT coeff_;
     	/// norm of d coefficients corresponding to key
-    	double dnorm_=-1.0;
+    	double dnorm_ = -1.0;
 
     public:
 
@@ -810,15 +805,15 @@ template<size_t NDIM>
 
     	/// the initial ctor making the root key
     	CoeffTracker(const implT* impl) : impl(impl), key_(), is_leaf_(no) {
-            if (impl) key_=impl->get_cdata().key0;
+            if (impl) key_ = impl->get_cdata().key0;
     	}
 
-    	/// ctor with a pair<keyT,nodeT>
+    	/// ctor with a pair<keyT, nodeT>
     	explicit CoeffTracker(const CoeffTracker& other, const datumT& datum)
     		: impl(other.impl), key_(other.key_), coeff_(datum.second.coeff()),
     			dnorm_(datum.second.dnorm) {
-            if (datum.second.is_leaf()) is_leaf_=yes;
-            else is_leaf_=no;
+            if (datum.second.is_leaf()) is_leaf_ = yes;
+            else is_leaf_ = no;
     	}
 
     	/// copy ctor
@@ -826,13 +821,13 @@ template<size_t NDIM>
     			is_leaf_(other.is_leaf_), coeff_(other.coeff_), dnorm_(other.dnorm_) {};
 
     	/// const reference to impl
-    	const implT* get_impl() const {return impl;}
+    	const implT* get_impl() const { return impl; }
 
     	/// const reference to the coeffs
-    	const coeffT& coeff() const {return coeff_;}
+    	const coeffT& coeff() const { return coeff_; }
 
     	/// const reference to the key
-    	const keyT& key() const {return key_;}
+    	const keyT& key() const { return key_; }
 
     	/// return the coefficients belonging to the passed-in key
 
@@ -844,13 +839,13 @@ template<size_t NDIM>
             MADNESS_ASSERT(impl);
             if (impl->is_compressed() or impl->is_nonstandard() or
             		impl->is_nonstandard_with_leaves())
-                return impl->parent_to_child_NS(key,key_,coeff_);
-            return impl->parent_to_child(coeff_,key_,key);
+                return impl->parent_to_child_NS(key, key_, coeff_);
+            return impl->parent_to_child(coeff_, key_, key);
     	}
 
     	/// return the s and dnorm belonging to the passed-in key
     	double dnorm(const keyT& key) const {
-    		if (key==key_) return dnorm_;
+    		if (key == key_) return dnorm_;
     		MADNESS_ASSERT(key.is_child_of(key_));
     		return 0.0;
     	}
@@ -865,16 +860,16 @@ template<size_t NDIM>
             if ((not impl) or impl->is_on_demand()) return CoeffTracker(*this);
 
             // can't make a child without knowing if this is a leaf -- activate first
-            MADNESS_ASSERT((is_leaf_==yes) or (is_leaf_==no));
+            MADNESS_ASSERT((is_leaf_ == yes) or (is_leaf_ == no));
 
             CoeffTracker result;
             if (impl) {
                 result.impl=impl;
-                if (is_leaf_==yes) result.key_=key_;
-                if (is_leaf_==no) {
+                if (is_leaf_ == yes) result.key_=key_;
+                if (is_leaf_ == no) {
                     result.key_=child;
                     // check if child is direct descendent of this, but root node is special case
-                    if (child.level()>0) MADNESS_ASSERT(result.key().level()==key().level()+1);
+                    if (child.level() > 0) MADNESS_ASSERT(result.key().level() == key().level()+1);
                 }
                 result.is_leaf_=unknown;
             }
@@ -891,33 +886,33 @@ template<size_t NDIM>
             if (not impl) return Future<CoeffTracker>(CoeffTracker());
             if (impl->is_on_demand()) return Future<CoeffTracker>(CoeffTracker(impl));
 
-            // this will return a <keyT,nodeT> from a remote node
-            ProcessID p=impl->get_coeffs().owner(key());
-            Future<datumT> datum1=impl->task(p, &implT::find_datum,key_,TaskAttributes::hipri());
+            // this will return a <keyT, nodeT> from a remote node
+            ProcessID p = impl->get_coeffs().owner(key());
+            Future<datumT> datum1 = impl->task(p, &implT::find_datum, key_, TaskAttributes::hipri());
 
             // construct a new CoeffTracker locally
             return impl->world.taskq.add(*const_cast<CoeffTracker*> (this),
-                                         &CoeffTracker::forward_ctor,*this,datum1);
+                                         &CoeffTracker::forward_ctor, *this, datum1);
     	}
 
     private:
     	/// taskq-compatible forwarding to the ctor
     	CoeffTracker forward_ctor(const CoeffTracker& other, const datumT& datum) const {
-            return CoeffTracker(other,datum);
+            return CoeffTracker(other, datum);
     	}
 
     public:
     	/// serialization
         template <typename Archive> void serialize(const Archive& ar) {
-            int il=int(is_leaf_);
+            int il = int(is_leaf_);
             ar & impl & key_ & il & coeff_ & dnorm_;
-            is_leaf_=LeafStatus(il);
+            is_leaf_ = LeafStatus(il);
         }
     };
 
     template<typename T, std::size_t NDIM>
     std::ostream&
-    operator<<(std::ostream& s, const CoeffTracker<T,NDIM>& ct) {
+    operator<<(std::ostream& s, const CoeffTracker<T, NDIM>& ct) {
         s << ct.key() << ct.is_leaf() << " " << ct.get_impl();
         return s;
     }
@@ -938,21 +933,21 @@ template<size_t NDIM>
     /// abused ... NOTHING except FunctionImpl methods should mess with FunctionImplData.
     /// The LB stuff might have to be an exception.
     template <typename T, std::size_t NDIM>
-    class FunctionImpl : public WorldObject< FunctionImpl<T,NDIM> > {
+    class FunctionImpl : public WorldObject< FunctionImpl<T, NDIM>> {
     private:
-        typedef WorldObject< FunctionImpl<T,NDIM> > woT; ///< Base class world object type
+        typedef WorldObject< FunctionImpl<T, NDIM>> woT; ///< Base class world object type
     public:
         typedef T typeT;
-        typedef FunctionImpl<T,NDIM> implT; ///< Type of this class (implementation)
-        typedef std::shared_ptr< FunctionImpl<T,NDIM> > pimplT; ///< pointer to this class
+        typedef FunctionImpl<T, NDIM> implT; ///< Type of this class (implementation)
+        typedef std::shared_ptr< FunctionImpl<T, NDIM>> pimplT; ///< pointer to this class
         typedef Tensor<T> tensorT; ///< Type of tensor for anything but to hold coeffs
-        typedef Vector<Translation,NDIM> tranT; ///< Type of array holding translation
+        typedef Vector<Translation, NDIM> tranT; ///< Type of array holding translation
         typedef Key<NDIM> keyT; ///< Type of key
-        typedef FunctionNode<T,NDIM> nodeT; ///< Type of node
+        typedef FunctionNode<T, NDIM> nodeT; ///< Type of node
         typedef GenTensor<T> coeffT; ///< Type of tensor used to hold coeffs
-        typedef WorldContainer<keyT,nodeT> dcT; ///< Type of container holding the coefficients
-        typedef std::pair<const keyT,nodeT> datumT; ///< Type of entry in container
-        typedef Vector<double,NDIM> coordT; ///< Type of vector holding coordinates
+        typedef WorldContainer<keyT, nodeT> dcT; ///< Type of container holding the coefficients
+        typedef std::pair<const keyT, nodeT> datumT; ///< Type of entry in container
+        typedef Vector<double, NDIM> coordT; ///< Type of vector holding coordinates
 
         //template <typename Q, int D> friend class Function;
         template <typename Q, std::size_t D> friend class FunctionImpl;
@@ -960,31 +955,31 @@ template<size_t NDIM>
         World& world;
 
         /// getter
-        int get_initial_level()const{return initial_level;}
-        int get_special_level()const{return special_level;}
-        const std::vector<Vector<double,NDIM> >& get_special_points()const{return special_points;}
+        int get_initial_level() const { return initial_level; }
+        int get_special_level() const { return special_level; }
+        const std::vector<Vector<double, NDIM>>& get_special_points() const { return special_points; }
 
     private:
         int k; ///< Wavelet order
         double thresh; ///< Screening threshold
         int initial_level; ///< Initial level for refinement
         int special_level; ///< Minimium level for refinement on special points
-        std::vector<Vector<double,NDIM> > special_points; ///< special points for further refinement (needed for composite functions or multiplication)
+        std::vector<Vector<double, NDIM>> special_points; ///< special points for further refinement (needed for composite functions or multiplication)
         int max_refine_level; ///< Do not refine below this level
         int truncate_mode; ///< 0=default=(|d|<thresh), 1=(|d|<thresh/2^n), 1=(|d|<thresh/4^n);
         bool autorefine; ///< If true, autorefine where appropriate
         bool truncate_on_project; ///< If true projection inserts at level n-1 not n
         TensorArgs targs; ///< type of tensor to be used in the FunctionNodes
 
-        const FunctionCommonData<T,NDIM>& cdata;
+        const FunctionCommonData<T, NDIM>& cdata;
 
-        std::shared_ptr< FunctionFunctorInterface<T,NDIM> > functor;
+        std::shared_ptr< FunctionFunctorInterface<T, NDIM>> functor;
         TreeState tree_state;
 
         dcT coeffs; ///< The coefficients
 
         // Disable the default copy constructor
-        FunctionImpl(const FunctionImpl<T,NDIM>& p);
+        FunctionImpl(const FunctionImpl<T, NDIM>& p);
 
     public:
         Timer timer_accumulate;
@@ -997,40 +992,40 @@ template<size_t NDIM>
         AtomicInt large;
 
         /// Initialize function impl from data in factory
-        FunctionImpl(const FunctionFactory<T,NDIM>& factory)
-            : WorldObject<implT>(factory._world)
-            , world(factory._world)
-            , k(factory._k)
-            , thresh(factory._thresh)
-            , initial_level(factory._initial_level)
-	    , special_level(factory._special_level)
-	    , special_points(factory._special_points)
-            , max_refine_level(factory._max_refine_level)
-            , truncate_mode(factory._truncate_mode)
-            , autorefine(factory._autorefine)
-            , truncate_on_project(factory._truncate_on_project)
-//		  , nonstandard(false)
-            , targs(factory._thresh,FunctionDefaults<NDIM>::get_tensor_type())
-            , cdata(FunctionCommonData<T,NDIM>::get(k))
-            , functor(factory.get_functor())
-//		  , on_demand(factory._is_on_demand)
-//		  , compressed(factory._compressed)
-//		  , redundant(false)
-		  , tree_state(factory._tree_state)
-            , coeffs(world,factory._pmap,false)
-            //, bc(factory._bc)
+        FunctionImpl(const FunctionFactory<T, NDIM>& factory)
+            : WorldObject<implT>(factory._world),
+              world(factory._world),
+              k(factory._k),
+              thresh(factory._thresh),
+              initial_level(factory._initial_level),
+	          special_level(factory._special_level),
+	          special_points(factory._special_points),
+              max_refine_level(factory._max_refine_level),
+              truncate_mode(factory._truncate_mode),
+              autorefine(factory._autorefine),
+              truncate_on_project(factory._truncate_on_project),
+              // nonstandard(false),
+              targs(factory._thresh, FunctionDefaults<NDIM>::get_tensor_type()),
+              cdata(FunctionCommonData<T, NDIM>::get(k)),
+              functor(factory.get_functor()),
+              // on_demand(factory._is_on_demand),
+              // compressed(factory._compressed),
+              // redundant(false),
+		      tree_state(factory._tree_state),
+              coeffs(world, factory._pmap, false)
+              // , bc(factory._bc)
         {
             // PROFILE_MEMBER_FUNC(FunctionImpl); // No need to profile this
             // !!! Ensure that all local state is correctly formed
             // before invoking process_pending for the coeffs and
             // for this.  Otherwise, there is a race condition.
-            MADNESS_ASSERT(k>0 && k<=MAXK);
+            MADNESS_ASSERT(k > 0 && k <= MAXK);
 
             bool empty = (factory._empty or is_on_demand());
             bool do_refine = factory._refine;
 
             if (do_refine)
-                initial_level = std::max(0,initial_level - 1);
+                initial_level = std::max(0, initial_level - 1);
 
             if (empty) { // Do not set any coefficients at all
                 // additional functors are only evaluated on-demand
@@ -1041,9 +1036,9 @@ template<size_t NDIM>
                 if (!functor_special_points.empty()) special_points.insert(special_points.end(), functor_special_points.begin(), functor_special_points.end());
 
                 typename dcT::const_iterator end = coeffs.end();
-                for (typename dcT::const_iterator it=coeffs.begin(); it!=end; ++it) {
+                for (typename dcT::const_iterator it = coeffs.begin(); it != end; ++it) {
                     if (it->second.is_leaf())
-                        woT::task(coeffs.owner(it->first), &implT::project_refine_op, it->first, do_refine,
+                        woT::task(coeffs.owner(it->first), &implT::project_refine_op, it->first, do_refine, 
                                   special_points);
                 }
             }
@@ -1064,30 +1059,30 @@ template<size_t NDIM>
         /// By default takes pmap from other but can also specify a different pmap.
         /// Does \em not copy the coefficients ... creates an empty container.
         template <typename Q>
-        FunctionImpl(const FunctionImpl<Q,NDIM>& other,
-                     const std::shared_ptr< WorldDCPmapInterface< Key<NDIM> > >& pmap,
+        FunctionImpl(const FunctionImpl<Q, NDIM>& other, 
+                     const std::shared_ptr<WorldDCPmapInterface<Key<NDIM>>>& pmap, 
                      bool dozero)
-                : WorldObject<implT>(other.world)
-                , world(other.world)
-                , k(other.k)
-                , thresh(other.thresh)
-                , initial_level(other.initial_level)
-                , special_level(other.special_level)
-                , special_points(other.special_points)
-                , max_refine_level(other.max_refine_level)
-                , truncate_mode(other.truncate_mode)
-                , autorefine(other.autorefine)
-                , truncate_on_project(other.truncate_on_project)
-                , targs(other.targs)
-                , cdata(FunctionCommonData<T,NDIM>::get(k))
-                , functor()
-                , tree_state(other.tree_state)
-                , coeffs(world, pmap ? pmap : other.coeffs.get_pmap())
+                : WorldObject<implT>(other.world),
+                  world(other.world),
+                  k(other.k),
+                  thresh(other.thresh),
+                  initial_level(other.initial_level),
+                  special_level(other.special_level),
+                  special_points(other.special_points),
+                  max_refine_level(other.max_refine_level),
+                  truncate_mode(other.truncate_mode),
+                  autorefine(other.autorefine),
+                  truncate_on_project(other.truncate_on_project),
+                  targs(other.targs),
+                  cdata(FunctionCommonData<T, NDIM>::get(k)),
+                  functor(),
+                  tree_state(other.tree_state),
+                  coeffs(world, pmap ? pmap : other.coeffs.get_pmap())
         {
             if (dozero) {
                 initial_level = 1;
                 insert_zero_down_to_initial_level(cdata.key0);
-                //world.gop.fence(); <<<<<<<<<<<<<<<<<<<<<<   needs a fence argument
+                // world.gop.fence(); <<<<<<<<<<<<<<<<<<<<<<   needs a fence argument
             }
             coeffs.process_pending();
             this->process_pending();
@@ -1095,27 +1090,27 @@ template<size_t NDIM>
 
         virtual ~FunctionImpl() { }
 
-        const std::shared_ptr< WorldDCPmapInterface< Key<NDIM> > >& get_pmap() const;
+        const std::shared_ptr<WorldDCPmapInterface<Key<NDIM>>>& get_pmap() const;
 
         void replicate(bool fence=true) {
         	coeffs.replicate(fence);
         }
 
-        void distribute(std::shared_ptr< WorldDCPmapInterface< Key<NDIM> > > newmap) const {
-        	auto currentmap=coeffs.get_pmap();
-        	currentmap->redistribute(world,newmap);
+        void distribute(std::shared_ptr<WorldDCPmapInterface<Key<NDIM>>> newmap) const {
+        	auto currentmap = coeffs.get_pmap();
+        	currentmap->redistribute(world, newmap);
         }
 
 
         /// Copy coeffs from other into self
         template <typename Q>
-        void copy_coeffs(const FunctionImpl<Q,NDIM>& other, bool fence) {
-            typename FunctionImpl<Q,NDIM>::dcT::const_iterator end = other.coeffs.end();
-            for (typename FunctionImpl<Q,NDIM>::dcT::const_iterator it=other.coeffs.begin();
-                 it!=end; ++it) {
+        void copy_coeffs(const FunctionImpl<Q, NDIM>& other, bool fence) {
+            typename FunctionImpl<Q, NDIM>::dcT::const_iterator end = other.coeffs.end();
+            for (typename FunctionImpl<Q, NDIM>::dcT::const_iterator it = other.coeffs.begin();
+                 it != end; ++it) {
                 const keyT& key = it->first;
-                const typename FunctionImpl<Q,NDIM>::nodeT& node = it->second;
-                coeffs.replace(key,node. template convert<T>());
+                const typename FunctionImpl<Q, NDIM>::nodeT& node = it->second;
+                coeffs.replace(key, node. template convert<T>());
             }
             if (fence)
                 world.gop.fence();
@@ -1126,9 +1121,9 @@ template<size_t NDIM>
         /// @param[in]	beta	prefactor for other
         /// @param[in]	g       the other function, reconstructed
         template<typename Q, typename R>
-        void gaxpy_inplace_reconstructed(const T& alpha, const FunctionImpl<Q,NDIM>& g, const R& beta, const bool fence) {
+        void gaxpy_inplace_reconstructed(const T& alpha, const FunctionImpl<Q, NDIM>& g, const R& beta, const bool fence) {
             // merge g's tree into this' tree
-            this->merge_trees(beta,g,alpha,true);
+            this->merge_trees(beta, g, alpha, true);
 
             // sum down the sum coeffs into the leafs
             if (world.rank() == coeffs.owner(cdata.key0)) sum_down_spawn(cdata.key0, coeffT());
@@ -1145,9 +1140,9 @@ template<size_t NDIM>
         /// @param[in]	beta	prefactor for other
         /// @param[in]	other	the other function, reconstructed
         template<typename Q, typename R>
-        void merge_trees(const T alpha, const FunctionImpl<Q,NDIM>& other, const R beta, const bool fence=true) {
+        void merge_trees(const T alpha, const FunctionImpl<Q, NDIM>& other, const R beta, const bool fence=true) {
             MADNESS_ASSERT(get_pmap() == other.get_pmap());
-            other.flo_unary_op_node_inplace(do_merge_trees<Q,R>(alpha,beta,*this),fence);
+            other.flo_unary_op_node_inplace(do_merge_trees<Q, R>(alpha, beta, *this), fence);
             if (fence) world.gop.fence();
         }
 
@@ -1157,13 +1152,13 @@ template<size_t NDIM>
         /// result+=alpha* this
         /// @param[in]	alpha	prefactor for this
         template<typename Q, typename R>
-        void accumulate_trees(FunctionImpl<Q,NDIM>& result, const R alpha, const bool fence=true) const {
-            flo_unary_op_node_inplace(do_accumulate_trees<Q,R>(result,alpha),fence);
+        void accumulate_trees(FunctionImpl<Q, NDIM>& result, const R alpha, const bool fence=true) const {
+            flo_unary_op_node_inplace(do_accumulate_trees<Q, R>(result, alpha), fence);
         }
 
         /// perform: this= alpha*f + beta*g, invoked by result
 
-        /// f and g are reconstructed, so we can save on the compress operation,
+        /// f and g are reconstructed, so we can save on the compress operation, 
         /// walk down the joint tree, and add leaf coefficients; effectively refines
         /// to common finest level.
 
@@ -1172,23 +1167,23 @@ template<size_t NDIM>
         /// @param[in]  f       first addend
         /// @param[in]  beta    prefactor for g
         /// @param[in]  g       second addend
-        void gaxpy_oop_reconstructed(const double alpha, const implT& f,
-                                     const double beta, const implT& g, const bool fence);
-
+        void gaxpy_oop_reconstructed(const double alpha, const implT& f, 
+                                     const double beta, const implT& g,
+                                     const bool fence);
         /// functor for the gaxpy_inplace method
         template <typename Q, typename R>
         struct do_gaxpy_inplace {
-            typedef Range<typename FunctionImpl<Q,NDIM>::dcT::const_iterator> rangeT;
-            FunctionImpl<T,NDIM>* f; ///< prefactor for current function impl
+            typedef Range<typename FunctionImpl<Q, NDIM>::dcT::const_iterator> rangeT;
+            FunctionImpl<T, NDIM>* f; ///< prefactor for current function impl
             T alpha; ///< the current function impl
             R beta; ///< prefactor for other function impl
             do_gaxpy_inplace() {};
-            do_gaxpy_inplace(FunctionImpl<T,NDIM>* f, T alpha, R beta) : f(f), alpha(alpha), beta(beta) {}
+            do_gaxpy_inplace(FunctionImpl<T, NDIM>* f, T alpha, R beta) : f(f), alpha(alpha), beta(beta) {}
             bool operator()(typename rangeT::iterator& it) const {
                 const keyT& key = it->first;
-                const FunctionNode<Q,NDIM>& other_node = it->second;
+                const FunctionNode<Q, NDIM>& other_node = it->second;
                 // Use send to get write accessor and automated construction if missing
-                f->coeffs.send(key, &nodeT:: template gaxpy_inplace<Q,R>, alpha, other_node, beta);
+                f->coeffs.send(key, &nodeT:: template gaxpy_inplace<Q, R>, alpha, other_node, beta);
                 return true;
             }
             template <typename Archive>
@@ -1202,12 +1197,12 @@ template<size_t NDIM>
         /// @param[in]  other   the other function impl
         /// @param[in]  beta    prefactor for other
         template <typename Q, typename R>
-        void gaxpy_inplace(const T& alpha,const FunctionImpl<Q,NDIM>& other, const R& beta, bool fence) {
-//            MADNESS_ASSERT(get_pmap() == other.get_pmap());
-            if (alpha != T(1.0)) scale_inplace(alpha,false);
-            typedef Range<typename FunctionImpl<Q,NDIM>::dcT::const_iterator> rangeT;
-            typedef do_gaxpy_inplace<Q,R> opT;
-            other.world.taskq. template for_each<rangeT,opT>(rangeT(other.coeffs.begin(), other.coeffs.end()), opT(this, T(1.0), beta));
+        void gaxpy_inplace(const T& alpha, const FunctionImpl<Q, NDIM>& other, const R& beta, bool fence) {
+            // MADNESS_ASSERT(get_pmap() == other.get_pmap());
+            if (alpha != T(1.0)) scale_inplace(alpha, false);
+            typedef Range<typename FunctionImpl<Q, NDIM>::dcT::const_iterator> rangeT;
+            typedef do_gaxpy_inplace<Q, R> opT;
+            other.world.taskq. template for_each<rangeT, opT>(rangeT(other.coeffs.begin(), other.coeffs.end()), opT(this, T(1.0), beta));
             if (fence)
                 other.world.gop.fence();
         }
@@ -1220,11 +1215,11 @@ template<size_t NDIM>
             int kk = 0;
             ar & kk;
 
-            MADNESS_ASSERT(kk==k);
+            MADNESS_ASSERT(kk == k);
 
             // note that functor should not be (re)stored
             ar & thresh & initial_level & max_refine_level & truncate_mode
-                & autorefine & truncate_on_project & tree_state;//nonstandard & compressed ; //& bc;
+                & autorefine & truncate_on_project & tree_state; //nonstandard & compressed; // & bc;
 
             ar & coeffs;
             world.gop.fence();
@@ -1238,7 +1233,7 @@ template<size_t NDIM>
 
             // note that functor should not be (re)stored
             ar & k & thresh & initial_level & max_refine_level & truncate_mode
-                & autorefine & truncate_on_project & tree_state;//nonstandard & compressed ; //& bc;
+                & autorefine & truncate_on_project & tree_state; // nonstandard & compressed; // & bc;
 
             ar & coeffs;
             world.gop.fence();
@@ -1267,11 +1262,11 @@ template<size_t NDIM>
 
         TreeState get_tree_state() const {return tree_state;}
 
-        void set_functor(const std::shared_ptr<FunctionFunctorInterface<T,NDIM> > functor1);
+        void set_functor(const std::shared_ptr<FunctionFunctorInterface<T, NDIM>> functor1);
 
-        std::shared_ptr<FunctionFunctorInterface<T,NDIM> > get_functor();
+        std::shared_ptr<FunctionFunctorInterface<T, NDIM>> get_functor();
 
-        std::shared_ptr<FunctionFunctorInterface<T,NDIM> > get_functor() const;
+        std::shared_ptr<FunctionFunctorInterface<T, NDIM>> get_functor() const;
 
         void unset_functor();
 
@@ -1295,7 +1290,7 @@ template<size_t NDIM>
 
         dcT& get_coeffs();
 
-        const FunctionCommonData<T,NDIM>& get_cdata() const;
+        const FunctionCommonData<T, NDIM>& get_cdata() const;
 
         void accumulate_timer(const double time) const; // !!!!!!!!!!!!  REDUNDANT !!!!!!!!!!!!!!!
 
@@ -1333,7 +1328,7 @@ template<size_t NDIM>
         /// @param[in] key the key to the current function node being evaluated for truncation
         /// @param[in] tol the tolerance for thresholding
         /// @param[in] v vector of Future<bool>'s that specify whether the current nodes children have coeffs
-        bool truncate_op(const keyT& key, double tol, const std::vector< Future<bool> >& v);
+        bool truncate_op(const keyT& key, double tol, const std::vector<Future<bool>>& v);
 
         /// Evaluate function at quadrature points in the specified box
 
@@ -1341,7 +1336,7 @@ template<size_t NDIM>
         /// @param[in] f the interface to the elementary function
         /// @param[in] qx quadrature points on a level=0 box
         /// @param[out] fval values
-        void fcube(const keyT& key, const FunctionFunctorInterface<T,NDIM>& f, const Tensor<double>& qx, tensorT& fval) const;
+        void fcube(const keyT& key, const FunctionFunctorInterface<T, NDIM>& f, const Tensor<double>& qx, tensorT& fval) const;
 
         /// Evaluate function at quadrature points in the specified box
 
@@ -1349,7 +1344,7 @@ template<size_t NDIM>
         /// @param[in] f the interface to the elementary function
         /// @param[in] qx quadrature points on a level=0 box
         /// @param[out] fval values
-        void fcube(const keyT& key,  T (*f)(const coordT&), const Tensor<double>& qx, tensorT& fval) const;
+        void fcube(const keyT& key, T (*f)(const coordT&), const Tensor<double>& qx, tensorT& fval) const;
 
         /// Returns cdata.key0
         const keyT& key0() const;
@@ -1378,26 +1373,26 @@ template<size_t NDIM>
         /// Functor for the do_print_tree_json method
         void do_print_tree_json(const keyT& key, std::multimap<Level, std::tuple<tranT, std::string>>& data, Level maxlevel) const;
 
-        /// convert a number [0,limit] to a hue color code [blue,red],
-        /// or, if log is set, a number [1.e-10,limit]
+        /// convert a number [0, limit] to a hue color code [blue, red],
+        /// or, if log is set, a number [1.e-10, limit]
         struct do_convert_to_color {
             double limit;
             bool log;
-            static double lower() {return 1.e-10;};
+            static double lower() { return 1.e-10; };
             do_convert_to_color() {};
             do_convert_to_color(const double limit, const bool log) : limit(limit), log(log) {}
             double operator()(double val) const {
                 double color=0.0;
 
                 if (log) {
-                    double val2=log10(val) - log10(lower());        // will yield >0.0
-                    double upper=log10(limit) -log10(lower());
-                    val2=0.7-(0.7/upper)*val2;
-                    color= std::max(0.0,val2);
-                    color= std::min(0.7,color);
+                    double val2 = log10(val) - log10(lower());  // will yield > 0.0
+                    double upper = log10(limit) - log10(lower());
+                    val2 = 0.7 - (0.7 / upper) * val2;
+                    color = std::max(0.0, val2);
+                    color = std::min(0.7, color);
                 } else {
-                    double hue=0.7-(0.7/limit)*(val);
-                    color= std::max(0.0,hue);
+                    double hue = 0.7 - (0.7 / limit) * (val);
+                    color = std::max(0.0, hue);
                 }
                 return color;
             }
@@ -1423,7 +1418,7 @@ template<size_t NDIM>
         /// @param[in] plotinfo plotting parameters
         /// @param[in]	xaxis	the x-axis in the plot (can be any axis of the MRA box)
         /// @param[in]	yaxis	the y-axis in the plot (can be any axis of the MRA box)
-        void do_print_plane(const std::string filename, std::vector<Tensor<double> > plotinfo,
+        void do_print_plane(const std::string filename, std::vector<Tensor<double>> plotinfo,
                             const int xaxis, const int yaxis, const coordT el2);
 
         /// print the grid (the roots of the quadrature of each leaf box)
@@ -1447,104 +1442,104 @@ template<size_t NDIM>
         /// @param[in]	gridfile 	file with grid points, w/o key, but with same ordering
         /// @param[in]	vnuc_functor	subtract the values of this functor if regularization is needed
         template<size_t FDIM>
-        typename std::enable_if<NDIM==FDIM>::type
+        typename std::enable_if<NDIM == FDIM>::type
         read_grid(const std::string keyfile, const std::string gridfile,
-                  std::shared_ptr< FunctionFunctorInterface<double,NDIM> > vnuc_functor) {
+                  std::shared_ptr< FunctionFunctorInterface<double, NDIM>> vnuc_functor) {
 
             std::ifstream kfile(keyfile.c_str());
             std::ifstream gfile(gridfile.c_str());
             std::string line;
 
-            long ndata,ndata1;
-            if (not (std::getline(kfile,line))) MADNESS_EXCEPTION("failed reading 1st line of key data",0);
-            if (not (std::istringstream(line) >> ndata)) MADNESS_EXCEPTION("failed reading k",0);
-            if (not (std::getline(gfile,line))) MADNESS_EXCEPTION("failed reading 1st line of grid data",0);
-            if (not (std::istringstream(line) >> ndata1)) MADNESS_EXCEPTION("failed reading k",0);
-            MADNESS_CHECK(ndata==ndata1);
-            if (not (std::getline(kfile,line))) MADNESS_EXCEPTION("failed reading 2nd line of key data",0);
-            if (not (std::getline(gfile,line))) MADNESS_EXCEPTION("failed reading 2nd line of grid data",0);
+            long ndata, ndata1;
+            if (not (std::getline(kfile, line))) MADNESS_EXCEPTION("failed reading 1st line of key data", 0);
+            if (not (std::istringstream(line) >> ndata)) MADNESS_EXCEPTION("failed reading k", 0);
+            if (not (std::getline(gfile, line))) MADNESS_EXCEPTION("failed reading 1st line of grid data", 0);
+            if (not (std::istringstream(line) >> ndata1)) MADNESS_EXCEPTION("failed reading k", 0);
+            MADNESS_CHECK(ndata == ndata1);
+            if (not (std::getline(kfile, line))) MADNESS_EXCEPTION("failed reading 2nd line of key data", 0);
+            if (not (std::getline(gfile, line))) MADNESS_EXCEPTION("failed reading 2nd line of grid data", 0);
 
             // the quadrature points in simulation coordinates of the root node
-            const Tensor<double> qx=cdata.quad_x;
+            const Tensor<double> qx = cdata.quad_x;
             const size_t npt = qx.dim(0);
 
-            // the number of coordinates (grid point tuples) per box ({x1},{x2},{x3},..,{xNDIM})
-            long npoints=power<NDIM>(npt);
+            // the number of coordinates (grid point tuples) per box ({x1}, {x2}, {x3}, .., {xNDIM})
+            long npoints = power<NDIM>(npt);
             // the number of boxes
-            long nboxes=ndata/npoints;
-            MADNESS_ASSERT(nboxes*npoints==ndata);
-            print("reading ",nboxes,"boxes from file",gridfile,keyfile);
+            long nboxes = ndata / npoints;
+            MADNESS_ASSERT(nboxes * npoints == ndata);
+            print("reading ", nboxes, "boxes from file", gridfile, keyfile);
 
             // these will be the data
-            Tensor<T> values(cdata.vk,false);
+            Tensor<T> values(cdata.vk, false);
 
-            int ii=0;
-            std::string gline,kline;
+            int ii = 0;
+            std::string gline, kline;
             //            while (1) {
-            while (std::getline(kfile,kline)) {
+            while (std::getline(kfile, kline)) {
 
-                double x,y,z,x1,y1,z1,val;
+                double x, y, z, x1, y1, z1, val;
 
                 // get the key
                 long nn;
-                Translation l1,l2,l3;
+                Translation l1, l2, l3;
                 // line looks like: # key:      n      l1   l2   l3
-                kline.erase(0,7);
+                kline.erase(0, 7);
                 std::stringstream(kline) >>  nn >> l1 >> l2 >> l3;
                 //				kfile >> s >>  nn >> l1 >> l2 >> l3;
-                const Vector<Translation,3> ll{ l1,l2,l3 };
-                Key<3> key(nn,ll);
+                const Vector<Translation, 3> ll{ l1, l2, l3 };
+                Key<3> key(nn, ll);
 
                 // this is borrowed from fcube
-                const Vector<Translation,3>& l = key.translation();
+                const Vector<Translation, 3>& l = key.translation();
                 const Level n = key.level();
-                const double h = std::pow(0.5,double(n));
+                const double h = std::pow(0.5, double(n));
                 coordT c; // will hold the point in user coordinates
                 const Tensor<double>& cell_width = FunctionDefaults<NDIM>::get_cell_width();
                 const Tensor<double>& cell = FunctionDefaults<NDIM>::get_cell();
 
 
                 if (NDIM == 3) {
-                    for (size_t i=0; i<npt; ++i) {
-                        c[0] = cell(0,0) + h*cell_width[0]*(l[0] + qx(i)); // x
-                        for (size_t j=0; j<npt; ++j) {
-                            c[1] = cell(1,0) + h*cell_width[1]*(l[1] + qx(j)); // y
-                            for (size_t k=0; k<npt; ++k) {
-                                c[2] = cell(2,0) + h*cell_width[2]*(l[2] + qx(k)); // z
-                                //								fprintf(pFile,"%18.12f %18.12f %18.12f\n",c[0],c[1],c[2]);
-                                auto& success1 = std::getline(gfile,gline); MADNESS_CHECK(success1);
-                                auto& success2 = std::getline(kfile,kline); MADNESS_CHECK(success2);
+                    for (size_t i = 0; i < npt; ++i) {
+                        c[0] = cell(0, 0) + h * cell_width[0] * (l[0] + qx(i)); // x
+                        for (size_t j = 0; j < npt; ++j) {
+                            c[1] = cell(1, 0) + h * cell_width[1] * (l[1] + qx(j)); // y
+                            for (size_t k = 0; k < npt; ++k) {
+                                c[2] = cell(2, 0) + h * cell_width[2] * (l[2] + qx(k)); // z
+                                // fprintf(pFile, "%18.12f %18.12f %18.12f\n", c[0], c[1], c[2]);
+                                auto& success1 = std::getline(gfile, gline); MADNESS_CHECK(success1);
+                                auto& success2 = std::getline(kfile, kline); MADNESS_CHECK(success2);
                                 std::istringstream(gline) >> x >> y >> z >> val;
                                 std::istringstream(kline) >> x1 >> y1 >> z1;
-                                MADNESS_CHECK(std::fabs(x-c[0])<1.e-4);
-                                MADNESS_CHECK(std::fabs(x1-c[0])<1.e-4);
-                                MADNESS_CHECK(std::fabs(y-c[1])<1.e-4);
-                                MADNESS_CHECK(std::fabs(y1-c[1])<1.e-4);
-                                MADNESS_CHECK(std::fabs(z-c[2])<1.e-4);
-                                MADNESS_CHECK(std::fabs(z1-c[2])<1.e-4);
+                                MADNESS_CHECK(std::fabs(x - c[0]) < 1.e-4);
+                                MADNESS_CHECK(std::fabs(x1 - c[0]) < 1.e-4);
+                                MADNESS_CHECK(std::fabs(y - c[1]) < 1.e-4);
+                                MADNESS_CHECK(std::fabs(y1 - c[1]) < 1.e-4);
+                                MADNESS_CHECK(std::fabs(z - c[2]) < 1.e-4);
+                                MADNESS_CHECK(std::fabs(z1 - c[2]) < 1.e-4);
 
                                 // regularize if a functor is given
-                                if (vnuc_functor) val-=(*vnuc_functor)(c);
-                                values(i,j,k)=val;
+                                if (vnuc_functor) val -= (*vnuc_functor)(c);
+                                values(i, j, k)=val;
                             }
                         }
                     }
                 } else {
-                    MADNESS_EXCEPTION("only NDIM=3 in print_grid",0);
+                    MADNESS_EXCEPTION("only NDIM = 3 in print_grid", 0);
                 }
 
                 // insert the new leaf node
-                const bool has_children=false;
-                coeffT coeff=coeffT(this->values2coeffs(key,values),targs);
-                nodeT node(coeff,has_children);
-                coeffs.replace(key,node);
-                const_cast<dcT&>(coeffs).send(key.parent(), &FunctionNode<T,NDIM>::set_has_children_recursive, coeffs, key.parent());
+                const bool has_children = false;
+                coeffT coeff = coeffT(this->values2coeffs(key, values), targs);
+                nodeT node(coeff, has_children);
+                coeffs.replace(key, node);
+                const_cast<dcT&>(coeffs).send(key.parent(), &FunctionNode<T, NDIM>::set_has_children_recursive, coeffs, key.parent());
                 ii++;
             }
 
             kfile.close();
             gfile.close();
-            MADNESS_CHECK(ii==nboxes);
+            MADNESS_CHECK(ii == nboxes);
 
         }
 
@@ -1554,95 +1549,94 @@ template<size_t NDIM>
         /// @param[in]	gridfile		file with keys and grid points and values for each key
         /// @param[in]	vnuc_functor	subtract the values of this functor if regularization is needed
         template<size_t FDIM>
-        typename std::enable_if<NDIM==FDIM>::type
+        typename std::enable_if<NDIM == FDIM>::type
         read_grid2(const std::string gridfile,
-                   std::shared_ptr< FunctionFunctorInterface<double,NDIM> > vnuc_functor) {
+                   std::shared_ptr< FunctionFunctorInterface<double, NDIM>> vnuc_functor) {
 
             std::ifstream gfile(gridfile.c_str());
             std::string line;
 
             long ndata;
-            if (not (std::getline(gfile,line))) MADNESS_EXCEPTION("failed reading 1st line of grid data",0);
-            if (not (std::istringstream(line) >> ndata)) MADNESS_EXCEPTION("failed reading k",0);
-            if (not (std::getline(gfile,line))) MADNESS_EXCEPTION("failed reading 2nd line of grid data",0);
+            if (not (std::getline(gfile, line))) MADNESS_EXCEPTION("failed reading 1st line of grid data", 0);
+            if (not (std::istringstream(line) >> ndata)) MADNESS_EXCEPTION("failed reading k", 0);
+            if (not (std::getline(gfile, line))) MADNESS_EXCEPTION("failed reading 2nd line of grid data", 0);
 
             // the quadrature points in simulation coordinates of the root node
-            const Tensor<double> qx=cdata.quad_x;
+            const Tensor<double> qx = cdata.quad_x;
             const size_t npt = qx.dim(0);
 
-            // the number of coordinates (grid point tuples) per box ({x1},{x2},{x3},..,{xNDIM})
-            long npoints=power<NDIM>(npt);
+            // the number of coordinates (grid point tuples) per box ({x1}, {x2}, {x3}, .., {xNDIM})
+            long npoints = power<NDIM>(npt);
             // the number of boxes
-            long nboxes=ndata/npoints;
-            MADNESS_CHECK(nboxes*npoints==ndata);
-            print("reading ",nboxes,"boxes from file",gridfile);
+            long nboxes = ndata / npoints;
+            MADNESS_CHECK(nboxes * npoints == ndata);
+            print("reading ", nboxes, "boxes from file", gridfile);
 
             // these will be the data
-            Tensor<T> values(cdata.vk,false);
+            Tensor<T> values(cdata.vk, false);
 
-            int ii=0;
+            int ii = 0;
             std::string gline;
             //            while (1) {
-            while (std::getline(gfile,gline)) {
+            while (std::getline(gfile, gline)) {
 
-                double x1,y1,z1,val;
+                double x1, y1, z1, val;
 
                 // get the key
                 long nn;
-                Translation l1,l2,l3;
+                Translation l1, l2, l3;
                 // line looks like: # key:      n      l1   l2   l3
-                gline.erase(0,7);
+                gline.erase(0, 7);
                 std::stringstream(gline) >>  nn >> l1 >> l2 >> l3;
-                const Vector<Translation,3> ll{ l1,l2,l3 };
-                Key<3> key(nn,ll);
+                const Vector<Translation, 3> ll{ l1, l2, l3 };
+                Key<3> key(nn, ll);
 
                 // this is borrowed from fcube
-                const Vector<Translation,3>& l = key.translation();
+                const Vector<Translation, 3>& l = key.translation();
                 const Level n = key.level();
-                const double h = std::pow(0.5,double(n));
+                const double h = std::pow(0.5, double(n));
                 coordT c; // will hold the point in user coordinates
                 const Tensor<double>& cell_width = FunctionDefaults<NDIM>::get_cell_width();
                 const Tensor<double>& cell = FunctionDefaults<NDIM>::get_cell();
 
-
                 if (NDIM == 3) {
-                    for (int i=0; i<npt; ++i) {
-                        c[0] = cell(0,0) + h*cell_width[0]*(l[0] + qx(i)); // x
-                        for (int j=0; j<npt; ++j) {
-                            c[1] = cell(1,0) + h*cell_width[1]*(l[1] + qx(j)); // y
+                    for (int i = 0; i < npt; ++i) {
+                        c[0] = cell(0, 0) + h * cell_width[0] * (l[0] + qx(i)); // x
+                        for (int j = 0; j < npt; ++j) {
+                            c[1] = cell(1, 0) + h * cell_width[1] * (l[1] + qx(j)); // y
                             for (int k=0; k<npt; ++k) {
-                                c[2] = cell(2,0) + h*cell_width[2]*(l[2] + qx(k)); // z
+                                c[2] = cell(2, 0) + h * cell_width[2] * (l[2] + qx(k)); // z
 
-                                auto& success = std::getline(gfile,gline);
+                                auto& success = std::getline(gfile, gline);
                                 MADNESS_CHECK(success);
                                 std::istringstream(gline) >> x1 >> y1 >> z1 >> val;
-                                MADNESS_CHECK(std::fabs(x1-c[0])<1.e-4);
-                                MADNESS_CHECK(std::fabs(y1-c[1])<1.e-4);
-                                MADNESS_CHECK(std::fabs(z1-c[2])<1.e-4);
+                                MADNESS_CHECK(std::fabs(x1 - c[0]) < 1.e-4);
+                                MADNESS_CHECK(std::fabs(y1 - c[1]) < 1.e-4);
+                                MADNESS_CHECK(std::fabs(z1 - c[2]) < 1.e-4);
 
                                 // regularize if a functor is given
-                                if (vnuc_functor) val-=(*vnuc_functor)(c);
-                                values(i,j,k)=val;
+                                if (vnuc_functor) val -= (*vnuc_functor)(c);
+                                values(i, j, k) = val;
                             }
                         }
                     }
                 } else {
-                    MADNESS_EXCEPTION("only NDIM=3 in print_grid",0);
+                    MADNESS_EXCEPTION("only NDIM=3 in print_grid", 0);
                 }
 
                 // insert the new leaf node
-                const bool has_children=false;
-                coeffT coeff=coeffT(this->values2coeffs(key,values),targs);
-                nodeT node(coeff,has_children);
-                coeffs.replace(key,node);
+                const bool has_children = false;
+                coeffT coeff = coeffT(this->values2coeffs(key, values), targs);
+                nodeT node(coeff, has_children);
+                coeffs.replace(key, node);
                 const_cast<dcT&>(coeffs).send(key.parent(),
-                                              &FunctionNode<T,NDIM>::set_has_children_recursive,
+                                              &FunctionNode<T, NDIM>::set_has_children_recursive,
                                               coeffs, key.parent());
                 ii++;
             }
 
             gfile.close();
-            MADNESS_CHECK(ii==nboxes);
+            MADNESS_CHECK(ii == nboxes);
 
         }
 
@@ -1672,12 +1666,12 @@ template<size_t NDIM>
         /// @param[in] specialpts vector of special points in the function where we need
         ///            to refine at a much finer level
         void project_refine_op(const keyT& key, bool do_refine,
-                               const std::vector<Vector<double,NDIM> >& specialpts);
+                               const std::vector<Vector<double, NDIM>>& specialpts);
 
         /// Compute the Legendre scaling functions for multiplication
 
         /// Evaluate parent polyn at quadrature points of a child.  The prefactor of
-        /// 2^n/2 is included.  The tensor must be preallocated as phi(k,npt).
+        /// 2^n/2 is included.  The tensor must be preallocated as phi(k, npt).
         /// Refer to the implementation notes for more info.
         /// @todo Robert please verify this comment. I don't understand this method.
         /// @param[in] np level of the parent function node (box)
@@ -1716,8 +1710,8 @@ template<size_t NDIM>
         template <typename Q>
         GenTensor<Q> coeffs2values(const keyT& key, const GenTensor<Q>& coeff) const {
             // PROFILE_MEMBER_FUNC(FunctionImpl); // Too fine grain for routine profiling
-            double scale = pow(2.0,0.5*NDIM*key.level())/sqrt(FunctionDefaults<NDIM>::get_cell_volume());
-            return transform(coeff,cdata.quad_phit).scale(scale);
+            double scale = pow(2.0, 0.5 * NDIM * key.level()) / sqrt(FunctionDefaults<NDIM>::get_cell_volume());
+            return transform(coeff, cdata.quad_phit).scale(scale);
         }
 
         /// convert S or NS coeffs to values on a 2k grid of the children
@@ -1732,27 +1726,27 @@ template<size_t NDIM>
         template <typename Q>
         GenTensor<Q> NScoeffs2values(const keyT& key, const GenTensor<Q>& coeff,
                                      const bool s_only) const {
-            // PROFILE_MEMBER_FUNC(FunctionImpl); // Too fine grain for routine profiling
+            // PROFILE_MEMBER_FUNC(FunctionImpl);  // Too fine grain for routine profiling
 
             // sanity checks
-            MADNESS_ASSERT((coeff.dim(0)==this->get_k()) == s_only);
-            MADNESS_ASSERT((coeff.dim(0)==this->get_k()) or (coeff.dim(0)==2*this->get_k()));
+            MADNESS_ASSERT((coeff.dim(0) == this->get_k()) == s_only);
+            MADNESS_ASSERT((coeff.dim(0) == this->get_k()) or (coeff.dim(0) == 2 * this->get_k()));
 
             // this is a block-diagonal matrix with the quadrature points on the diagonal
-            Tensor<double> quad_phit_2k(2*cdata.k,2*cdata.npt);
-            quad_phit_2k(cdata.s[0],cdata.s[0])=cdata.quad_phit;
-            quad_phit_2k(cdata.s[1],cdata.s[1])=cdata.quad_phit;
+            Tensor<double> quad_phit_2k(2 * cdata.k, 2 * cdata.npt);
+            quad_phit_2k(cdata.s[0], cdata.s[0]) = cdata.quad_phit;
+            quad_phit_2k(cdata.s[1], cdata.s[1]) = cdata.quad_phit;
 
             // the transformation matrix unfilters (cdata.hg) and transforms to values in one step
             const Tensor<double> transf = (s_only)
-                ? inner(cdata.hg(Slice(0,k-1),_),quad_phit_2k)	// S coeffs
-                : inner(cdata.hg,quad_phit_2k);					// NS coeffs
+                ? inner(cdata.hg(Slice(0, k-1), _), quad_phit_2k)	// S coeffs
+                : inner(cdata.hg, quad_phit_2k);					// NS coeffs
 
             // increment the level since the coeffs2values part happens on level n+1
-            const double scale = pow(2.0,0.5*NDIM*(key.level()+1))/
+            const double scale = pow(2.0, 0.5 * NDIM * (key.level() + 1)) /
                 sqrt(FunctionDefaults<NDIM>::get_cell_volume());
 
-           return transform(coeff,transf).scale(scale);
+           return transform(coeff, transf).scale(scale);
         }
 
         /// Compute the function values for multiplication
@@ -1771,39 +1765,38 @@ template<size_t NDIM>
             // PROFILE_MEMBER_FUNC(FunctionImpl); // Too fine grain for routine profiling
 
             // sanity checks
-            MADNESS_ASSERT((coeff.dim(0)==this->get_k()) == s_only);
-            MADNESS_ASSERT((coeff.dim(0)==this->get_k()) or (coeff.dim(0)==2*this->get_k()));
+            MADNESS_ASSERT((coeff.dim(0) == this->get_k()) == s_only);
+            MADNESS_ASSERT((coeff.dim(0) == this->get_k()) or (coeff.dim(0) == 2 * this->get_k()));
 
             // fast return if possible
-            //            if (child.level()==parent.level()) return NScoeffs2values(child,coeff,s_only);
+            // if (child.level() == parent.level()) return NScoeffs2values(child, coeff, s_only);
 
             if (s_only) {
-
                 Tensor<double> quad_phi[NDIM];
                 // tmp tensor
-                Tensor<double> phi1(cdata.k,cdata.npt);
+                Tensor<double> phi1(cdata.k, cdata.npt);
 
-                for (std::size_t d=0; d<NDIM; ++d) {
+                for (std::size_t d = 0; d < NDIM; ++d) {
 
                     // input is S coeffs (dimension k), output is values on 2*npt grid points
-                    quad_phi[d]=Tensor<double>(cdata.k,2*cdata.npt);
+                    quad_phi[d]=Tensor<double>(cdata.k, 2 * cdata.npt);
 
                     // for both children of "child" evaluate the Legendre polynomials
                     // first the left child on level n+1 and translations 2l
-                    phi_for_mul(parent.level(),parent.translation()[d],
-                                child.level()+1, 2*child.translation()[d], phi1);
-                    quad_phi[d](_,Slice(0,k-1))=phi1;
+                    phi_for_mul(parent.level(), parent.translation()[d],
+                                child.level() + 1, 2 * child.translation()[d], phi1);
+                    quad_phi[d](_, Slice(0, k - 1)) = phi1;
 
                     // next the right child on level n+1 and translations 2l+1
-                    phi_for_mul(parent.level(),parent.translation()[d],
-                                child.level()+1, 2*child.translation()[d]+1, phi1);
-                    quad_phi[d](_,Slice(k,2*k-1))=phi1;
+                    phi_for_mul(parent.level(), parent.translation()[d],
+                                child.level() + 1, 2 * child.translation()[d] + 1, phi1);
+                    quad_phi[d](_, Slice(k, 2 * k - 1)) = phi1;
                 }
 
-                const double scale = 1.0/sqrt(FunctionDefaults<NDIM>::get_cell_volume());
-                return general_transform(coeff,quad_phi).scale(scale);
+                const double scale = 1.0 / sqrt(FunctionDefaults<NDIM>::get_cell_volume());
+                return general_transform(coeff, quad_phi).scale(scale);
             }
-            MADNESS_EXCEPTION("you should not be here in NS_fcube_for_mul",1);
+            MADNESS_EXCEPTION("you should not be here in NS_fcube_for_mul", 1);
             return GenTensor<Q>();
         }
 
@@ -1819,21 +1812,21 @@ template<size_t NDIM>
             //PROFILE_MEMBER_FUNC(FunctionImpl);  // Too fine grain for routine profiling
 
             // sanity checks
-            MADNESS_ASSERT(values.dim(0)==2*this->get_k());
+            MADNESS_ASSERT(values.dim(0) == 2 * this->get_k());
 
             // this is a block-diagonal matrix with the quadrature points on the diagonal
-            Tensor<double> quad_phit_2k(2*cdata.npt,2*cdata.k);
-            quad_phit_2k(cdata.s[0],cdata.s[0])=cdata.quad_phiw;
-            quad_phit_2k(cdata.s[1],cdata.s[1])=cdata.quad_phiw;
+            Tensor<double> quad_phit_2k(2 * cdata.npt, 2 * cdata.k);
+            quad_phit_2k(cdata.s[0], cdata.s[0]) = cdata.quad_phiw;
+            quad_phit_2k(cdata.s[1], cdata.s[1]) = cdata.quad_phiw;
 
             // the transformation matrix unfilters (cdata.hg) and transforms to values in one step
-            const Tensor<double> transf=inner(quad_phit_2k,cdata.hgT);
+            const Tensor<double> transf=inner(quad_phit_2k, cdata.hgT);
 
             // increment the level since the values2coeffs part happens on level n+1
-            const double scale = pow(0.5,0.5*NDIM*(key.level()+1))
-                *sqrt(FunctionDefaults<NDIM>::get_cell_volume());
+            const double scale = pow(0.5, 0.5 * NDIM * (key.level() + 1))
+                * sqrt(FunctionDefaults<NDIM>::get_cell_volume());
 
-            return transform(values,transf).scale(scale);
+            return transform(values, transf).scale(scale);
         }
 
         /// Return the scaling function coeffs when given the function values at the quadrature points
@@ -1842,22 +1835,22 @@ template<size_t NDIM>
         template <typename Q>
         Tensor<Q> coeffs2values(const keyT& key, const Tensor<Q>& coeff) const {
             // PROFILE_MEMBER_FUNC(FunctionImpl); // Too fine grain for routine profiling
-            double scale = pow(2.0,0.5*NDIM*key.level())/sqrt(FunctionDefaults<NDIM>::get_cell_volume());
-            return transform(coeff,cdata.quad_phit).scale(scale);
+            double scale = pow(2.0, 0.5 * NDIM * key.level()) / sqrt(FunctionDefaults<NDIM>::get_cell_volume());
+            return transform(coeff, cdata.quad_phit).scale(scale);
         }
 
         template <typename Q>
         GenTensor<Q> values2coeffs(const keyT& key, const GenTensor<Q>& values) const {
             // PROFILE_MEMBER_FUNC(FunctionImpl); // Too fine grain for routine profiling
-            double scale = pow(0.5,0.5*NDIM*key.level())*sqrt(FunctionDefaults<NDIM>::get_cell_volume());
-            return transform(values,cdata.quad_phiw).scale(scale);
+            double scale = pow(0.5, 0.5*NDIM*key.level())*sqrt(FunctionDefaults<NDIM>::get_cell_volume());
+            return transform(values, cdata.quad_phiw).scale(scale);
         }
 
         template <typename Q>
         Tensor<Q> values2coeffs(const keyT& key, const Tensor<Q>& values) const {
             // PROFILE_MEMBER_FUNC(FunctionImpl); // Too fine grain for routine profiling
-            double scale = pow(0.5,0.5*NDIM*key.level())*sqrt(FunctionDefaults<NDIM>::get_cell_volume());
-            return transform(values,cdata.quad_phiw).scale(scale);
+            double scale = pow(0.5, 0.5 * NDIM * key.level()) * sqrt(FunctionDefaults<NDIM>::get_cell_volume());
+            return transform(values, cdata.quad_phiw).scale(scale);
         }
 
         /// Compute the function values for multiplication
@@ -1874,16 +1867,16 @@ template<size_t NDIM>
                 return coeffs2values(parent, coeff);
             }
             else if (child.level() < parent.level()) {
-                MADNESS_EXCEPTION("FunctionImpl: fcube_for_mul: child-parent relationship bad?",0);
+                MADNESS_EXCEPTION("FunctionImpl: fcube_for_mul: child-parent relationship bad?", 0);
             }
             else {
                 Tensor<double> phi[NDIM];
-                for (std::size_t d=0; d<NDIM; ++d) {
-                    phi[d] = Tensor<double>(cdata.k,cdata.npt);
-                    phi_for_mul(parent.level(),parent.translation()[d],
+                for (std::size_t d = 0; d < NDIM; ++d) {
+                    phi[d] = Tensor<double>(cdata.k, cdata.npt);
+                    phi_for_mul(parent.level(), parent.translation()[d],
                                 child.level(), child.translation()[d], phi[d]);
                 }
-                return general_transform(coeff,phi).scale(1.0/sqrt(FunctionDefaults<NDIM>::get_cell_volume()));;
+                return general_transform(coeff, phi).scale(1.0 / sqrt(FunctionDefaults<NDIM>::get_cell_volume()));;
             }
         }
 
@@ -1902,24 +1895,24 @@ template<size_t NDIM>
                 return coeffs2values(parent, coeff);
             }
             else if (child.level() < parent.level()) {
-                MADNESS_EXCEPTION("FunctionImpl: fcube_for_mul: child-parent relationship bad?",0);
+                MADNESS_EXCEPTION("FunctionImpl: fcube_for_mul: child-parent relationship bad?", 0);
             }
             else {
                 Tensor<double> phi[NDIM];
-                for (size_t d=0; d<NDIM; d++) {
-                    phi[d] = Tensor<double>(cdata.k,cdata.npt);
-                    phi_for_mul(parent.level(),parent.translation()[d],
+                for (size_t d = 0; d < NDIM; d++) {
+                    phi[d] = Tensor<double>(cdata.k, cdata.npt);
+                    phi_for_mul(parent.level(), parent.translation()[d],
                                 child.level(), child.translation()[d], phi[d]);
                 }
-                return general_transform(coeff,phi).scale(1.0/sqrt(FunctionDefaults<NDIM>::get_cell_volume()));
+                return general_transform(coeff, phi).scale(1.0 / sqrt(FunctionDefaults<NDIM>::get_cell_volume()));
             }
         }
 
 
         /// Functor for the mul method
         template <typename L, typename R>
-        void do_mul(const keyT& key, const Tensor<L>& left, const std::pair< keyT, Tensor<R> >& arg) {
-            // PROFILE_MEMBER_FUNC(FunctionImpl); // Too fine grain for routine profiling
+        void do_mul(const keyT& key, const Tensor<L>& left, const std::pair< keyT, Tensor<R>>& arg) {
+            // PROFILE_MEMBER_FUNC(FunctionImpl);  // Too fine grain for routine profiling
             const keyT& rkey = arg.first;
             const Tensor<R>& rcoeff = arg.second;
             //madness::print("do_mul: r", rkey, rcoeff.size());
@@ -1927,11 +1920,11 @@ template<size_t NDIM>
             //madness::print("do_mul: l", key, left.size());
             Tensor<L> lcube = fcube_for_mul(key, key, left);
 
-            Tensor<T> tcube(cdata.vk,false);
+            Tensor<T> tcube(cdata.vk, false);
             TERNARY_OPTIMIZED_ITERATOR(T, tcube, L, lcube, R, rcube, *_p0 = *_p1 * *_p2;);
-            double scale = pow(0.5,0.5*NDIM*key.level())*sqrt(FunctionDefaults<NDIM>::get_cell_volume());
-            tcube = transform(tcube,cdata.quad_phiw).scale(scale);
-            coeffs.replace(key, nodeT(coeffT(tcube,targs),false));
+            double scale = pow(0.5, 0.5 * NDIM * key.level()) * sqrt(FunctionDefaults<NDIM>::get_cell_volume());
+            tcube = transform(tcube, cdata.quad_phiw).scale(scale);
+            coeffs.replace(key, nodeT(coeffT(tcube, targs), false));
         }
 
 
@@ -1943,25 +1936,25 @@ template<size_t NDIM>
         /// @param[in]	npt	number of grid points (optional, default is cdata.npt)
         /// @return		coefficient tensor holding the product of the values of c1 and c2
         template<typename R>
-        Tensor<TENSOR_RESULT_TYPE(T,R)> mul(const Tensor<T>& c1, const Tensor<R>& c2,
+        Tensor<TENSOR_RESULT_TYPE(T, R)> mul(const Tensor<T>& c1, const Tensor<R>& c2,
                                             const int npt, const keyT& key) const {
-            typedef TENSOR_RESULT_TYPE(T,R) resultT;
+            typedef TENSOR_RESULT_TYPE(T, R) resultT;
 
-            const FunctionCommonData<T,NDIM>& cdata2=FunctionCommonData<T,NDIM>::get(npt);
+            const FunctionCommonData<T, NDIM>& cdata2 = FunctionCommonData<T, NDIM>::get(npt);
 
             // construct a tensor with the npt coeffs
             Tensor<T> c11(cdata2.vk), c22(cdata2.vk);
-            c11(this->cdata.s0)=c1;
-            c22(this->cdata.s0)=c2;
+            c11(this->cdata.s0) = c1;
+            c22(this->cdata.s0) = c2;
 
             // it's sufficient to scale once
-            double scale = pow(2.0,0.5*NDIM*key.level())/sqrt(FunctionDefaults<NDIM>::get_cell_volume());
-            Tensor<T> c1value=transform(c11,cdata2.quad_phit).scale(scale);
-            Tensor<R> c2value=transform(c22,cdata2.quad_phit);
-            Tensor<resultT> resultvalue(cdata2.vk,false);
+            double scale = pow(2.0, 0.5 * NDIM * key.level()) / sqrt(FunctionDefaults<NDIM>::get_cell_volume());
+            Tensor<T> c1value = transform(c11, cdata2.quad_phit).scale(scale);
+            Tensor<R> c2value = transform(c22, cdata2.quad_phit);
+            Tensor<resultT> resultvalue(cdata2.vk, false);
             TERNARY_OPTIMIZED_ITERATOR(resultT, resultvalue, T, c1value, R, c2value, *_p0 = *_p1 * *_p2;);
 
-            Tensor<resultT> result=transform(resultvalue,cdata2.quad_phiw);
+            Tensor<resultT> result=transform(resultvalue, cdata2.quad_phiw);
 
             // return a copy of the slice to have the tensor contiguous
             return copy(result(this->cdata.s0));
@@ -1970,21 +1963,21 @@ template<size_t NDIM>
 
         /// Functor for the binary_op method
         template <typename L, typename R, typename opT>
-	  void do_binary_op(const keyT& key, const Tensor<L>& left,
-			    const std::pair< keyT, Tensor<R> >& arg,
+	    void do_binary_op(const keyT& key, const Tensor<L>& left,
+			    const std::pair< keyT, Tensor<R>>& arg,
 			    const opT& op) {
-            //PROFILE_MEMBER_FUNC(FunctionImpl); // Too fine grain for routine profiling
-	  const keyT& rkey = arg.first;
-	  const Tensor<R>& rcoeff = arg.second;
-	  Tensor<R> rcube = fcube_for_mul(key, rkey, rcoeff);
-	  Tensor<L> lcube = fcube_for_mul(key, key, left);
+            // PROFILE_MEMBER_FUNC(FunctionImpl); // Too fine grain for routine profiling
+            const keyT& rkey = arg.first;
+            const Tensor<R>& rcoeff = arg.second;
+            Tensor<R> rcube = fcube_for_mul(key, rkey, rcoeff);
+            Tensor<L> lcube = fcube_for_mul(key, key, left);
 
-	  Tensor<T> tcube(cdata.vk,false);
-	  op(key, tcube, lcube, rcube);
-	  double scale = pow(0.5,0.5*NDIM*key.level())*sqrt(FunctionDefaults<NDIM>::get_cell_volume());
-	  tcube = transform(tcube,cdata.quad_phiw).scale(scale);
-	  coeffs.replace(key, nodeT(coeffT(tcube,targs),false));
-	}
+            Tensor<T> tcube(cdata.vk, false);
+            op(key, tcube, lcube, rcube);
+            double scale = pow(0.5, 0.5*NDIM*key.level())*sqrt(FunctionDefaults<NDIM>::get_cell_volume());
+            tcube = transform(tcube, cdata.quad_phiw).scale(scale);
+            coeffs.replace(key, nodeT(coeffT(tcube, targs), false));
+	    }
 
         /// Invoked by result to perform result += alpha*left+beta*right in wavelet basis
 
@@ -1993,26 +1986,26 @@ template<size_t NDIM>
         /// out of place gaxpy.  If all functions have the same distribution there is
         /// no communication except for the optional fence.
         template <typename L, typename R>
-        void gaxpy(T alpha, const FunctionImpl<L,NDIM>& left,
-                   T beta, const FunctionImpl<R,NDIM>& right, bool fence) {
+        void gaxpy(T alpha, const FunctionImpl<L, NDIM>& left,
+                   T beta, const FunctionImpl<R, NDIM>& right, bool fence) {
             // Loop over local nodes in both functions.  Add in left and subtract right.
             // Not that efficient in terms of memory bandwidth but ensures we do
             // not miss any nodes.
-            typename FunctionImpl<L,NDIM>::dcT::const_iterator left_end = left.coeffs.end();
-            for (typename FunctionImpl<L,NDIM>::dcT::const_iterator it=left.coeffs.begin();
-                 it!=left_end;
+            typename FunctionImpl<L, NDIM>::dcT::const_iterator left_end = left.coeffs.end();
+            for (typename FunctionImpl<L, NDIM>::dcT::const_iterator it = left.coeffs.begin();
+                 it != left_end;
                  ++it) {
                 const keyT& key = it->first;
-                const typename FunctionImpl<L,NDIM>::nodeT& other_node = it->second;
-                coeffs.send(key, &nodeT:: template gaxpy_inplace<T,L>, 1.0, other_node, alpha);
+                const typename FunctionImpl<L, NDIM>::nodeT& other_node = it->second;
+                coeffs.send(key, &nodeT:: template gaxpy_inplace<T, L>, 1.0, other_node, alpha);
             }
-            typename FunctionImpl<R,NDIM>::dcT::const_iterator right_end = right.coeffs.end();
-            for (typename FunctionImpl<R,NDIM>::dcT::const_iterator it=right.coeffs.begin();
-                 it!=right_end;
+            typename FunctionImpl<R, NDIM>::dcT::const_iterator right_end = right.coeffs.end();
+            for (typename FunctionImpl<R, NDIM>::dcT::const_iterator it = right.coeffs.begin();
+                 it != right_end;
                  ++it) {
                 const keyT& key = it->first;
-                const typename FunctionImpl<L,NDIM>::nodeT& other_node = it->second;
-                coeffs.send(key, &nodeT:: template gaxpy_inplace<T,R>, 1.0, other_node, beta);
+                const typename FunctionImpl<L, NDIM>::nodeT& other_node = it->second;
+                coeffs.send(key, &nodeT:: template gaxpy_inplace<T, R>, 1.0, other_node, beta);
             }
             if (fence)
                 world.gop.fence();
@@ -2023,16 +2016,16 @@ template<size_t NDIM>
         template <typename opT>
         void unary_op_coeff_inplace(const opT& op, bool fence) {
             typename dcT::iterator end = coeffs.end();
-            for (typename dcT::iterator it=coeffs.begin(); it!=end; ++it) {
+            for (typename dcT::iterator it = coeffs.begin(); it != end; ++it) {
                 const keyT& parent = it->first;
                 nodeT& node = it->second;
                 if (node.has_coeff()) {
-                    //                    op(parent, node.coeff());
-                    TensorArgs full(-1.0,TT_FULL);
-                    change_tensor_type(node.coeff(),full);
+                    // op(parent, node.coeff());
+                    TensorArgs full(-1.0, TT_FULL);
+                    change_tensor_type(node.coeff(), full);
                     op(parent, node.coeff().full_tensor());
-                    change_tensor_type(node.coeff(),targs);
-                    //                	op(parent,node);
+                    change_tensor_type(node.coeff(), targs);
+                    // op(parent, node);
                 }
             }
             if (fence)
@@ -2044,7 +2037,7 @@ template<size_t NDIM>
         template <typename opT>
         void unary_op_node_inplace(const opT& op, bool fence) {
             typename dcT::iterator end = coeffs.end();
-            for (typename dcT::iterator it=coeffs.begin(); it!=end; ++it) {
+            for (typename dcT::iterator it = coeffs.begin(); it != end; ++it) {
                 const keyT& parent = it->first;
                 nodeT& node = it->second;
                 op(parent, node);
@@ -2054,12 +2047,12 @@ template<size_t NDIM>
         }
 
         /// Integrate over one particle of a two particle function and get a one particle function
-        /// bsp \int g(1,2) \delta(2-1) d2 = f(1)
+        /// bsp \int g(1, 2) \delta(2-1) d2 = f(1)
         /// The overall dimension of g should be even
 
 		/// The operator
         template<std::size_t LDIM>
-		void dirac_convolution_op(const keyT &key, const nodeT &node, FunctionImpl<T,LDIM>* f) const {
+		void dirac_convolution_op(const keyT &key, const nodeT &node, FunctionImpl<T, LDIM>* f) const {
 			// fast return if the node has children (not a leaf node)
 			if(node.has_children()) return;
 
@@ -2067,53 +2060,52 @@ template<size_t NDIM>
 
 			// break the 6D key into two 3D keys (may also work for every even dimension)
 			Key<LDIM> key1, key2;
-			key.break_apart(key1,key2);
+			key.break_apart(key1, key2);
 
 			// get the coefficients of the 6D function g
 			const coeffT& g_coeff = node.coeff();
 
 			// get the values of the 6D function g
-			coeffT g_values = g->coeffs2values(key,g_coeff);
+			coeffT g_values = g->coeffs2values(key, g_coeff);
 
 			// Determine rank and k
-			const long rank=g_values.rank();
-			const long maxk=f->get_k();
-			MADNESS_ASSERT(maxk==g_coeff.dim(0));
+			const long rank = g_values.rank();
+			const long maxk = f->get_k();
+			MADNESS_ASSERT(maxk == g_coeff.dim(0));
 
 			// get tensors for particle 1 and 2 (U and V in SVD)
-			tensorT vec1=copy(g_values.get_svdtensor().ref_vector(0).reshape(rank,maxk,maxk,maxk));
-			tensorT vec2=g_values.get_svdtensor().ref_vector(1).reshape(rank,maxk,maxk,maxk);
-			tensorT result(maxk,maxk,maxk);  // should give zero tensor
+			tensorT vec1 = copy(g_values.get_svdtensor().ref_vector(0).reshape(rank, maxk, maxk, maxk));
+			tensorT vec2 = g_values.get_svdtensor().ref_vector(1).reshape(rank, maxk, maxk, maxk);
+			tensorT result(maxk, maxk, maxk);  // should give zero tensor
 			// Multiply the values of each U and V vector
-			for (long i=0; i<rank; ++i) {
-				tensorT c1=vec1(Slice(i,i),_,_,_); // shallow copy (!)
-				tensorT c2=vec2(Slice(i,i),_,_,_);
+			for (long i = 0; i < rank; ++i) {
+				tensorT c1 = vec1(Slice(i, i), _, _, _); // shallow copy (!)
+				tensorT c2 = vec2(Slice(i, i), _, _, _);
 				c1.emul(c2); // this changes vec1 because of shallow copy, but not the g function because of the deep copy made above
 				double singular_value_i = g_values.get_svdtensor().weights(i);
-				result += (singular_value_i*c1);
+				result += (singular_value_i * c1);
 			}
 
 			// accumulate coefficients (since only diagonal boxes are used the coefficients get just replaced, but accumulate is needed to create the right tree structure
-			tensorT f_coeff = f->values2coeffs(key1,result);
-			f->coeffs.task(key1, &FunctionNode<T,LDIM>::accumulate2, f_coeff, f->coeffs, key1, TaskAttributes::hipri());
-//             coeffs.task(dest, &nodeT::accumulate2, result, coeffs, dest, TaskAttributes::hipri());
-
+			tensorT f_coeff = f->values2coeffs(key1, result);
+			f->coeffs.task(key1, &FunctionNode<T, LDIM>::accumulate2, f_coeff, f->coeffs, key1, TaskAttributes::hipri());
+            // coeffs.task(dest, &nodeT::accumulate2, result, coeffs, dest, TaskAttributes::hipri());
 
 			return;
 		}
 
 
         template<std::size_t LDIM>
-        void do_dirac_convolution(FunctionImpl<T,LDIM>* f, bool fence) const {
+        void do_dirac_convolution(FunctionImpl<T, LDIM>* f, bool fence) const {
             typename dcT::const_iterator end = this->coeffs.end();
-            for (typename dcT::const_iterator it=this->coeffs.begin(); it!=end; ++it) {
+            for (typename dcT::const_iterator it = this->coeffs.begin(); it != end; ++it) {
                 // looping through all the leaf(!) coefficients in the NDIM function ("this")
                 const keyT& key = it->first;
-                const FunctionNode<T,NDIM>& node = it->second;
+                const FunctionNode<T, NDIM>& node = it->second;
                 if (node.is_leaf()) {
                 	// only process the diagonal boxes
         			Key<LDIM> key1, key2;
-        			key.break_apart(key1,key2);
+        			key.break_apart(key1, key2);
         			if(key1 == key2){
                         ProcessID p = coeffs.owner(key);
                         woT::task(p, &implT:: template dirac_convolution_op<LDIM>, key, node, f);
@@ -2123,9 +2115,9 @@ template<size_t NDIM>
             world.gop.fence(); // fence is necessary if trickle down is used afterwards
             // trickle down and undo redundand shouldnt change anything if only the diagonal elements are considered above -> check this
             f->trickle_down(true); // fence must be true otherwise undo_redundant will have trouble
-//            f->undo_redundant(true);
+            // f->undo_redundant(true);
             f->verify_tree();
-            //if (fence) world.gop.fence(); // unnecessary, fence is activated in undo_redundant
+            // if (fence) world.gop.fence(); // unnecessary, fence is activated in undo_redundant
 
         }
 
@@ -2135,8 +2127,8 @@ template<size_t NDIM>
         template <typename opT>
         void flo_unary_op_node_inplace(const opT& op, bool fence) {
             typedef Range<typename dcT::iterator> rangeT;
-//            typedef do_unary_op_value_inplace<opT> xopT;
-            world.taskq.for_each<rangeT,opT>(rangeT(coeffs.begin(), coeffs.end()), op);
+            // typedef do_unary_op_value_inplace<opT> xopT;
+            world.taskq.for_each<rangeT, opT>(rangeT(coeffs.begin(), coeffs.end()), op);
             if (fence) world.gop.fence();
         }
 
@@ -2145,8 +2137,8 @@ template<size_t NDIM>
         template <typename opT>
         void flo_unary_op_node_inplace(const opT& op, bool fence) const {
             typedef Range<typename dcT::const_iterator> rangeT;
-//            typedef do_unary_op_value_inplace<opT> xopT;
-            world.taskq.for_each<rangeT,opT>(rangeT(coeffs.begin(), coeffs.end()), op);
+            // typedef do_unary_op_value_inplace<opT> xopT;
+            world.taskq.for_each<rangeT, opT>(rangeT(coeffs.begin(), coeffs.end()), op);
             if (fence)
                 world.gop.fence();
         }
@@ -2172,15 +2164,15 @@ template<size_t NDIM>
 
                 if (node.is_leaf() and node.coeff().has_data()) {
                     coeffT d = copy(node.coeff());
-                    d(f->cdata.s0)=0.0;
-                    const double error=d.normf();
-                    const double tol=f->truncate_tol(f->get_thresh(),key);
-                    if (error<tol) node.coeff()=copy(node.coeff()(f->cdata.s0));
+                    d(f->cdata.s0) = 0.0;
+                    const double error = d.normf();
+                    const double tol = f->truncate_tol(f->get_thresh(), key);
+                    if (error<tol) node.coeff() = copy(node.coeff()(f->cdata.s0));
                 }
                 return true;
             }
-            template <typename Archive> void serialize(const Archive& ar) {}
 
+            template <typename Archive> void serialize(const Archive& ar) {}
         };
 
         /// remove all coefficients of internal nodes
@@ -2196,6 +2188,7 @@ template<size_t NDIM>
                 if (node.has_children()) node.clear_coeff();
                 return true;
             }
+
             template <typename Archive> void serialize(const Archive& ar) {}
 
         };
@@ -2212,8 +2205,8 @@ template<size_t NDIM>
                 if (not node.has_children()) node.clear_coeff();
                 return true;
             }
-            template <typename Archive> void serialize(const Archive& ar) {}
 
+            template <typename Archive> void serialize(const Archive& ar) {}
         };
 
 
@@ -2232,8 +2225,8 @@ template<size_t NDIM>
                 node.coeff()=s;
                 return true;
             }
-            template <typename Archive> void serialize(const Archive& ar) {}
 
+            template <typename Archive> void serialize(const Archive& ar) {}
         };
 
 
@@ -2248,16 +2241,16 @@ template<size_t NDIM>
             do_reduce_rank() {}
             do_reduce_rank(const TensorArgs& targs) : args(targs) {}
             do_reduce_rank(const double& thresh) {
-                args.thresh=thresh;
+                args.thresh = thresh;
             }
 
             //
             bool operator()(typename rangeT::iterator& it) const {
-
                 nodeT& node = it->second;
                 node.reduceRank(args.thresh);
                 return true;
             }
+
             template <typename Archive> void serialize(const Archive& ar) {}
         };
 
@@ -2272,73 +2265,70 @@ template<size_t NDIM>
 
             /// return the norm of the difference of this node and its "mirror" node
             double operator()(typename rangeT::iterator& it) const {
+                // Temporary fix to GCC whining about out of range access for NDIM != 6
+                if constexpr(NDIM == 6) {
+                    const keyT& key = it->first;
+                    const nodeT& fnode = it->second;
 
-	      // Temporary fix to GCC whining about out of range access for NDIM!=6
-  	      if constexpr(NDIM==6) {
-                const keyT& key = it->first;
-                const nodeT& fnode = it->second;
+                    // skip internal nodes
+                    if (fnode.has_children()) return 0.0;
 
-                // skip internal nodes
-                if (fnode.has_children()) return 0.0;
+                    if (f->world.size()>1) return 0.0;
 
-                if (f->world.size()>1) return 0.0;
+                    // exchange particles
+                    std::vector<long> map(NDIM);
+                    map[0]=3; map[1]=4; map[2]=5;
+                    map[3]=0; map[4]=1; map[5]=2;
 
-                // exchange particles
-                std::vector<long> map(NDIM);
-                map[0]=3; map[1]=4; map[2]=5;
-                map[3]=0; map[4]=1; map[5]=2;
+                    // make mapped key
+                    Vector<Translation, NDIM> l;
+                    for (std::size_t i = 0; i < NDIM; ++i) l[map[i]] = key.translation()[i];
+                    const keyT mapkey(key.level(), l);
 
-                // make mapped key
-                Vector<Translation,NDIM> l;
-                for (std::size_t i=0; i<NDIM; ++i) l[map[i]] = key.translation()[i];
-                const keyT mapkey(key.level(),l);
-
-                double norm=0.0;
+                    double norm = 0.0;
 
 
-                // hope it's local
-                if (f->get_coeffs().probe(mapkey)) {
-                    MADNESS_ASSERT(f->get_coeffs().probe(mapkey));
-                    const nodeT& mapnode=f->get_coeffs().find(mapkey).get()->second;
+                    // hope it's local
+                    if (f->get_coeffs().probe(mapkey)) {
+                        MADNESS_ASSERT(f->get_coeffs().probe(mapkey));
+                        const nodeT& mapnode = f->get_coeffs().find(mapkey).get()->second;
 
-//                    bool have_c1=fnode.coeff().has_data() and fnode.coeff().config().has_data();
-//                    bool have_c2=mapnode.coeff().has_data() and mapnode.coeff().config().has_data();
-                    bool have_c1=fnode.coeff().has_data();
-                    bool have_c2=mapnode.coeff().has_data();
+                        // bool have_c1 = fnode.coeff().has_data() and fnode.coeff().config().has_data();
+                        // bool have_c2 = mapnode.coeff().has_data() and mapnode.coeff().config().has_data();
+                        bool have_c1 = fnode.coeff().has_data();
+                        bool have_c2 = mapnode.coeff().has_data();
 
-                    if (have_c1 and have_c2) {
-                        tensorT c1=fnode.coeff().full_tensor_copy();
-                        tensorT c2=mapnode.coeff().full_tensor_copy();
-                        c2 = copy(c2.mapdim(map));
-                        norm=(c1-c2).normf();
-                    } else if (have_c1) {
-                        tensorT c1=fnode.coeff().full_tensor_copy();
-                        norm=c1.normf();
-                    } else if (have_c2) {
-                        tensorT c2=mapnode.coeff().full_tensor_copy();
-                        norm=c2.normf();
+                        if (have_c1 and have_c2) {
+                            tensorT c1 = fnode.coeff().full_tensor_copy();
+                            tensorT c2 = mapnode.coeff().full_tensor_copy();
+                            c2 = copy(c2.mapdim(map));
+                            norm = (c1 - c2).normf();
+                        } else if (have_c1) {
+                            tensorT c1 = fnode.coeff().full_tensor_copy();
+                            norm = c1.normf();
+                        } else if (have_c2) {
+                            tensorT c2 = mapnode.coeff().full_tensor_copy();
+                            norm = c2.normf();
+                        } else {
+                            norm = 0.0;
+                        }
                     } else {
-                        norm=0.0;
+                        norm = fnode.coeff().normf();
                     }
-                } else {
-                    norm=fnode.coeff().normf();
+                    return norm * norm;
                 }
-                return norm*norm;
-	      }
-	      else {
-		throw "ONLY FOR DIM 6!";
-	      }
-            }
+                else {
+                    throw "ONLY FOR DIM 6!";
+                }
+            }  // end operator()
 
             double operator()(double a, double b) const {
-                return (a+b);
+                return (a + b);
             }
 
             template <typename Archive> void serialize(const Archive& ar) {
-                MADNESS_EXCEPTION("no serialization of do_check_symmetry yet",1);
+                MADNESS_EXCEPTION("no serialization of do_check_symmetry yet", 1);
             }
-
-
         };
 
         /// merge the coefficent boxes of this into result's tree
@@ -2347,26 +2337,25 @@ template<size_t NDIM>
         /// this and result don't have to have the same distribution or live in the same world
         /// no comm, and the tree should be in an consistent state by virtue
         template<typename Q, typename R>
-        struct do_accumulate_trees{
+        struct do_accumulate_trees {
             typedef Range<typename dcT::const_iterator> rangeT;
-            FunctionImpl<Q,NDIM>* result=0;
-            T alpha=T(1.0);
+            FunctionImpl<Q, NDIM>* result = 0;
+            T alpha = T(1.0);
             do_accumulate_trees() = default;
-            do_accumulate_trees(FunctionImpl<Q,NDIM>& result, const T alpha)
+            do_accumulate_trees(FunctionImpl<Q, NDIM>& result, const T alpha)
                 : result(&result), alpha(alpha) {}
 
             /// return the norm of the difference of this node and its "mirror" node
             bool operator()(typename rangeT::iterator& it) const {
-
                 const keyT& key = it->first;
                 const nodeT& node = it->second;
                 if (node.has_coeff()) result->get_coeffs().task(key, &nodeT::accumulate,
-                    alpha*node.coeff(), result->get_coeffs(), key, result->targs);
+                    alpha * node.coeff(), result->get_coeffs(), key, result->targs);
                 return true;
             }
 
             template <typename Archive> void serialize(const Archive& ar) {
-                MADNESS_EXCEPTION("no serialization of do_accumulate_trees",1);
+                MADNESS_EXCEPTION("no serialization of do_accumulate_trees", 1);
             }
         };
 
@@ -2378,35 +2367,34 @@ template<size_t NDIM>
         template<typename Q, typename R>
         struct do_merge_trees {
             typedef Range<typename dcT::const_iterator> rangeT;
-            FunctionImpl<Q,NDIM>* other;
+            FunctionImpl<Q, NDIM>* other;
             T alpha;
             R beta;
             do_merge_trees() : other(0) {}
-            do_merge_trees(const T alpha, const R beta, FunctionImpl<Q,NDIM>& other)
+            do_merge_trees(const T alpha, const R beta, FunctionImpl<Q, NDIM>& other)
                 : other(&other), alpha(alpha), beta(beta) {}
 
             /// return the norm of the difference of this node and its "mirror" node
             bool operator()(typename rangeT::iterator& it) const {
-
                 const keyT& key = it->first;
                 const nodeT& fnode = it->second;
 
                 // if other's node exists: add this' coeffs to it
                 // otherwise insert this' node into other's tree
                 typename dcT::accessor acc;
-                if (other->get_coeffs().find(acc,key)) {
+                if (other->get_coeffs().find(acc, key)) {
                     nodeT& gnode=acc->second;
-                    gnode.gaxpy_inplace(beta,fnode,alpha);
+                    gnode.gaxpy_inplace(beta, fnode, alpha);
                 } else {
                     nodeT gnode=fnode;
                     gnode.scale(alpha);
-                    other->get_coeffs().replace(key,gnode);
+                    other->get_coeffs().replace(key, gnode);
                 }
                 return true;
             }
 
             template <typename Archive> void serialize(const Archive& ar) {
-                MADNESS_EXCEPTION("no serialization of do_merge_trees",1);
+                MADNESS_EXCEPTION("no serialization of do_merge_trees", 1);
             }
         };
 
@@ -2422,23 +2410,22 @@ template<size_t NDIM>
             do_mapdim(const std::vector<long> map, implT& f) : map(map), f(&f) {}
 
             bool operator()(typename rangeT::iterator& it) const {
-
                 const keyT& key = it->first;
                 const nodeT& node = it->second;
 
-                Vector<Translation,NDIM> l;
-                for (std::size_t i=0; i<NDIM; ++i) l[map[i]] = key.translation()[i];
+                Vector<Translation, NDIM> l;
+                for (std::size_t i = 0; i < NDIM; ++i) l[map[i]] = key.translation()[i];
                 tensorT c = node.coeff().reconstruct_tensor();
                 if (c.size()) c = copy(c.mapdim(map));
-                coeffT cc(c,f->get_tensor_args());
-                f->get_coeffs().replace(keyT(key.level(),l), nodeT(cc,node.has_children()));
+                coeffT cc(c, f->get_tensor_args());
+                f->get_coeffs().replace(keyT(key.level(), l), nodeT(cc, node.has_children()));
 
                 return true;
             }
-            template <typename Archive> void serialize(const Archive& ar) {
-                MADNESS_EXCEPTION("no serialization of do_mapdim",1);
-            }
 
+            template <typename Archive> void serialize(const Archive& ar) {
+                MADNESS_EXCEPTION("no serialization of do_mapdim", 1);
+            }
         };
 
         /// mirror dimensions of this, write result on f
@@ -2452,15 +2439,14 @@ template<size_t NDIM>
             do_mirror(const std::vector<long> mirror, implT& f) : mirror(mirror), f(&f) {}
 
             bool operator()(typename rangeT::iterator& it) const {
-
                 const keyT& key = it->first;
                 const nodeT& node = it->second;
 
                 // mirror translation index: l_new + l_old = l_max
-                Vector<Translation,NDIM> l=key.translation();
-                Translation lmax = (Translation(1)<<key.level()) - 1;
-                for (std::size_t i=0; i<NDIM; ++i) {
-                	if (mirror[i]==-1) l[i]= lmax - key.translation()[i];
+                Vector<Translation, NDIM> l=key.translation();
+                Translation lmax = (Translation(1) << key.level()) - 1;
+                for (std::size_t i = 0; i < NDIM; ++i) {
+                	if (mirror[i] == -1) l[i] = lmax - key.translation()[i];
                 }
 
                 // mirror coefficients: multiply all odd-k slices with -1
@@ -2469,33 +2455,33 @@ template<size_t NDIM>
             		std::vector<Slice> s(___);
 
                 	// loop over dimensions and over k
-                	for (size_t i=0; i<NDIM; ++i) {
-                		std::size_t kmax=c.dim(i);
-                		if (mirror[i]==-1) {
-                			for (size_t k=1; k<kmax; k+=2) {
-                				s[i]=Slice(k,k,1);
-                				c(s)*=(-1.0);
+                	for (size_t i = 0; i < NDIM; ++i) {
+                		std::size_t kmax = c.dim(i);
+                		if (mirror[i] == -1) {
+                			for (size_t k = 1; k < kmax; k += 2) {
+                				s[i] = Slice(k, k, 1);
+                				c(s) *= (-1.0);
                 			}
-                			s[i]=_;
+                			s[i] = _;
                 		}
                 	}
                 }
-                coeffT cc(c,f->get_tensor_args());
-                f->get_coeffs().replace(keyT(key.level(),l), nodeT(cc,node.has_children()));
+                coeffT cc(c, f->get_tensor_args());
+                f->get_coeffs().replace(keyT(key.level(), l), nodeT(cc, node.has_children()));
 
                 return true;
             }
-            template <typename Archive> void serialize(const Archive& ar) {
-                MADNESS_EXCEPTION("no serialization of do_mirror",1);
-            }
 
+            template <typename Archive> void serialize(const Archive& ar) {
+                MADNESS_EXCEPTION("no serialization of do_mirror", 1);
+            }
         };
 
         /// mirror dimensions of this, write result on f
         struct do_map_and_mirror {
             typedef Range<typename dcT::iterator> rangeT;
 
-            std::vector<long> map,mirror;
+            std::vector<long> map, mirror;
             implT* f;
 
             do_map_and_mirror() = default;
@@ -2508,54 +2494,52 @@ template<size_t NDIM>
                 const nodeT& node = it->second;
 
                 tensorT c = node.coeff().full_tensor_copy();
-                Vector<Translation,NDIM> l=key.translation();
+                Vector<Translation, NDIM> l = key.translation();
 
                 // do the mapping first (if present)
-                if (map.size()>0) {
-                	Vector<Translation,NDIM> l1=l;
-                	for (std::size_t i=0; i<NDIM; ++i) l1[map[i]] = l[i];
-                	std::swap(l,l1);
+                if (map.size() > 0) {
+                	Vector<Translation, NDIM> l1 = l;
+                	for (std::size_t i = 0; i < NDIM; ++i) l1[map[i]] = l[i];
+                	std::swap(l, l1);
                 	if (c.size()) c = copy(c.mapdim(map));
                 }
 
-                if (mirror.size()>0) {
+                if (mirror.size() > 0) {
 					// mirror translation index: l_new + l_old = l_max
-                	Vector<Translation,NDIM> l1=l;
-					Translation lmax = (Translation(1)<<key.level()) - 1;
-					for (std::size_t i=0; i<NDIM; ++i) {
-						if (mirror[i]==-1) l1[i]= lmax - l[i];
+                	Vector<Translation, NDIM> l1 = l;
+					Translation lmax = (Translation(1) << key.level()) - 1;
+					for (std::size_t i = 0; i < NDIM; ++i) {
+						if (mirror[i] == -1) l1[i] = lmax - l[i];
 					}
-                	std::swap(l,l1);
+                	std::swap(l, l1);
 
                 	// mirror coefficients: multiply all odd-k slices with -1
 					if (c.size()) {
 						std::vector<Slice> s(___);
 
 						// loop over dimensions and over k
-						for (size_t i=0; i<NDIM; ++i) {
-							std::size_t kmax=c.dim(i);
-							if (mirror[i]==-1) {
-								for (size_t k=1; k<kmax; k+=2) {
-									s[i]=Slice(k,k,1);
-									c(s)*=(-1.0);
+						for (size_t i = 0; i < NDIM; ++i) {
+							std::size_t kmax = c.dim(i);
+							if (mirror[i] == -1) {
+								for (size_t k = 1; k < kmax; k += 2) {
+									s[i] = Slice(k, k, 1);
+									c(s) *= (-1.0);
 								}
-								s[i]=_;
+								s[i] = _;
 							}
 						}
 					}
                 }
 
-                coeffT cc(c,f->get_tensor_args());
-                f->get_coeffs().replace(keyT(key.level(),l), nodeT(cc,node.has_children()));
+                coeffT cc(c, f->get_tensor_args());
+                f->get_coeffs().replace(keyT(key.level(), l), nodeT(cc, node.has_children()));
                 return true;
             }
+
             template <typename Archive> void serialize(const Archive& ar) {
-                MADNESS_EXCEPTION("no serialization of do_mirror",1);
+                MADNESS_EXCEPTION("no serialization of do_mirror", 1);
             }
-
         };
-
-
 
         /// "put" this on g
         struct do_average {
@@ -2577,11 +2561,11 @@ template<size_t NDIM>
 
                     // check if there is a node already existing
                     typename dcT::accessor acc;
-                    if (g->get_coeffs().find(acc,key)) {
+                    if (g->get_coeffs().find(acc, key)) {
                         nodeT& gnode=acc->second;
                         if (gnode.has_coeff()) gnode.coeff()+=fnode.coeff();
                     } else {
-                        g->get_coeffs().replace(key,fnode);
+                        g->get_coeffs().replace(key, fnode);
                     }
                 }
 
@@ -2600,21 +2584,19 @@ template<size_t NDIM>
 
             // constructor takes target precision
             do_change_tensor_type() {}
-//            do_change_tensor_type(const TensorArgs& targs) : targs(targs) {}
+            // do_change_tensor_type(const TensorArgs& targs) : targs(targs) {}
             do_change_tensor_type(const TensorArgs& targs, implT& g) : targs(targs), f(&g) {}
 
             //
             bool operator()(typename rangeT::iterator& it) const {
-
-            	double cpu0=cpu_time();
+            	double cpu0 = cpu_time();
                 nodeT& node = it->second;
-                change_tensor_type(node.coeff(),targs);
-            	double cpu1=cpu_time();
-                f->timer_change_tensor_type.accumulate(cpu1-cpu0);
-
+                change_tensor_type(node.coeff(), targs);
+            	double cpu1 = cpu_time();
+                f->timer_change_tensor_type.accumulate(cpu1 - cpu0);
                 return true;
-
             }
+
             template <typename Archive> void serialize(const Archive& ar) {}
         };
 
@@ -2631,6 +2613,7 @@ template<size_t NDIM>
                 it->second.consolidate_buffer(targs);
                 return true;
             }
+
             template <typename Archive> void serialize(const Archive& ar) {}
         };
 
@@ -2642,69 +2625,70 @@ template<size_t NDIM>
             implT* impl;
             opT op;
             do_unary_op_value_inplace(implT* impl, const opT& op) : impl(impl), op(op) {}
+
             bool operator()(typename rangeT::iterator& it) const {
                 const keyT& key = it->first;
                 nodeT& node = it->second;
                 if (node.has_coeff()) {
-                    const TensorArgs full_args(-1.0,TT_FULL);
-                    change_tensor_type(node.coeff(),full_args);
-                    tensorT& t= node.coeff().full_tensor();
-                    //double before = t.normf();
+                    const TensorArgs full_args(-1.0, TT_FULL);
+                    change_tensor_type(node.coeff(), full_args);
+                    tensorT& t = node.coeff().full_tensor();
+                    // double before = t.normf();
                     tensorT values = impl->fcube_for_mul(key, key, t);
                     op(key, values);
-                    double scale = pow(0.5,0.5*NDIM*key.level())*sqrt(FunctionDefaults<NDIM>::get_cell_volume());
-                    t = transform(values,impl->cdata.quad_phiw).scale(scale);
-                    node.coeff()=coeffT(t,impl->get_tensor_args());
-                    //double after = t.normf();
-                    //madness::print("XOP:", key, before, after);
+                    double scale = pow(0.5, 0.5 * NDIM * key.level()) * sqrt(FunctionDefaults<NDIM>::get_cell_volume());
+                    t = transform(values, impl->cdata.quad_phiw).scale(scale);
+                    node.coeff() = coeffT(t, impl->get_tensor_args());
+                    // double after = t.normf();
+                    // madness::print("XOP:", key, before, after);
                 }
                 return true;
             }
+
             template <typename Archive> void serialize(const Archive& ar) {}
         };
 
         template <typename Q, typename R>
         /// @todo I don't know what this does other than a trasform
-        void vtransform_doit(const std::shared_ptr< FunctionImpl<R,NDIM> >& right,
+        void vtransform_doit(const std::shared_ptr< FunctionImpl<R, NDIM>>& right,
                              const Tensor<Q>& c,
-                             const std::vector< std::shared_ptr< FunctionImpl<T,NDIM> > >& vleft,
+                             const std::vector< std::shared_ptr< FunctionImpl<T, NDIM>> >& vleft,
                              double tol) {
             // To reduce crunch on vectors being transformed each task
             // does them in a random order
             std::vector<unsigned int> ind(vleft.size());
-            for (unsigned int i=0; i<vleft.size(); ++i) {
+            for (unsigned int i = 0; i < vleft.size(); ++i) {
                 ind[i] = i;
             }
-            for (unsigned int i=0; i<vleft.size(); ++i) {
-                unsigned int j = RandomValue<int>()%vleft.size();
-                std::swap(ind[i],ind[j]);
+            for (unsigned int i = 0; i < vleft.size(); ++i) {
+                unsigned int j = RandomValue<int>() % vleft.size();
+                std::swap(ind[i], ind[j]);
             }
 
-            typename FunctionImpl<R,NDIM>::dcT::const_iterator end = right->coeffs.end();
-            for (typename FunctionImpl<R,NDIM>::dcT::const_iterator it=right->coeffs.begin(); it != end; ++it) {
+            typename FunctionImpl<R, NDIM>::dcT::const_iterator end = right->coeffs.end();
+            for (typename FunctionImpl<R, NDIM>::dcT::const_iterator it = right->coeffs.begin(); it != end; ++it) {
                 if (it->second.has_coeff()) {
                     const Key<NDIM>& key = it->first;
                     const GenTensor<R>& r = it->second.coeff();
                     double norm = r.normf();
-                    double keytol = truncate_tol(tol,key);
+                    double keytol = truncate_tol(tol, key);
 
-                    for (unsigned int j=0; j<vleft.size(); ++j) {
+                    for (unsigned int j = 0; j < vleft.size(); ++j) {
                         unsigned int i = ind[j]; // Random permutation
                         if (std::abs(norm*c(i)) > keytol) {
                             implT* left = vleft[i].get();
                             typename dcT::accessor acc;
-                            bool newnode = left->coeffs.insert(acc,key);
+                            bool newnode = left->coeffs.insert(acc, key);
                             if (newnode && key.level()>0) {
                                 Key<NDIM> parent = key.parent();
-				if (left->coeffs.is_local(parent))
-				  left->coeffs.send(parent, &nodeT::set_has_children_recursive, left->coeffs, parent);
-				else
-				  left->coeffs.task(parent, &nodeT::set_has_children_recursive, left->coeffs, parent);
-
+                                if (left->coeffs.is_local(parent))
+                                    left->coeffs.send(parent, &nodeT::set_has_children_recursive, left->coeffs, parent);
+                                else
+                                    left->coeffs.task(parent, &nodeT::set_has_children_recursive, left->coeffs, parent);
                             }
                             nodeT& node = acc->second;
                             if (!node.has_coeff())
-                                node.set_coeff(coeffT(cdata.v2k,targs));
+                                node.set_coeff(coeffT(cdata.v2k, targs));
                             coeffT& t = node.coeff();
                             t.gaxpy(1.0, r, c(i));
                         }
@@ -2718,7 +2702,7 @@ template<size_t NDIM>
         /// @param v the vector of functions we are refining.
         /// @param key the current node.
         /// @param c the vector of coefficients passed from above.
-        void refine_to_common_level(const std::vector<FunctionImpl<T,NDIM>*>& v,
+        void refine_to_common_level(const std::vector<FunctionImpl<T, NDIM>*>& v,
                                     const std::vector<tensorT>& c,
                                     const keyT key);
 
@@ -2729,14 +2713,14 @@ template<size_t NDIM>
         template <typename opT>
         void multiop_values_doit(const keyT& key, const opT& op, const std::vector<implT*>& v) {
             std::vector<tensorT> c(v.size());
-            for (unsigned int i=0; i<v.size(); i++) {
+            for (unsigned int i = 0; i < v.size(); i++) {
                 if (v[i]) {
                     coeffT cc = coeffs2values(key, v[i]->coeffs.find(key).get()->second.coeff());
-                    c[i]=cc.full_tensor();
+                    c[i] = cc.full_tensor();
                 }
             }
             tensorT r = op(key, c);
-            coeffs.replace(key, nodeT(coeffT(values2coeffs(key, r),targs),false));
+            coeffs.replace(key, nodeT(coeffT(values2coeffs(key, r), targs), false));
         }
 
         /// Inplace operate on many functions (impl's) with an operator within a certain box
@@ -2746,18 +2730,18 @@ template<size_t NDIM>
         template <typename opT>
         void multiop_values(const opT& op, const std::vector<implT*>& v) {
             // rough check on refinement level (ignore non-initialized functions
-            for (std::size_t i=1; i<v.size(); ++i) {
-                if (v[i] and v[i-1]) {
-                    MADNESS_ASSERT(v[i]->coeffs.size()==v[i-1]->coeffs.size());
+            for (std::size_t i = 1; i < v.size(); ++i) {
+                if (v[i] and v[i - 1]) {
+                    MADNESS_ASSERT(v[i]->coeffs.size() == v[i - 1]->coeffs.size());
                 }
             }
             typename dcT::iterator end = v[0]->coeffs.end();
-            for (typename dcT::iterator it=v[0]->coeffs.begin(); it!=end; ++it) {
+            for (typename dcT::iterator it = v[0]->coeffs.begin(); it != end; ++it) {
                 const keyT& key = it->first;
                 if (it->second.has_coeff())
                     world.taskq.add(*this, &implT:: template multiop_values_doit<opT>, key, op, v);
                 else
-                    coeffs.replace(key, nodeT(coeffT(),true));
+                    coeffs.replace(key, nodeT(coeffT(), true));
             }
             world.gop.fence();
         }
@@ -2772,16 +2756,16 @@ template<size_t NDIM>
         void multi_to_multi_op_values_doit(const keyT& key, const opT& op,
                 const std::vector<implT*>& vin, std::vector<implT*>& vout) {
             std::vector<tensorT> c(vin.size());
-            for (unsigned int i=0; i<vin.size(); i++) {
+            for (unsigned int i = 0; i < vin.size(); i++) {
                 if (vin[i]) {
                     coeffT cc = coeffs2values(key, vin[i]->coeffs.find(key).get()->second.coeff());
-                    c[i]=cc.full_tensor();
+                    c[i] = cc.full_tensor();
                 }
             }
             std::vector<tensorT> r = op(key, c);
-            MADNESS_ASSERT(r.size()==vout.size());
-            for (std::size_t i=0; i<vout.size(); ++i) {
-                vout[i]->coeffs.replace(key, nodeT(coeffT(values2coeffs(key, r[i]),targs),false));
+            MADNESS_ASSERT(r.size() == vout.size());
+            for (std::size_t i = 0; i < vout.size(); ++i) {
+                vout[i]->coeffs.replace(key, nodeT(coeffT(values2coeffs(key, r[i]), targs), false));
             }
         }
 
@@ -2795,13 +2779,13 @@ template<size_t NDIM>
         void multi_to_multi_op_values(const opT& op, const std::vector<implT*>& vin,
                 std::vector<implT*>& vout, const bool fence=true) {
             // rough check on refinement level (ignore non-initialized functions
-            for (std::size_t i=1; i<vin.size(); ++i) {
+            for (std::size_t i = 1; i < vin.size(); ++i) {
                 if (vin[i] and vin[i-1]) {
-                    MADNESS_ASSERT(vin[i]->coeffs.size()==vin[i-1]->coeffs.size());
+                    MADNESS_ASSERT(vin[i]->coeffs.size() == vin[i - 1]->coeffs.size());
                 }
             }
             typename dcT::iterator end = vin[0]->coeffs.end();
-            for (typename dcT::iterator it=vin[0]->coeffs.begin(); it!=end; ++it) {
+            for (typename dcT::iterator it = vin[0]->coeffs.begin(); it != end; ++it) {
                 const keyT& key = it->first;
                 if (it->second.has_coeff())
                     world.taskq.add(*this, &implT:: template multi_to_multi_op_values_doit<opT>,
@@ -2809,25 +2793,25 @@ template<size_t NDIM>
                 else {
                     // fill result functions with empty box in this key
                     for (implT* it2 : vout) {
-                        it2->coeffs.replace(key, nodeT(coeffT(),true));
+                        it2->coeffs.replace(key, nodeT(coeffT(), true));
                     }
                 }
             }
             if (fence) world.gop.fence();
         }
 
-        /// Transforms a vector of functions left[i] = sum[j] right[j]*c[j,i] using sparsity
+        /// Transforms a vector of functions left[i] = sum[j] right[j]*c[j, i] using sparsity
         /// @param[in] vright vector of functions (impl's) on which to be transformed
         /// @param[in] c the tensor (matrix) transformer
         /// @param[in] vleft vector of of the *newly* transformed functions (impl's)
         template <typename Q, typename R>
-        void vtransform(const std::vector< std::shared_ptr< FunctionImpl<R,NDIM> > >& vright,
+        void vtransform(const std::vector< std::shared_ptr< FunctionImpl<R, NDIM>> >& vright,
                         const Tensor<Q>& c,
-                        const std::vector< std::shared_ptr< FunctionImpl<T,NDIM> > >& vleft,
+                        const std::vector< std::shared_ptr< FunctionImpl<T, NDIM>> >& vleft,
                         double tol,
                         bool fence) {
-            for (unsigned int j=0; j<vright.size(); ++j) {
-                world.taskq.add(*this, &implT:: template vtransform_doit<Q,R>, vright[j], copy(c(j,_)), vleft, tol);
+            for (unsigned int j = 0; j < vright.size(); ++j) {
+                world.taskq.add(*this, &implT:: template vtransform_doit<Q, R>, vright[j], copy(c(j, _)), vleft, tol);
             }
             if (fence)
                 world.gop.fence();
@@ -2839,7 +2823,7 @@ template<size_t NDIM>
         void unary_op_value_inplace(const opT& op, bool fence) {
             typedef Range<typename dcT::iterator> rangeT;
             typedef do_unary_op_value_inplace<opT> xopT;
-            world.taskq.for_each<rangeT,xopT>(rangeT(coeffs.begin(), coeffs.end()), xopT(this,op));
+            world.taskq.for_each<rangeT, xopT>(rangeT(coeffs.begin(), coeffs.end()), xopT(this, op));
             if (fence)
                 world.gop.fence();
         }
@@ -2857,13 +2841,13 @@ template<size_t NDIM>
         /// @param[out] vresultin the vector of resulting functions (impl's)
         template <typename L, typename R>
         void mulXXveca(const keyT& key,
-                       const FunctionImpl<L,NDIM>* left, const Tensor<L>& lcin,
-                       const std::vector<const FunctionImpl<R,NDIM>*> vrightin,
-                       const std::vector< Tensor<R> >& vrcin,
-                       const std::vector<FunctionImpl<T,NDIM>*> vresultin,
+                       const FunctionImpl<L, NDIM>* left, const Tensor<L>& lcin,
+                       const std::vector<const FunctionImpl<R, NDIM>*> vrightin,
+                       const std::vector< Tensor<R>>& vrcin,
+                       const std::vector<FunctionImpl<T, NDIM>*> vresultin,
                        double tol) {
-            typedef typename FunctionImpl<L,NDIM>::dcT::const_iterator literT;
-            typedef typename FunctionImpl<R,NDIM>::dcT::const_iterator riterT;
+            typedef typename FunctionImpl<L, NDIM>::dcT::const_iterator literT;
+            typedef typename FunctionImpl<R, NDIM>::dcT::const_iterator riterT;
 
             double lnorm = 1e99;
             Tensor<L> lc = lcin;
@@ -2876,16 +2860,16 @@ template<size_t NDIM>
             }
 
             // Loop thru RHS functions seeing if anything can be multiplied
-            std::vector<FunctionImpl<T,NDIM>*> vresult;
-            std::vector<const FunctionImpl<R,NDIM>*> vright;
-            std::vector< Tensor<R> > vrc;
+            std::vector<FunctionImpl<T, NDIM>*> vresult;
+            std::vector<const FunctionImpl<R, NDIM>*> vright;
+            std::vector< Tensor<R>> vrc;
             vresult.reserve(vrightin.size());
             vright.reserve(vrightin.size());
             vrc.reserve(vrightin.size());
 
-            for (unsigned int i=0; i<vrightin.size(); ++i) {
-                FunctionImpl<T,NDIM>* result = vresultin[i];
-                const FunctionImpl<R,NDIM>* right = vrightin[i];
+            for (unsigned int i = 0; i < vrightin.size(); ++i) {
+                FunctionImpl<T, NDIM>* result = vresultin[i];
+                const FunctionImpl<R, NDIM>* right = vrightin[i];
                 Tensor<R> rc = vrcin[i];
                 double rnorm;
                 if (rc.size() == 0) {
@@ -2900,13 +2884,13 @@ template<size_t NDIM>
                 }
 
                 if (rc.size() && lc.size()) { // Yipee!
-                    result->task(world.rank(), &implT:: template do_mul<L,R>, key, lc, std::make_pair(key,rc));
+                    result->task(world.rank(), &implT:: template do_mul<L, R>, key, lc, std::make_pair(key, rc));
                 }
                 else if (tol && lnorm*rnorm < truncate_tol(tol, key)) {
-                    result->coeffs.replace(key, nodeT(coeffT(cdata.vk,targs),false)); // Zero leaf
+                    result->coeffs.replace(key, nodeT(coeffT(cdata.vk, targs), false)); // Zero leaf
                 }
                 else {  // Interior node
-                    result->coeffs.replace(key, nodeT(coeffT(),true));
+                    result->coeffs.replace(key, nodeT(coeffT(), true));
                     vresult.push_back(result);
                     vright.push_back(right);
                     vrc.push_back(rc);
@@ -2921,8 +2905,8 @@ template<size_t NDIM>
                     lss = left->unfilter(ld);
                 }
 
-                std::vector< Tensor<R> > vrss(vresult.size());
-                for (unsigned int i=0; i<vresult.size(); ++i) {
+                std::vector< Tensor<R>> vrss(vresult.size());
+                for (unsigned int i = 0; i < vresult.size(); ++i) {
                     if (vrc[i].size()) {
                         Tensor<R> rd(cdata.v2k);
                         rd(cdata.s0) = vrc[i](___);
@@ -2939,13 +2923,13 @@ template<size_t NDIM>
                     if (lc.size())
                         ll = copy(lss(cp));
 
-                    std::vector< Tensor<R> > vv(vresult.size());
-                    for (unsigned int i=0; i<vresult.size(); ++i) {
+                    std::vector< Tensor<R>> vv(vresult.size());
+                    for (unsigned int i = 0; i < vresult.size(); ++i) {
                         if (vrc[i].size())
                             vv[i] = copy(vrss[i](cp));
                     }
 
-                    woT::task(coeffs.owner(child), &implT:: template mulXXveca<L,R>, child, left, ll, vright, vv, vresult, tol);
+                    woT::task(coeffs.owner(child), &implT:: template mulXXveca<L, R>, child, left, ll, vright, vv, vresult, tol);
                 }
             }
         }
@@ -2961,13 +2945,13 @@ template<size_t NDIM>
         ///            current box in the right function
         template <typename L, typename R>
         void mulXXa(const keyT& key,
-                    const FunctionImpl<L,NDIM>* left, const Tensor<L>& lcin,
-                    const FunctionImpl<R,NDIM>* right,const Tensor<R>& rcin,
+                    const FunctionImpl<L, NDIM>* left, const Tensor<L>& lcin,
+                    const FunctionImpl<R, NDIM>* right, const Tensor<R>& rcin,
                     double tol) {
-            typedef typename FunctionImpl<L,NDIM>::dcT::const_iterator literT;
-            typedef typename FunctionImpl<R,NDIM>::dcT::const_iterator riterT;
+            typedef typename FunctionImpl<L, NDIM>::dcT::const_iterator literT;
+            typedef typename FunctionImpl<R, NDIM>::dcT::const_iterator riterT;
 
-            double lnorm=1e99, rnorm=1e99;
+            double lnorm = 1e99, rnorm = 1e99;
 
             Tensor<L> lc = lcin;
             if (lc.size() == 0) {
@@ -2989,7 +2973,7 @@ template<size_t NDIM>
 
             // both nodes are leaf nodes: multiply and return
             if (rc.size() && lc.size()) { // Yipee!
-                do_mul<L,R>(key, lc, std::make_pair(key,rc));
+                do_mul<L, R>(key, lc, std::make_pair(key, rc));
                 return;
             }
 
@@ -2998,14 +2982,14 @@ template<size_t NDIM>
                     lnorm = lc.normf(); // Otherwise got from norm tree above
                 if (rc.size())
                     rnorm = rc.normf();
-                if (lnorm*rnorm < truncate_tol(tol, key)) {
-                    coeffs.replace(key, nodeT(coeffT(cdata.vk,targs),false)); // Zero leaf node
+                if (lnorm * rnorm < truncate_tol(tol, key)) {
+                    coeffs.replace(key, nodeT(coeffT(cdata.vk, targs), false)); // Zero leaf node
                     return;
                 }
             }
 
             // Recur down
-            coeffs.replace(key, nodeT(coeffT(),true)); // Interior node
+            coeffs.replace(key, nodeT(coeffT(), true)); // Interior node
 
             Tensor<L> lss;
             if (lc.size()) {
@@ -3030,7 +3014,7 @@ template<size_t NDIM>
                 if (rc.size())
                     rr = copy(rss(child_patch(child)));
 
-                woT::task(coeffs.owner(child), &implT:: template mulXXa<L,R>, child, left, ll, right, rr, tol);
+                woT::task(coeffs.owner(child), &implT:: template mulXXa<L, R>, child, left, ll, right, rr, tol);
             }
         }
 
@@ -3047,11 +3031,11 @@ template<size_t NDIM>
         /// @param[in] op the binary operator
         template <typename L, typename R, typename opT>
         void binaryXXa(const keyT& key,
-                       const FunctionImpl<L,NDIM>* left, const Tensor<L>& lcin,
-                       const FunctionImpl<R,NDIM>* right,const Tensor<R>& rcin,
+                       const FunctionImpl<L, NDIM>* left, const Tensor<L>& lcin,
+                       const FunctionImpl<R, NDIM>* right, const Tensor<R>& rcin,
                        const opT& op) {
-            typedef typename FunctionImpl<L,NDIM>::dcT::const_iterator literT;
-            typedef typename FunctionImpl<R,NDIM>::dcT::const_iterator riterT;
+            typedef typename FunctionImpl<L, NDIM>::dcT::const_iterator literT;
+            typedef typename FunctionImpl<R, NDIM>::dcT::const_iterator riterT;
 
             Tensor<L> lc = lcin;
             if (lc.size() == 0) {
@@ -3070,12 +3054,12 @@ template<size_t NDIM>
             }
 
             if (rc.size() && lc.size()) { // Yipee!
-                do_binary_op<L,R>(key, lc, std::make_pair(key,rc), op);
+                do_binary_op<L, R>(key, lc, std::make_pair(key, rc), op);
                 return;
             }
 
             // Recur down
-            coeffs.replace(key, nodeT(coeffT(),true)); // Interior node
+            coeffs.replace(key, nodeT(coeffT(), true)); // Interior node
 
             Tensor<L> lss;
             if (lc.size()) {
@@ -3100,18 +3084,18 @@ template<size_t NDIM>
                 if (rc.size())
                     rr = copy(rss(child_patch(child)));
 
-                woT::task(coeffs.owner(child), &implT:: template binaryXXa<L,R,opT>, child, left, ll, right, rr, op);
+                woT::task(coeffs.owner(child), &implT:: template binaryXXa<L, R, opT>, child, left, ll, right, rr, op);
             }
         }
 
         template <typename Q, typename opT>
         struct coeff_value_adaptor {
             typedef typename opT::resultT resultT;
-            const FunctionImpl<Q,NDIM>* impl_func;
+            const FunctionImpl<Q, NDIM>* impl_func;
             opT op;
 
             coeff_value_adaptor() {};
-            coeff_value_adaptor(const FunctionImpl<Q,NDIM>* impl_func,
+            coeff_value_adaptor(const FunctionImpl<Q, NDIM>* impl_func,
                                 const opT& op)
                 : impl_func(impl_func), op(op) {}
 
@@ -3139,22 +3123,22 @@ template<size_t NDIM>
         /// @param[in] op the unary operator
         template <typename Q, typename opT>
         void unaryXXa(const keyT& key,
-                      const FunctionImpl<Q,NDIM>* func, const opT& op) {
+                      const FunctionImpl<Q, NDIM>* func, const opT& op) {
 
             //            const Tensor<Q>& fc = func->coeffs.find(key).get()->second.full_tensor_copy();
             const Tensor<Q> fc = func->coeffs.find(key).get()->second.coeff().reconstruct_tensor();
 
             if (fc.size() == 0) {
                 // Recur down
-                coeffs.replace(key, nodeT(coeffT(),true)); // Interior node
+                coeffs.replace(key, nodeT(coeffT(), true)); // Interior node
                 for (KeyChildIterator<NDIM> kit(key); kit; ++kit) {
                     const keyT& child = kit.key();
-                    woT::task(coeffs.owner(child), &implT:: template unaryXXa<Q,opT>, child, func, op);
+                    woT::task(coeffs.owner(child), &implT:: template unaryXXa<Q, opT>, child, func, op);
                 }
             }
             else {
-                tensorT t=op(key,fc);
-                coeffs.replace(key, nodeT(coeffT(t,targs),false)); // Leaf node
+                tensorT t = op(key, fc);
+                coeffs.replace(key, nodeT(coeffT(t, targs), false)); // Leaf node
             }
         }
 
@@ -3163,12 +3147,11 @@ template<size_t NDIM>
         /// @param[in] right pointer to the right function impl
         /// @param[in] tol numerical tolerance
         template <typename L, typename R>
-        void mulXX(const FunctionImpl<L,NDIM>* left, const FunctionImpl<R,NDIM>* right, double tol, bool fence) {
+        void mulXX(const FunctionImpl<L, NDIM>* left, const FunctionImpl<R, NDIM>* right, double tol, bool fence) {
             if (world.rank() == coeffs.owner(cdata.key0))
                 mulXXa(cdata.key0, left, Tensor<L>(), right, Tensor<R>(), tol);
             if (fence)
                 world.gop.fence();
-
             //verify_tree();
         }
 
@@ -3177,13 +3160,12 @@ template<size_t NDIM>
         /// @param[in] right pointer to the right function impl
         /// @param[in] op the binary operator
         template <typename L, typename R, typename opT>
-        void binaryXX(const FunctionImpl<L,NDIM>* left, const FunctionImpl<R,NDIM>* right,
+        void binaryXX(const FunctionImpl<L, NDIM>* left, const FunctionImpl<R, NDIM>* right,
                       const opT& op, bool fence) {
             if (world.rank() == coeffs.owner(cdata.key0))
                 binaryXXa(cdata.key0, left, Tensor<L>(), right, Tensor<R>(), op);
             if (fence)
                 world.gop.fence();
-
             //verify_tree();
         }
 
@@ -3191,12 +3173,11 @@ template<size_t NDIM>
         /// @param[in] func function impl of the operand
         /// @param[in] op the unary operator
         template <typename Q, typename opT>
-        void unaryXX(const FunctionImpl<Q,NDIM>* func, const opT& op, bool fence) {
+        void unaryXX(const FunctionImpl<Q, NDIM>* func, const opT& op, bool fence) {
             if (world.rank() == coeffs.owner(cdata.key0))
                 unaryXXa(cdata.key0, func, op);
             if (fence)
                 world.gop.fence();
-
             //verify_tree();
         }
 
@@ -3204,12 +3185,11 @@ template<size_t NDIM>
         /// @param[in] func function impl of the operand
         /// @param[in] op the unary operator
         template <typename Q, typename opT>
-        void unaryXXvalues(const FunctionImpl<Q,NDIM>* func, const opT& op, bool fence) {
+        void unaryXXvalues(const FunctionImpl<Q, NDIM>* func, const opT& op, bool fence) {
             if (world.rank() == coeffs.owner(cdata.key0))
-                unaryXXa(cdata.key0, func, coeff_value_adaptor<Q,opT>(func,op));
+                unaryXXa(cdata.key0, func, coeff_value_adaptor<Q, opT>(func, op));
             if (fence)
                 world.gop.fence();
-
             //verify_tree();
         }
 
@@ -3220,12 +3200,12 @@ template<size_t NDIM>
         /// @param[in] tol numerical tolerance
         /// @param[out] vresult vector of pointers to the resulting function impl's
         template <typename L, typename R>
-        void mulXXvec(const FunctionImpl<L,NDIM>* left,
-                      const std::vector<const FunctionImpl<R,NDIM>*>& vright,
-                      const std::vector<FunctionImpl<T,NDIM>*>& vresult,
+        void mulXXvec(const FunctionImpl<L, NDIM>* left,
+                      const std::vector<const FunctionImpl<R, NDIM>*>& vright,
+                      const std::vector<FunctionImpl<T, NDIM>*>& vresult,
                       double tol,
                       bool fence) {
-            std::vector< Tensor<R> > vr(vright.size());
+            std::vector< Tensor<R>> vr(vright.size());
             if (world.rank() == coeffs.owner(cdata.key0))
                 mulXXveca(cdata.key0, left, Tensor<L>(), vright, vr, vresult, tol);
             if (fence)
@@ -3252,7 +3232,7 @@ template<size_t NDIM>
         /// useful for debugging and paranoia.
         void verify_tree() const;
 
-        /// Walk up the tree returning pair(key,node) for first node with coefficients
+        /// Walk up the tree returning pair(key, node) for first node with coefficients
 
         /// Three possibilities.
         ///
@@ -3271,19 +3251,18 @@ template<size_t NDIM>
         /// parallelism but much less communication.
         /// @todo Robert .... help!
         void sock_it_to_me(const keyT& key,
-                           const RemoteReference< FutureImpl< std::pair<keyT,coeffT> > >& ref) const;
+                           const RemoteReference< FutureImpl< std::pair<keyT, coeffT>> >& ref) const;
         /// As above, except
         /// 3) The coeffs are constructed from the avg of nodes further down the tree
         /// @todo Robert .... help!
         void sock_it_to_me_too(const keyT& key,
-                               const RemoteReference< FutureImpl< std::pair<keyT,coeffT> > >& ref) const;
+                               const RemoteReference< FutureImpl< std::pair<keyT, coeffT>> >& ref) const;
 
         /// @todo help!
-        void plot_cube_kernel(archive::archive_ptr< Tensor<T> > ptr,
+        void plot_cube_kernel(archive::archive_ptr< Tensor<T>> ptr,
                               const keyT& key,
-                              const coordT& plotlo, const coordT& plothi, const std::vector<long>& npt,
+                              const coordT& plotlo, const coordT& plothi, const std::vector<long>& npt, 
                               bool eval_refine) const;
-
 
         /// Evaluate a cube/slice of points ... plotlo and plothi are already in simulation coordinates
         /// No communications
@@ -3295,20 +3274,18 @@ template<size_t NDIM>
                                  const std::vector<long>& npt,
                                  const bool eval_refine = false) const;
 
-
-        /// Evaluate function only if point is local returning (true,value); otherwise return (false,0.0)
+        /// Evaluate function only if point is local returning (true, value); otherwise return (false, 0.0)
 
         /// maxlevel is the maximum depth to search down to --- the max local depth can be
         /// computed with max_local_depth();
-        std::pair<bool,T> eval_local_only(const Vector<double,NDIM>& xin, Level maxlevel) ;
-
+        std::pair<bool, T> eval_local_only(const Vector<double, NDIM>& xin, Level maxlevel) ;
 
         /// Evaluate the function at a point in \em simulation coordinates
 
         /// Only the invoking process will get the result via the
         /// remote reference to a future.  Active messages may be sent
         /// to other nodes.
-        void eval(const Vector<double,NDIM>& xin,
+        void eval(const Vector<double, NDIM>& xin,
                   const keyT& keyin,
                   const typename Future<T>::remote_refT& ref);
 
@@ -3319,7 +3296,7 @@ template<size_t NDIM>
         /// to other nodes.
         ///
         /// This function is a minimally-modified version of eval()
-        void evaldepthpt(const Vector<double,NDIM>& xin,
+        void evaldepthpt(const Vector<double, NDIM>& xin,
                          const keyT& keyin,
                          const typename Future<Level>::remote_refT& ref);
 
@@ -3330,7 +3307,7 @@ template<size_t NDIM>
         /// to other nodes.
         ///
         /// This function is a minimally-modified version of eval()
-        void evalR(const Vector<double,NDIM>& xin,
+        void evalR(const Vector<double, NDIM>& xin,
                    const keyT& keyin,
                    const typename Future<long>::remote_refT& ref);
 
@@ -3342,8 +3319,8 @@ template<size_t NDIM>
         /// ... lo ... the block of t for all polynomials of order < k/2
         /// ... hi ... the block of t for all polynomials of order >= k/2
         ///
-        /// k=5   0,1,2,3,4     --> 0,1,2 ... 3,4
-        /// k=6   0,1,2,3,4,5   --> 0,1,2 ... 3,4,5
+        /// k=5   0, 1, 2, 3, 4     --> 0, 1, 2 ... 3, 4
+        /// k=6   0, 1, 2, 3, 4, 5   --> 0, 1, 2 ... 3, 4, 5
         ///
         /// k=number of wavelets, so k=5 means max order is 4, so max exactly
         /// representable squarable polynomial is of order 2.
@@ -3379,16 +3356,16 @@ template<size_t NDIM>
         /// After 1d push operator must sum coeffs down the tree to restore correct scaling function coefficients
         void sum_down(bool fence);
 
-        /// perform this multiplication: h(1,2) = f(1,2) * g(1)
+        /// perform this multiplication: h(1, 2) = f(1, 2) * g(1)
         template<size_t LDIM>
         struct multiply_op {
 
-            static bool randomize() {return false;}
-            typedef CoeffTracker<T,NDIM> ctT;
-            typedef CoeffTracker<T,LDIM> ctL;
+            static bool randomize() { return false; }
+            typedef CoeffTracker<T, NDIM> ctT;
+            typedef CoeffTracker<T, LDIM> ctL;
             typedef multiply_op<LDIM> this_type;
 
-            implT* h;     ///< the result function h(1,2) = f(1,2) * g(1)
+            implT* h;     ///< the result function h(1, 2) = f(1, 2) * g(1)
             ctT f;
             ctL g;
             int particle;       ///< if g is g(1) or g(2)
@@ -3407,12 +3384,12 @@ template<size_t NDIM>
                 MADNESS_ASSERT(g.get_impl());
                 MADNESS_ASSERT(h);
 
-                double glo=0.0, ghi=0.0, flo=0.0, fhi=0.0;
+                double glo = 0.0, ghi = 0.0, flo = 0.0, fhi = 0.0;
                 g.get_impl()->tnorm(gcoeff.get_tensor(), &glo, &ghi);
-                g.get_impl()->tnorm(fcoeff.get_svdtensor(),&flo,&fhi,particle);
+                g.get_impl()->tnorm(fcoeff.get_svdtensor(), &flo, &fhi, particle);
 
-                double total_hi=glo*fhi + ghi*flo + fhi*ghi;
-                return (total_hi<h->truncate_tol(h->get_thresh(),key));
+                double total_hi = glo * fhi + ghi * flo + fhi * ghi;
+                return (total_hi<h->truncate_tol(h->get_thresh(), key));
 
             }
 
@@ -3420,67 +3397,66 @@ template<size_t NDIM>
 
             /// @param[in]  key key for FunctionNode in f and g, (g: broken into particles)
             /// @return <this node is a leaf, coefficients of this node>
-            std::pair<bool,coeffT> operator()(const Key<NDIM>& key) const {
-
-                //                bool is_leaf=(not fdatum.second.has_children());
-                //                if (not is_leaf) return std::pair<bool,coeffT> (is_leaf,coeffT());
+            std::pair<bool, coeffT> operator()(const Key<NDIM>& key) const {
+                // bool is_leaf=(not fdatum.second.has_children());
+                // if (not is_leaf) return std::pair<bool, coeffT> (is_leaf, coeffT());
 
                 // break key into particles (these are the child keys, with f/gdatum come the parent keys)
-                Key<LDIM> key1,key2;
-                key.break_apart(key1,key2);
-                const Key<LDIM> gkey= (particle==1) ? key1 : key2;
+                Key<LDIM> key1, key2;
+                key.break_apart(key1, key2);
+                const Key<LDIM> gkey = (particle == 1) ? key1 : key2;
 
                 // get coefficients of the actual FunctionNode
-                coeffT coeff1=f.get_impl()->parent_to_child(f.coeff(),f.key(),key);
+                coeffT coeff1 = f.get_impl()->parent_to_child(f.coeff(), f.key(), key);
                 coeff1.normalize();
-                const coeffT coeff2=g.get_impl()->parent_to_child(g.coeff(),g.key(),gkey);
+                const coeffT coeff2 = g.get_impl()->parent_to_child(g.coeff(), g.key(), gkey);
 
                 // multiplication is done in TT_2D
-                coeffT coeff1_2D=coeff1.convert(TensorArgs(h->get_thresh(),TT_2D));
+                coeffT coeff1_2D = coeff1.convert(TensorArgs(h->get_thresh(), TT_2D));
                 coeff1_2D.normalize();
 
-                bool is_leaf=screen(coeff1_2D,coeff2,key);
-                if (key.level()<2) is_leaf=false;
+                bool is_leaf = screen(coeff1_2D, coeff2, key);
+                if (key.level() < 2) is_leaf = false;
 
                 coeffT hcoeff;
                 if (is_leaf) {
 
                     // convert coefficients to values
-                    coeffT hvalues=f.get_impl()->coeffs2values(key,coeff1_2D);
-                    coeffT gvalues=g.get_impl()->coeffs2values(gkey,coeff2);
+                    coeffT hvalues = f.get_impl()->coeffs2values(key, coeff1_2D);
+                    coeffT gvalues = g.get_impl()->coeffs2values(gkey, coeff2);
 
                     // perform multiplication
-                    coeffT result_val=h->multiply(hvalues,gvalues,particle-1);
+                    coeffT result_val = h->multiply(hvalues, gvalues, particle - 1);
 
-                    hcoeff=h->values2coeffs(key,result_val);
+                    hcoeff = h->values2coeffs(key, result_val);
 
                     // conversion on coeffs, not on values, because it implies truncation!
                     if (not hcoeff.is_of_tensortype(h->get_tensor_type()))
-                        hcoeff=hcoeff.convert(h->get_tensor_args());
+                        hcoeff = hcoeff.convert(h->get_tensor_args());
                 }
 
-                return std::pair<bool,coeffT> (is_leaf,hcoeff);
+                return std::pair<bool, coeffT> (is_leaf, hcoeff);
             }
 
             this_type make_child(const keyT& child) const {
 
                 // break key into particles
                 Key<LDIM> key1, key2;
-                child.break_apart(key1,key2);
-                const Key<LDIM> gkey= (particle==1) ? key1 : key2;
+                child.break_apart(key1, key2);
+                const Key<LDIM> gkey = (particle == 1) ? key1 : key2;
 
-                return this_type(h,f.make_child(child),g.make_child(gkey),particle);
+                return this_type(h, f.make_child(child), g.make_child(gkey), particle);
             }
 
             Future<this_type> activate() const {
-            	Future<ctT> f1=f.activate();
-            	Future<ctL> g1=g.activate();
+            	Future<ctT> f1 = f.activate();
+            	Future<ctL> g1 = g.activate();
                 return h->world.taskq.add(detail::wrap_mem_fn(*const_cast<this_type *> (this),
-                                          &this_type::forward_ctor),h,f1,g1,particle);
+                                          &this_type::forward_ctor), h, f1, g1, particle);
             }
 
             this_type forward_ctor(implT* h1, const ctT& f1, const ctL& g1, const int particle) {
-            	return this_type(h1,f1,g1,particle);
+            	return this_type(h1, f1, g1, particle);
             }
 
             template <typename Archive> void serialize(const Archive& ar) {
@@ -3492,13 +3468,13 @@ template<size_t NDIM>
         /// add two functions f and g: result=alpha * f  +  beta * g
         struct add_op {
 
-            typedef CoeffTracker<T,NDIM> ctT;
+            typedef CoeffTracker<T, NDIM> ctT;
             typedef add_op this_type;
 
-            bool randomize() const {return false;}
+            bool randomize() const { return false; }
 
             /// tracking coeffs of first and second addend
-            ctT f,g;
+            ctT f, g;
             /// prefactor for f, g
             double alpha, beta;
 
@@ -3507,65 +3483,63 @@ template<size_t NDIM>
                 : f(f), g(g), alpha(alpha), beta(beta){}
 
             /// if we are at the bottom of the trees, return the sum of the coeffs
-            std::pair<bool,coeffT> operator()(const keyT& key) const {
+            std::pair<bool, coeffT> operator()(const keyT& key) const {
 
-                bool is_leaf=(f.is_leaf() and g.is_leaf());
-                if (not is_leaf) return std::pair<bool,coeffT> (is_leaf,coeffT());
+                bool is_leaf = (f.is_leaf() and g.is_leaf());
+                if (not is_leaf) return std::pair<bool, coeffT> (is_leaf, coeffT());
 
-                coeffT fcoeff=f.get_impl()->parent_to_child(f.coeff(),f.key(),key);
-                coeffT gcoeff=g.get_impl()->parent_to_child(g.coeff(),g.key(),key);
-                coeffT hcoeff=copy(fcoeff);
-                hcoeff.gaxpy(alpha,gcoeff,beta);
+                coeffT fcoeff = f.get_impl()->parent_to_child(f.coeff(), f.key(), key);
+                coeffT gcoeff = g.get_impl()->parent_to_child(g.coeff(), g.key(), key);
+                coeffT hcoeff = copy(fcoeff);
+                hcoeff.gaxpy(alpha, gcoeff, beta);
                 hcoeff.reduce_rank(f.get_impl()->get_tensor_args().thresh);
-                return std::pair<bool,coeffT> (is_leaf,hcoeff);
+                return std::pair<bool, coeffT> (is_leaf, hcoeff);
             }
 
             this_type make_child(const keyT& child) const {
-                return this_type(f.make_child(child),g.make_child(child),alpha,beta);
+                return this_type(f.make_child(child), g.make_child(child), alpha, beta);
             }
 
             /// retrieve the coefficients (parent coeffs might be remote)
             Future<this_type> activate() const {
-            	Future<ctT> f1=f.activate();
-            	Future<ctT> g1=g.activate();
-                return f.get_impl()->world.taskq.add(detail::wrap_mem_fn(*const_cast<this_type *> (this),
-                                                     &this_type::forward_ctor),f1,g1,alpha,beta);
+            	Future<ctT> f1 = f.activate();
+            	Future<ctT> g1 = g.activate();
+                return f.get_impl()->world.taskq.add(detail::wrap_mem_fn(*const_cast<this_type *> (this), 
+                                                     &this_type::forward_ctor), f1, g1, alpha, beta);
             }
 
             /// taskq-compatible ctor
             this_type forward_ctor(const ctT& f1, const ctT& g1, const double alpha, const double beta) {
-            	return this_type(f1,g1,alpha,beta);
+            	return this_type(f1, g1, alpha, beta);
             }
 
             template <typename Archive> void serialize(const Archive& ar) {
                 ar & f & g & alpha & beta;
             }
-
         };
 
         /// multiply f (a pair function of NDIM) with an orbital g (LDIM=NDIM/2)
 
-        /// as in (with h(1,2)=*this) : h(1,2) = g(1) * f(1,2)
+        /// as in (with h(1, 2)=*this) : h(1, 2) = g(1) * f(1, 2)
         /// use tnorm as a measure to determine if f (=*this) must be refined
-        /// @param[in]  f           the NDIM function f=f(1,2)
+        /// @param[in]  f           the NDIM function f=f(1, 2)
         /// @param[in]  g           the LDIM function g(1) (or g(2))
         /// @param[in]  particle    1 or 2, as in g(1) or g(2)
         template<size_t LDIM>
-        void multiply(const implT* f, const FunctionImpl<T,LDIM>* g, const int particle) {
+        void multiply(const implT* f, const FunctionImpl<T, LDIM>* g, const int particle) {
+            CoeffTracker<T, NDIM> ff(f);
+            CoeffTracker<T, LDIM> gg(g);
 
-                CoeffTracker<T,NDIM> ff(f);
-                CoeffTracker<T,LDIM> gg(g);
+            typedef multiply_op<LDIM> coeff_opT;
+            coeff_opT coeff_op(this, ff, gg, particle);
 
-                typedef multiply_op<LDIM> coeff_opT;
-                coeff_opT coeff_op(this,ff,gg,particle);
+            typedef insert_op<T, NDIM> apply_opT;
+            apply_opT apply_op(this);
 
-                typedef insert_op<T,NDIM> apply_opT;
-                apply_opT apply_op(this);
-
-            keyT key0=f->cdata.key0;
+            keyT key0 = f->cdata.key0;
 			if (world.rank() == coeffs.owner(key0)) {
-                ProcessID p= coeffs.owner(key0);
-                woT::task(p, &implT:: template forward_traverse<coeff_opT,apply_opT>, coeff_op, apply_op, key0);
+                ProcessID p = coeffs.owner(key0);
+                woT::task(p, &implT:: template forward_traverse<coeff_opT, apply_opT>, coeff_op, apply_op, key0);
             }
 
             set_tree_state(reconstructed);
@@ -3574,10 +3548,10 @@ template<size_t NDIM>
         /// Hartree product of two LDIM functions to yield a NDIM = 2*LDIM function
         template<size_t LDIM, typename leaf_opT>
         struct hartree_op {
-            bool randomize() const {return false;}
+            bool randomize() const { return false; }
 
-            typedef hartree_op<LDIM,leaf_opT> this_type;
-            typedef CoeffTracker<T,LDIM> ctL;
+            typedef hartree_op<LDIM, leaf_opT> this_type;
+            typedef CoeffTracker<T, LDIM> ctL;
 
             implT* result; 	    ///< where to construct the pair function
             ctL p1, p2;			///< tracking coeffs of the two lo-dim functions
@@ -3587,50 +3561,50 @@ template<size_t NDIM>
             hartree_op() : result() {}
             hartree_op(implT* result, const ctL& p11, const ctL& p22, const leaf_opT& leaf_op)
                 : result(result), p1(p11), p2(p22), leaf_op(leaf_op) {
-                MADNESS_ASSERT(LDIM+LDIM==NDIM);
+                MADNESS_ASSERT(LDIM+LDIM == NDIM);
             }
 
-            std::pair<bool,coeffT> operator()(const Key<NDIM>& key) const {
+            std::pair<bool, coeffT> operator()(const Key<NDIM>& key) const {
 
                 // break key into particles (these are the child keys, with datum1/2 come the parent keys)
-                Key<LDIM> key1,key2;
-                key.break_apart(key1,key2);
+                Key<LDIM> key1, key2;
+                key.break_apart(key1, key2);
 
                 // this returns the appropriate NS coeffs for key1 and key2 resp.
-            	const coeffT fcoeff=p1.coeff(key1);
-                const coeffT gcoeff=p2.coeff(key2);
-                bool is_leaf=leaf_op(key,fcoeff.full_tensor(),gcoeff.full_tensor());
-                if (not is_leaf) return std::pair<bool,coeffT> (is_leaf,coeffT());
+            	const coeffT fcoeff = p1.coeff(key1);
+                const coeffT gcoeff = p2.coeff(key2);
+                bool is_leaf = leaf_op(key, fcoeff.full_tensor(), gcoeff.full_tensor());
+                if (not is_leaf) return std::pair<bool, coeffT> (is_leaf, coeffT());
 
                 // extract the sum coeffs from the NS coeffs
-                const coeffT s1=fcoeff(p1.get_impl()->cdata.s0);
-                const coeffT s2=gcoeff(p2.get_impl()->cdata.s0);
+                const coeffT s1 = fcoeff(p1.get_impl()->cdata.s0);
+                const coeffT s2 = gcoeff(p2.get_impl()->cdata.s0);
 
                 // new coeffs are simply the hartree/kronecker/outer product --
-                coeffT coeff=outer(s1,s2,result->get_tensor_args());
+                coeffT coeff = outer(s1, s2, result->get_tensor_args());
                 // no post-determination
-                //                is_leaf=leaf_op(key,coeff);
-                return std::pair<bool,coeffT>(is_leaf,coeff);
+                //                is_leaf=leaf_op(key, coeff);
+                return std::pair<bool, coeffT>(is_leaf, coeff);
             }
 
             this_type make_child(const keyT& child) const {
 
                 // break key into particles
                 Key<LDIM> key1, key2;
-                child.break_apart(key1,key2);
+                child.break_apart(key1, key2);
 
-                return this_type(result,p1.make_child(key1),p2.make_child(key2),leaf_op);
+                return this_type(result, p1.make_child(key1), p2.make_child(key2), leaf_op);
             }
 
             Future<this_type> activate() const {
-            	Future<ctL> p11=p1.activate();
-            	Future<ctL> p22=p2.activate();
+            	Future<ctL> p11 = p1.activate();
+            	Future<ctL> p22 = p2.activate();
                 return result->world.taskq.add(detail::wrap_mem_fn(*const_cast<this_type *> (this),
-                                               &this_type::forward_ctor),result,p11,p22,leaf_op);
+                                               &this_type::forward_ctor), result, p11, p22, leaf_op);
             }
 
             this_type forward_ctor(implT* result1, const ctL& p11, const ctL& p22, const leaf_opT& leaf_op) {
-            	return this_type(result1,p11,p22,leaf_op);
+            	return this_type(result1, p11, p22, leaf_op);
             }
 
             template <typename Archive> void serialize(const Archive& ar) {
@@ -3647,8 +3621,8 @@ template<size_t NDIM>
         template<typename coeff_opT, typename apply_opT>
         void forward_traverse(const coeff_opT& coeff_op, const apply_opT& apply_op, const keyT& key) const {
             MADNESS_ASSERT(coeffs.is_local(key));
-            Future<coeff_opT> active_coeff=coeff_op.activate();
-            woT::task(world.rank(), &implT:: template traverse_tree<coeff_opT,apply_opT>, active_coeff, apply_op, key);
+            Future<coeff_opT> active_coeff = coeff_op.activate();
+            woT::task(world.rank(), &implT:: template traverse_tree<coeff_opT, apply_opT>, active_coeff, apply_op, key);
         }
 
 
@@ -3662,19 +3636,19 @@ template<size_t NDIM>
         void traverse_tree(const coeff_opT& coeff_op, const apply_opT& apply_op, const keyT& key) const {
             MADNESS_ASSERT(coeffs.is_local(key));
 
-            typedef typename std::pair<bool,coeffT> argT;
-            const argT arg=coeff_op(key);
-            apply_op.operator()(key,arg.second,arg.first);
+            typedef typename std::pair<bool, coeffT> argT;
+            const argT arg = coeff_op(key);
+            apply_op.operator()(key, arg.second, arg.first);
 
-            const bool has_children=(not arg.first);
+            const bool has_children = (not arg.first);
             if (has_children) {
                 for (KeyChildIterator<NDIM> kit(key); kit; ++kit) {
-                    const keyT& child=kit.key();
-                    coeff_opT child_op=coeff_op.make_child(child);
+                    const keyT& child = kit.key();
+                    coeff_opT child_op = coeff_op.make_child(child);
                     // spawn activation where child is local
-                    ProcessID p=coeffs.owner(child);
+                    ProcessID p = coeffs.owner(child);
 
-                    void (implT::*ft)(const coeff_opT&, const apply_opT&, const keyT&) const = &implT::forward_traverse<coeff_opT,apply_opT>;
+                    void (implT::*ft)(const coeff_opT&, const apply_opT&, const keyT&) const = &implT::forward_traverse<coeff_opT, apply_opT>;
 
                     woT::task(p, ft, child_op, apply_op, child);
                 }
@@ -3684,37 +3658,37 @@ template<size_t NDIM>
 
         /// given two functions of LDIM, perform the Hartree/Kronecker/outer product
 
-        /// |Phi(1,2)> = |phi(1)> x |phi(2)>
+        /// |Phi(1, 2)> = |phi(1)> x |phi(2)>
         /// @param[in]	p1	FunctionImpl of particle 1
         /// @param[in]	p2	FunctionImpl of particle 2
         /// @param[in]	leaf_op	operator determining of a given box will be a leaf
         template<std::size_t LDIM, typename leaf_opT>
-        void hartree_product(const std::vector<std::shared_ptr<FunctionImpl<T,LDIM>>> p1,
-                             const std::vector<std::shared_ptr<FunctionImpl<T,LDIM>>> p2,
+        void hartree_product(const std::vector<std::shared_ptr<FunctionImpl<T, LDIM>>> p1,
+                             const std::vector<std::shared_ptr<FunctionImpl<T, LDIM>>> p2,
                              const leaf_opT& leaf_op, bool fence) {
-            MADNESS_CHECK_THROW(p1.size()==p2.size(),"hartree_product: p1 and p2 must have the same size");
+            MADNESS_CHECK_THROW(p1.size() == p2.size(), "hartree_product: p1 and p2 must have the same size");
             for (auto& p : p1) MADNESS_CHECK(p->is_nonstandard() or p->is_nonstandard_with_leaves());
             for (auto& p : p2) MADNESS_CHECK(p->is_nonstandard() or p->is_nonstandard_with_leaves());
 
-            const keyT key0=cdata.key0;
+            const keyT key0 = cdata.key0;
 
-            for (std::size_t i=0; i<p1.size(); ++i) {
+            for (std::size_t i = 0; i < p1.size(); ++i) {
                 if (world.rank() == this->get_coeffs().owner(key0)) {
 
                     // prepare the CoeffTracker
-                    CoeffTracker<T,LDIM> iap1(p1[i].get());
-                    CoeffTracker<T,LDIM> iap2(p2[i].get());
+                    CoeffTracker<T, LDIM> iap1(p1[i].get());
+                    CoeffTracker<T, LDIM> iap2(p2[i].get());
 
                     // the operator making the coefficients
-                    typedef hartree_op<LDIM,leaf_opT> coeff_opT;
-                    coeff_opT coeff_op(this,iap1,iap2,leaf_op);
+                    typedef hartree_op<LDIM, leaf_opT> coeff_opT;
+                    coeff_opT coeff_op(this, iap1, iap2, leaf_op);
 
                     // this operator simply inserts the coeffs into this' tree
-//                typedef insert_op<T,NDIM> apply_opT;
-                    typedef accumulate_op<T,NDIM> apply_opT;
+                    // typedef insert_op<T, NDIM> apply_opT;
+                    typedef accumulate_op<T, NDIM> apply_opT;
                     apply_opT apply_op(this);
 
-                    woT::task(world.rank(), &implT:: template forward_traverse<coeff_opT,apply_opT>,
+                    woT::task(world.rank(), &implT:: template forward_traverse<coeff_opT, apply_opT>,
                               coeff_op, apply_op, cdata.key0);
 
                 }
@@ -3731,31 +3705,31 @@ template<size_t NDIM>
             const opT* op = pop.ptr;
             const Level n = key.level();
             const double cnorm = c.normf();
-            const double tol = truncate_tol(thresh, key)*0.1; // ??? why this value????
+            const double tol = truncate_tol(thresh, key) * 0.1; // ??? why this value????
 
-            Vector<Translation,NDIM> lnew(key.translation());
+            Vector<Translation, NDIM> lnew(key.translation());
             const Translation lold = lnew[axis];
             const Translation maxs = Translation(1)<<n;
 
             int nsmall = 0; // Counts neglected blocks to terminate s loop
-            for (Translation s=0; s<maxs; ++s) {
+            for (Translation s = 0; s < maxs; ++s) {
                 int maxdir = s ? 1 : -1;
-                for (int direction=-1; direction<=maxdir; direction+=2) {
-                    lnew[axis] = lold + direction*s;
+                for (int direction = -1; direction <= maxdir; direction += 2) {
+                    lnew[axis] = lold + direction * s;
                     if (lnew[axis] >= 0 && lnew[axis] < maxs) { // NON-ZERO BOUNDARY CONDITIONS IGNORED HERE !!!!!!!!!!!!!!!!!!!!
-                        const Tensor<typename opT::opT>& r = op->rnlij(n, s*direction, true);
+                        const Tensor<typename opT::opT>& r = op->rnlij(n, s * direction, true);
                         double Rnorm = r.normf();
 
                         if (Rnorm == 0.0) {
                             return; // Hard zero means finished!
                         }
 
-                        if (s <= 1  ||  r.normf()*cnorm > tol) { // Always do kernel and neighbor
+                        if (s <= 1 || r.normf() * cnorm > tol) { // Always do kernel and neighbor
                             nsmall = 0;
-                            tensorT result = transform_dir(c,r,axis);
+                            tensorT result = transform_dir(c, r, axis);
 
-                            if (result.normf() > tol*0.3) {
-                                Key<NDIM> dest(n,lnew);
+                            if (result.normf() > tol * 0.3) {
+                                Key<NDIM> dest(n, lnew);
                                 coeffs.task(dest, &nodeT::accumulate2, result, coeffs, dest, TaskAttributes::hipri());
                             }
                         }
@@ -3778,41 +3752,41 @@ template<size_t NDIM>
 
         template <typename opT, typename R>
         void
-        apply_1d_realspace_push(const opT& op, const FunctionImpl<R,NDIM>* f, int axis, bool fence) {
+        apply_1d_realspace_push(const opT& op, const FunctionImpl<R, NDIM>* f, int axis, bool fence) {
             MADNESS_ASSERT(!f->is_compressed());
 
-            typedef typename FunctionImpl<R,NDIM>::dcT::const_iterator fiterT;
-            typedef FunctionNode<R,NDIM> fnodeT;
+            typedef typename FunctionImpl<R, NDIM>::dcT::const_iterator fiterT;
+            typedef FunctionNode<R, NDIM> fnodeT;
             fiterT end = f->coeffs.end();
             ProcessID me = world.rank();
-            for (fiterT it=f->coeffs.begin(); it!=end; ++it) {
+            for (fiterT it = f->coeffs.begin(); it != end; ++it) {
                 const fnodeT& node = it->second;
                 if (node.has_coeff()) {
                     const keyT& key = it->first;
                     const Tensor<R>& c = node.coeff().full_tensor_copy();
-                    woT::task(me, &implT:: template apply_1d_realspace_push_op<opT,R>,
+                    woT::task(me, &implT:: template apply_1d_realspace_push_op<opT, R>,
                               archive::archive_ptr<const opT>(&op), axis, key, c);
                 }
             }
             if (fence) world.gop.fence();
         }
 
-        void forward_do_diff1(const DerivativeBase<T,NDIM>* D,
+        void forward_do_diff1(const DerivativeBase<T, NDIM>* D,
                               const implT* f,
                               const keyT& key,
-                              const std::pair<keyT,coeffT>& left,
-                              const std::pair<keyT,coeffT>& center,
-                              const std::pair<keyT,coeffT>& right);
+                              const std::pair<keyT, coeffT>& left,
+                              const std::pair<keyT, coeffT>& center,
+                              const std::pair<keyT, coeffT>& right);
 
-        void do_diff1(const DerivativeBase<T,NDIM>* D,
+        void do_diff1(const DerivativeBase<T, NDIM>* D,
                       const implT* f,
                       const keyT& key,
-                      const std::pair<keyT,coeffT>& left,
-                      const std::pair<keyT,coeffT>& center,
-                      const std::pair<keyT,coeffT>& right);
+                      const std::pair<keyT, coeffT>& left,
+                      const std::pair<keyT, coeffT>& center,
+                      const std::pair<keyT, coeffT>& right);
 
         // Called by result function to differentiate f
-        void diff(const DerivativeBase<T,NDIM>* D, const implT* f, bool fence);
+        void diff(const DerivativeBase<T, NDIM>* D, const implT* f, bool fence);
 
         /// Returns key of general neighbor enforcing BC
 
@@ -3822,14 +3796,14 @@ template<size_t NDIM>
         keyT neighbor(const keyT& key, const keyT& disp, const std::vector<bool>& is_periodic) const;
 
         /// find_me. Called by diff_bdry to get coefficients of boundary function
-        Future< std::pair<keyT,coeffT> > find_me(const keyT& key) const;
+        Future< std::pair<keyT, coeffT>> find_me(const keyT& key) const;
 
         /// return the a std::pair<key, node>, which MUST exist
-        std::pair<Key<NDIM>,ShallowNode<T,NDIM> > find_datum(keyT key) const;
+        std::pair<Key<NDIM>, ShallowNode<T, NDIM>> find_datum(keyT key) const;
 
-        /// multiply the ket with a one-electron potential rr(1,2)= f(1,2)*g(1)
+        /// multiply the ket with a one-electron potential rr(1, 2)= f(1, 2)*g(1)
 
-        /// @param[in]	val_ket	function values of f(1,2)
+        /// @param[in]	val_ket	function values of f(1, 2)
         /// @param[in]	val_pot	function values of g(1)
         /// @param[in]	particle	if 0 then g(1), if 1 then g(2)
         /// @return		the resulting function values
@@ -3838,8 +3812,8 @@ template<size_t NDIM>
 
         /// given several coefficient tensors, assemble a result tensor
 
-        /// the result looks like: 	(v(1,2) + v(1) + v(2)) |ket(1,2)>
-        /// or 						(v(1,2) + v(1) + v(2)) |p(1) p(2)>
+        /// the result looks like: 	(v(1, 2) + v(1) + v(2)) |ket(1, 2)>
+        /// or 						(v(1, 2) + v(1) + v(2)) |p(1) p(2)>
         /// i.e. coefficients for the ket and coefficients for the two particles are
         /// mutually exclusive. All potential terms are optional, just pass in empty coeffs.
         /// @param[in]	key			the key of the FunctionNode to which these coeffs belong
@@ -3856,63 +3830,63 @@ template<size_t NDIM>
         template<std::size_t LDIM>
         struct pointwise_multiplier {
         	coeffT val_lhs, coeff_lhs;
-            long oversampling=1;
-        	double error=0.0;
-        	double lo=0.0, hi=0.0, lo1=0.0, hi1=0.0, lo2=0.0, hi2=0.0;
+            long oversampling = 1;
+        	double error = 0.0;
+        	double lo = 0.0, hi = 0.0, lo1 = 0.0, hi1 = 0.0, lo2 = 0.0, hi2 = 0.0;
 
     	    pointwise_multiplier() {}
         	pointwise_multiplier(const Key<NDIM> key, const coeffT& clhs) : coeff_lhs(clhs) {
-                const auto& fcf=FunctionCommonFunctionality<T,NDIM>(coeff_lhs.dim(0));
-        		val_lhs=fcf.coeffs2values(key,coeff_lhs);
-        		error=0.0;
-        		implT::tnorm(coeff_lhs,&lo,&hi);
+                const auto& fcf = FunctionCommonFunctionality<T, NDIM>(coeff_lhs.dim(0));
+        		val_lhs = fcf.coeffs2values(key, coeff_lhs);
+        		error = 0.0;
+        		implT::tnorm(coeff_lhs, &lo, &hi);
                 if (coeff_lhs.is_svd_tensor()) {
-                    FunctionImpl<T,LDIM>::tnorm(coeff_lhs.get_svdtensor(),&lo1,&hi1,1);
-                    FunctionImpl<T,LDIM>::tnorm(coeff_lhs.get_svdtensor(),&lo2,&hi2,2);
+                    FunctionImpl<T, LDIM>::tnorm(coeff_lhs.get_svdtensor(), &lo1, &hi1, 1);
+                    FunctionImpl<T, LDIM>::tnorm(coeff_lhs.get_svdtensor(), &lo2, &hi2, 2);
                 }
         	}
 
         	/// multiply values of rhs and lhs, result on rhs, rhs and lhs are of the same dimensions
         	tensorT operator()(const Key<NDIM> key, const tensorT& coeff_rhs) {
 
-				MADNESS_ASSERT(coeff_rhs.dim(0)==coeff_lhs.dim(0));
-                auto fcf=FunctionCommonFunctionality<T,NDIM>(coeff_lhs.dim(0));
+				MADNESS_ASSERT(coeff_rhs.dim(0) == coeff_lhs.dim(0));
+                auto fcf = FunctionCommonFunctionality<T, NDIM>(coeff_lhs.dim(0));
 
 				// the tnorm estimate is not tight enough to be efficient, better use oversampling
 				bool use_tnorm=false;
         		if (use_tnorm) {
 					double rlo, rhi;
-					implT::tnorm(coeff_rhs,&rlo,&rhi);
-					error = hi*rlo + rhi*lo + rhi*hi;
-					tensorT val_rhs=fcf.coeffs2values(key, coeff_rhs);
+					implT::tnorm(coeff_rhs, &rlo, &rhi);
+					error = hi * rlo + rhi * lo + rhi * hi;
+					tensorT val_rhs = fcf.coeffs2values(key, coeff_rhs);
 					val_rhs.emul(val_lhs.full_tensor_copy());
-					return fcf.values2coeffs(key,val_rhs);
+					return fcf.values2coeffs(key, val_rhs);
         		} else {	// use quadrature of order k+1
 
-    	            auto& cdata=FunctionCommonData<T,NDIM>::get(coeff_rhs.dim(0));		// npt=k+1
-                    auto& cdata_npt=FunctionCommonData<T,NDIM>::get(coeff_rhs.dim(0)+oversampling);		// npt=k+1
-                	FunctionCommonFunctionality<T,NDIM> fcf_hi_npt(cdata_npt);
+    	            auto& cdata = FunctionCommonData<T, NDIM>::get(coeff_rhs.dim(0));  // npt=k+1
+                    auto& cdata_npt = FunctionCommonData<T, NDIM>::get(coeff_rhs.dim(0)+oversampling);  // npt=k+1
+                	FunctionCommonFunctionality<T, NDIM> fcf_hi_npt(cdata_npt);
 
     	            // coeffs2values for rhs: k -> npt=k+1
 		            tensorT coeff1(cdata_npt.vk);
-		            coeff1(cdata.s0)=coeff_rhs;		// s0 is smaller than vk!
-		            tensorT val_rhs_k1=fcf_hi_npt.coeffs2values(key,coeff1);
+		            coeff1(cdata.s0) = coeff_rhs;  // s0 is smaller than vk!
+		            tensorT val_rhs_k1 = fcf_hi_npt.coeffs2values(key, coeff1);
 
 		            // coeffs2values for lhs: k -> npt=k+1
 		            tensorT coeff_lhs_k1(cdata_npt.vk);
-		            coeff_lhs_k1(cdata.s0)=coeff_lhs.full_tensor_copy();
-		            tensorT val_lhs_k1=fcf_hi_npt.coeffs2values(key,coeff_lhs_k1);
+		            coeff_lhs_k1(cdata.s0) = coeff_lhs.full_tensor_copy();
+		            tensorT val_lhs_k1 = fcf_hi_npt.coeffs2values(key, coeff_lhs_k1);
 
 		            // multiply
 		            val_lhs_k1.emul(val_rhs_k1);
 
                     // values2coeffs: npt = k+1-> k
-		            tensorT result1=fcf_hi_npt.values2coeffs(key,val_lhs_k1);
+		            tensorT result1 = fcf_hi_npt.values2coeffs(key, val_lhs_k1);
 
                     // extract coeffs up to k
-                    tensorT result=copy(result1(cdata.s0));
-                    result1(cdata.s0)=0.0;
-                    error=result1.normf();
+                    tensorT result = copy(result1(cdata.s0));
+                    result1(cdata.s0) = 0.0;
+                    error = result1.normf();
                     return result;
         		}
         	}
@@ -3920,44 +3894,44 @@ template<size_t NDIM>
         	/// multiply values of rhs and lhs, result on rhs, rhs and lhs are of differnet dimensions
         	coeffT operator()(const Key<NDIM> key, const tensorT& coeff_rhs, const int particle) {
                 Key<LDIM> key1, key2;
-                key.break_apart(key1,key2);
-                const long k=coeff_rhs.dim(0);
-                auto& cdata=FunctionCommonData<T,NDIM>::get(k);
-                auto& cdata_lowdim=FunctionCommonData<T,LDIM>::get(k);
-            	FunctionCommonFunctionality<T,LDIM> fcf_lo(cdata_lowdim);
-            	FunctionCommonFunctionality<T,NDIM> fcf_hi(cdata);
-            	FunctionCommonFunctionality<T,LDIM> fcf_lo_npt(k+oversampling);
-            	FunctionCommonFunctionality<T,NDIM> fcf_hi_npt(k+oversampling);
+                key.break_apart(key1, key2);
+                const long k = coeff_rhs.dim(0);
+                auto& cdata = FunctionCommonData<T, NDIM>::get(k);
+                auto& cdata_lowdim = FunctionCommonData<T, LDIM>::get(k);
+            	FunctionCommonFunctionality<T, LDIM> fcf_lo(cdata_lowdim);
+            	FunctionCommonFunctionality<T, NDIM> fcf_hi(cdata);
+            	FunctionCommonFunctionality<T, LDIM> fcf_lo_npt(k + oversampling);
+            	FunctionCommonFunctionality<T, NDIM> fcf_hi_npt(k + oversampling);
 
 
             	// make hi-dim values from lo-dim coeff_rhs on npt grid points
-                tensorT ones=tensorT(fcf_lo_npt.cdata.vk);
-                ones=1.0;
+                tensorT ones = tensorT(fcf_lo_npt.cdata.vk);
+                ones = 1.0;
 
                 tensorT coeff_rhs_npt1(fcf_lo_npt.cdata.vk);
-                coeff_rhs_npt1(fcf_lo.cdata.s0)=coeff_rhs;
-                tensorT val_rhs_npt1=fcf_lo_npt.coeffs2values(key1,coeff_rhs_npt1);
+                coeff_rhs_npt1(fcf_lo.cdata.s0) = coeff_rhs;
+                tensorT val_rhs_npt1 = fcf_lo_npt.coeffs2values(key1, coeff_rhs_npt1);
 
-                TensorArgs targs(-1.0,TT_2D);
+                TensorArgs targs(-1.0, TT_2D);
                 coeffT val_rhs;
-                if (particle==1) val_rhs=outer(val_rhs_npt1,ones,targs);
-                if (particle==2) val_rhs=outer(ones,val_rhs_npt1,targs);
+                if (particle == 1) val_rhs=outer(val_rhs_npt1, ones, targs);
+                if (particle == 2) val_rhs=outer(ones, val_rhs_npt1, targs);
 
             	// make values from hi-dim coeff_lhs on npt grid points
-	            coeffT coeff_lhs_k1(fcf_hi_npt.cdata.vk,coeff_lhs.tensor_type());
-	            coeff_lhs_k1(fcf_hi.cdata.s0)+=coeff_lhs;
-	            coeffT val_lhs_npt=fcf_hi_npt.coeffs2values(key,coeff_lhs_k1);
+	            coeffT coeff_lhs_k1(fcf_hi_npt.cdata.vk, coeff_lhs.tensor_type());
+	            coeff_lhs_k1(fcf_hi.cdata.s0) += coeff_lhs;
+	            coeffT val_lhs_npt = fcf_hi_npt.coeffs2values(key, coeff_lhs_k1);
 
 	            // multiply
 	            val_lhs_npt.emul(val_rhs);
 
                 // values2coeffs: npt = k+1-> k
-	            coeffT result1=fcf_hi_npt.values2coeffs(key,val_lhs_npt);
+	            coeffT result1 = fcf_hi_npt.values2coeffs(key, val_lhs_npt);
 
                 // extract coeffs up to k
-	            coeffT result=copy(result1(cdata.s0));
-                result1(cdata.s0)=0.0;
-                error=result1.normf();
+	            coeffT result = copy(result1(cdata.s0));
+                result1(cdata.s0) = 0.0;
+                error = result1.normf();
                 return result;
         	}
 
@@ -3977,11 +3951,11 @@ template<size_t NDIM>
         template<typename opT, size_t LDIM>
         struct Vphi_op_NS {
 
-            bool randomize() const {return true;}
+            bool randomize() const { return true; }
 
-            typedef Vphi_op_NS<opT,LDIM> this_type;
-            typedef CoeffTracker<T,NDIM> ctT;
-            typedef CoeffTracker<T,LDIM> ctL;
+            typedef Vphi_op_NS<opT, LDIM> this_type;
+            typedef CoeffTracker<T, NDIM> ctT;
+            typedef CoeffTracker<T, LDIM> ctL;
 
             implT* result;  		///< where to construct Vphi, no need to track parents
             opT leaf_op;    	    ///< deciding if a given FunctionNode will be a leaf node
@@ -3990,10 +3964,10 @@ template<size_t NDIM>
             ctL iav1, iav2;			///< potentials for particles 1 and 2
             const implT* eri;		///< 2-particle potential, must be on-demand
 
-            bool have_ket() const {return iaket.get_impl();}
-            bool have_v1() const {return iav1.get_impl();}
-            bool have_v2() const {return iav2.get_impl();}
-            bool have_eri() const {return eri;}
+            bool have_ket() const { return iaket.get_impl(); }
+            bool have_v1() const { return iav1.get_impl(); }
+            bool have_v2() const { return iav2.get_impl(); }
+            bool have_eri() const { return eri; }
 
             void accumulate_into_result(const Key<NDIM>& key, const coeffT& coeff) const {
                 result->get_coeffs().task(key, &nodeT::accumulate, coeff, result->get_coeffs(), key, result->targs);
@@ -4004,26 +3978,26 @@ template<size_t NDIM>
             Vphi_op_NS(implT* result, const opT& leaf_op, const ctT& iaket,
                        const ctL& iap1, const ctL& iap2, const ctL& iav1, const ctL& iav2,
                        const implT* eri)
-                    : result(result), leaf_op(leaf_op), iaket(iaket), iap1(iap1), iap2(iap2)
-                    , iav1(iav1), iav2(iav2), eri(eri) {
+                    : result(result), leaf_op(leaf_op), iaket(iaket), iap1(iap1), iap2(iap2),
+                      iav1(iav1), iav2(iav2), eri(eri) {
 
                 // 2-particle potential must be on-demand
                 if (eri) MADNESS_ASSERT(eri->is_on_demand());
             }
 
             /// make and insert the coefficients into result's tree
-            std::pair<bool,coeffT> operator()(const Key<NDIM>& key) const {
+            std::pair<bool, coeffT> operator()(const Key<NDIM>& key) const {
 
                 MADNESS_ASSERT(result->get_coeffs().is_local(key));
                 if(leaf_op.do_pre_screening()){
                     // this means that we only construct the boxes which are leaf boxes from the other function in the leaf_op
                     if(leaf_op.pre_screening(key)){
                         // construct sum_coefficients, insert them and leave
-                        auto [sum_coeff, error]=make_sum_coeffs(key);
-                        accumulate_into_result(key,sum_coeff);
-                        return std::pair<bool,coeffT> (true,coeffT());
+                        auto [sum_coeff, error] = make_sum_coeffs(key);
+                        accumulate_into_result(key, sum_coeff);
+                        return std::pair<bool, coeffT> (true, coeffT());
                     }else{
-                        return continue_recursion(std::vector<bool>(1<<NDIM,false),tensorT(),key);
+                        return continue_recursion(std::vector<bool>(1<<NDIM, false), tensorT(), key);
                     }
                 }
 
@@ -4032,32 +4006,32 @@ template<size_t NDIM>
                 // if the initial level is not reached then this must not be a leaf box
                 size_t il = result->get_initial_level();
                 if(FunctionDefaults<NDIM>::get_refine()) il+=1;
-                if(key.level()<int(il)){
-                    return continue_recursion(std::vector<bool>(1<<NDIM,false),tensorT(),key);
+                if(key.level() < int(il)){
+                    return continue_recursion(std::vector<bool>(1<<NDIM, false), tensorT(), key);
                 }
                 // if further refinement is needed (because we are at a special box, special point)
                 // and the special_level is not reached then this must not be a leaf box
-                if(key.level()<result->get_special_level() and leaf_op.special_refinement_needed(key)){
-                    return continue_recursion(std::vector<bool>(1<<NDIM,false),tensorT(),key);
+                if(key.level() < result->get_special_level() and leaf_op.special_refinement_needed(key)){
+                    return continue_recursion(std::vector<bool>(1 << NDIM, false), tensorT(), key);
                 }
 
-                auto [sum_coeff,error]=make_sum_coeffs(key);
+                auto [sum_coeff, error] = make_sum_coeffs(key);
 
                 // coeffs are leaf (for whatever reason), insert into tree and stop recursion
-                if(leaf_op.post_screening(key,sum_coeff)){
-                    accumulate_into_result(key,sum_coeff);
-                    return std::pair<bool,coeffT> (true,coeffT());
+                if(leaf_op.post_screening(key, sum_coeff)){
+                    accumulate_into_result(key, sum_coeff);
+                    return std::pair<bool, coeffT> (true, coeffT());
                 }
 
                 // coeffs are accurate, insert into tree and stop recursion
-                if(error<result->truncate_tol(result->get_thresh(),key)){
-                    accumulate_into_result(key,sum_coeff);
-                    return std::pair<bool,coeffT> (true,coeffT());
+                if(error<result->truncate_tol(result->get_thresh(), key)){
+                    accumulate_into_result(key, sum_coeff);
+                    return std::pair<bool, coeffT> (true, coeffT());
                 }
 
                 // coeffs are inaccurate, continue recursion
-                std::vector<bool> child_is_leaf(1<<NDIM,false);
-                return continue_recursion(child_is_leaf,tensorT(),key);
+                std::vector<bool> child_is_leaf(1<<NDIM, false);
+                return continue_recursion(child_is_leaf, tensorT(), key);
             }
 
 
@@ -4066,31 +4040,31 @@ template<size_t NDIM>
             /// @param[in]	child_is_leaf	for each child: is it a leaf?
             /// @param[in]	coeffs	coefficient tensor with 2^N sum coeffs (=unfiltered NS coeffs)
             /// @param[in]	key		the key for the NS coeffs (=parent key of the children)
-            /// @return		to avoid recursion outside this return: std::pair<is_leaf,coeff> = true,coeffT()
-            std::pair<bool,coeffT> continue_recursion(const std::vector<bool> child_is_leaf,
+            /// @return		to avoid recursion outside this return: std::pair<is_leaf, coeff> = true, coeffT()
+            std::pair<bool, coeffT> continue_recursion(const std::vector<bool> child_is_leaf,
                                                       const tensorT& coeffs, const keyT& key) const {
-                std::size_t i=0;
+                std::size_t i = 0;
                 for (KeyChildIterator<NDIM> kit(key); kit; ++kit, ++i) {
-                    keyT child=kit.key();
-                    bool is_leaf=child_is_leaf[i];
+                    keyT child = kit.key();
+                    bool is_leaf = child_is_leaf[i];
 
                     if (is_leaf) {
                         // insert the sum coeffs
-                        insert_op<T,NDIM> iop(result);
-                        iop(child,coeffT(copy(coeffs(result->child_patch(child))),result->get_tensor_args()),is_leaf);
+                        insert_op<T, NDIM> iop(result);
+                        iop(child, coeffT(copy(coeffs(result->child_patch(child))), result->get_tensor_args()), is_leaf);
                     } else {
-                        this_type child_op=this->make_child(child);
-                        noop<T,NDIM> no;
+                        this_type child_op = this->make_child(child);
+                        noop<T, NDIM> no;
                         // spawn activation where child is local
-                        ProcessID p=result->get_coeffs().owner(child);
+                        ProcessID p = result->get_coeffs().owner(child);
 
-                        void (implT::*ft)(const Vphi_op_NS<opT,LDIM>&, const noop<T,NDIM>&, const keyT&) const = &implT:: template forward_traverse< Vphi_op_NS<opT,LDIM>, noop<T,NDIM> >;
+                        void (implT::*ft)(const Vphi_op_NS<opT, LDIM>&, const noop<T, NDIM>&, const keyT&) const = &implT:: template forward_traverse< Vphi_op_NS<opT, LDIM>, noop<T, NDIM>>;
                         result->task(p, ft, child_op, no, child);
                     }
                 }
                 // return e sum coeffs; also return always is_leaf=true:
                 // the recursion is continued within this struct, not outside in traverse_tree!
-                return std::pair<bool,coeffT> (true,coeffT());
+                return std::pair<bool, coeffT> (true, coeffT());
             }
 
             tensorT eri_coeffs(const keyT& key) const {
@@ -4100,8 +4074,8 @@ template<size_t NDIM>
                     return eri->get_functor()->coeff(key).full_tensor();
                 } else {
                     tensorT val_eri(eri->cdata.vk);
-                    eri->fcube(key,*(eri->get_functor()),eri->cdata.quad_x,val_eri);
-                    return eri->values2coeffs(key,val_eri);
+                    eri->fcube(key, *(eri->get_functor()), eri->cdata.quad_x, val_eri);
+                    return eri->values2coeffs(key, val_eri);
                 }
             }
 
@@ -4117,91 +4091,90 @@ template<size_t NDIM>
                                                             const tensorT& ceri) const {
                 double error = 0.0;
                 Key<LDIM> key1, key2;
-                key.break_apart(key1,key2);
+                key.break_apart(key1, key2);
 
                 PROFILE_BLOCK(compute_error);
                 double dnorm_ket, snorm_ket;
                 if (have_ket()) {
-                    snorm_ket=iaket.coeff(key).normf();
-                    dnorm_ket=iaket.dnorm(key);
+                    snorm_ket = iaket.coeff(key).normf();
+                    dnorm_ket = iaket.dnorm(key);
                 } else {
-                    double s1=iap1.coeff(key1).normf();
-                    double s2=iap2.coeff(key2).normf();
-                    double d1=iap1.dnorm(key1);
-                    double d2=iap2.dnorm(key2);
-                    snorm_ket=s1*s2;
-                    dnorm_ket=s1*d2 + s2*d1 + d1*d2;
+                    double s1 = iap1.coeff(key1).normf();
+                    double s2 = iap2.coeff(key2).normf();
+                    double d1 = iap1.dnorm(key1);
+                    double d2 = iap2.dnorm(key2);
+                    snorm_ket = s1 * s2;
+                    dnorm_ket = s1 * d2 + s2 * d1 + d1 * d2;
                 }
 
                 if (have_v1()) {
-                    double snorm=iav1.coeff(key1).normf();
-                    double dnorm=iav1.dnorm(key1);
-                    error+=snorm*dnorm_ket + dnorm*snorm_ket + dnorm*dnorm_ket;
+                    double snorm = iav1.coeff(key1).normf();
+                    double dnorm = iav1.dnorm(key1);
+                    error += snorm * dnorm_ket + dnorm * snorm_ket + dnorm * dnorm_ket;
                 }
                 if (have_v2()) {
-                    double snorm=iav2.coeff(key2).normf();
-                    double dnorm=iav2.dnorm(key2);
-                    error+=snorm*dnorm_ket + dnorm*snorm_ket + dnorm*dnorm_ket;
+                    double snorm = iav2.coeff(key2).normf();
+                    double dnorm = iav2.dnorm(key2);
+                    error += snorm * dnorm_ket + dnorm * snorm_ket + dnorm * dnorm_ket;
                 }
                 if (have_eri()) {
-                    tensorT s_coeffs=ceri(result->cdata.s0);
-                    double snorm=s_coeffs.normf();
-                    tensorT d=copy(ceri);
-                    d(result->cdata.s0)=0.0;
-                    double dnorm=d.normf();
-                    error+=snorm*dnorm_ket + dnorm*snorm_ket + dnorm*dnorm_ket;
+                    tensorT s_coeffs = ceri(result->cdata.s0);
+                    double snorm = s_coeffs.normf();
+                    tensorT d = copy(ceri);
+                    d(result->cdata.s0) = 0.0;
+                    double dnorm = d.normf();
+                    error += snorm * dnorm_ket + dnorm * snorm_ket + dnorm * dnorm_ket;
                 }
 
-                bool no_potential=not ((have_v1() or have_v2() or have_eri()));
+                bool no_potential = not ((have_v1() or have_v2() or have_eri()));
                 if (no_potential) {
-                    error=dnorm_ket;
+                    error = dnorm_ket;
                 }
                 return error;
             }
 
             /// make the sum coeffs for key
-            std::pair<coeffT,double> make_sum_coeffs(const keyT& key) const {
+            std::pair<coeffT, double> make_sum_coeffs(const keyT& key) const {
                 PROFILE_BLOCK(make_sum_coeffs);
                 // break key into particles
                 Key<LDIM> key1, key2;
-                key.break_apart(key1,key2);
+                key.break_apart(key1, key2);
 
-        		// bool printme=(int(key.translation()[0])==int(std::pow(key.level(),2)/2)) and
-        		// 		(int(key.translation()[1])==int(std::pow(key.level(),2)/2)) and
-			// 			(int(key.translation()[2])==int(std::pow(key.level(),2)/2));
-
-//        		printme=false;
+        		// bool printme = (int(key.translation()[0]) == int(std::pow(key.level(), 2) / 2)) and
+                // (int(key.translation()[1]) == int(std::pow(key.level(), 2) / 2)) and
+                // (int(key.translation()[2]) == int(std::pow(key.level(), 2) / 2));
+                // printme = false;
 
                 // get/make all coefficients
                 const coeffT coeff_ket = (iaket.get_impl()) ? iaket.coeff(key)
-                                                            : outer(iap1.coeff(key1),iap2.coeff(key2),result->get_tensor_args());
+                                                            : outer(iap1.coeff(key1), iap2.coeff(key2), result->get_tensor_args());
                 const coeffT cpot1 = (have_v1()) ? iav1.coeff(key1) : coeffT();
                 const coeffT cpot2 = (have_v2()) ? iav2.coeff(key2) : coeffT();
                 const tensorT ceri = (have_eri()) ? eri_coeffs(key) : tensorT();
 
                 // compute first part of the total error
-                double refine_error=compute_error_from_inaccurate_refinement(key,ceri);
-                double error=refine_error;
+                double refine_error = compute_error_from_inaccurate_refinement(key, ceri);
+                double error = refine_error;
 
         		// prepare the multiplication
-        		pointwise_multiplier<LDIM> pm(key,coeff_ket);
+        		pointwise_multiplier<LDIM> pm(key, coeff_ket);
 
         		// perform the multiplication, compute tnorm part of the total error
-        		coeffT cresult(result->cdata.vk,result->get_tensor_args());
+        		coeffT cresult(result->cdata.vk, result->get_tensor_args());
         		if (have_v1()) {
-        			cresult+=pm(key,cpot1.get_tensor(),1);
-        			error+=pm.error;
+        			cresult += pm(key, cpot1.get_tensor(), 1);
+        			error += pm.error;
             	}
         		if (have_v2()) {
-        			cresult+=pm(key,cpot2.get_tensor(),2);
-        			error+=pm.error;
+        			cresult += pm(key, cpot2.get_tensor(), 2);
+        			error += pm.error;
         		}
 
                 if (have_eri()) {
                     tensorT result1=cresult.full_tensor_copy();
-                    result1+=pm(key,copy(ceri(result->cdata.s0)));
-                    cresult=coeffT(result1,result->get_tensor_args());
-                    error+=pm.error;
+                    result1 += pm(key, copy(ceri(result->cdata.s0)));
+                    cresult = coeffT(result1, result->get_tensor_args());
+                    error += pm.error;
                 } else {
                     cresult.reduce_rank(result->get_tensor_args().thresh);
                 }
@@ -4209,35 +4182,35 @@ template<size_t NDIM>
                     cresult=coeff_ket;
                 }
 
-                return std::make_pair(cresult,error);
+                return std::make_pair(cresult, error);
             }
 
             this_type make_child(const keyT& child) const {
 
                 // break key into particles
                 Key<LDIM> key1, key2;
-                child.break_apart(key1,key2);
+                child.break_apart(key1, key2);
 
-                return this_type(result,leaf_op,iaket.make_child(child),
-                                 iap1.make_child(key1),iap2.make_child(key2),
-                                 iav1.make_child(key1),iav2.make_child(key2),eri);
+                return this_type(result, leaf_op, iaket.make_child(child),
+                                 iap1.make_child(key1), iap2.make_child(key2),
+                                 iav1.make_child(key1), iav2.make_child(key2), eri);
             }
 
             Future<this_type> activate() const {
-                Future<ctT> iaket1=iaket.activate();
-                Future<ctL> iap11=iap1.activate();
-                Future<ctL> iap21=iap2.activate();
-                Future<ctL> iav11=iav1.activate();
-                Future<ctL> iav21=iav2.activate();
+                Future<ctT> iaket1 = iaket.activate();
+                Future<ctL> iap11 = iap1.activate();
+                Future<ctL> iap21 = iap2.activate();
+                Future<ctL> iav11 = iav1.activate();
+                Future<ctL> iav21 = iav2.activate();
                 return result->world.taskq.add(detail::wrap_mem_fn(*const_cast<this_type *> (this),
-                                                                   &this_type::forward_ctor),result,leaf_op,
-                                               iaket1,iap11,iap21,iav11,iav21,eri);
+                                                                   &this_type::forward_ctor), result, leaf_op,
+                                               iaket1, iap11, iap21, iav11, iav21, eri);
             }
 
             this_type forward_ctor(implT* result1, const opT& leaf_op, const ctT& iaket1,
                                    const ctL& iap11, const ctL& iap21, const ctL& iav11, const ctL& iav21,
                                    const implT* eri1) {
-                return this_type(result1,leaf_op,iaket1,iap11,iap21,iav11,iav21,eri1);
+                return this_type(result1, leaf_op, iaket1, iap11, iap21, iav11, iav21, eri1);
             }
 
             /// serialize this (needed for use in recursive_op)
@@ -4255,43 +4228,41 @@ template<size_t NDIM>
         /// @param[in]  fence   global fence
         template<typename opT>
         void make_Vphi(const opT& leaf_op, const bool fence=true) {
-
-            constexpr size_t LDIM=NDIM/2;
-            MADNESS_CHECK_THROW(NDIM==LDIM*2,"make_Vphi only works for even dimensions");
-
+            constexpr size_t LDIM = NDIM / 2;
+            MADNESS_CHECK_THROW(NDIM == LDIM * 2, "make_Vphi only works for even dimensions");
 
             // keep the functor available, but remove it from the result
             // result will return false upon is_on_demand(), which is necessary for the
             // CoeffTracker to track the parent coeffs correctly for error_leaf_op
-            std::shared_ptr< FunctionFunctorInterface<T,NDIM> > func2(this->get_functor());
+            std::shared_ptr< FunctionFunctorInterface<T, NDIM>> func2(this->get_functor());
             this->unset_functor();
 
-            CompositeFunctorInterface<T,NDIM,LDIM>* func=
-                    dynamic_cast<CompositeFunctorInterface<T,NDIM,LDIM>* >(&(*func2));
+            CompositeFunctorInterface<T, NDIM, LDIM>* func=
+                    dynamic_cast<CompositeFunctorInterface<T, NDIM, LDIM>* >(&(*func2));
             MADNESS_ASSERT(func);
 
             // make sure everything is in place if no fence is requested
             if (fence) func->make_redundant(true);          // no-op if already redundant
-            MADNESS_CHECK_THROW(func->check_redundant(),"make_Vphi requires redundant functions");
+            MADNESS_CHECK_THROW(func->check_redundant(), "make_Vphi requires redundant functions");
 
             // loop over all functions in the functor (either ket or particles)
             for (auto& ket : func->impl_ket_vector) {
-                FunctionImpl<T,NDIM>* eri=func->impl_eri.get();
-                FunctionImpl<T,LDIM>* v1=func->impl_m1.get();
-                FunctionImpl<T,LDIM>* v2=func->impl_m2.get();
-                FunctionImpl<T,LDIM>* p1=nullptr;
-                FunctionImpl<T,LDIM>* p2=nullptr;
-                make_Vphi_only(leaf_op,ket.get(),v1,v2,p1,p2,eri,false);
+                FunctionImpl<T, NDIM>* eri=func->impl_eri.get();
+                FunctionImpl<T, LDIM>* v1=func->impl_m1.get();
+                FunctionImpl<T, LDIM>* v2=func->impl_m2.get();
+                FunctionImpl<T, LDIM>* p1=nullptr;
+                FunctionImpl<T, LDIM>* p2=nullptr;
+                make_Vphi_only(leaf_op, ket.get(), v1, v2, p1, p2, eri, false);
             }
 
-            for (std::size_t i=0; i<func->impl_p1_vector.size(); ++i) {
-                FunctionImpl<T,NDIM>* ket=nullptr;
-                FunctionImpl<T,NDIM>* eri=func->impl_eri.get();
-                FunctionImpl<T,LDIM>* v1=func->impl_m1.get();
-                FunctionImpl<T,LDIM>* v2=func->impl_m2.get();
-                FunctionImpl<T,LDIM>* p1=func->impl_p1_vector[i].get();
-                FunctionImpl<T,LDIM>* p2=func->impl_p2_vector[i].get();
-                make_Vphi_only(leaf_op,ket,v1,v2,p1,p2,eri,false);
+            for (std::size_t i = 0; i < func->impl_p1_vector.size(); ++i) {
+                FunctionImpl<T, NDIM>* ket=nullptr;
+                FunctionImpl<T, NDIM>* eri=func->impl_eri.get();
+                FunctionImpl<T, LDIM>* v1=func->impl_m1.get();
+                FunctionImpl<T, LDIM>* v2=func->impl_m2.get();
+                FunctionImpl<T, LDIM>* p1=func->impl_p1_vector[i].get();
+                FunctionImpl<T, LDIM>* p2=func->impl_p2_vector[i].get();
+                make_Vphi_only(leaf_op, ket, v1, v2, p1, p2, eri, false);
             }
 
             // some post-processing:
@@ -4299,12 +4270,10 @@ template<size_t NDIM>
             // - the operation constructs sum coefficients on all scales -> sum down to get a well-defined tree-state
             if (fence) {
                 world.gop.fence();
-                flo_unary_op_node_inplace(do_consolidate_buffer(get_tensor_args()),true);
+                flo_unary_op_node_inplace(do_consolidate_buffer(get_tensor_args()), true);
                 sum_down(true);
                 set_tree_state(reconstructed);
             }
-
-
         }
 
         /// assemble the function V*phi using V and phi given from the functor
@@ -4315,35 +4284,33 @@ template<size_t NDIM>
         /// @param[in]  leaf_op  operator to decide if a given node is a leaf node
         /// @param[in]  fence   global fence
         template<typename opT, std::size_t LDIM>
-        void make_Vphi_only(const opT& leaf_op, FunctionImpl<T,NDIM>* ket,
-                            FunctionImpl<T,LDIM>* v1, FunctionImpl<T,LDIM>* v2,
-                            FunctionImpl<T,LDIM>* p1, FunctionImpl<T,LDIM>* p2,
-                            FunctionImpl<T,NDIM>* eri,
+        void make_Vphi_only(const opT& leaf_op, FunctionImpl<T, NDIM>* ket,
+                            FunctionImpl<T, LDIM>* v1, FunctionImpl<T, LDIM>* v2,
+                            FunctionImpl<T, LDIM>* p1, FunctionImpl<T, LDIM>* p2,
+                            FunctionImpl<T, NDIM>* eri, 
                             const bool fence=true) {
-
             // prepare the CoeffTracker
-            CoeffTracker<T,NDIM> iaket(ket);
-            CoeffTracker<T,LDIM> iap1(p1);
-            CoeffTracker<T,LDIM> iap2(p2);
-            CoeffTracker<T,LDIM> iav1(v1);
-            CoeffTracker<T,LDIM> iav2(v2);
+            CoeffTracker<T, NDIM> iaket(ket);
+            CoeffTracker<T, LDIM> iap1(p1);
+            CoeffTracker<T, LDIM> iap2(p2);
+            CoeffTracker<T, LDIM> iav1(v1);
+            CoeffTracker<T, LDIM> iav2(v2);
 
             // the operator making the coefficients
-            typedef Vphi_op_NS<opT,LDIM> coeff_opT;
-            coeff_opT coeff_op(this,leaf_op,iaket,iap1,iap2,iav1,iav2,eri);
+            typedef Vphi_op_NS<opT, LDIM> coeff_opT;
+            coeff_opT coeff_op(this, leaf_op, iaket, iap1, iap2, iav1, iav2, eri);
 
             // this operator simply inserts the coeffs into this' tree
-            typedef noop<T,NDIM> apply_opT;
+            typedef noop<T, NDIM> apply_opT;
             apply_opT apply_op;
 
             if (world.rank() == coeffs.owner(cdata.key0)) {
-                woT::task(world.rank(), &implT:: template forward_traverse<coeff_opT,apply_opT>,
+                woT::task(world.rank(), &implT:: template forward_traverse<coeff_opT, apply_opT>,
                           coeff_op, apply_op, cdata.key0);
             }
 
             set_tree_state(redundant_after_merge);
             if (fence) world.gop.fence();
-
         }
 
         /// Permute the dimensions of f according to map, result on this
@@ -4385,12 +4352,12 @@ template<size_t NDIM>
         struct do_compute_snorm_and_dnorm {
             typedef Range<typename dcT::iterator> rangeT;
 
-            const FunctionCommonData<T,NDIM>& cdata;
-            do_compute_snorm_and_dnorm(const FunctionCommonData<T,NDIM>& cdata) :
+            const FunctionCommonData<T, NDIM>& cdata;
+            do_compute_snorm_and_dnorm(const FunctionCommonData<T, NDIM>& cdata) :
                     cdata(cdata) {}
 
             bool operator()(typename rangeT::iterator& it) const {
-                auto& node=it->second;
+                auto& node = it->second;
                 node.recompute_snorm_and_dnorm(cdata);
                 return true;
             }
@@ -4441,7 +4408,7 @@ template<size_t NDIM>
         /// @param[in]  key key of level n
         /// @param[in]  v   vector of sum coefficients of level n+1
         /// @return     sum coefficients on level n in full tensor format
-        tensorT downsample(const keyT& key, const std::vector< Future<coeffT > >& v) const;
+        tensorT downsample(const keyT& key, const std::vector< Future<coeffT >>& v) const;
 
         /// upsample the sum coefficients of level 1 to sum coeffs on level n+1
 
@@ -4466,11 +4433,11 @@ template<size_t NDIM>
             // Must allow for someone already having autorefined the coeffs
             // and we get a write accessor just in case they are already executing
             typename dcT::accessor acc;
-            const auto found = coeffs.find(acc,key);
+            const auto found = coeffs.find(acc, key);
             MADNESS_CHECK(found);
             nodeT& node = acc->second;
             if (node.has_coeff() && key.level() < max_refine_level && op(this, key, node)) {
-                coeffT d(cdata.v2k,targs);
+                coeffT d(cdata.v2k, targs);
                 d(cdata.s0) += copy(node.coeff());
                 d = unfilter(d);
                 node.clear_coeff();
@@ -4479,8 +4446,8 @@ template<size_t NDIM>
                     const keyT& child = kit.key();
                     coeffT ss = copy(d(child_patch(child)));
                     ss.reduce_rank(targs.thresh);
-                    //                    coeffs.replace(child,nodeT(ss,-1.0,false).node_to_low_rank());
-                    coeffs.replace(child,nodeT(ss,-1.0,false));
+                    //                    coeffs.replace(child, nodeT(ss, -1.0, false).node_to_low_rank());
+                    coeffs.replace(child, nodeT(ss, -1.0, false));
                     // Note value -1.0 for norm tree to indicate result of refinement
                 }
             }
@@ -4511,8 +4478,7 @@ template<size_t NDIM>
 
         bool exists_and_is_leaf(const keyT& key) const;
 
-
-        void broaden_op(const keyT& key, const std::vector< Future <bool> >& v);
+        void broaden_op(const keyT& key, const std::vector< Future <bool>>& v);
 
         // For each local node sets value of norm tree, snorm and dnorm to 0.0
         void zero_norm_tree();
@@ -4534,7 +4500,7 @@ template<size_t NDIM>
         void change_tree_state(const TreeState finalstate, bool fence=true);
 
         // Invoked on node where key is local
-        //        void reconstruct_op(const keyT& key, const tensorT& s);
+        // void reconstruct_op(const keyT& key, const tensorT& s);
         void reconstruct_op(const keyT& key, const coeffT& s, const bool accumulate_NS=true);
 
         /// compress the wave function
@@ -4544,11 +4510,11 @@ template<size_t NDIM>
         /// @param[in] nonstandard	keep sum coeffs at all other levels, except leaves
         /// @param[in] keepleaves	keep sum coeffs (but no diff coeffs) at leaves
         /// @param[in] redundant    keep only sum coeffs at all levels, discard difference coeffs
-//        void compress(bool nonstandard, bool keepleaves, bool redundant, bool fence);
+        // void compress(bool nonstandard, bool keepleaves, bool redundant, bool fence);
         void compress(const TreeState newstate, bool fence);
 
         /// Invoked on node where key is local
-        Future<std::pair<coeffT,double> > compress_spawn(const keyT& key, bool nonstandard, bool keepleaves,
+        Future<std::pair<coeffT, double>> compress_spawn(const keyT& key, bool nonstandard, bool keepleaves,
         		bool redundant1);
 
         private:
@@ -4566,7 +4532,7 @@ template<size_t NDIM>
         /// compute for each FunctionNode the norm of the function inside that node
         void norm_tree(bool fence);
 
-        double norm_tree_op(const keyT& key, const std::vector< Future<double> >& v);
+        double norm_tree_op(const keyT& key, const std::vector< Future<double>>& v);
 
         Future<double> norm_tree_spawn(const keyT& key);
 
@@ -4578,7 +4544,7 @@ template<size_t NDIM>
         /// given the sum coefficients of all children, truncate or not
 
         /// @return     new sum coefficients (empty if internal, not empty, if new leaf); might delete its children
-        coeffT truncate_reconstructed_op(const keyT& key, const std::vector< Future<coeffT > >& v, const double tol);
+        coeffT truncate_reconstructed_op(const keyT& key, const std::vector< Future<coeffT >>& v, const double tol);
 
         /// calculate the wavelet coefficients using the sum coefficients of all child nodes
 
@@ -4588,7 +4554,7 @@ template<size_t NDIM>
         /// @param[in] nonstandard  keep the sum coefficients with the wavelet coefficients
         /// @param[in] redundant    keep only the sum coefficients, discard the wavelet coefficients
         /// @return 		the sum coefficients
-        std::pair<coeffT,double> compress_op(const keyT& key, const std::vector< Future<std::pair<coeffT,double>> >& v, bool nonstandard);
+        std::pair<coeffT, double> compress_op(const keyT& key, const std::vector< Future<std::pair<coeffT, double>>>& v, bool nonstandard);
 
 
         /// similar to compress_op, but insert only the sum coefficients in the tree
@@ -4597,7 +4563,7 @@ template<size_t NDIM>
         /// @param[in] key  this's key
         /// @param[in] v    sum coefficients of the child nodes
         /// @return         the sum coefficients
-        std::pair<coeffT,double> make_redundant_op(const keyT& key,const std::vector< Future<std::pair<coeffT,double> > >& v);
+        std::pair<coeffT, double> make_redundant_op(const keyT& key, const std::vector< Future<std::pair<coeffT, double>> >& v);
 
         /// Changes non-standard compressed form to standard compressed form
         void standard(bool fence);
@@ -4615,13 +4581,12 @@ template<size_t NDIM>
 
             //
             bool operator()(typename rangeT::iterator& it) const {
-
                 const keyT& key = it->first;
                 nodeT& node = it->second;
                 if (key.level()> 0 && node.has_coeff()) {
                     if (node.has_children()) {
                         // Zero out scaling coeffs
-                    	MADNESS_ASSERT(node.coeff().dim(0)==2*impl->get_k());
+                    	MADNESS_ASSERT(node.coeff().dim(0) == 2*impl->get_k());
                         node.coeff()(impl->cdata.s0)=0.0;
                         node.reduceRank(impl->targs.thresh);
                     } else {
@@ -4631,8 +4596,9 @@ template<size_t NDIM>
                 }
                 return true;
             }
+
             template <typename Archive> void serialize(const Archive& ar) {
-                MADNESS_EXCEPTION("no serialization of do_standard",1);
+                MADNESS_EXCEPTION("no serialization of do_standard", 1);
             }
         };
 
@@ -4640,15 +4606,17 @@ template<size_t NDIM>
         /// laziness
         template<size_t OPDIM>
         struct do_op_args {
-            Key<OPDIM> key,d;
+            Key<OPDIM> key, d;
             keyT dest;
             double tol, fac, cnorm;
+
             do_op_args() {}
             do_op_args(const Key<OPDIM>& key, const Key<OPDIM>& d, const keyT& dest, double tol, double fac, double cnorm)
                 : key(key), d(d), dest(dest), tol(tol), fac(fac), cnorm(cnorm) {}
+
             template <class Archive>
             void serialize(Archive& ar) {
-                ar & archive::wrap_opaque(this,1);
+                ar & archive::wrap_opaque(this, 1);
             }
         };
 
@@ -4665,9 +4633,9 @@ template<size_t NDIM>
             // Screen here to reduce communication cost of negligible data
             // and also to ensure we don't needlessly widen the tree when
             // applying the operator
-            if (result.normf()> 0.3*args.tol/args.fac) {
+            if (result.normf() > 0.3 * args.tol / args.fac) {
                 coeffs.task(args.dest, &nodeT::accumulate2, result, coeffs, args.dest, TaskAttributes::hipri());
-                //woT::task(world.rank(),&implT::accumulate_timer,time,TaskAttributes::hipri());
+                // woT::task(world.rank(), &implT::accumulate_timer, time, TaskAttributes::hipri());
                 // UGLY BUT ADDED THE OPTIMIZATION BACK IN HERE EXPLICITLY/
                 if (args.dest == world.rank()) {
                     coeffs.send(args.dest, &nodeT::accumulate, result, coeffs, args.dest);
@@ -4690,26 +4658,26 @@ template<size_t NDIM>
                                 const TensorArgs& apply_targs) {
 
             tensorT result_full = op->apply(args.key, args.d, c, args.tol/args.fac/args.cnorm);
-            const double norm=result_full.normf();
+            const double norm = result_full.normf();
 
             // Screen here to reduce communication cost of negligible data
             // and also to ensure we don't needlessly widen the tree when
             // applying the operator
             // OPTIMIZATION NEEDED HERE ... CHANGING THIS TO TASK NOT SEND REMOVED
             // BUILTIN OPTIMIZATION TO SHORTCIRCUIT MSG IF DATA IS LOCAL
-            if (norm > 0.3*args.tol/args.fac) {
+            if (norm > 0.3 * args.tol / args.fac) {
 
                 small++;
-                //double cpu0=cpu_time();
-                coeffT result=coeffT(result_full,apply_targs);
+                // double cpu0 = cpu_time();
+                coeffT result = coeffT(result_full, apply_targs);
                 MADNESS_ASSERT(result.is_full_tensor() or result.is_svd_tensor());
-                //double cpu1=cpu_time();
-                //timer_lr_result.accumulate(cpu1-cpu0);
+                // double cpu1 = cpu_time();
+                // timer_lr_result.accumulate(cpu1 - cpu0);
 
                 coeffs.task(args.dest, &nodeT::accumulate, result, coeffs, args.dest, apply_targs,
                                                 TaskAttributes::hipri());
 
-                //woT::task(world.rank(),&implT::accumulate_timer,time,TaskAttributes::hipri());
+                // woT::task(world.rank(), &implT::accumulate_timer, time, TaskAttributes::hipri());
             }
             return norm;
         }
@@ -4728,26 +4696,25 @@ template<size_t NDIM>
                                 const TensorArgs& apply_targs) {
 
             coeffT result;
-            if (2*OPDIM==NDIM) result= op->apply2_lowdim(args.key, args.d, coeff,
-                    args.tol/args.fac/args.cnorm, args.tol/args.fac);
-            if (OPDIM==NDIM) result = op->apply2(args.key, args.d, coeff,
-                    args.tol/args.fac/args.cnorm, args.tol/args.fac);
+            if (2 * OPDIM == NDIM) result = op->apply2_lowdim(args.key, args.d, coeff,
+                    args.tol / args.fac / args.cnorm, args.tol / args.fac);
+            if (OPDIM == NDIM) result = op->apply2(args.key, args.d, coeff,
+                    args.tol / args.fac / args.cnorm, args.tol / args.fac);
 
-            const double result_norm=result.svd_normf();
+            const double result_norm = result.svd_normf();
 
-            if (result_norm> 0.3*args.tol/args.fac) {
+            if (result_norm > 0.3 * args.tol / args.fac) {
                 small++;
 
-                double cpu0=cpu_time();
-                if (not result.is_of_tensortype(targs.tt)) result=result.convert(targs);
-                double cpu1=cpu_time();
-                timer_lr_result.accumulate(cpu1-cpu0);
+                double cpu0 = cpu_time();
+                if (not result.is_of_tensortype(targs.tt)) result = result.convert(targs);
+                double cpu1 = cpu_time();
+                timer_lr_result.accumulate(cpu1 - cpu0);
 
                 // accumulate also expects result in SVD form
                 coeffs.task(args.dest, &nodeT::accumulate, result, coeffs, args.dest, apply_targs,
-                                                TaskAttributes::hipri());
-//                woT::task(world.rank(),&implT::accumulate_timer,time,TaskAttributes::hipri());
-
+                            TaskAttributes::hipri());
+                // woT::task(world.rank(), &implT::accumulate_timer, time, TaskAttributes::hipri());
             }
             return result_norm;
 
@@ -4755,7 +4722,7 @@ template<size_t NDIM>
 
         // volume of n-dimensional sphere of radius R
         double vol_nsphere(int n, double R) {
-            return std::pow(madness::constants::pi,n*0.5)*std::pow(R,n)/std::tgamma(1+0.5*n);
+            return std::pow(madness::constants::pi, n * 0.5) * std::pow(R, n) / std::tgamma(1 + 0.5 * n);
         }
         
 
@@ -4769,19 +4736,18 @@ template<size_t NDIM>
         void do_apply(const opT* op, const keyT& key, const Tensor<R>& c) {
             PROFILE_MEMBER_FUNC(FunctionImpl);
 
-	    // working assumption here WAS that the operator is
-	    // isotropic and montonically decreasing with distance
-	    // ... however, now we are using derivative Gaussian
-	    // expansions (and also non-cubic boxes) isotropic is
-	    // violated. While not strictly monotonically decreasing,
-	    // the derivative gaussian is still such that once it
-	    // becomes negligible we are in the asymptotic region.
+            // working assumption here WAS that the operator is
+            // isotropic and montonically decreasing with distance
+            // ... however, now we are using derivative Gaussian
+            // expansions (and also non-cubic boxes) isotropic is
+            // violated. While not strictly monotonically decreasing,
+            // the derivative gaussian is still such that once it
+            // becomes negligible we are in the asymptotic region.
 
             typedef typename opT::keyT opkeyT;
-            static const size_t opdim=opT::opdim;
-            const opkeyT source=op->get_source_key(key);
+            static const size_t opdim = opT::opdim;
+            const opkeyT source = op->get_source_key(key);
 
-            
             // Tuning here is based on observation that with
             // sufficiently high-order wavelet relative to the
             // precision, that only nearest neighbor boxes contribute,
@@ -4798,36 +4764,36 @@ template<size_t NDIM>
             // tol/fac
 
             // radius of shell (nearest neighbor is diameter of 3 boxes, so radius=1.5)
-            double radius = 1.5 + 0.33*std::max(0.0,2-std::log10(thresh)-k); // 0.33 was 0.5
+            double radius = 1.5 + 0.33 * std::max(0.0, 2 - std::log10(thresh) - k); // 0.33 was 0.5
             double fac = vol_nsphere(NDIM, radius);
-            //previously fac=10.0 selected empirically constrained by qmprop
+            // previously fac = 10.0 selected empirically constrained by qmprop
 
             double cnorm = c.normf();
 
             const std::vector<opkeyT>& disp = op->get_disp(key.level()); // list of displacements sorted in orer of increasing distance
-            const std::vector<bool> is_periodic(NDIM,false); // Periodic sum is already done when making rnlp
-            int nvalid=1;       // Counts #valid at each distance
-            int nused=1;	// Counts #used at each distance
-	    uint64_t distsq = 99999999999999;
+            const std::vector<bool> is_periodic(NDIM, false); // Periodic sum is already done when making rnlp
+            int nvalid = 1;       // Counts #valid at each distance
+            int nused = 1;	// Counts #used at each distance
+	        uint64_t distsq = 99999999999999;
             for (typename std::vector<opkeyT>::const_iterator it=disp.begin(); it != disp.end(); ++it) {
-	        keyT d;
+	            keyT d;
                 Key<NDIM-opdim> nullkey(key.level());
-                if (op->particle()==1) d=it->merge_with(nullkey);
-                if (op->particle()==2) d=nullkey.merge_with(*it);
+                if (op->particle() == 1) d=it->merge_with(nullkey);
+                if (op->particle() == 2) d=nullkey.merge_with(*it);
 
-		uint64_t dsq = d.distsq();
-		if (dsq != distsq) { // Moved to next shell of neighbors
-		    if (nvalid > 0 && nused == 0 && dsq > 1) {
-		        // Have at least done the input box and all first
-		        // nearest neighbors, and for all of the last set
-		        // of neighbors had no contribution.  Thus,
-		        // assuming monotonic decrease, we are done.
-		        break;
-		    }
-		    nused = 0;
+                uint64_t dsq = d.distsq();
+                if (dsq != distsq) { // Moved to next shell of neighbors
+                    if (nvalid > 0 && nused == 0 && dsq > 1) {
+                        // Have at least done the input box and all first
+                        // nearest neighbors, and for all of the last set
+                        // of neighbors had no contribution.  Thus,
+                        // assuming monotonic decrease, we are done.
+                        break;
+                    }
+                    nused = 0;
                     nvalid = 0;
-		    distsq = dsq;
-		} 
+                    distsq = dsq;
+                }
 
                 keyT dest = neighbor(key, d, is_periodic);
                 if (dest.is_valid()) {
@@ -4835,14 +4801,14 @@ template<size_t NDIM>
                     double opnorm = op->norm(key.level(), *it, source);
                     double tol = truncate_tol(thresh, key);
 
-                    if (cnorm*opnorm> tol/fac) {
+                    if (cnorm * opnorm > tol / fac) {
                         nused++;
-		        tensorT result = op->apply(source, *it, c, tol/fac/cnorm);
-			if (result.normf() > 0.3*tol/fac) {
-			  if (coeffs.is_local(dest))
-			      coeffs.send(dest, &nodeT::accumulate2, result, coeffs, dest);
-			  else
-  			      coeffs.task(dest, &nodeT::accumulate2, result, coeffs, dest);
+                        tensorT result = op->apply(source, *it, c, tol / fac / cnorm);
+                        if (result.normf() > 0.3 * tol / fac) {
+                            if (coeffs.is_local(dest))
+                                coeffs.send(dest, &nodeT::accumulate2, result, coeffs, dest);
+                            else
+                                coeffs.task(dest, &nodeT::accumulate2, result, coeffs, dest);
                         }
                     }
                 }
@@ -4852,19 +4818,19 @@ template<size_t NDIM>
 
         /// apply an operator on f to return this
         template <typename opT, typename R>
-        void apply(opT& op, const FunctionImpl<R,NDIM>& f, bool fence) {
+        void apply(opT& op, const FunctionImpl<R, NDIM>& f, bool fence) {
             PROFILE_MEMBER_FUNC(FunctionImpl);
             MADNESS_ASSERT(!op.modified());
             typename dcT::const_iterator end = f.coeffs.end();
-            for (typename dcT::const_iterator it=f.coeffs.begin(); it!=end; ++it) {
+            for (typename dcT::const_iterator it = f.coeffs.begin(); it != end; ++it) {
                 // looping through all the coefficients in the source
                 const keyT& key = it->first;
-                const FunctionNode<R,NDIM>& node = it->second;
+                const FunctionNode<R, NDIM>& node = it->second;
                 if (node.has_coeff()) {
                     if (node.coeff().dim(0) != k || op.doleaves) {
                         ProcessID p = FunctionDefaults<NDIM>::get_apply_randomize() ? world.random_proc() : coeffs.owner(key);
-//                        woT::task(p, &implT:: template do_apply<opT,R>, &op, key, node.coeff()); //.full_tensor_copy() ????? why copy ????
-                        woT::task(p, &implT:: template do_apply<opT,R>, &op, key, node.coeff().reconstruct_tensor());
+                        // woT::task(p, &implT:: template do_apply<opT, R>, &op, key, node.coeff()); //.full_tensor_copy() ????? why copy ????
+                        woT::task(p, &implT:: template do_apply<opT, R>, &op, key, node.coeff().reconstruct_tensor());
                     }
                 }
             }
@@ -4872,10 +4838,9 @@ template<size_t NDIM>
                 world.gop.fence();
 
             set_tree_state(nonstandard_after_apply);
-//            this->compressed=true;
-//            this->nonstandard=true;
-//            this->redundant=false;
-
+            // this->compressed = true;
+            // this->nonstandard = true;
+            // this->redundant = false;
         }
 
 
@@ -4898,49 +4863,49 @@ template<size_t NDIM>
             // screening: contains all displacement keys that had small result norms
             std::list<opkeyT> blacklist;
 
-            static const size_t opdim=opT::opdim;
+            static const size_t opdim = opT::opdim;
             Key<NDIM-opdim> nullkey(key.level());
 
             // source is that part of key that corresponds to those dimensions being processed
-            const opkeyT source=op->get_source_key(key);
+            const opkeyT source = op->get_source_key(key);
 
             const double tol = truncate_tol(thresh, key);
 
             // fac is the root of the number of contributing neighbors (1st shell)
-            double fac=std::pow(3,NDIM*0.5);
+            double fac = std::pow(3, NDIM*0.5);
             double cnorm = coeff.normf();
 
             // for accumulation: keep slightly tighter TensorArgs
             TensorArgs apply_targs(targs);
-            apply_targs.thresh=tol/fac*0.03;
+            apply_targs.thresh = tol / fac * 0.03;
 
-            double maxnorm=0.0;
+            double maxnorm = 0.0;
 
             // for the kernel it may be more efficient to do the convolution in full rank
             tensorT coeff_full;
             // for partial application (exchange operator) it's more efficient to
             // do SVD tensors instead of tensortrains, because addition in apply
             // can be done in full form for the specific particle
-            coeffT coeff_SVD=coeff.convert(TensorArgs(-1.0,TT_2D));
+            coeffT coeff_SVD = coeff.convert(TensorArgs(-1.0, TT_2D));
 #ifdef HAVE_GENTENSOR
-            coeff_SVD.get_svdtensor().orthonormalize(tol*GenTensor<T>::fac_reduce());
+            coeff_SVD.get_svdtensor().orthonormalize(tol * GenTensor<T>::fac_reduce());
 #endif
 
             const std::vector<opkeyT>& disp = op->get_disp(key.level());
-            const std::vector<bool> is_periodic(NDIM,false); // Periodic sum is already done when making rnlp
+            const std::vector<bool> is_periodic(NDIM, false); // Periodic sum is already done when making rnlp
 
-            for (typename std::vector<opkeyT>::const_iterator it=disp.begin(); it != disp.end(); ++it) {
+            for (typename std::vector<opkeyT>::const_iterator it = disp.begin(); it != disp.end(); ++it) {
                 const opkeyT& d = *it;
 
-                const int shell=d.distsq();
-                if (do_kernel and (shell>0)) break;
-                if ((not do_kernel) and (shell==0)) continue;
+                const int shell = d.distsq();
+                if (do_kernel and (shell > 0)) break;
+                if ((not do_kernel) and (shell == 0)) continue;
 
                 keyT disp1;
-                if (op->particle()==1) disp1=it->merge_with(nullkey);
-                else if (op->particle()==2) disp1=nullkey.merge_with(*it);
+                if (op->particle() == 1) disp1 = it->merge_with(nullkey);
+                else if (op->particle() == 2) disp1 = nullkey.merge_with(*it);
                 else {
-                    MADNESS_EXCEPTION("confused particle in operato??",1);
+                    MADNESS_EXCEPTION("confused particle in operato??", 1);
                 }
 
                 keyT dest = neighbor(key, disp1, is_periodic);
@@ -4950,69 +4915,66 @@ template<size_t NDIM>
                 // directed screening
                 // working assumption here is that the operator is isotropic and
                 // monotonically decreasing with distance
-                bool screened=false;
+                bool screened = false;
                 typename std::list<opkeyT>::const_iterator it2;
-                for (it2=blacklist.begin(); it2!=blacklist.end(); it2++) {
+                for (it2 = blacklist.begin(); it2 != blacklist.end(); it2++) {
                     if (d.is_farther_out_than(*it2)) {
-                        screened=true;
+                        screened = true;
                         break;
                     }
                 }
                 if (not screened) {
 
                     double opnorm = op->norm(key.level(), d, source);
-                    double norm=0.0;
+                    double norm = 0.0;
 
-                    if (cnorm*opnorm> tol/fac) {
+                    if (cnorm * opnorm > tol / fac) {
 
-                        double cost_ratio=op->estimate_costs(source, d, coeff_SVD, tol/fac/cnorm, tol/fac);
-                        //                        cost_ratio=1.5;     // force low rank
-                        //                        cost_ratio=0.5;     // force full rank
+                        double cost_ratio = op->estimate_costs(source, d, coeff_SVD, tol / fac / cnorm, tol / fac);
+                        // cost_ratio = 1.5; // force low rank
+                        // cost_ratio = 0.5; // force full rank
 
-                        if (cost_ratio>0.0) {
+                        if (cost_ratio > 0.0) {
 
                             do_op_args<opdim> args(source, d, dest, tol, fac, cnorm);
-                            norm=0.0;
-                            if (cost_ratio<1.0) {
-                                if (not coeff_full.has_data()) coeff_full=coeff.full_tensor_copy();
-                                norm=do_apply_kernel2(op, coeff_full,args,apply_targs);
+                            norm = 0.0;
+                            if (cost_ratio < 1.0) {
+                                if (not coeff_full.has_data()) coeff_full = coeff.full_tensor_copy();
+                                norm = do_apply_kernel2(op, coeff_full, args, apply_targs);
                             } else {
-                                if (2*opdim==NDIM) {    // apply operator on one particle only
-                                    norm=do_apply_kernel3(op,coeff_SVD,args,apply_targs);
+                                if (2 * opdim == NDIM) {  // apply operator on one particle only
+                                    norm = do_apply_kernel3(op, coeff_SVD, args, apply_targs);
                                 } else {
-                                    norm=do_apply_kernel3(op,coeff,args,apply_targs);
+                                    norm = do_apply_kernel3(op, coeff, args, apply_targs);
                                 }
                             }
-                            maxnorm=std::max(norm,maxnorm);
+                            maxnorm = std::max(norm, maxnorm);
                         }
-
                     } else if (shell >= 12) {
                         break; // Assumes monotonic decay beyond nearest neighbor
                     }
-                    if (norm<0.3*tol/fac) blacklist.push_back(d);
+                    if (norm < 0.3 * tol / fac) blacklist.push_back(d);
                 }
             }
             return maxnorm;
         }
 
-
         /// similar to apply, but for low rank coeffs
         template <typename opT, typename R>
-        void apply_source_driven(opT& op, const FunctionImpl<R,NDIM>& f, bool fence) {
+        void apply_source_driven(opT& op, const FunctionImpl<R, NDIM>& f, bool fence) {
             PROFILE_MEMBER_FUNC(FunctionImpl);
 
             MADNESS_ASSERT(not op.modified());
             // looping through all the coefficients of the source f
             typename dcT::const_iterator end = f.get_coeffs().end();
-            for (typename dcT::const_iterator it=f.get_coeffs().begin(); it!=end; ++it) {
-
+            for (typename dcT::const_iterator it = f.get_coeffs().begin(); it != end; ++it) {
                 const keyT& key = it->first;
                 const coeffT& coeff = it->second.coeff();
 
-                if (coeff.has_data() and (coeff.rank()!=0)) {
+                if (coeff.has_data() and (coeff.rank() != 0)) {
                     ProcessID p = FunctionDefaults<NDIM>::get_apply_randomize() ? world.random_proc() : coeffs.owner(key);
-                    woT::task(p, &implT:: template do_apply_directed_screening<opT,R>, &op, key, coeff, true);
-                    woT::task(p, &implT:: template do_apply_directed_screening<opT,R>, &op, key, coeff, false);
+                    woT::task(p, &implT:: template do_apply_directed_screening<opT, R>, &op, key, coeff, true);
+                    woT::task(p, &implT:: template do_apply_directed_screening<opT, R>, &op, key, coeff, false);
                 }
             }
             if (fence) world.gop.fence();
@@ -5039,25 +5001,25 @@ template<size_t NDIM>
         /// @param[in]	fimpl    the funcimpl of the function of particle 1
         /// @param[in]	gimpl    the funcimpl of the function of particle 2
         template<typename opT, std::size_t LDIM>
-        void recursive_apply(opT& apply_op, const FunctionImpl<T,LDIM>* fimpl,
-                             const FunctionImpl<T,LDIM>* gimpl, const bool fence) {
+        void recursive_apply(opT& apply_op, const FunctionImpl<T, LDIM>* fimpl,
+                             const FunctionImpl<T, LDIM>* gimpl, const bool fence) {
 
             //print("IN RECUR2");
-            const keyT& key0=cdata.key0;
+            const keyT& key0 = cdata.key0;
 
             if (world.rank() == coeffs.owner(key0)) {
 
-                CoeffTracker<T,LDIM> ff(fimpl);
-                CoeffTracker<T,LDIM> gg(gimpl);
+                CoeffTracker<T, LDIM> ff(fimpl);
+                CoeffTracker<T, LDIM> gg(gimpl);
 
-                typedef recursive_apply_op<opT,LDIM> coeff_opT;
-                coeff_opT coeff_op(this,ff,gg,&apply_op);
+                typedef recursive_apply_op<opT, LDIM> coeff_opT;
+                coeff_opT coeff_op(this, ff, gg, &apply_op);
 
-                typedef noop<T,NDIM> apply_opT;
+                typedef noop<T, NDIM> apply_opT;
                 apply_opT apply_op;
 
-                ProcessID p= coeffs.owner(key0);
-                woT::task(p, &implT:: template forward_traverse<coeff_opT,apply_opT>, coeff_op, apply_op, key0);
+                ProcessID p = coeffs.owner(key0);
+                woT::task(p, &implT:: template forward_traverse<coeff_opT, apply_opT>, coeff_op, apply_op, key0);
 
             }
             if (fence) world.gop.fence();
@@ -5067,22 +5029,22 @@ template<size_t NDIM>
         /// recursive part of recursive_apply
         template<typename opT, std::size_t LDIM>
         struct recursive_apply_op {
-            bool randomize() const {return true;}
+            bool randomize() const { return true; }
 
-            typedef recursive_apply_op<opT,LDIM> this_type;
+            typedef recursive_apply_op<opT, LDIM> this_type;
 
             implT* result;
-            CoeffTracker<T,LDIM> iaf;
-            CoeffTracker<T,LDIM> iag;
+            CoeffTracker<T, LDIM> iaf;
+            CoeffTracker<T, LDIM> iag;
             opT* apply_op;
 
             // ctor
             recursive_apply_op() {}
             recursive_apply_op(implT* result,
-                               const CoeffTracker<T,LDIM>& iaf, const CoeffTracker<T,LDIM>& iag,
+                               const CoeffTracker<T, LDIM>& iaf, const CoeffTracker<T, LDIM>& iag,
                                const opT* apply_op) : result(result), iaf(iaf), iag(iag), apply_op(apply_op)
             {
-                MADNESS_ASSERT(LDIM+LDIM==NDIM);
+                MADNESS_ASSERT(LDIM + LDIM == NDIM);
             }
             recursive_apply_op(const recursive_apply_op& other) : result(other.result), iaf(other.iaf),
                                                                   iag(other.iag), apply_op(other.apply_op) {}
@@ -5090,75 +5052,73 @@ template<size_t NDIM>
 
             /// make the NS-coefficients and send off the application of the operator
 
-            /// @return		a Future<bool,coeffT>(is_leaf,coeffT())
-            std::pair<bool,coeffT> operator()(const Key<NDIM>& key) const {
-
-                //            	World& world=result->world;
+            /// @return		a Future<bool, coeffT>(is_leaf, coeffT())
+            std::pair<bool, coeffT> operator()(const Key<NDIM>& key) const {
+                // World& world = result->world;
                 // break key into particles (these are the child keys, with datum1/2 come the parent keys)
-                Key<LDIM> key1,key2;
-                key.break_apart(key1,key2);
+                Key<LDIM> key1, key2;
+                key.break_apart(key1, key2);
 
                 // the lo-dim functions should be in full tensor form
-                const tensorT fcoeff=iaf.coeff(key1).full_tensor();
-                const tensorT gcoeff=iag.coeff(key2).full_tensor();
+                const tensorT fcoeff = iaf.coeff(key1).full_tensor();
+                const tensorT gcoeff = iag.coeff(key2).full_tensor();
 
                 // would this be a leaf node? If so, then its sum coeffs have already been
                 // processed by the parent node's wavelet coeffs. Therefore we won't
                 // process it any more.
-                hartree_leaf_op<T,NDIM> leaf_op(result,result->get_k());
-                bool is_leaf=leaf_op(key,fcoeff,gcoeff);
+                hartree_leaf_op<T, NDIM> leaf_op(result, result->get_k());
+                bool is_leaf = leaf_op(key, fcoeff, gcoeff);
 
                 if (not is_leaf) {
                     // new coeffs are simply the hartree/kronecker/outer product --
-                    const std::vector<Slice>& s0=iaf.get_impl()->cdata.s0;
+                    const std::vector<Slice>& s0 = iaf.get_impl()->cdata.s0;
                     const coeffT coeff = (apply_op->modified())
-                        ? outer(copy(fcoeff(s0)),copy(gcoeff(s0)),result->targs)
-                        : outer(fcoeff,gcoeff,result->targs);
+                        ? outer(copy(fcoeff(s0)), copy(gcoeff(s0)), result->targs)
+                        : outer(fcoeff, gcoeff, result->targs);
 
                     // now send off the application
                     tensorT coeff_full;
-                    ProcessID p=result->world.rank();
-                    double norm0=result->do_apply_directed_screening<opT,T>(apply_op, key, coeff, true);
+                    ProcessID p = result->world.rank();
+                    double norm0 = result->do_apply_directed_screening<opT, T>(apply_op, key, coeff, true);
 
-                    result->task(p,&implT:: template do_apply_directed_screening<opT,T>,
-                                 apply_op,key,coeff,false);
+                    result->task(p, &implT:: template do_apply_directed_screening<opT, T>,
+                                 apply_op, key, coeff, false);
 
-                    return finalize(norm0,key,coeff);
+                    return finalize(norm0, key, coeff);
 
                 } else {
-                    return std::pair<bool,coeffT> (is_leaf,coeffT());
+                    return std::pair<bool, coeffT> (is_leaf, coeffT());
                 }
             }
 
             /// sole purpose is to wait for the kernel norm, wrap it and send it back to caller
-            std::pair<bool,coeffT> finalize(const double kernel_norm, const keyT& key,
+            std::pair<bool, coeffT> finalize(const double kernel_norm, const keyT& key,
                                             const coeffT& coeff) const {
-            	const double thresh=result->get_thresh()*0.1;
-            	bool is_leaf=(kernel_norm<result->truncate_tol(thresh,key));
-            	if (key.level()<2) is_leaf=false;
-            	return std::pair<bool,coeffT> (is_leaf,coeff);
+            	const double thresh = result->get_thresh() * 0.1;
+            	bool is_leaf = (kernel_norm<result->truncate_tol(thresh, key));
+            	if (key.level() < 2) is_leaf = false;
+            	return std::pair<bool, coeffT> (is_leaf, coeff);
             }
 
 
             this_type make_child(const keyT& child) const {
-
                 // break key into particles
                 Key<LDIM> key1, key2;
-                child.break_apart(key1,key2);
+                child.break_apart(key1, key2);
 
-                return this_type(result,iaf.make_child(key1),iag.make_child(key2),apply_op);
+                return this_type(result, iaf.make_child(key1), iag.make_child(key2), apply_op);
             }
 
             Future<this_type> activate() const {
-            	Future<CoeffTracker<T,LDIM> > f1=iaf.activate();
-            	Future<CoeffTracker<T,LDIM> > g1=iag.activate();
+            	Future<CoeffTracker<T, LDIM>> f1 = iaf.activate();
+            	Future<CoeffTracker<T, LDIM>> g1 = iag.activate();
                 return result->world.taskq.add(detail::wrap_mem_fn(*const_cast<this_type *> (this),
-                                               &this_type::forward_ctor),result,f1,g1,apply_op);
+                                               &this_type::forward_ctor), result, f1, g1, apply_op);
             }
 
-            this_type forward_ctor(implT* r, const CoeffTracker<T,LDIM>& f1, const CoeffTracker<T,LDIM>& g1,
+            this_type forward_ctor(implT* r, const CoeffTracker<T, LDIM>& f1, const CoeffTracker<T, LDIM>& g1,
                                    const opT* apply_op1) {
-            	return this_type(r,f1,g1,apply_op1);
+            	return this_type(r, f1, g1, apply_op1);
             }
 
             template <typename Archive> void serialize(const Archive& ar) {
@@ -5177,17 +5137,17 @@ template<size_t NDIM>
 
             print("IN RECUR1");
 
-            const keyT& key0=cdata.key0;
+            const keyT& key0 = cdata.key0;
 
             if (world.rank() == coeffs.owner(key0)) {
 
                 typedef recursive_apply_op2<opT> coeff_opT;
-                coeff_opT coeff_op(this,fimpl,&apply_op);
+                coeff_opT coeff_op(this, fimpl, &apply_op);
 
-                typedef noop<T,NDIM> apply_opT;
+                typedef noop<T, NDIM> apply_opT;
                 apply_opT apply_op;
 
-                woT::task(world.rank(), &implT:: template forward_traverse<coeff_opT,apply_opT>,
+                woT::task(world.rank(), &implT:: template forward_traverse<coeff_opT, apply_opT>,
                           coeff_op, apply_op, cdata.key0);
 
             }
@@ -5198,11 +5158,11 @@ template<size_t NDIM>
         /// recursive part of recursive_apply
         template<typename opT>
         struct recursive_apply_op2 {
-            bool randomize() const {return true;}
+            bool randomize() const { return true; }
 
             typedef recursive_apply_op2<opT> this_type;
-            typedef CoeffTracker<T,NDIM> ctT;
-            typedef std::pair<bool,coeffT> argT;
+            typedef CoeffTracker<T, NDIM> ctT;
+            typedef std::pair<bool, coeffT> argT;
 
             mutable implT* result;
             ctT iaf;			/// need this for randomization
@@ -5221,59 +5181,54 @@ template<size_t NDIM>
 
             /// the first (core) neighbor (ie. the box itself) is processed
             /// immediately, all other ones are shoved into the taskq
-            /// @return		a pair<bool,coeffT>(is_leaf,coeffT())
+            /// @return		a pair<bool, coeffT>(is_leaf, coeffT())
             argT operator()(const Key<NDIM>& key) const {
 
-            	const coeffT& coeff=iaf.coeff();
+            	const coeffT& coeff = iaf.coeff();
 
                 if (coeff.has_data()) {
-
                     // now send off the application for all neighbor boxes
-                    ProcessID p=result->world.rank();
-                    result->task(p,&implT:: template do_apply_directed_screening<opT,T>,
+                    ProcessID p = result->world.rank();
+                    result->task(p, &implT:: template do_apply_directed_screening<opT, T>,
                                  apply_op, key, coeff, false);
 
                     // process the core box
-                    double norm0=result->do_apply_directed_screening<opT,T>(apply_op,key,coeff,true);
+                    double norm0 = result->do_apply_directed_screening<opT, T>(apply_op, key, coeff, true);
 
-                    if (iaf.is_leaf()) return argT(true,coeff);
-                    return finalize(norm0,key,coeff,result);
-
+                    if (iaf.is_leaf()) return argT(true, coeff);
+                    return finalize(norm0, key, coeff, result);
                 } else {
-                    const bool is_leaf=true;
-                    return argT(is_leaf,coeffT());
+                    const bool is_leaf = true;
+                    return argT(is_leaf, coeffT());
                 }
             }
 
             /// sole purpose is to wait for the kernel norm, wrap it and send it back to caller
             argT finalize(const double kernel_norm, const keyT& key,
                           const coeffT& coeff, const implT* r) const {
-            	const double thresh=r->get_thresh()*0.1;
-            	bool is_leaf=(kernel_norm<r->truncate_tol(thresh,key));
-            	if (key.level()<2) is_leaf=false;
-            	return argT(is_leaf,coeff);
+            	const double thresh = r->get_thresh()*0.1;
+            	bool is_leaf = (kernel_norm<r->truncate_tol(thresh, key));
+            	if (key.level() < 2) is_leaf = false;
+            	return argT(is_leaf, coeff);
             }
 
-
             this_type make_child(const keyT& child) const {
-                return this_type(result,iaf.make_child(child),apply_op);
+                return this_type(result, iaf.make_child(child), apply_op);
             }
 
             /// retrieve the coefficients (parent coeffs might be remote)
             Future<this_type> activate() const {
-            	Future<ctT> f1=iaf.activate();
-
-//                Future<ctL> g1=g.activate();
-//                return h->world.taskq.add(detail::wrap_mem_fn(*const_cast<this_type *> (this),
-//                                          &this_type::forward_ctor),h,f1,g1,particle);
-
+            	Future<ctT> f1 = iaf.activate();
+                // Future<ctL> g1=g.activate();
+                // return h->world.taskq.add(detail::wrap_mem_fn(*const_cast<this_type *> (this),
+                //                           &this_type::forward_ctor), h, f1, g1, particle);
                 return result->world.taskq.add(detail::wrap_mem_fn(*const_cast<this_type *> (this),
-                                               &this_type::forward_ctor),result,f1,apply_op);
+                                               &this_type::forward_ctor), result, f1, apply_op);
             }
 
             /// taskq-compatible ctor
             this_type forward_ctor(implT* result1, const ctT& iaf1, const opT* apply_op1) {
-            	return this_type(result1,iaf1,apply_op1);
+            	return this_type(result1, iaf1, apply_op1);
             }
 
             template <typename Archive> void serialize(const Archive& ar) {
@@ -5289,30 +5244,29 @@ template<size_t NDIM>
         double err_box(const keyT& key, const nodeT& node, const opT& func,
                        int npt, const Tensor<double>& qx, const Tensor<double>& quad_phit,
                        const Tensor<double>& quad_phiw) const {
-
             std::vector<long> vq(NDIM);
-            for (std::size_t i=0; i<NDIM; ++i)
+            for (std::size_t i = 0; i < NDIM; ++i)
                 vq[i] = npt;
-            tensorT fval(vq,false), work(vq,false), result(vq,false);
+            tensorT fval(vq, false), work(vq, false), result(vq, false);
 
             // Compute the "exact" function in this volume at npt points
             // where npt is usually this->npt+1.
             fcube(key, func, qx, fval);
 
             // Transform into the scaling function basis of order npt
-            double scale = pow(0.5,0.5*NDIM*key.level())*sqrt(FunctionDefaults<NDIM>::get_cell_volume());
-            fval = fast_transform(fval,quad_phiw,result,work).scale(scale);
+            double scale = pow(0.5, 0.5 * NDIM * key.level()) * sqrt(FunctionDefaults<NDIM>::get_cell_volume());
+            fval = fast_transform(fval, quad_phiw, result, work).scale(scale);
 
             // Subtract to get the error ... the original coeffs are in the order k
             // basis but we just computed the coeffs in the order npt(=k+1) basis
             // so we can either use slices or an iterator macro.
             const tensorT coeff = node.coeff().full_tensor_copy();
-            ITERATOR(coeff,fval(IND)-=coeff(IND););
+            ITERATOR(coeff, fval(IND) -= coeff(IND););
             // flo note: we do want to keep a full tensor here!
 
             // Compute the norm of what remains
             double err = fval.normf();
-            return err*err;
+            return err * err;
         }
 
         template <typename opT>
@@ -5343,7 +5297,7 @@ template<size_t NDIM>
             }
 
             double operator()(double a, double b) const {
-                return a+b;
+                return a + b;
             }
 
             template <typename Archive>
@@ -5359,15 +5313,15 @@ template<size_t NDIM>
             // Make quadrature rule of higher order
             const int npt = cdata.npt + 1;
             Tensor<double> qx, qw, quad_phi, quad_phiw, quad_phit;
-            FunctionCommonData<T,NDIM>::_init_quadrature(k+1, npt, qx, qw, quad_phi, quad_phiw, quad_phit);
+            FunctionCommonData<T, NDIM>::_init_quadrature(k + 1, npt, qx, qw, quad_phi, quad_phiw, quad_phit);
 
             typedef Range<typename dcT::const_iterator> rangeT;
             rangeT range(coeffs.begin(), coeffs.end());
-            return world.taskq.reduce< double,rangeT,do_err_box<opT> >(range,
+            return world.taskq.reduce<double, rangeT, do_err_box<opT>>(range,
                                                                        do_err_box<opT>(this, &func, npt, qx, quad_phit, quad_phiw));
         }
 
-        /// Returns \c int(f(x),x) in local volume
+        /// Returns \c int(f(x), x) in local volume
         T trace_local() const;
 
         struct do_norm2sq_local {
@@ -5398,23 +5352,23 @@ template<size_t NDIM>
         /// compute the inner product of this range with other
         template<typename R>
         struct do_inner_local {
-            const FunctionImpl<R,NDIM>* other;
+            const FunctionImpl<R, NDIM>* other;
             bool leaves_only;
-            typedef TENSOR_RESULT_TYPE(T,R) resultT;
+            typedef TENSOR_RESULT_TYPE(T, R) resultT;
 
-            do_inner_local(const FunctionImpl<R,NDIM>* other, const bool leaves_only)
+            do_inner_local(const FunctionImpl<R, NDIM>* other, const bool leaves_only)
             	: other(other), leaves_only(leaves_only) {}
             resultT operator()(typename dcT::const_iterator& it) const {
 
-            	TENSOR_RESULT_TYPE(T,R) sum=0.0;
-            	const keyT& key=it->first;
+            	TENSOR_RESULT_TYPE(T, R) sum = 0.0;
+            	const keyT& key = it->first;
                 const nodeT& fnode = it->second;
                 if (fnode.has_coeff()) {
                     if (other->coeffs.probe(it->first)) {
-                        const FunctionNode<R,NDIM>& gnode = other->coeffs.find(key).get()->second;
+                        const FunctionNode<R, NDIM>& gnode = other->coeffs.find(key).get()->second;
                         if (gnode.has_coeff()) {
                             if (gnode.coeff().dim(0) != fnode.coeff().dim(0)) {
-                                madness::print("INNER", it->first, gnode.coeff().dim(0),fnode.coeff().dim(0));
+                                madness::print("INNER", it->first, gnode.coeff().dim(0), fnode.coeff().dim(0));
                                 MADNESS_EXCEPTION("functions have different k or compress/reconstruct error", 0);
                             }
                             if (leaves_only) {
@@ -5443,113 +5397,112 @@ template<size_t NDIM>
 
         /// handles compressed and redundant form
         template <typename R>
-        TENSOR_RESULT_TYPE(T,R) inner_local(const FunctionImpl<R,NDIM>& g) const {
+        TENSOR_RESULT_TYPE(T, R) inner_local(const FunctionImpl<R, NDIM>& g) const {
             PROFILE_MEMBER_FUNC(FunctionImpl);
             typedef Range<typename dcT::const_iterator> rangeT;
-            typedef TENSOR_RESULT_TYPE(T,R) resultT;
+            typedef TENSOR_RESULT_TYPE(T, R) resultT;
 
             // make sure the states of the trees are consistent
-            MADNESS_ASSERT(this->is_redundant()==g.is_redundant());
-            bool leaves_only=(this->is_redundant());
-            return world.taskq.reduce<resultT,rangeT,do_inner_local<R> >
-                (rangeT(coeffs.begin(),coeffs.end()),do_inner_local<R>(&g, leaves_only));
+            MADNESS_ASSERT(this->is_redundant() == g.is_redundant());
+            bool leaves_only = (this->is_redundant());
+            return world.taskq.reduce<resultT, rangeT, do_inner_local<R>>
+                (rangeT(coeffs.begin(), coeffs.end()), do_inner_local<R>(&g, leaves_only));
         }
 
 
         /// compute the inner product of this range with other
         template<typename R>
         struct do_inner_local_on_demand {
-            const FunctionImpl<T,NDIM>* bra;
-            const FunctionImpl<R,NDIM>* ket;
+            const FunctionImpl<T, NDIM>* bra;
+            const FunctionImpl<R, NDIM>* ket;
             bool leaves_only=true;
-            typedef TENSOR_RESULT_TYPE(T,R) resultT;
+            typedef TENSOR_RESULT_TYPE(T, R) resultT;
 
-            do_inner_local_on_demand(const FunctionImpl<T,NDIM>* bra, const FunctionImpl<R,NDIM>* ket,
+            do_inner_local_on_demand(const FunctionImpl<T, NDIM>* bra, const FunctionImpl<R, NDIM>* ket,
                                      const bool leaves_only=true)
                     : bra(bra), ket(ket), leaves_only(leaves_only) {}
             resultT operator()(typename dcT::const_iterator& it) const {
+                constexpr std::size_t LDIM=std::max(NDIM/2, std::size_t(1));
 
-                constexpr std::size_t LDIM=std::max(NDIM/2,std::size_t(1));
-
-                const keyT& key=it->first;
+                const keyT& key = it->first;
                 const nodeT& fnode = it->second;
                 if (not fnode.has_coeff()) return resultT(0.0); // probably internal nodes
 
                 // assuming all boxes (esp the low-dim ones) are local, i.e. the functions are replicated
                 auto find_valid_parent = [](auto& key, auto& impl, auto&& find_valid_parent) {
-                    MADNESS_CHECK(impl->get_coeffs().owner(key)==impl->world.rank()); // make sure everything is local!
+                    MADNESS_CHECK(impl->get_coeffs().owner(key) == impl->world.rank()); // make sure everything is local!
                     if (impl->get_coeffs().probe(key)) return key;
-                    auto parentkey=key.parent();
+                    auto parentkey = key.parent();
                     return find_valid_parent(parentkey, impl, find_valid_parent);
                 };
 
                 // returns coefficients, empty if no functor present
                 auto get_coeff = [&find_valid_parent](const auto& key, const auto& v_impl) {
-                    if ((v_impl.size()>0) and v_impl.front().get()) {
-                        auto impl=v_impl.front();
+                    if ((v_impl.size() > 0) and v_impl.front().get()) {
+                        auto impl = v_impl.front();
 
-//                    bool have_impl=impl.get();
-//                    if (have_impl) {
+                        // bool have_impl=impl.get();
+                        // if (have_impl) {
                         auto parentkey = find_valid_parent(key, impl, find_valid_parent);
                         MADNESS_CHECK(impl->get_coeffs().probe(parentkey));
                         typename decltype(impl->coeffs)::accessor acc;
-                        impl->get_coeffs().find(acc,parentkey);
-                        auto parentcoeff=acc->second.coeff();
+                        impl->get_coeffs().find(acc, parentkey);
+                        auto parentcoeff = acc->second.coeff();
                         auto coeff=impl->parent_to_child(parentcoeff, parentkey, key);
                         return coeff;
                     } else {
                         // get type of vector elements
                         typedef typename std::decay_t<decltype(v_impl)>::value_type::element_type::typeT S;
-//                        typedef typename std::decay_t<decltype(v_impl)>::value_type S;
+                        // typedef typename std::decay_t<decltype(v_impl)>::value_type S;
                         return GenTensor<S>();
-//                        return GenTensor<typename std::decay_t<decltype(*impl)>::typeT>();
+                        // return GenTensor<typename std::decay_t<decltype(*impl)>::typeT>();
                     }
                 };
 
                 auto make_vector = [](auto& arg) {
-                    return std::vector<std::decay_t<decltype(arg)>>(1,arg);
+                    return std::vector<std::decay_t<decltype(arg)>>(1, arg);
                 };
 
 
-                Key<LDIM> key1,key2;
-                key.break_apart(key1,key2);
+                Key<LDIM> key1, key2;
+                key.break_apart(key1, key2);
 
-                auto func=dynamic_cast<CompositeFunctorInterface<R,NDIM,LDIM>* >(ket->functor.get());
+                auto func = dynamic_cast<CompositeFunctorInterface<R, NDIM, LDIM>*>(ket->functor.get());
                 MADNESS_ASSERT(func);
 
-                MADNESS_CHECK_THROW(func->impl_ket_vector.size()==0 or func->impl_ket_vector.size()==1,
+                MADNESS_CHECK_THROW(func->impl_ket_vector.size() == 0 or func->impl_ket_vector.size() == 1,
                                     "only one ket function supported in inner_on_demand");
-                MADNESS_CHECK_THROW(func->impl_p1_vector.size()==0 or func->impl_p1_vector.size()==1,
+                MADNESS_CHECK_THROW(func->impl_p1_vector.size() == 0 or func->impl_p1_vector.size() == 1,
                                     "only one p1 function supported in inner_on_demand");
-                MADNESS_CHECK_THROW(func->impl_p2_vector.size()==0 or func->impl_p2_vector.size()==1,
+                MADNESS_CHECK_THROW(func->impl_p2_vector.size() == 0 or func->impl_p2_vector.size() == 1,
                                     "only one p2 function supported in inner_on_demand");
-                auto coeff_bra=fnode.coeff();
-                auto coeff_ket=get_coeff(key,func->impl_ket_vector);
-                auto coeff_v1=get_coeff(key1,make_vector(func->impl_m1));
-                auto coeff_v2=get_coeff(key2,make_vector(func->impl_m2));
-                auto coeff_p1=get_coeff(key1,func->impl_p1_vector);
-                auto coeff_p2=get_coeff(key2,func->impl_p2_vector);
+                auto coeff_bra = fnode.coeff();
+                auto coeff_ket = get_coeff(key, func->impl_ket_vector);
+                auto coeff_v1 = get_coeff(key1, make_vector(func->impl_m1));
+                auto coeff_v2 = get_coeff(key2, make_vector(func->impl_m2));
+                auto coeff_p1 = get_coeff(key1, func->impl_p1_vector);
+                auto coeff_p2 = get_coeff(key2, func->impl_p2_vector);
 
-                // construct |ket(1,2)> or |p(1)p(2)> or |p(1)p(2) ket(1,2)>
-                double error=0.0;
+                // construct |ket(1, 2)> or |p(1)p(2)> or |p(1)p(2) ket(1, 2)>
+                double error = 0.0;
                 if (coeff_ket.has_data() and coeff_p1.has_data()) {
-                    pointwise_multiplier<LDIM> pm(key,coeff_ket);
-                    coeff_ket=pm(key,outer(coeff_p1,coeff_p2,TensorArgs(TT_FULL,-1.0)).full_tensor());
-                    error+=pm.error;
+                    pointwise_multiplier<LDIM> pm(key, coeff_ket);
+                    coeff_ket = pm(key, outer(coeff_p1, coeff_p2, TensorArgs(TT_FULL, -1.0)).full_tensor());
+                    error += pm.error;
                 } else if (coeff_ket.has_data() or coeff_p1.has_data()) {
-                    coeff_ket = (coeff_ket.has_data()) ? coeff_ket : outer(coeff_p1,coeff_p2);
+                    coeff_ket = (coeff_ket.has_data()) ? coeff_ket : outer(coeff_p1, coeff_p2);
                 } else { // not ket and no p1p2
-                    MADNESS_EXCEPTION("confused ket/p1p2 in do_inner_local_on_demand",1);
+                    MADNESS_EXCEPTION("confused ket/p1p2 in do_inner_local_on_demand", 1);
                 }
 
-                // construct (v(1) + v(2)) |ket(1,2)>
+                // construct (v(1) + v(2)) |ket(1, 2)>
                 coeffT v1v2ket;
                 if (coeff_v1.has_data()) {
-                    pointwise_multiplier<LDIM> pm(key,coeff_ket);
-                    v1v2ket = pm(key,coeff_v1.full_tensor(), 1);
-                    error+=pm.error;
-                    v1v2ket+= pm(key,coeff_v2.full_tensor(), 2);
-                    error+=pm.error;
+                    pointwise_multiplier<LDIM> pm(key, coeff_ket);
+                    v1v2ket = pm(key, coeff_v1.full_tensor(), 1);
+                    error += pm.error;
+                    v1v2ket += pm(key, coeff_v2.full_tensor(), 2);
+                    error += pm.error;
                 } else {
                     v1v2ket = coeff_ket;
                 }
@@ -5557,21 +5510,21 @@ template<size_t NDIM>
                 resultT result;
                 if (func->impl_eri) {         // project bra*ket onto eri, avoid multiplication with eri
                     MADNESS_CHECK(func->impl_eri->get_functor()->provides_coeff());
-                    coeffT coeff_eri=func->impl_eri->get_functor()->coeff(key).full_tensor();
-                    pointwise_multiplier<LDIM> pm(key,v1v2ket);
-                    tensorT braket=pm(key,coeff_bra.full_tensor_copy().conj());
-                    error+=pm.error;
-                    if (error>1.e-3) print("error in key",key,error);
-                    result=coeff_eri.full_tensor().trace(braket);
+                    coeffT coeff_eri = func->impl_eri->get_functor()->coeff(key).full_tensor();
+                    pointwise_multiplier<LDIM> pm(key, v1v2ket);
+                    tensorT braket = pm(key, coeff_bra.full_tensor_copy().conj());
+                    error += pm.error;
+                    if (error > 1.e-3) print("error in key", key, error);
+                    result = coeff_eri.full_tensor().trace(braket);
 
                 } else {                            // no eri, project ket onto bra
-                    result=coeff_bra.full_tensor_copy().trace_conj(v1v2ket.full_tensor_copy());
+                    result = coeff_bra.full_tensor_copy().trace_conj(v1v2ket.full_tensor_copy());
                 }
                 return result;
             }
 
             resultT operator()(resultT a, resultT b) const {
-                return (a+b);
+                return (a + b);
             }
 
             template <typename Archive> void serialize(const Archive& ar) {
@@ -5583,7 +5536,7 @@ template<size_t NDIM>
 
         /// the leaf boxes of this' MRA tree defines the inner product
         template <typename R>
-        TENSOR_RESULT_TYPE(T,R) inner_local_on_demand(const FunctionImpl<R,NDIM>& gimpl) const {
+        TENSOR_RESULT_TYPE(T, R) inner_local_on_demand(const FunctionImpl<R, NDIM>& gimpl) const {
             PROFILE_MEMBER_FUNC(FunctionImpl);
             MADNESS_CHECK(this->is_reconstructed());
 
@@ -5594,7 +5547,7 @@ template<size_t NDIM>
         }
 
         /// Type of the entry in the map returned by make_key_vec_map
-        typedef std::vector< std::pair<int,const coeffT*> > mapvecT;
+        typedef std::vector< std::pair<int, const coeffT*>> mapvecT;
 
         /// Type of the map returned by make_key_vec_map
         typedef ConcurrentHashMap< keyT, mapvecT > mapT;
@@ -5602,13 +5555,13 @@ template<size_t NDIM>
         /// Adds keys to union of local keys with specified index
         void add_keys_to_map(mapT* map, int index) const {
             typename dcT::const_iterator end = coeffs.end();
-            for (typename dcT::const_iterator it=coeffs.begin(); it!=end; ++it) {
+            for (typename dcT::const_iterator it = coeffs.begin(); it != end; ++it) {
                 typename mapT::accessor acc;
                 const keyT& key = it->first;
-                const FunctionNode<T,NDIM>& node = it->second;
+                const FunctionNode<T, NDIM>& node = it->second;
                 if (node.has_coeff()) {
-                    [[maybe_unused]] auto inserted = map->insert(acc,key);
-                    acc->second.push_back(std::make_pair(index,&(node.coeff())));
+                    [[maybe_unused]] auto inserted = map->insert(acc, key);
+                    acc->second.push_back(std::make_pair(index, &(node.coeff())));
                 }
             }
         }
@@ -5618,12 +5571,12 @@ template<size_t NDIM>
         /// Local concurrency and synchronization only; no communication
         static
         mapT
-        make_key_vec_map(const std::vector<const FunctionImpl<T,NDIM>*>& v) {
+        make_key_vec_map(const std::vector<const FunctionImpl<T, NDIM>*>& v) {
             mapT map(100000);
             // This loop must be parallelized
-            for (unsigned int i=0; i<v.size(); i++) {
-                //v[i]->add_keys_to_map(&map,i);
-                v[i]->world.taskq.add(*(v[i]), &FunctionImpl<T,NDIM>::add_keys_to_map, &map, int(i));
+            for (unsigned int i = 0; i < v.size(); i++) {
+                // v[i]->add_keys_to_map(&map, i);
+                v[i]->world.taskq.add(*(v[i]), &FunctionImpl<T, NDIM>::add_keys_to_map, &map, int(i));
             }
             if (v.size()) v[0]->world.taskq.fence();
             return map;
@@ -5634,31 +5587,31 @@ template<size_t NDIM>
         template <typename R>
         static void do_inner_localX(const typename mapT::iterator lstart,
                                     const typename mapT::iterator lend,
-                                    typename FunctionImpl<R,NDIM>::mapT* rmap_ptr,
+                                    typename FunctionImpl<R, NDIM>::mapT* rmap_ptr,
                                     const bool sym,
-                                    Tensor< TENSOR_RESULT_TYPE(T,R) >* result_ptr,
+                                    Tensor<TENSOR_RESULT_TYPE(T, R)>* result_ptr,
                                     Mutex* mutex) {
-            Tensor< TENSOR_RESULT_TYPE(T,R) >& result = *result_ptr;
-            Tensor< TENSOR_RESULT_TYPE(T,R) > r(result.dim(0),result.dim(1));
-            for (typename mapT::iterator lit=lstart; lit!=lend; ++lit) {
+            Tensor<TENSOR_RESULT_TYPE(T, R)>& result = *result_ptr;
+            Tensor<TENSOR_RESULT_TYPE(T, R)> r(result.dim(0), result.dim(1));
+            for (typename mapT::iterator lit = lstart; lit != lend; ++lit) {
                 const keyT& key = lit->first;
-                typename FunctionImpl<R,NDIM>::mapT::iterator rit=rmap_ptr->find(key);
+                typename FunctionImpl<R, NDIM>::mapT::iterator rit = rmap_ptr->find(key);
                 if (rit != rmap_ptr->end()) {
                     const mapvecT& leftv = lit->second;
-                    const typename FunctionImpl<R,NDIM>::mapvecT& rightv =rit->second;
+                    const typename FunctionImpl<R, NDIM>::mapvecT& rightv = rit->second;
                     const int nleft = leftv.size();
-                    const int nright= rightv.size();
+                    const int nright = rightv.size();
 
-                    for (int iv=0; iv<nleft; iv++) {
+                    for (int iv = 0; iv<nleft; iv++) {
                         const int i = leftv[iv].first;
                         const GenTensor<T>* iptr = leftv[iv].second;
 
-                        for (int jv=0; jv<nright; jv++) {
+                        for (int jv = 0; jv<nright; jv++) {
                             const int j = rightv[jv].first;
                             const GenTensor<R>* jptr = rightv[jv].second;
 
-                            if (!sym || (sym && i<=j))
-                                r(i,j) += iptr->trace_conj(*jptr);
+                            if (!sym || (sym && i <= j))
+                                r(i, j) += iptr->trace_conj(*jptr);
                         }
                     }
                 }
@@ -5671,36 +5624,36 @@ template<size_t NDIM>
        template <typename R>
        static void do_inner_localX(const typename mapT::iterator lstart,
                                    const typename mapT::iterator lend,
-                                   typename FunctionImpl<R,NDIM>::mapT* rmap_ptr,
+                                   typename FunctionImpl<R, NDIM>::mapT* rmap_ptr,
                                    const bool sym,
-                                   Tensor< TENSOR_RESULT_TYPE(T,R) >* result_ptr,
+                                   Tensor<TENSOR_RESULT_TYPE(T, R)>* result_ptr,
                                    Mutex* mutex) {
-           Tensor< TENSOR_RESULT_TYPE(T,R) >& result = *result_ptr;
-           //Tensor< TENSOR_RESULT_TYPE(T,R) > r(result.dim(0),result.dim(1));
-           for (typename mapT::iterator lit=lstart; lit!=lend; ++lit) {
+           Tensor<TENSOR_RESULT_TYPE(T, R)>& result = *result_ptr;
+           // Tensor<TENSOR_RESULT_TYPE(T, R)> r(result.dim(0), result.dim(1));
+           for (typename mapT::iterator lit = lstart; lit != lend; ++lit) {
                const keyT& key = lit->first;
-               typename FunctionImpl<R,NDIM>::mapT::iterator rit=rmap_ptr->find(key);
+               typename FunctionImpl<R, NDIM>::mapT::iterator rit = rmap_ptr->find(key);
                if (rit != rmap_ptr->end()) {
                    const mapvecT& leftv = lit->second;
-                   const typename FunctionImpl<R,NDIM>::mapvecT& rightv =rit->second;
+                   const typename FunctionImpl<R, NDIM>::mapvecT& rightv = rit->second;
                    const size_t nleft = leftv.size();
                    const size_t nright= rightv.size();
 
                    unsigned int size = leftv[0].second->size();
                    Tensor<T> Left(nleft, size);
                    Tensor<R> Right(nright, size);
-                   Tensor< TENSOR_RESULT_TYPE(T,R)> r(nleft, nright);
-                   for(unsigned int iv = 0; iv < nleft; ++iv) Left(iv,_) = *(leftv[iv].second);
-                   for(unsigned int jv = 0; jv < nright; ++jv) Right(jv,_) = *(rightv[jv].second);
+                   Tensor< TENSOR_RESULT_TYPE(T, R)> r(nleft, nright);
+                   for(unsigned int iv = 0; iv < nleft; ++iv) Left(iv, _) = *(leftv[iv].second);
+                   for(unsigned int jv = 0; jv < nright; ++jv) Right(jv, _) = *(rightv[jv].second);
                    // call mxmT from mxm.h in tensor
-                   if(TensorTypeData<T>::iscomplex) Left = Left.conj();  //Should handle complex case and leave real case alone
+                   if(TensorTypeData<T>::iscomplex) Left = Left.conj();  // Should handle complex case and leave real case alone
                    mxmT(nleft, nright, size, r.ptr(), Left.ptr(), Right.ptr());
                    mutex->lock();
                    for(unsigned int iv = 0; iv < nleft; ++iv) {
                        const int i = leftv[iv].first;
                        for(unsigned int jv = 0; jv < nright; ++jv) {
                          const int j = rightv[jv].first;
-                         if (!sym || (sym && i<=j)) result(i,j) += r(iv,jv);
+                         if (!sym || (sym && i <= j)) result(i, j) += r(iv, jv);
                        }
                    }
                    mutex->unlock();
@@ -5718,9 +5671,9 @@ template<size_t NDIM>
         }
 
         template <typename R>
-        static Tensor< TENSOR_RESULT_TYPE(T,R) >
-        inner_local(const std::vector<const FunctionImpl<T,NDIM>*>& left,
-                    const std::vector<const FunctionImpl<R,NDIM>*>& right,
+        static Tensor<TENSOR_RESULT_TYPE(T, R)>
+        inner_local(const std::vector<const FunctionImpl<T, NDIM>*>& left,
+                    const std::vector<const FunctionImpl<R, NDIM>*>& right,
                     bool sym) {
 
             // This is basically a sparse matrix^T * matrix product
@@ -5736,33 +5689,33 @@ template<size_t NDIM>
             //                Rij += Aki*Bkj
 
             mapT lmap = make_key_vec_map(left);
-            typename FunctionImpl<R,NDIM>::mapT rmap;
-            typename FunctionImpl<R,NDIM>::mapT* rmap_ptr = (typename FunctionImpl<R,NDIM>::mapT*)(&lmap);
-            if ((std::vector<const FunctionImpl<R,NDIM>*>*)(&left) != &right) {
-                rmap = FunctionImpl<R,NDIM>::make_key_vec_map(right);
+            typename FunctionImpl<R, NDIM>::mapT rmap;
+            typename FunctionImpl<R, NDIM>::mapT* rmap_ptr = (typename FunctionImpl<R, NDIM>::mapT*)(&lmap);
+            if ((std::vector<const FunctionImpl<R, NDIM>*>*)(&left) != &right) {
+                rmap = FunctionImpl<R, NDIM>::make_key_vec_map(right);
                 rmap_ptr = &rmap;
             }
 
-            size_t chunk = (lmap.size()-1)/(3*4*5)+1;
+            size_t chunk = (lmap.size() - 1) / (3 * 4 * 5) + 1;
 
-            Tensor< TENSOR_RESULT_TYPE(T,R) > r(left.size(), right.size());
+            Tensor<TENSOR_RESULT_TYPE(T, R)> r(left.size(), right.size());
             Mutex mutex;
 
             typename mapT::iterator lstart=lmap.begin();
             while (lstart != lmap.end()) {
                 typename mapT::iterator lend = lstart;
-                advance(lend,chunk);
-                left[0]->world.taskq.add(&FunctionImpl<T,NDIM>::do_inner_localX<R>, lstart, lend, rmap_ptr, sym, &r, &mutex);
+                advance(lend, chunk);
+                left[0]->world.taskq.add(&FunctionImpl<T, NDIM>::do_inner_localX<R>, lstart, lend, rmap_ptr, sym, &r, &mutex);
                 lstart = lend;
             }
             left[0]->world.taskq.fence();
 
             if (sym) {
-                for (long i=0; i<r.dim(0); i++) {
-                    for (long j=0; j<i; j++) {
-                        TENSOR_RESULT_TYPE(T,R) sum = r(i,j)+conj(r(j,i));
-                        r(i,j) = sum;
-                        r(j,i) = conj(sum);
+                for (long i = 0; i < r.dim(0); i++) {
+                    for (long j = 0; j < i; j++) {
+                        TENSOR_RESULT_TYPE(T, R) sum = r(i, j) + conj(r(j, i));
+                        r(i, j) = sum;
+                        r(j, i) = conj(sum);
                     }
                 }
             }
@@ -5779,48 +5732,48 @@ template<size_t NDIM>
 
         /// invoked by result
 
-        /// contract 2 functions f(x,z) = \int g(x,y) * h(y,z) dy
+        /// contract 2 functions f(x, z) = \int g(x, y) * h(y, z) dy
         /// @tparam CDIM: the dimension of the contraction variable (y)
-        /// @tparam NDIM: the dimension of the result (x,z)
-        /// @tparam LDIM: the dimension of g(x,y)
-        /// @tparam KDIM: the dimension of h(y,z)
+        /// @tparam NDIM: the dimension of the result (x, z)
+        /// @tparam LDIM: the dimension of g(x, y)
+        /// @tparam KDIM: the dimension of h(y, z)
         template<typename Q, std::size_t LDIM, typename R, std::size_t KDIM,
                 std::size_t CDIM = (KDIM + LDIM - NDIM) / 2>
         void partial_inner(const FunctionImpl<Q, LDIM>& g, const FunctionImpl<R, KDIM>& h,
                            const std::array<int, CDIM> v1, const std::array<int, CDIM> v2) {
 
             typedef std::multimap<Key<NDIM>, std::list<Key<CDIM>>> contractionmapT;
-            //double wall_get_lists=0.0;
-            //double wall_recur=0.0;
-            //double wall_contract=0.0;
-            std::size_t nmax=FunctionDefaults<CDIM>::get_max_refine_level();
-            const double thresh=FunctionDefaults<NDIM>::get_thresh();
+            // double wall_get_lists = 0.0;
+            // double wall_recur = 0.0;
+            // double wall_contract = 0.0;
+            std::size_t nmax = FunctionDefaults<CDIM>::get_max_refine_level();
+            const double thresh = FunctionDefaults<NDIM>::get_thresh();
 
             // auto print_map = [](const auto& map) {
-                // for (const auto& kv : map) print(kv.first,"--",kv.second);
+                // for (const auto& kv : map) print(kv.first, "--", kv.second);
             // };
             // logical constness, not bitwise constness
-            FunctionImpl<Q,LDIM>& g_nc=const_cast<FunctionImpl<Q,LDIM>&>(g);
-            FunctionImpl<R,KDIM>& h_nc=const_cast<FunctionImpl<R,KDIM>&>(h);
+            auto& g_nc=const_cast<FunctionImpl<Q, LDIM>&>(g);
+            auto& h_nc=const_cast<FunctionImpl<R, KDIM>&>(h);
 
             std::list<contractionmapT> all_contraction_maps;
-            for (std::size_t n=0; n<nmax; ++n) {
+            for (std::size_t n = 0; n < nmax; ++n) {
 
                 // list of nodes with d coefficients (and their parents)
-	      //double wall0 = wall_time();
+	            // double wall0 = wall_time();
                 auto [g_ijlist, g_jlist] = g.get_contraction_node_lists(n, v1);
                 auto [h_ijlist, h_jlist] = h.get_contraction_node_lists(n, v2);
                 if ((g_ijlist.size() == 0) and (h_ijlist.size() == 0)) break;
-                //double wall1 = wall_time();
-                //wall_get_lists += (wall1 - wall0);
-                //wall0 = wall1;
-//                print("g_jlist");
-//                for (const auto& kv : g_jlist) print(kv.first,kv.second);
-//                print("h_jlist");
-//                for (const auto& kv : h_jlist) print(kv.first,kv.second);
+                // double wall1 = wall_time();
+                // wall_get_lists += (wall1 - wall0);
+                // wall0 = wall1;
+                // print("g_jlist");
+                // for (const auto& kv : g_jlist) print(kv.first, kv.second);
+                // print("h_jlist");
+                // for (const auto& kv : h_jlist) print(kv.first, kv.second);
 
                 // next lines will insert s nodes into g and h -> possible race condition!
-                bool this_first = true;  // are the remaining indices of g before those of g: f(x,z) = g(x,y) h(y,z)
+                bool this_first = true;  // are the remaining indices of g before those of g: f(x, z) = g(x, y) h(y, z)
                 // CDIM, NDIM, KDIM
                 contractionmapT contraction_map = g_nc.recur_down_for_contraction_map(
                         g_nc.key0(), g_nc.get_coeffs().find(g_nc.key0()).get()->second, v1, v2,
@@ -5828,7 +5781,7 @@ template<size_t NDIM>
 
                 this_first = false;
                 // CDIM, NDIM, LDIM
-                auto hnode0=h_nc.get_coeffs().find(h_nc.key0()).get()->second;
+                auto hnode0 = h_nc.get_coeffs().find(h_nc.key0()).get()->second;
                 contractionmapT contraction_map1 = h_nc.recur_down_for_contraction_map(
                         h_nc.key0(), hnode0, v2, v1,
                         g_ijlist, g_jlist, this_first, thresh);
@@ -5847,39 +5800,39 @@ template<size_t NDIM>
                     }
                     it = it_end;
                 }
-//                print("thresh               ",thresh);
-//                print("contraction list size",contraction_map.size());
+                // print("thresh               ", thresh);
+                // print("contraction list size", contraction_map.size());
 
                 // remove all double entries
                 for (auto& elem: contraction_map) {
                     elem.second.sort();
                     elem.second.unique();
                 }
-                //wall1 = wall_time();
-                //wall_recur += (wall1 - wall0);
-//                if (n==2) {
-//                    print("contraction map for n=", n);
-//                    print_map(contraction_map);
-//                }
+                // wall1 = wall_time();
+                // wall_recur += (wall1 - wall0);
+                // if (n == 2) {
+                //     print("contraction map for n=", n);
+                //     print_map(contraction_map);
+                // }
                 all_contraction_maps.push_back(contraction_map);
 
-                long mapsize=contraction_map.size();
-                if (mapsize==0) break;
+                long mapsize = contraction_map.size();
+                if (mapsize == 0) break;
             }
 
 
             // finally do the contraction
             for (const auto& contraction_map : all_contraction_maps) {
                 for (const auto& key_list : contraction_map) {
-                    const Key<NDIM>& key=key_list.first;
-                    const std::list<Key<CDIM>>& list=key_list.second;
-                    woT::task(coeffs.owner(key), &implT:: template partial_inner_contract<Q,LDIM,R,KDIM>,
-                              &g,&h,v1,v2,key,list);
+                    const Key<NDIM>& key = key_list.first;
+                    const std::list<Key<CDIM>>& list = key_list.second;
+                    woT::task(coeffs.owner(key), &implT:: template partial_inner_contract<Q, LDIM, R, KDIM>,
+                              &g, &h, v1, v2, key, list);
                 }
             }
         }
 
-        /// for contraction two functions f(x,z) = \int g(x,y) h(y,z) dy
+        /// for contraction two functions f(x, z) = \int g(x, y) h(y, z) dy
 
         /// find all nodes with d coefficients and return a list of complete keys and of
         /// keys holding only the y dimension, also the maximum norm of all d for the j dimension
@@ -5887,37 +5840,37 @@ template<size_t NDIM>
         /// @param[in]  v   array holding the indices of the integration variable
         /// @return     ijlist: list of all nodes with d coeffs; jlist: j-part of ij list only
         template<std::size_t CDIM>
-        std::tuple<std::set<Key<NDIM>>, std::map<Key<CDIM>,double>>
+        std::tuple<std::set<Key<NDIM>>, std::map<Key<CDIM>, double>>
         get_contraction_node_lists(const std::size_t n, const std::array<int, CDIM>& v) const {
 
-            const auto& cdata=get_cdata();
+            const auto& cdata = get_cdata();
             auto has_d_coeffs = [&cdata](const coeffT& coeff) {
                 if (coeff.has_no_data()) return false;
-                return (coeff.dim(0)==2*cdata.k);
+                return (coeff.dim(0) == 2*cdata.k);
             };
 
             // keys to be contracted in g
             std::set<Key<NDIM>> ij_list;           // full key
-            std::map<Key<CDIM>,double> j_list;      // only that dimension that will be contracted
+            std::map<Key<CDIM>, double> j_list;      // only that dimension that will be contracted
 
-            for (auto it=get_coeffs().begin(); it!=get_coeffs().end(); ++it) {
-                const Key<NDIM>& key=it->first;
-                const FunctionNode<T,NDIM>& node=it->second;
-                if ((key.level()==n) and (has_d_coeffs(node.coeff()))) {
+            for (auto it=get_coeffs().begin(); it != get_coeffs().end(); ++it) {
+                const Key<NDIM>& key = it->first;
+                const FunctionNode<T, NDIM>& node = it->second;
+                if ((key.level() == n) and (has_d_coeffs(node.coeff()))) {
                     ij_list.insert(key);
-                    Vector<Translation,CDIM> j_trans;
-                    for (std::size_t i=0; i<CDIM; ++i) j_trans[i]=key.translation()[v[i]];
-                    Key<CDIM> jkey(n,j_trans);
-                    const double max_d_norm=j_list[jkey];
-                    j_list.insert_or_assign(jkey,std::max(max_d_norm,node.get_dnorm()));
-                    Key<CDIM> parent_jkey=jkey.parent();
-                    while (j_list.count(parent_jkey)==0) {
-                        j_list.insert({parent_jkey,1.0});
-                        parent_jkey=parent_jkey.parent();
+                    Vector<Translation, CDIM> j_trans;
+                    for (std::size_t i = 0; i < CDIM; ++i) j_trans[i] = key.translation()[v[i]];
+                    Key<CDIM> jkey(n, j_trans);
+                    const double max_d_norm = j_list[jkey];
+                    j_list.insert_or_assign(jkey, std::max(max_d_norm, node.get_dnorm()));
+                    Key<CDIM> parent_jkey = jkey.parent();
+                    while (j_list.count(parent_jkey) == 0) {
+                        j_list.insert({parent_jkey, 1.0});
+                        parent_jkey = parent_jkey.parent();
                     }
                 }
             }
-            return std::make_tuple(ij_list,j_list);
+            return std::make_tuple(ij_list, j_list);
         }
 
         /// make a map of all nodes that will contribute to a partial inner product
@@ -5943,10 +5896,10 @@ template<size_t NDIM>
         template<std::size_t CDIM, std::size_t ODIM, std::size_t FDIM=NDIM+ODIM-2*CDIM>
         std::multimap<Key<FDIM>, std::list<Key<CDIM>>> recur_down_for_contraction_map(
                 const keyT& key, const nodeT& node,
-                const std::array<int,CDIM>& v_this,
-                const std::array<int,CDIM>& v_other,
+                const std::array<int, CDIM>& v_this,
+                const std::array<int, CDIM>& v_other,
                 const std::set<Key<ODIM>>& ij_other_list,
-                const std::map<Key<CDIM>,double>& j_other_list,
+                const std::map<Key<CDIM>, double>& j_other_list,
                 bool this_first, const double thresh) {
 
             std::multimap<Key<FDIM>, std::list<Key<CDIM>>> contraction_map;
@@ -5956,84 +5909,82 @@ template<size_t NDIM>
 
             // continue recursion if this node may be contracted with the j column
             // extract relevant node translations from this node
-            const auto j_this_key=key.extract_key(v_this);
+            const auto j_this_key = key.extract_key(v_this);
 
-//            print("\nkey, j_this_key", key, j_this_key);
-            const double max_d_norm=j_other_list.find(j_this_key)->second;
-            const bool sd_norm_product_large = node.get_snorm() * max_d_norm > truncate_tol(thresh,key);
-//            print("sd_product_norm",node.get_snorm() * max_d_norm, thresh);
+            // print("\nkey, j_this_key", key, j_this_key);
+            const double max_d_norm = j_other_list.find(j_this_key)->second;
+            const bool sd_norm_product_large = node.get_snorm() * max_d_norm > truncate_tol(thresh, key);
+            // print("sd_product_norm", node.get_snorm() * max_d_norm, thresh);
 
             // end recursion if we have reached the final scale n
             // with which nodes from other will this node be contracted?
-            bool final_scale=key.level()==ij_other_list.begin()->level();
+            bool final_scale = key.level() == ij_other_list.begin()->level();
             if (final_scale and sd_norm_product_large) {
                 for (auto& other_key : ij_other_list) {
-                    const auto j_other_key=other_key.extract_key(v_other);
+                    const auto j_other_key = other_key.extract_key(v_other);
                     if (j_this_key != j_other_key) continue;
-                    auto i_key=key.extract_complement_key(v_this);
-                    auto k_key=other_key.extract_complement_key(v_other);
-//                    print("key, ij_other_key",key,other_key);
-//                    print("i, k, j key",i_key, k_key, j_this_key);
-                    Key<FDIM> ik_key=(this_first) ? i_key.merge_with(k_key) : k_key.merge_with(i_key);
-//                    print("ik_key",ik_key);
-//                    MADNESS_CHECK(contraction_map.count(ik_key)==0);
-                    contraction_map.insert(std::make_pair(ik_key,std::list<Key<CDIM>>{j_this_key}));
+                    auto i_key = key.extract_complement_key(v_this);
+                    auto k_key = other_key.extract_complement_key(v_other);
+                    // print("key, ij_other_key", key, other_key);
+                    // print("i, k, j key", i_key, k_key, j_this_key);
+                    Key<FDIM> ik_key = (this_first) ? i_key.merge_with(k_key) : k_key.merge_with(i_key);
+                    // print("ik_key", ik_key);
+                    // MADNESS_CHECK(contraction_map.count(ik_key) == 0);
+                    contraction_map.insert(std::make_pair(ik_key, std::list<Key<CDIM>>{j_this_key}));
                 }
                 return contraction_map;
             }
 
-            bool continue_recursion = (j_other_list.count(j_this_key)==1);
+            bool continue_recursion = (j_other_list.count(j_this_key) == 1);
             if (not continue_recursion) return contraction_map;
-
 
             // continue recursion if norms are large
             continue_recursion = (node.has_children() or sd_norm_product_large);
 
             if (continue_recursion) {
                 // in case we need to compute children's coefficients: unfilter only once
-                bool compute_child_s_coeffs=true;
+                bool compute_child_s_coeffs = true;
                 coeffT d = node.coeff();
-//                print("continuing recursion from key",key);
+                // print("continuing recursion from key", key);
 
                 for (KeyChildIterator<NDIM> kit(key); kit; ++kit) {
-                    keyT child=kit.key();
+                    keyT child = kit.key();
                     typename dcT::accessor acc;
 
                     // make child's s coeffs if it doesn't exist or if is has no s coeffs
-                    bool childnode_exists=get_coeffs().find(acc,child);
-                    bool need_s_coeffs= childnode_exists ? (acc->second.get_snorm()<=0.0) : true;
+                    bool childnode_exists = get_coeffs().find(acc, child);
+                    bool need_s_coeffs = childnode_exists ? (acc->second.get_snorm() <= 0.0) : true;
 
                     coeffT child_s_coeffs;
                     if (need_s_coeffs and compute_child_s_coeffs) {
-                        if (d.dim(0)==cdata.vk[0]) {        // s coeffs only in this node
-                            coeffT d1(cdata.v2k,get_tensor_args());
-                            d1(cdata.s0)+=d;
-                            d=d1;
+                        if (d.dim(0) == cdata.vk[0]) {        // s coeffs only in this node
+                            coeffT d1(cdata.v2k, get_tensor_args());
+                            d1(cdata.s0) += d;
+                            d = d1;
                         }
                         d = unfilter(d);
-                        child_s_coeffs=copy(d(child_patch(child)));
+                        child_s_coeffs = copy(d(child_patch(child)));
                         child_s_coeffs.reduce_rank(thresh);
-                        compute_child_s_coeffs=false;
+                        compute_child_s_coeffs = false;
                     }
 
                     if (not childnode_exists) {
-                        get_coeffs().replace(child,nodeT(child_s_coeffs,false));
-                        get_coeffs().find(acc,child);
+                        get_coeffs().replace(child, nodeT(child_s_coeffs, false));
+                        get_coeffs().find(acc, child);
                     } else if (childnode_exists and need_s_coeffs) {
-                        acc->second.coeff()=child_s_coeffs;
+                        acc->second.coeff() = child_s_coeffs;
                     }
-                    bool exists= get_coeffs().find(acc,child);
+                    bool exists = get_coeffs().find(acc, child);
                     MADNESS_CHECK(exists);
                     nodeT& childnode = acc->second;
                     if (need_s_coeffs) childnode.recompute_snorm_and_dnorm(get_cdata());
-//                    print("recurring down to",child);
-                    contraction_map.merge(recur_down_for_contraction_map(child,childnode, v_this, v_other,
+                    // print("recurring down to", child);
+                    contraction_map.merge(recur_down_for_contraction_map(child, childnode, v_this, v_other,
                                                                          ij_other_list, j_other_list, this_first, thresh));
-//                    print("contraction_map.size()",contraction_map.size());
+                    // print("contraction_map.size()", contraction_map.size());
                 }
 
             }
-
             return contraction_map;
         }
 
@@ -6051,7 +6002,6 @@ template<size_t NDIM>
         void partial_inner_contract(const FunctionImpl<Q, LDIM>* g, const FunctionImpl<R, KDIM>* h,
                                const std::array<int, CDIM> v1, const std::array<int, CDIM> v2,
                                const Key<NDIM>& key, const std::list<Key<CDIM>>& j_key_list) {
-
             Key<LDIM - CDIM> i_key;
             Key<KDIM - CDIM> k_key;
             key.break_apart(i_key, k_key);
@@ -6101,7 +6051,7 @@ template<size_t NDIM>
                     hcoeff1 = hcoeff;
                 }
 
-                // offset: 0 for full tensor, 1 for svd representation with rand being the first dimension (r,d1,d2,d3) -> (r,d1*d2*d3)
+                // offset: 0 for full tensor, 1 for svd representation with rand being the first dimension (r, d1, d2, d3) -> (r, d1*d2*d3)
                 auto fuse = [](Tensor<T> tensor, const std::array<int, CDIM>& v, int offset) {
                     for (std::size_t i = 0; i < CDIM - 1; ++i) {
                         MADNESS_CHECK((v[i] + 1) == v[i + 1]); // make sure v is contiguous and ascending
@@ -6110,22 +6060,22 @@ template<size_t NDIM>
                     return tensor;
                 };
 
-                // use case: partial_projection of 2-electron functions in svd representation  f(1) = \int g(2) h(1,2) d2
+                // use case: partial_projection of 2-electron functions in svd representation  f(1) = \int g(2) h(1, 2) d2
                 // c_i = \sum_j a_j b_ij = \sum_jr a_j b_rj b'_rj
                 //                       = \sum_jr ( a_j b_rj) b'_rj )
                 auto contract2 = [](const auto& svdcoeff, const auto& tensor, const int particle) {
 #if HAVE_GENTENSOR
-                    const int spectator_particle=(particle+1)%2;
+                    const int spectator_particle = (particle + 1) % 2;
                     Tensor<Q> gtensor = svdcoeff.get_svdtensor().make_vector_with_weights(particle);
-                    gtensor=gtensor.reshape(svdcoeff.rank(),gtensor.size()/svdcoeff.rank());
-                    MADNESS_CHECK(gtensor.ndim()==2);
+                    gtensor=gtensor.reshape(svdcoeff.rank(), gtensor.size() / svdcoeff.rank());
+                    MADNESS_CHECK(gtensor.ndim() == 2);
                     Tensor<Q> gtensor_other = svdcoeff.get_svdtensor().ref_vector(spectator_particle);
-                    Tensor<T> tmp1=inner(gtensor,tensor.flat(),1,0);          // tmp1(r) = sum_j a'_(r,j) b(j)
-                    MADNESS_CHECK(tmp1.ndim()==1);
-                    Tensor<T> tmp2=inner(gtensor_other,tmp1,0,0);          // tmp2(i) = sum_r a_(r,i) tmp1(r)
+                    Tensor<T> tmp1 = inner(gtensor, tensor.flat(), 1, 0);          // tmp1(r) = sum_j a'_(r, j) b(j)
+                    MADNESS_CHECK(tmp1.ndim() == 1);
+                    Tensor<T> tmp2 = inner(gtensor_other, tmp1, 0, 0);          // tmp2(i) = sum_r a_(r, i) tmp1(r)
                     return tmp2;
 #else
-                    MADNESS_EXCEPTION("no partial_inner using svd without GenTensor",1);
+                    MADNESS_EXCEPTION("no partial_inner using svd without GenTensor", 1);
                     return Tensor<T>();
 #endif
                 };
@@ -6146,74 +6096,76 @@ template<size_t NDIM>
                 }
 
 
-                // use case: 2-electron functions in svd representation  f(1,3) = \int g(1,2) h(2,3) d2
+                // use case: 2-electron functions in svd representation  f(1, 3) = \int g(1, 2) h(2, 3) d2
                 // c_ik = \sum_j a_ij b_jk = \sum_jrr' a_ri a'_rj b_r'j b_r'k
                 //                         = \sum_jrr' ( a_ri (a'_rj b_r'j) )  b_r'k
                 //                         = \sum_jrr' c_r'i  b_r'k
                 else if (gcoeff.is_svd_tensor() and hcoeff.is_svd_tensor() and result_coeff.is_svd_tensor()) {
-                    MADNESS_CHECK(v1[0]==0 or v1[CDIM-1]==LDIM-1);
-                    MADNESS_CHECK(v2[0]==0 or v2[CDIM-1]==KDIM-1);
-                    int gparticle=  v1[0]==0 ? 0 : 1;       // which particle to integrate over
-                    int hparticle=  v2[0]==0 ? 0 : 1;       // which particle to integrate over
+                    MADNESS_CHECK(v1[0] == 0 or v1[CDIM - 1] == LDIM - 1);
+                    MADNESS_CHECK(v2[0] == 0 or v2[CDIM - 1] == KDIM - 1);
+                    int gparticle = v1[0] == 0 ? 0 : 1;  // which particle to integrate over
+                    int hparticle = v2[0] == 0 ? 0 : 1;  // which particle to integrate over
                     // merge multiple contraction dimensions into one
                     Tensor<Q> gtensor = gcoeff1.get_svdtensor().flat_vector_with_weights(gparticle);
-                    Tensor<Q> gtensor_other = gcoeff1.get_svdtensor().flat_vector((gparticle+1)%2);
+                    Tensor<Q> gtensor_other = gcoeff1.get_svdtensor().flat_vector((gparticle + 1) % 2);
                     Tensor<R> htensor = hcoeff1.get_svdtensor().flat_vector_with_weights(hparticle);
-                    Tensor<R> htensor_other = hcoeff1.get_svdtensor().flat_vector((hparticle+1)%2);
-                    Tensor<T> tmp1=inner(gtensor,htensor,1,1);      // tmp1(r,r') = sum_j b(r,j) a(r',j)
-                    Tensor<T> tmp2=inner(tmp1,gtensor_other,0,0);   // tmp2(r',i) = sum_r tmp1(r,r') a(r,i)
+                    Tensor<R> htensor_other = hcoeff1.get_svdtensor().flat_vector((hparticle + 1) % 2);
+                    Tensor<T> tmp1 = inner(gtensor, htensor, 1, 1);      // tmp1(r, r') = sum_j b(r, j) a(r', j)
+                    Tensor<T> tmp2 = inner(tmp1, gtensor_other, 0, 0);   // tmp2(r', i) = sum_r tmp1(r, r') a(r, i)
                     Tensor< typename Tensor<T>::scalar_type > w(tmp2.dim(0));
-                    MADNESS_CHECK(tmp2.dim(0)==htensor_other.dim(0));
+                    MADNESS_CHECK(tmp2.dim(0) == htensor_other.dim(0));
                     w=1.0;
                     coeffT result_tmp(get_cdata().v2k, get_tensor_type());
-                    result_tmp.get_svdtensor().set_vectors_and_weights(w,tmp2,htensor_other);
+                    result_tmp.get_svdtensor().set_vectors_and_weights(w, tmp2, htensor_other);
                     if (key.level() > 0) {
                         GenTensor<Q> gcoeff2 = copy(gcoeff1(g->get_cdata().s0));
                         GenTensor<R> hcoeff2 = copy(hcoeff1(h->get_cdata().s0));
                         Tensor<Q> gtensor = gcoeff2.get_svdtensor().flat_vector_with_weights(gparticle);
-                        Tensor<Q> gtensor_other = gcoeff2.get_svdtensor().flat_vector((gparticle+1)%2);
+                        Tensor<Q> gtensor_other = gcoeff2.get_svdtensor().flat_vector((gparticle + 1) % 2);
                         Tensor<R> htensor = hcoeff2.get_svdtensor().flat_vector_with_weights(hparticle);
-                        Tensor<R> htensor_other = hcoeff2.get_svdtensor().flat_vector((hparticle+1)%2);
-                        Tensor<T> tmp1=inner(gtensor,htensor,1,1);      // tmp1(r,r') = sum_j b(r,j) a(r',j)
-                        Tensor<T> tmp2=inner(tmp1,gtensor_other,0,0);   // tmp2(r',i) = sum_r tmp1(r,r') a(r,i)
+                        Tensor<R> htensor_other = hcoeff2.get_svdtensor().flat_vector((hparticle + 1) % 2);
+                        Tensor<T> tmp1 = inner(gtensor, htensor, 1, 1);      // tmp1(r, r') = sum_j b(r, j) a(r', j)
+                        Tensor<T> tmp2 = inner(tmp1, gtensor_other, 0, 0);   // tmp2(r', i) = sum_r tmp1(r, r') a(r, i)
                         Tensor< typename Tensor<T>::scalar_type > w(tmp2.dim(0));
-                        MADNESS_CHECK(tmp2.dim(0)==htensor_other.dim(0));
-                        w=1.0;
+                        MADNESS_CHECK(tmp2.dim(0) == htensor_other.dim(0));
+                        w = 1.0;
                         coeffT result_coeff1(get_cdata().vk, get_tensor_type());
-                        result_coeff1.get_svdtensor().set_vectors_and_weights(w,tmp2,htensor_other);
-                        result_tmp(get_cdata().s0)-=result_coeff1;
+                        result_coeff1.get_svdtensor().set_vectors_and_weights(w, tmp2, htensor_other);
+                        result_tmp(get_cdata().s0) -= result_coeff1;
                     }
-                    result_coeff+=result_tmp;
+                    result_coeff += result_tmp;
                 }
 
-                // use case: partial_projection of 2-electron functions in svd representation  f(1) = \int g(2) h(1,2) d2
+                // use case: partial_projection of 2-electron functions in svd representation  f(1) = \int g(2) h(1, 2) d2
                 // c_i = \sum_j a_j b_ij = \sum_jr a_j b_rj b'_rj
                 //                       = \sum_jr ( a_j b_rj) b'_rj )
                 else if (gcoeff.is_full_tensor() and hcoeff.is_svd_tensor() and result_coeff.is_full_tensor()) {
-                    MADNESS_CHECK(v1[0]==0 and v1[CDIM-1]==LDIM-1);
-                    MADNESS_CHECK(v2[0]==0 or v2[CDIM-1]==KDIM-1);
-                    MADNESS_CHECK(LDIM==CDIM);
-                    int hparticle=  v2[0]==0 ? 0 : 1;       // which particle to integrate over
+                    MADNESS_CHECK(v1[0] == 0 and v1[CDIM-1] == LDIM-1);
+                    MADNESS_CHECK(v2[0] == 0 or v2[CDIM-1] == KDIM-1);
+                    MADNESS_CHECK(LDIM == CDIM);
+                    int hparticle = v2[0] == 0 ? 0 : 1;       // which particle to integrate over
 
-                    Tensor<T> r=contract2(hcoeff1,gcoeff1.full_tensor(),hparticle);
-                    if (key.level()>0) r(get_cdata().s0)-=contract2(copy(hcoeff1(h->get_cdata().s0)),copy(gcoeff.full_tensor()(g->get_cdata().s0)),hparticle);
-                    result_coeff.full_tensor()+=r;
+                    Tensor<T> r = contract2(hcoeff1, gcoeff1.full_tensor(), hparticle);
+                    if (key.level() > 0)
+                        r(get_cdata().s0) -= contract2(copy(hcoeff1(h->get_cdata().s0)), copy(gcoeff.full_tensor()(g->get_cdata().s0)), hparticle);
+                    result_coeff.full_tensor() += r;
                 }
-                // use case: partial_projection of 2-electron functions in svd representation  f(1) = \int g(1,2) h(2) d2
+                // use case: partial_projection of 2-electron functions in svd representation  f(1) = \int g(1, 2) h(2) d2
                 // c_i = \sum_j a_ij b_j = \sum_jr a_ri a'_rj b_j
                 //                       = \sum_jr ( a_ri (a'_rj b_j) )
                 else if (gcoeff.is_svd_tensor() and hcoeff.is_full_tensor() and result_coeff.is_full_tensor()) {
-                    MADNESS_CHECK(v1[0]==0 or v1[CDIM-1]==LDIM-1);
-                    MADNESS_CHECK(v2[0]==0 and v2[CDIM-1]==KDIM-1);
-                    MADNESS_CHECK(KDIM==CDIM);
-                    int gparticle=  v1[0]==0 ? 0 : 1;       // which particle to integrate over
+                    MADNESS_CHECK(v1[0] == 0 or v1[CDIM-1] == LDIM-1);
+                    MADNESS_CHECK(v2[0] == 0 and v2[CDIM-1] == KDIM-1);
+                    MADNESS_CHECK(KDIM == CDIM);
+                    int gparticle=  v1[0] == 0 ? 0 : 1;       // which particle to integrate over
 
-                    Tensor<T> r=contract2(gcoeff1,hcoeff1.full_tensor(),gparticle);
-                    if (key.level()>0) r(get_cdata().s0)-=contract2(copy(gcoeff1(g->get_cdata().s0)),copy(hcoeff.full_tensor()(h->get_cdata().s0)),gparticle);
+                    Tensor<T> r=contract2(gcoeff1, hcoeff1.full_tensor(), gparticle);
+                    if (key.level() > 0)
+                        r(get_cdata().s0) -= contract2(copy(gcoeff1(g->get_cdata().s0)), copy(hcoeff.full_tensor()(h->get_cdata().s0)), gparticle);
                     result_coeff.full_tensor()+=r;
 
                 } else {
-                    MADNESS_EXCEPTION("unknown case in partial_inner_contract",1);
+                    MADNESS_EXCEPTION("unknown case in partial_inner_contract", 1);
                 }
             }
 
@@ -6232,7 +6184,7 @@ template<size_t NDIM>
         /// @param[in] c Tensor of coefficients for the function at the function node given by key
         /// @param[in] f Reference to FunctionFunctorInterface. This is the externally provided function
         /// @return Returns the inner product over the domain of a single function node, no guarantee of accuracy.
-        T inner_ext_node(keyT key, tensorT c, const std::shared_ptr< FunctionFunctorInterface<T,NDIM> > f) const {
+        T inner_ext_node(keyT key, tensorT c, const std::shared_ptr< FunctionFunctorInterface<T, NDIM>> f) const {
             tensorT fvals = tensorT(this->cdata.vk);
             // Compute the value of the external function at the quadrature points.
             fcube(key, *(f), cdata.quad_x, fvals);
@@ -6249,7 +6201,7 @@ template<size_t NDIM>
         /// @param[in] leaf_refine boolean switch to turn on/off refinement past leaf nodes
         /// @param[in] old_inner the inner product on the parent function node
         /// @return Returns the inner product over the domain of a single function, checks for convergence.
-        T inner_ext_recursive(keyT key, tensorT c, const std::shared_ptr< FunctionFunctorInterface<T,NDIM> > f, const bool leaf_refine, T old_inner=T(0)) const {
+        T inner_ext_recursive(keyT key, tensorT c, const std::shared_ptr< FunctionFunctorInterface<T, NDIM>> f, const bool leaf_refine, T old_inner=T(0)) const {
             int i = 0;
             tensorT c_child, inner_child;
             T new_inner, result = 0.0;
@@ -6321,12 +6273,12 @@ template<size_t NDIM>
         }
 
         struct do_inner_ext_local_ffi {
-            const std::shared_ptr< FunctionFunctorInterface<T, NDIM> > fref;
+            const std::shared_ptr< FunctionFunctorInterface<T, NDIM>> fref;
             const implT * impl;
             const bool leaf_refine;
             const bool do_leaves;   ///< start with leaf nodes instead of initial_level
 
-            do_inner_ext_local_ffi(const std::shared_ptr< FunctionFunctorInterface<T,NDIM> > f,
+            do_inner_ext_local_ffi(const std::shared_ptr< FunctionFunctorInterface<T, NDIM>> f,
                     const implT * impl, const bool leaf_refine, const bool do_leaves)
                     : fref(f), impl(impl), leaf_refine(leaf_refine), do_leaves(do_leaves) {};
 
@@ -6355,10 +6307,10 @@ template<size_t NDIM>
         /// @param[in] f Reference to FunctionFunctorInterface. This is the externally provided function
         /// @param[in] leaf_refine boolean switch to turn on/off refinement past leaf nodes
         /// @return Returns local part of the inner product, i.e. over the domain of all function nodes on this compute node.
-        T inner_ext_local(const std::shared_ptr< FunctionFunctorInterface<T,NDIM> > f, const bool leaf_refine) const {
+        T inner_ext_local(const std::shared_ptr< FunctionFunctorInterface<T, NDIM>> f, const bool leaf_refine) const {
             typedef Range<typename dcT::const_iterator> rangeT;
 
-            return world.taskq.reduce<T, rangeT, do_inner_ext_local_ffi>(rangeT(coeffs.begin(),coeffs.end()),
+            return world.taskq.reduce<T, rangeT, do_inner_ext_local_ffi>(rangeT(coeffs.begin(), coeffs.end()),
                     do_inner_ext_local_ffi(f, this, leaf_refine, false));
         }
 
@@ -6366,10 +6318,10 @@ template<size_t NDIM>
         /// @param[in] f Reference to FunctionFunctorInterface. This is the externally provided function
         /// @param[in] leaf_refine boolean switch to turn on/off refinement past leaf nodes
         /// @return Returns local part of the inner product, i.e. over the domain of all function nodes on this compute node.
-        T inner_adaptive_local(const std::shared_ptr< FunctionFunctorInterface<T,NDIM> > f, const bool leaf_refine) const {
+        T inner_adaptive_local(const std::shared_ptr< FunctionFunctorInterface<T, NDIM>> f, const bool leaf_refine) const {
             typedef Range<typename dcT::const_iterator> rangeT;
 
-            return world.taskq.reduce<T, rangeT, do_inner_ext_local_ffi>(rangeT(coeffs.begin(),coeffs.end()),
+            return world.taskq.reduce<T, rangeT, do_inner_ext_local_ffi>(rangeT(coeffs.begin(), coeffs.end()),
                     do_inner_ext_local_ffi(f, this, leaf_refine, true));
         }
 
@@ -6381,12 +6333,12 @@ template<size_t NDIM>
         /// @param[in] old_inner the inner product on the parent function node
         /// @return Returns the inner product over the domain of a single function, checks for convergence.
         T inner_adaptive_recursive(keyT key, const tensorT& c,
-                const std::shared_ptr< FunctionFunctorInterface<T,NDIM> > f,
+                const std::shared_ptr< FunctionFunctorInterface<T, NDIM>> f,
                 const bool leaf_refine, T old_inner=T(0)) const {
 
             // the inner product in the current node
             old_inner = inner_ext_node(key, c, f);
-            T result=0.0;
+            T result = 0.0;
 
             // the inner product in the child nodes
 
@@ -6401,11 +6353,11 @@ template<size_t NDIM>
             for (KeyChildIterator<NDIM> it(key); it; ++it) {
                 const keyT& child = it.key();
                 tensorT cc = tensorT(c_child(child_patch(child)));
-                new_inner+= inner_ext_node(child, cc, f);
+                new_inner += inner_ext_node(child, cc, f);
             }
 
             // continue recursion if needed
-            const double tol=truncate_tol(thresh,key);
+            const double tol = truncate_tol(thresh, key);
             if (leaf_refine and (std::abs(new_inner - old_inner) > tol)) {
                 for (KeyChildIterator<NDIM> it(key); it; ++it) {
                     const keyT& child = it.key();
@@ -6457,10 +6409,10 @@ template<size_t NDIM>
         /// @param[in] tol convergence tolerance...when the norm of the gaxpy's
         ///            difference coefficients is less than tol, we are done.
         template <typename L>
-        void gaxpy_ext_recursive(const keyT& key, const FunctionImpl<L,NDIM>* left,
+        void gaxpy_ext_recursive(const keyT& key, const FunctionImpl<L, NDIM>* left,
                                  Tensor<L> lcin, tensorT c, T (*f)(const coordT&),
                                  T alpha, T beta, double tol, bool below_leaf) {
-            typedef typename FunctionImpl<L,NDIM>::dcT::const_iterator literT;
+            typedef typename FunctionImpl<L, NDIM>::dcT::const_iterator literT;
 
             // If we haven't yet reached the leaf level, check whether the
             // current key is a leaf node of left. If so, set below_leaf to true
@@ -6473,7 +6425,7 @@ template<size_t NDIM>
                     this->coeffs.replace(key, nodeT(coeffT(), true));
                     for (KeyChildIterator<NDIM> it(key); it; ++it) {
                         const keyT& child = it.key();
-                        woT::task(left->coeffs.owner(child), &implT:: template gaxpy_ext_recursive<L>,
+                        woT::task(left->coeffs.owner(child), &implT:: template gaxpy_ext_recursive<L>, 
                                   child, left, Tensor<L>(), tensorT(), f, alpha, beta, tol, below_leaf);
                     }
                     return;
@@ -6527,8 +6479,8 @@ template<size_t NDIM>
 
             // Small d.normf means we've reached a good level of resolution
             // Store the coefficients and return.
-            if (dnorm <= truncate_tol(tol,key)) {
-                this->coeffs.replace(key, nodeT(coeffT(c,targs), false));
+            if (dnorm <= truncate_tol(tol, key)) {
+                this->coeffs.replace(key, nodeT(coeffT(c, targs), false));
             } else {
                 // Otherwise, make this a parent node and recur down
                 this->coeffs.replace(key, nodeT(coeffT(), true)); // Interior node
@@ -6544,14 +6496,14 @@ template<size_t NDIM>
         }
 
         template <typename L>
-        void gaxpy_ext(const FunctionImpl<L,NDIM>* left, T (*f)(const coordT&), T alpha, T beta, double tol, bool fence) {
+        void gaxpy_ext(const FunctionImpl<L, NDIM>* left, T (*f)(const coordT&), T alpha, T beta, double tol, bool fence) {
             if (world.rank() == coeffs.owner(cdata.key0))
                 gaxpy_ext_recursive<L> (cdata.key0, left, Tensor<L>(), tensorT(), f, alpha, beta, tol, false);
             if (fence)
                 world.gop.fence();
         }
 
-        /// project the low-dim function g on the hi-dim function f: result(x) = <this(x,y) | g(y)>
+        /// project the low-dim function g on the hi-dim function f: result(x) = <this(x, y) | g(y)>
 
         /// invoked by the hi-dim function, a function of NDIM+LDIM
 
@@ -6560,39 +6512,35 @@ template<size_t NDIM>
         /// @param[in]  gimpl  	lo-dim function of LDIM
         /// @param[in]  dim over which dimensions to be integrated: 0..LDIM or LDIM..LDIM+NDIM-1
         template<size_t LDIM>
-        void project_out(FunctionImpl<T,NDIM-LDIM>* result, const FunctionImpl<T,LDIM>* gimpl,
+        void project_out(FunctionImpl<T, NDIM-LDIM>* result, const FunctionImpl<T, LDIM>* gimpl,
                          const int dim, const bool fence) {
-
-            const keyT& key0=cdata.key0;
+            const keyT& key0 = cdata.key0;
 
             if (world.rank() == coeffs.owner(key0)) {
-
                 // coeff_op will accumulate the result
                 typedef project_out_op<LDIM> coeff_opT;
-                coeff_opT coeff_op(this,result,CoeffTracker<T,LDIM>(gimpl),dim);
+                coeff_opT coeff_op(this, result, CoeffTracker<T, LDIM>(gimpl), dim);
 
                 // don't do anything on this -- coeff_op will accumulate into result
-                typedef noop<T,NDIM> apply_opT;
+                typedef noop<T, NDIM> apply_opT;
                 apply_opT apply_op;
 
-                woT::task(world.rank(), &implT:: template forward_traverse<coeff_opT,apply_opT>,
+                woT::task(world.rank(), &implT:: template forward_traverse<coeff_opT, apply_opT>,
                           coeff_op, apply_op, cdata.key0);
-
             }
             if (fence) world.gop.fence();
-
         }
 
 
-        /// project the low-dim function g on the hi-dim function f: result(x) = <f(x,y) | g(y)>
+        /// project the low-dim function g on the hi-dim function f: result(x) = <f(x, y) | g(y)>
         template<size_t LDIM>
         struct project_out_op {
-            bool randomize() const {return false;}
+            bool randomize() const { return false; }
 
             typedef project_out_op<LDIM> this_type;
-            typedef CoeffTracker<T,LDIM> ctL;
-            typedef FunctionImpl<T,NDIM-LDIM> implL1;
-            typedef std::pair<bool,coeffT> argT;
+            typedef CoeffTracker<T, LDIM> ctL;
+            typedef FunctionImpl<T, NDIM-LDIM> implL1;
+            typedef std::pair<bool, coeffT> argT;
 
             const implT* fimpl;		///< the hi dim function f
             mutable implL1* result;	///< the low dim result function
@@ -6610,42 +6558,42 @@ template<size_t NDIM>
             /// do the actual contraction
             Future<argT> operator()(const Key<NDIM>& key) const {
 
-            	Key<LDIM> key1,key2,dest;
-            	key.break_apart(key1,key2);
+            	Key<LDIM> key1, key2, dest;
+            	key.break_apart(key1, key2);
 
             	// make the right coefficients
                 coeffT gcoeff;
-                if (dim==0) {
-                    gcoeff=iag.get_impl()->parent_to_child(iag.coeff(),iag.key(),key1);
-                    dest=key2;
+                if (dim == 0) {
+                    gcoeff = iag.get_impl()->parent_to_child(iag.coeff(), iag.key(), key1);
+                    dest = key2;
                 }
-                if (dim==1) {
-                    gcoeff=iag.get_impl()->parent_to_child(iag.coeff(),iag.key(),key2);
-                    dest=key1;
+                if (dim == 1) {
+                    gcoeff = iag.get_impl()->parent_to_child(iag.coeff(), iag.key(), key2);
+                    dest = key1;
                 }
 
                 MADNESS_ASSERT(fimpl->get_coeffs().probe(key));		// must be local!
-                const nodeT& fnode=fimpl->get_coeffs().find(key).get()->second;
-                const coeffT& fcoeff=fnode.coeff();
+                const nodeT& fnode = fimpl->get_coeffs().find(key).get()->second;
+                const coeffT& fcoeff = fnode.coeff();
 
                 // fast return if possible
                 if (fcoeff.has_no_data() or gcoeff.has_no_data())
-                    return Future<argT> (argT(fnode.is_leaf(),coeffT()));;
+                    return Future<argT> (argT(fnode.is_leaf(), coeffT()));;
 
                 MADNESS_CHECK(gcoeff.is_full_tensor());
                 tensorT final(result->cdata.vk);
-                const int k=fcoeff.dim(0);
-                const int k_ldim=std::pow(k,LDIM);
+                const int k = fcoeff.dim(0);
+                const int k_ldim = std::pow(k, LDIM);
                 std::vector<long> shape(LDIM, k);
 
                 if (fcoeff.is_full_tensor()) {
                     //  result_i = \sum_j g_j f_ji
                     const tensorT gtensor = gcoeff.full_tensor().reshape(k_ldim);
-                    const tensorT ftensor = fcoeff.full_tensor().reshape(k_ldim,k_ldim);
-                    final=inner(gtensor,ftensor,0,dim).reshape(shape);
+                    const tensorT ftensor = fcoeff.full_tensor().reshape(k_ldim, k_ldim);
+                    final=inner(gtensor, ftensor, 0, dim).reshape(shape);
 
                 } else if (fcoeff.is_svd_tensor()) {
-                    if (fcoeff.rank()>0) {
+                    if (fcoeff.rank() > 0) {
 
                         //  result_i = \sum_jr g_j a_rj w_r b_ri
                         const int otherdim = (dim + 1) % 2;
@@ -6660,45 +6608,43 @@ template<size_t NDIM>
                         for (int r = 0; r < fcoeff.rank(); ++r) final += weights(r) * btensor(r, _);
                         final = final.reshape(shape);
                     }
-
                 } else {
-                    MADNESS_EXCEPTION("unsupported tensor type in project_out_op",1);
+                    MADNESS_EXCEPTION("unsupported tensor type in project_out_op", 1);
                 }
 
                 // accumulate the result
-                result->coeffs.task(dest, &FunctionNode<T,LDIM>::accumulate2, final, result->coeffs, dest, TaskAttributes::hipri());
+                result->coeffs.task(dest, &FunctionNode<T, LDIM>::accumulate2, final, result->coeffs, dest, TaskAttributes::hipri());
 
-                return Future<argT> (argT(fnode.is_leaf(),coeffT()));
+                return Future<argT> (argT(fnode.is_leaf(), coeffT()));
             }
 
             this_type make_child(const keyT& child) const {
-            	Key<LDIM> key1,key2;
-            	child.break_apart(key1,key2);
-            	const Key<LDIM> gkey = (dim==0) ? key1 : key2;
+            	Key<LDIM> key1, key2;
+            	child.break_apart(key1, key2);
+            	const Key<LDIM> gkey = (dim == 0) ? key1 : key2;
 
-                return this_type(fimpl,result,iag.make_child(gkey),dim);
+                return this_type(fimpl, result, iag.make_child(gkey), dim);
             }
 
             /// retrieve the coefficients (parent coeffs might be remote)
             Future<this_type> activate() const {
-            	Future<ctL> g1=iag.activate();
+            	Future<ctL> g1 = iag.activate();
                 return result->world.taskq.add(detail::wrap_mem_fn(*const_cast<this_type *> (this),
-                                               &this_type::forward_ctor),fimpl,result,g1,dim);
+                                               &this_type::forward_ctor), fimpl, result, g1, dim);
             }
 
             /// taskq-compatible ctor
             this_type forward_ctor(const implT* fimpl1, implL1* result1, const ctL& iag1, const int dim1) {
-            	return this_type(fimpl1,result1,iag1,dim1);
+            	return this_type(fimpl1, result1, iag1, dim1);
             }
 
             template <typename Archive> void serialize(const Archive& ar) {
                 ar & result & iag & fimpl & dim;
             }
-
         };
 
 
-        /// project the low-dim function g on the hi-dim function f: this(x) = <f(x,y) | g(y)>
+        /// project the low-dim function g on the hi-dim function f: this(x) = <f(x, y) | g(y)>
 
         /// invoked by result, a function of NDIM
 
@@ -6706,52 +6652,50 @@ template<size_t NDIM>
         /// @param[in]  g   lo-dim function of LDIM
         /// @param[in]  dim over which dimensions to be integrated: 0..LDIM or LDIM..LDIM+NDIM-1
         template<size_t LDIM>
-        void project_out2(const FunctionImpl<T,LDIM+NDIM>* f, const FunctionImpl<T,LDIM>* g, const int dim) {
-
-            typedef std::pair< keyT,coeffT > pairT;
-            typedef typename FunctionImpl<T,NDIM+LDIM>::dcT::const_iterator fiterator;
+        void project_out2(const FunctionImpl<T, LDIM + NDIM>* f, const FunctionImpl<T, LDIM>* g, const int dim) {
+            typedef std::pair< keyT, coeffT > pairT;
+            typedef typename FunctionImpl<T, NDIM+LDIM>::dcT::const_iterator fiterator;
 
             // loop over all nodes of hi-dim f, compute the inner products with all
             // appropriate nodes of g, and accumulate in result
             fiterator end = f->get_coeffs().end();
-            for (fiterator it=f->get_coeffs().begin(); it!=end; ++it) {
-                const Key<LDIM+NDIM> key=it->first;
-                const FunctionNode<T,LDIM+NDIM> fnode=it->second;
-                const coeffT& fcoeff=fnode.coeff();
+            for (fiterator it = f->get_coeffs().begin(); it != end; ++it) {
+                const Key<LDIM+NDIM> key = it->first;
+                const FunctionNode<T, LDIM + NDIM> fnode = it->second;
+                const coeffT& fcoeff = fnode.coeff();
 
                 if (fnode.is_leaf() and fcoeff.has_data()) {
 
                     // break key into particle: over key1 will be summed, over key2 will be
                     // accumulated, or vice versa, depending on dim
-                    if (dim==0) {
+                    if (dim == 0) {
                         Key<NDIM> key1;
                         Key<LDIM> key2;
-                        key.break_apart(key1,key2);
+                        key.break_apart(key1, key2);
 
                         Future<pairT> result;
-                        //                        sock_it_to_me(key1, result.remote_ref(world));
+                        // sock_it_to_me(key1, result.remote_ref(world));
                         g->task(coeffs.owner(key1), &implT::sock_it_to_me, key1, result.remote_ref(world), TaskAttributes::hipri());
-                        woT::task(world.rank(),&implT:: template do_project_out<LDIM>,fcoeff,result,key1,key2,dim);
+                        woT::task(world.rank(), &implT:: template do_project_out<LDIM>, fcoeff, result, key1, key2, dim);
 
-                    } else if (dim==1) {
+                    } else if (dim == 1) {
                         Key<LDIM> key1;
                         Key<NDIM> key2;
-                        key.break_apart(key1,key2);
+                        key.break_apart(key1, key2);
 
                         Future<pairT> result;
-                        //                        sock_it_to_me(key2, result.remote_ref(world));
+                        // sock_it_to_me(key2, result.remote_ref(world));
                         g->task(coeffs.owner(key2), &implT::sock_it_to_me, key2, result.remote_ref(world), TaskAttributes::hipri());
-                        woT::task(world.rank(),&implT:: template do_project_out<LDIM>,fcoeff,result,key2,key1,dim);
-
+                        woT::task(world.rank(), &implT:: template do_project_out<LDIM>, fcoeff, result, key2, key1, dim);
                     } else {
-                        MADNESS_EXCEPTION("confused dim in project_out",1);
+                        MADNESS_EXCEPTION("confused dim in project_out", 1);
                     }
                 }
             }
             set_tree_state(redundant);
-//            this->compressed=false;
-//            this->nonstandard=false;
-//            this->redundant=true;
+            // this->compressed=false;
+            // this->nonstandard=false;
+            // this->redundant=true;
         }
 
 
@@ -6764,40 +6708,36 @@ template<size_t NDIM>
         /// @param[in]  dest    destination node for the result
         /// @param[in]  dim     which dimensions should be contracted: 0..LDIM-1 or LDIM..NDIM+LDIM-1
         template<size_t LDIM>
-        void do_project_out(const coeffT& fcoeff, const std::pair<keyT,coeffT> gpair, const keyT& gkey,
+        void do_project_out(const coeffT& fcoeff, const std::pair<keyT, coeffT> gpair, const keyT& gkey,
                             const Key<NDIM>& dest, const int dim) const {
-
-            const coeffT gcoeff=parent_to_child(gpair.second,gpair.first,gkey);
+            const coeffT gcoeff = parent_to_child(gpair.second, gpair.first, gkey);
 
             // fast return if possible
             if (fcoeff.has_no_data() or gcoeff.has_no_data()) return;
 
             // let's specialize for the time being on SVD tensors for f and full tensors of half dim for g
-            MADNESS_ASSERT(gcoeff.tensor_type()==TT_FULL);
-            MADNESS_ASSERT(fcoeff.tensor_type()==TT_2D);
+            MADNESS_ASSERT(gcoeff.tensor_type() == TT_FULL);
+            MADNESS_ASSERT(fcoeff.tensor_type() == TT_2D);
             const tensorT gtensor=gcoeff.full_tensor();
             tensorT result(cdata.vk);
 
-            const int otherdim=(dim+1)%2;
+            const int otherdim = (dim + 1) % 2;
             const int k=fcoeff.dim(0);
-            std::vector<Slice> s(fcoeff.config().dim_per_vector()+1,_);
+            std::vector<Slice> s(fcoeff.config().dim_per_vector()+1, _);
 
             // do the actual contraction
-            for (int r=0; r<fcoeff.rank(); ++r) {
-                s[0]=Slice(r,r);
-                const tensorT contracted_tensor=fcoeff.config().ref_vector(dim)(s).reshape(k,k,k);
-                const tensorT other_tensor=fcoeff.config().ref_vector(otherdim)(s).reshape(k,k,k);
-                const double ovlp= gtensor.trace_conj(contracted_tensor);
-                const double fac=ovlp * fcoeff.config().weights(r);
-                result+=fac*other_tensor;
+            for (int r = 0; r < fcoeff.rank(); ++r) {
+                s[0] = Slice(r, r);
+                const tensorT contracted_tensor = fcoeff.config().ref_vector(dim)(s).reshape(k, k, k);
+                const tensorT other_tensor = fcoeff.config().ref_vector(otherdim)(s).reshape(k, k, k);
+                const double ovlp = gtensor.trace_conj(contracted_tensor);
+                const double fac = ovlp * fcoeff.config().weights(r);
+                result += fac * other_tensor;
             }
 
             // accumulate the result
             coeffs.task(dest, &nodeT::accumulate2, result, coeffs, dest, TaskAttributes::hipri());
         }
-
-
-
 
         /// Returns the maximum local depth of the tree ... no communications.
         std::size_t max_local_depth() const;
@@ -6835,19 +6775,19 @@ template<size_t NDIM>
 
         /// Out-of-place scale by a constant
         template <typename Q, typename F>
-        void scale_oop(const Q q, const FunctionImpl<F,NDIM>& f, bool fence) {
-            typedef typename FunctionImpl<F,NDIM>::nodeT fnodeT;
-            typedef typename FunctionImpl<F,NDIM>::dcT fdcT;
+        void scale_oop(const Q q, const FunctionImpl<F, NDIM>& f, bool fence) {
+            typedef typename FunctionImpl<F, NDIM>::nodeT fnodeT;
+            typedef typename FunctionImpl<F, NDIM>::dcT fdcT;
             typename fdcT::const_iterator end = f.coeffs.end();
-            for (typename fdcT::const_iterator it=f.coeffs.begin(); it!=end; ++it) {
+            for (typename fdcT::const_iterator it = f.coeffs.begin(); it != end; ++it) {
                 const keyT& key = it->first;
                 const fnodeT& node = it->second;
 
                 if (node.has_coeff()) {
-                    coeffs.replace(key,nodeT(node.coeff()*q,node.has_children()));
+                    coeffs.replace(key, nodeT(node.coeff()*q, node.has_children()));
                 }
                 else {
-                    coeffs.replace(key,nodeT(coeffT(),node.has_children()));
+                    coeffs.replace(key, nodeT(coeffT(), node.has_children()));
                 }
             }
             if (fence)
@@ -6858,7 +6798,7 @@ template<size_t NDIM>
 
         /// \param[in] impl pointer to a FunctionImpl
         /// \return The hash.
-        inline friend hashT hash_value(const FunctionImpl<T,NDIM>* pimpl) {
+        inline friend hashT hash_value(const FunctionImpl<T, NDIM>* pimpl) {
             hashT seed = hash_value(pimpl->id().get_world_id());
             detail::combine_hash(seed, hash_value(pimpl->id().get_obj_id()));
             return seed;
@@ -6868,104 +6808,104 @@ template<size_t NDIM>
 
         /// \param[in] impl pointer to a FunctionImpl
         /// \return The hash.
-        inline friend hashT hash_value(const std::shared_ptr<FunctionImpl<T,NDIM>> impl) {
+        inline friend hashT hash_value(const std::shared_ptr<FunctionImpl<T, NDIM>> impl) {
             return hash_value(impl.get());
         }
     };
 
     namespace archive {
         template <class Archive, class T, std::size_t NDIM>
-        struct ArchiveLoadImpl<Archive,const FunctionImpl<T,NDIM>*> {
-            static void load(const Archive& ar, const FunctionImpl<T,NDIM>*& ptr) {
-                bool exists=false;
+        struct ArchiveLoadImpl<Archive, const FunctionImpl<T, NDIM>*> {
+            static void load(const Archive& ar, const FunctionImpl<T, NDIM>*& ptr) {
+                bool exists = false;
                 ar & exists;
                 if (exists) {
                     uniqueidT id;
                     ar & id;
                     World* world = World::world_from_id(id.get_world_id());
                     MADNESS_ASSERT(world);
-                    auto ptr_opt = world->ptr_from_id< WorldObject< FunctionImpl<T,NDIM> > >(id);
+                    auto ptr_opt = world->ptr_from_id< WorldObject< FunctionImpl<T, NDIM>> >(id);
                     if (!ptr_opt)
-                      MADNESS_EXCEPTION("FunctionImpl: remote operation attempting to use a locally uninitialized object",0);
-                    ptr = static_cast< const FunctionImpl<T,NDIM>*>(*ptr_opt);
+                      MADNESS_EXCEPTION("FunctionImpl: remote operation attempting to use a locally uninitialized object", 0);
+                    ptr = static_cast< const FunctionImpl<T, NDIM>*>(*ptr_opt);
                     if (!ptr)
-                        MADNESS_EXCEPTION("FunctionImpl: remote operation attempting to use an unregistered object",0);
+                        MADNESS_EXCEPTION("FunctionImpl: remote operation attempting to use an unregistered object", 0);
                 } else {
-                    ptr=nullptr;
+                    ptr = nullptr;
                 }
             }
         };
 
         template <class Archive, class T, std::size_t NDIM>
-        struct ArchiveStoreImpl<Archive,const FunctionImpl<T,NDIM>*> {
-            static void store(const Archive& ar, const FunctionImpl<T,NDIM>*const& ptr) {
-                bool exists=(ptr) ? true : false;
+        struct ArchiveStoreImpl<Archive, const FunctionImpl<T, NDIM>*> {
+            static void store(const Archive& ar, const FunctionImpl<T, NDIM>*const& ptr) {
+                bool exists = (ptr) ? true : false;
                 ar & exists;
                 if (exists) ar & ptr->id();
             }
         };
 
         template <class Archive, class T, std::size_t NDIM>
-        struct ArchiveLoadImpl<Archive, FunctionImpl<T,NDIM>*> {
-            static void load(const Archive& ar, FunctionImpl<T,NDIM>*& ptr) {
-                bool exists=false;
+        struct ArchiveLoadImpl<Archive, FunctionImpl<T, NDIM>*> {
+            static void load(const Archive& ar, FunctionImpl<T, NDIM>*& ptr) {
+                bool exists = false;
                 ar & exists;
                 if (exists) {
                     uniqueidT id;
                     ar & id;
                     World* world = World::world_from_id(id.get_world_id());
                     MADNESS_ASSERT(world);
-                    auto ptr_opt = world->ptr_from_id< WorldObject< FunctionImpl<T,NDIM> > >(id);
+                    auto ptr_opt = world->ptr_from_id< WorldObject< FunctionImpl<T, NDIM>> >(id);
                     if (!ptr_opt)
-                      MADNESS_EXCEPTION("FunctionImpl: remote operation attempting to use a locally uninitialized object",0);
-                    ptr = static_cast< FunctionImpl<T,NDIM>*>(*ptr_opt);
+                      MADNESS_EXCEPTION("FunctionImpl: remote operation attempting to use a locally uninitialized object", 0);
+                    ptr = static_cast< FunctionImpl<T, NDIM>*>(*ptr_opt);
                     if (!ptr)
-                      MADNESS_EXCEPTION("FunctionImpl: remote operation attempting to use an unregistered object",0);
+                      MADNESS_EXCEPTION("FunctionImpl: remote operation attempting to use an unregistered object", 0);
                 } else {
-                    ptr=nullptr;
+                    ptr = nullptr;
                 }
             }
         };
 
         template <class Archive, class T, std::size_t NDIM>
-        struct ArchiveStoreImpl<Archive, FunctionImpl<T,NDIM>*> {
-            static void store(const Archive& ar, FunctionImpl<T,NDIM>*const& ptr) {
-                bool exists=(ptr) ? true : false;
+        struct ArchiveStoreImpl<Archive, FunctionImpl<T, NDIM>*> {
+            static void store(const Archive& ar, FunctionImpl<T, NDIM>*const& ptr) {
+                bool exists = (ptr) ? true : false;
                 ar & exists;
                 if (exists) ar & ptr->id();
-                //                ar & ptr->id();
+                // ar & ptr->id();
             }
         };
 
         template <class Archive, class T, std::size_t NDIM>
-        struct ArchiveLoadImpl<Archive, std::shared_ptr<const FunctionImpl<T,NDIM> > > {
-            static void load(const Archive& ar, std::shared_ptr<const FunctionImpl<T,NDIM> >& ptr) {
-                const FunctionImpl<T,NDIM>* f = nullptr;
-                ArchiveLoadImpl<Archive, const FunctionImpl<T,NDIM>*>::load(ar, f);
-                ptr.reset(f, [] (const FunctionImpl<T,NDIM> *p_) -> void {});
+        struct ArchiveLoadImpl<Archive, std::shared_ptr<const FunctionImpl<T, NDIM>> > {
+            static void load(const Archive& ar, std::shared_ptr<const FunctionImpl<T, NDIM>>& ptr) {
+                const FunctionImpl<T, NDIM>* f = nullptr;
+                ArchiveLoadImpl<Archive, const FunctionImpl<T, NDIM>*>::load(ar, f);
+                ptr.reset(f, [] (const FunctionImpl<T, NDIM> *p_) -> void {});
             }
         };
 
         template <class Archive, class T, std::size_t NDIM>
-        struct ArchiveStoreImpl<Archive, std::shared_ptr<const FunctionImpl<T,NDIM> > > {
-            static void store(const Archive& ar, const std::shared_ptr<const FunctionImpl<T,NDIM> >& ptr) {
-                ArchiveStoreImpl<Archive, const FunctionImpl<T,NDIM>*>::store(ar, ptr.get());
+        struct ArchiveStoreImpl<Archive, std::shared_ptr<const FunctionImpl<T, NDIM>> > {
+            static void store(const Archive& ar, const std::shared_ptr<const FunctionImpl<T, NDIM>>& ptr) {
+                ArchiveStoreImpl<Archive, const FunctionImpl<T, NDIM>*>::store(ar, ptr.get());
             }
         };
 
         template <class Archive, class T, std::size_t NDIM>
-        struct ArchiveLoadImpl<Archive, std::shared_ptr<FunctionImpl<T,NDIM> > > {
-            static void load(const Archive& ar, std::shared_ptr<FunctionImpl<T,NDIM> >& ptr) {
-                FunctionImpl<T,NDIM>* f = nullptr;
-                ArchiveLoadImpl<Archive, FunctionImpl<T,NDIM>*>::load(ar, f);
-                ptr.reset(f, [] (FunctionImpl<T,NDIM> *p_) -> void {});
+        struct ArchiveLoadImpl<Archive, std::shared_ptr<FunctionImpl<T, NDIM>> > {
+            static void load(const Archive& ar, std::shared_ptr<FunctionImpl<T, NDIM>>& ptr) {
+                FunctionImpl<T, NDIM>* f = nullptr;
+                ArchiveLoadImpl<Archive, FunctionImpl<T, NDIM>*>::load(ar, f);
+                ptr.reset(f, [] (FunctionImpl<T, NDIM> *p_) -> void {});
             }
         };
 
         template <class Archive, class T, std::size_t NDIM>
-        struct ArchiveStoreImpl<Archive, std::shared_ptr<FunctionImpl<T,NDIM> > > {
-            static void store(const Archive& ar, const std::shared_ptr<FunctionImpl<T,NDIM> >& ptr) {
-                ArchiveStoreImpl<Archive, FunctionImpl<T,NDIM>*>::store(ar, ptr.get());
+        struct ArchiveStoreImpl<Archive, std::shared_ptr<FunctionImpl<T, NDIM>> > {
+            static void store(const Archive& ar, const std::shared_ptr<FunctionImpl<T, NDIM>>& ptr) {
+                ArchiveStoreImpl<Archive, FunctionImpl<T, NDIM>*>::store(ar, ptr.get());
             }
         };
     }

--- a/src/madness/mra/funcimpl.h
+++ b/src/madness/mra/funcimpl.h
@@ -2327,7 +2327,7 @@ template<size_t NDIM>
                 return norm*norm;
 	      }
 	      else {
-		throw "ONLY FOR DIM 6!";
+		      MADNESS_EXCEPTION("ONLY FOR DIM 6!", 1);
 	      }
             }
 
@@ -5350,7 +5350,7 @@ template<size_t NDIM>
 
             template <typename Archive>
             void serialize(const Archive& ar) {
-                throw "not yet";
+                MADNESS_EXCEPTION("not yet", 1);
             }
         };
 
@@ -5660,7 +5660,7 @@ template<size_t NDIM>
                             const GenTensor<R>* jptr = rightv[jv].second;
 
                             if (!sym || (sym && i <= j))
-                                r(i, j) += iptr->trace(*jptr);
+                                r(i, j) += iptr->trace_conj(*jptr);
                         }
                     }
                 }
@@ -5695,6 +5695,7 @@ template<size_t NDIM>
                    for(unsigned int iv = 0; iv < nleft; ++iv) Left(iv,_) = *(leftv[iv].second);
                    for(unsigned int jv = 0; jv < nright; ++jv) Right(jv,_) = *(rightv[jv].second);
                    // call mxmT from mxm.h in tensor
+                   if(TensorTypeData<T>::iscomplex) Left = Left.conj();  // Should handle complex case and leave real case alone
                    mxmT(nleft, nright, size, r.ptr(), Left.ptr(), Right.ptr());
                    mutex->lock();
                    for(unsigned int iv = 0; iv < nleft; ++iv) {
@@ -5734,7 +5735,7 @@ template<size_t NDIM>
                         const int i = leftv[iv].first;
                         const GenTensor<T>* iptr = leftv[iv].second;
 
-                        for (int jv = 0; jv<nright; jv++) {
+                        for (int jv = 0; jv < nright; jv++) {
                             const int j = rightv[jv].first;
                             const GenTensor<R>* jptr = rightv[jv].second;
 
@@ -5875,9 +5876,9 @@ template<size_t NDIM>
                 rmap_ptr = &rmap;
             }
 
-            size_t chunk = (lmap.size()-1)/(3*4*5)+1;
+            size_t chunk = (lmap.size() - 1) / (3 * 4 * 5) + 1;
 
-            Tensor< TENSOR_RESULT_TYPE(T,R) > r(left.size(), right.size());
+            Tensor<TENSOR_RESULT_TYPE(T, R)> r(left.size(), right.size());
             Mutex mutex;
 
             typename mapT::iterator lstart=lmap.begin();
@@ -5891,11 +5892,11 @@ template<size_t NDIM>
 
             // sym is for hermiticity
             if (sym) {
-                for (long i=0; i<r.dim(0); i++) {
-                    for (long j=0; j<i; j++) {
-                        TENSOR_RESULT_TYPE(T,R) sum = r(i,j)+conj(r(j,i));
-                        r(i,j) = sum;
-                        r(j,i) = conj(sum);
+                for (long i = 0; i < r.dim(0); i++) {
+                    for (long j = 0; j < i; j++) {
+                        TENSOR_RESULT_TYPE(T, R) sum = r(i, j) + conj(r(j, i));
+                        r(i, j) = sum;
+                        r(j, i) = conj(sum);
                     }
                 }
             }

--- a/src/madness/mra/testvmra.cc
+++ b/src/madness/mra/testvmra.cc
@@ -1,3 +1,5 @@
+#include "funcdefaults.h"
+#include "madness_exception.h"
 #define NO_GENTENSOR
 #include <madness/mra/mra.h>
 #include <madness/mra/vmra.h>
@@ -9,8 +11,12 @@ const double PI = 3.1415926535897932384;
 using namespace madness;
 
 double ttt, sss;
-#define START_TIMER world.gop.fence(); ttt=wall_time(); sss=cpu_time()
-#define END_TIMER(msg) ttt=wall_time()-ttt; sss=cpu_time()-sss; if (world.rank()==0) printf("timer: %20.20s %8.2fs %8.2fs\n", msg, sss, ttt)
+#define START_TIMER world.gop.fence(); \
+                    ttt = wall_time(); \
+                    sss = cpu_time()
+#define END_TIMER(msg) ttt = wall_time() - ttt; \
+                       sss = cpu_time() - sss;  \
+                       if (world.rank() == 0) printf("timer: %20.20s %8.2fs %8.2fs\n", msg, sss, ttt)
 
 template <typename T>
 T complexify(T c) {
@@ -18,11 +24,11 @@ T complexify(T c) {
 }
 
 template <> double_complex complexify<double_complex>(double_complex c) {
-    return double_complex(c.real(),c.real()*c.real());
+    return double_complex(c.real(), c.real() * c.real());
 }
 
 template <> float_complex complexify<float_complex>(float_complex c) {
-    return c*float_complex(c.real(),c.real()*c.real());
+    return c * float_complex(c.real(), c.real() * c.real());
 }
 
 /// struct to test the multi_to_multi_op_values
@@ -34,20 +40,20 @@ struct many_to_many_op {
     std::size_t result_size;
     std::size_t get_result_size() const {return result_size;}
 
-    std::vector<madness::Tensor<double> > operator()(const madness::Key<NDIM> & key,
-            const std::vector< madness::Tensor<double> >& t) const {
-        std::vector<madness::Tensor<double> > result(result_size);
-        result[0]=2.0*t[0];
-        result[1]=t[1]+t[2];
+    std::vector<madness::Tensor<double>> operator()(const madness::Key<NDIM> & key,
+            const std::vector< madness::Tensor<double>>& t) const {
+        std::vector<madness::Tensor<double>> result(result_size);
+        result[0] = 2.0 * t[0];
+        result[1] = t[1] + t[2];
         return result;
     }
 };
 
 
 template <typename T, std::size_t NDIM>
-class Gaussian : public FunctionFunctorInterface<T,NDIM> {
+class Gaussian : public FunctionFunctorInterface<T, NDIM> {
 public:
-    typedef Vector<double,NDIM> coordT;
+    typedef Vector<double, NDIM> coordT;
     const coordT center;
     const double exponent;
     const T coefficient;
@@ -57,9 +63,9 @@ public:
 
     T operator()(const coordT& x) const {
         double sum = 0.0;
-        for (std::size_t i=0; i<NDIM; ++i) {
-            double xx = center[i]-x[i];
-            sum += xx*xx;
+        for (std::size_t i = 0; i < NDIM; ++i) {
+            double xx = center[i] - x[i];
+            sum += xx * xx;
         };
         return coefficient*exp(-exponent*sum);
     };
@@ -67,30 +73,29 @@ public:
 
 /// Makes a square-normalized Gaussian with random origin and exponent
 template <typename T, std::size_t NDIM>
-Gaussian<T,NDIM>*
-RandomGaussian(const Tensor<double> cell, double expntmax=1e5) {
-    typedef Vector<double,NDIM> coordT;
+Gaussian<T, NDIM>*
+RandomGaussian(const Tensor<double> cell, double expntmax = 1e5) {
+    typedef Vector<double, NDIM> coordT;
     coordT origin;
-    for (std::size_t i=0; i<NDIM; ++i) {
-        origin[i] = RandomValue<double>()*(cell(i,1)-cell(i,0)) + cell(i,0);
+    for (std::size_t i = 0; i < NDIM; ++i) {
+        origin[i] = RandomValue<double>() * (cell(i, 1) - cell(i, 0)) + cell(i, 0);
     }
     double lo = log(0.01);
     double hi = log(expntmax);
-    double expnt = exp(RandomValue<double>()*(hi-lo) + lo);
-    T coeff = pow(2.0*expnt/PI,0.25*NDIM);
+    double expnt = exp(RandomValue<double>() * (hi - lo) + lo);
+    T coeff = pow(2.0 * expnt / PI, 0.25 * NDIM);
     //print("RandomGaussian: origin", origin, "expnt", expnt, "coeff", coeff);
-    return new Gaussian<T,NDIM>(origin,expnt,coeff);
+    return new Gaussian<T, NDIM>(origin, expnt, coeff);
 }
-
 
 template <typename T, std::size_t NDIM>
 void test_add(World& world) {
 
-    const double thresh=1.e-7;
-    Tensor<double> cell(NDIM,2);
-    for (std::size_t i=0; i<NDIM; ++i) {
-        cell(i,0) = -11.0-2*i;  // Deliberately asymmetric bounding box
-        cell(i,1) =  10.0+i;
+    const double thresh = 1.e-7;
+    Tensor<double> cell(NDIM, 2);
+    for (std::size_t i = 0; i < NDIM; ++i) {
+        cell(i, 0) = -11.0 - 2 * i;  // Deliberately asymmetric bounding box
+        cell(i, 1) =  10.0 + i;
     }
     FunctionDefaults<NDIM>::set_cell(cell);
     FunctionDefaults<NDIM>::set_k(8);
@@ -99,50 +104,54 @@ void test_add(World& world) {
     FunctionDefaults<NDIM>::set_initial_level(3);
     FunctionDefaults<NDIM>::set_truncate_mode(1);
 
-    std::size_t nvec=5;
-    std::vector<Function<T,NDIM> > add1(nvec), add2(nvec), sum(nvec), diff(nvec);
+    std::size_t nvec = 5;
+    std::vector<Function<T, NDIM>> add1(nvec), add2(nvec), sum(nvec), diff(nvec);
 
-    for (int i=0; i<nvec; ++i) {
-        add1[i]=FunctionFactory<T,NDIM>(world).functor([] (const Vector<double,3>& r) {return r.normf();});
-        add2[i]=FunctionFactory<T,NDIM>(world).functor([] (const Vector<double,3>& r) {return 2.0*r.normf();});
-        sum[i]=FunctionFactory<T,NDIM>(world).functor([] (const Vector<double,3>& r) {return 3.0*r.normf();});
-        diff[i]=FunctionFactory<T,NDIM>(world).functor([] (const Vector<double,3>& r) {return -1.0*r.normf();});
+    for (int i = 0; i<nvec; ++i) {
+        add1[i] = FunctionFactory<T, NDIM>(world).functor([] (const Vector<double, 3>& r) {return r.normf();});
+        add2[i] = FunctionFactory<T, NDIM>(world).functor([] (const Vector<double, 3>& r) {return 2.0 * r.normf();});
+        sum[i] = FunctionFactory<T, NDIM>(world).functor([] (const Vector<double, 3>& r) {return 3.0 * r.normf();});
+        diff[i] = FunctionFactory<T, NDIM>(world).functor([] (const Vector<double, 3>& r) {return -1.0 * r.normf();});
     }
 
-    std::vector<Function<T,NDIM> > r1=add1+add2;
-    std::vector<Function<T,NDIM> > r3=add1+add2[0];
-    std::vector<Function<T,NDIM> > r5=add1[0]+add2;
+    std::vector<Function<T, NDIM>> r1 = add1 + add2;
+    std::vector<Function<T, NDIM>> r3 = add1 + add2[0];
+    std::vector<Function<T, NDIM>> r5 = add1[0] + add2;
 
-    std::vector<Function<T,NDIM> > r2=add1-add2;
-    std::vector<Function<T,NDIM> > r4=add1-add2[0];
-    std::vector<Function<T,NDIM> > r6=add1[0]-add2;
+    std::vector<Function<T, NDIM>> r2 = add1 - add2;
+    std::vector<Function<T, NDIM>> r4 = add1 - add2[0];
+    std::vector<Function<T, NDIM>> r6 = add1[0] - add2;
 
-    double error1=0.0,error2=0.0,error3=0.0,error4=0.0,error5=0.0,error6=0.0;
-    for (int i=0; i<nvec; ++i) {
-    	error1+=(r1[i]-sum[i]).norm2();
-    	error3+=(r3[i]-sum[i]).norm2();
-    	error5+=(r5[i]-sum[i]).norm2();
+    double error1 = 0.0, error2 = 0.0, error3 = 0.0, error4 = 0.0, error5 = 0.0, error6 = 0.0;
+    for (int i = 0; i < nvec; ++i) {
+    	error1 += (r1[i] - sum[i]).norm2();
+    	error3 += (r3[i] - sum[i]).norm2();
+    	error5 += (r5[i] - sum[i]).norm2();
 
-    	error2+=(r2[i]-diff[i]).norm2();
-    	error4+=(r4[i]-diff[i]).norm2();
-    	error6+=(r6[i]-diff[i]).norm2();
+     	error2 += (r2[i] - diff[i]).norm2();
+    	error4 += (r4[i] - diff[i]).norm2();
+    	error6 += (r6[i] - diff[i]).norm2();
     }
-    print("errors in add", error1,error3,error5,error2,error4,error6);
+    print("errors in add", error1, error3, error5, error2, error4, error6);
+    MADNESS_CHECK(error1 < FunctionDefaults<NDIM>::get_thresh());
+    MADNESS_CHECK(error3 < FunctionDefaults<NDIM>::get_thresh());
+    MADNESS_CHECK(error5 < FunctionDefaults<NDIM>::get_thresh());
+    MADNESS_CHECK(error2 < FunctionDefaults<NDIM>::get_thresh());
+    MADNESS_CHECK(error4 < FunctionDefaults<NDIM>::get_thresh());
+    MADNESS_CHECK(error6 < FunctionDefaults<NDIM>::get_thresh());
 
 }
 
-
-
 template <typename T, typename R, int NDIM, bool sym>
 void test_inner(World& world) {
-    typedef std::shared_ptr< FunctionFunctorInterface<T,NDIM> > ffunctorT;
-    typedef std::shared_ptr< FunctionFunctorInterface<R,NDIM> > gfunctorT;
+    typedef std::shared_ptr<FunctionFunctorInterface<T, NDIM>> ffunctorT;
+    typedef std::shared_ptr<FunctionFunctorInterface<R, NDIM>> gfunctorT;
 
-    const double thresh=1.e-7;
-    Tensor<double> cell(NDIM,2);
-    for (std::size_t i=0; i<NDIM; ++i) {
-        cell(i,0) = -11.0-2*i;  // Deliberately asymmetric bounding box
-        cell(i,1) =  10.0+i;
+    const double thresh = 1.e-7;
+    Tensor<double> cell(NDIM, 2);
+    for (std::size_t i = 0; i < NDIM; ++i) {
+        cell(i, 0) = -11.0 - 2 * i;  // Deliberately asymmetric bounding box
+        cell(i, 1) =  10.0 + i;
     }
     FunctionDefaults<NDIM>::set_cell(cell);
     FunctionDefaults<NDIM>::set_k(8);
@@ -154,53 +163,58 @@ void test_inner(World& world) {
     const int nleft=95, nright=sym ? nleft : 94;
 
     if (world.rank() == 0) 
-        print("testing matrix_inner<",archive::get_type_name<T>(),",",archive::get_type_name<R>(),">","sym =",sym);
+        print("testing matrix_inner<", archive::get_type_name<T>(), ", ", archive::get_type_name<R>(), ">", "sym  = ", sym);
 
     START_TIMER;
-    std::vector< Function<T,NDIM> > left(nleft);
-    for (int i=0; i<nleft; ++i) {
-        ffunctorT f(RandomGaussian<T,NDIM>(FunctionDefaults<NDIM>::get_cell(),0.5));
-        left[i] = FunctionFactory<T,NDIM>(world).functor(f);
+    std::vector<Function<T, NDIM>> left(nleft);
+    for (int i = 0; i < nleft; ++i) {
+        ffunctorT f(RandomGaussian<T, NDIM>(FunctionDefaults<NDIM>::get_cell(), 0.5));
+        left[i] = FunctionFactory<T, NDIM>(world).functor(f);
     }
-    std::vector< Function<R,NDIM> > right(nright);
-    std::vector< Function<R,NDIM> >* pright = &right;
+    std::vector<Function<R, NDIM>> right(nright);
+    std::vector<Function<R, NDIM>>* pright = &right;
     if (sym) {
-        pright = (std::vector< Function<R,NDIM> >*)(&left);
+        pright = (std::vector<Function<R, NDIM>>*)(&left);
     }
     else {
-        for (int i=0; i<nright; ++i) {
-            gfunctorT f(RandomGaussian<R,NDIM>(FunctionDefaults<NDIM>::get_cell(),0.5));
-            right[i] = FunctionFactory<R,NDIM>(world).functor(f);
+        for (int i = 0; i < nright; ++i) {
+            gfunctorT f(RandomGaussian<R, NDIM>(FunctionDefaults<NDIM>::get_cell(), 0.5));
+            right[i] = FunctionFactory<R, NDIM>(world).functor(f);
         }
     }
     END_TIMER("project");
 
     START_TIMER;
-    compress(world,left);
-    compress(world,right);
+    compress(world, left);
+    compress(world, right);
     END_TIMER("compress");
     
     START_TIMER;
-    Tensor<TENSOR_RESULT_TYPE(T,R)> rnew = matrix_inner(world,left,*pright,sym);
+    Tensor<TENSOR_RESULT_TYPE(T, R)> rnew = matrix_inner(world, left, *pright, sym);
     END_TIMER("new");
+
     START_TIMER;
-    Tensor<TENSOR_RESULT_TYPE(T,R)> rold = matrix_inner_old(world,left,*pright,sym);
+    Tensor<TENSOR_RESULT_TYPE(T, R)> rold = matrix_inner_old(world, left, *pright, sym);
     END_TIMER("old");
 
     if (world.rank() == 0) 
-        print("error norm",(rold-rnew).normf(),"\n");
+        print("error norm", (rold - rnew).normf(), "\n");
+    
+    // With sym = true, the error is larger on the order of 2.0e-6
+    auto check_thresh = (sym) ? 50 * thresh : thresh;
+    MADNESS_CHECK((rold - rnew).normf() < check_thresh);
 }
 
 template <typename T, typename R, int NDIM, bool sym>
 void test_dot(World& world) {
-    typedef std::shared_ptr< FunctionFunctorInterface<T,NDIM> > ffunctorT;
-    typedef std::shared_ptr< FunctionFunctorInterface<R,NDIM> > gfunctorT;
+    typedef std::shared_ptr<FunctionFunctorInterface<T, NDIM>> ffunctorT;
+    typedef std::shared_ptr<FunctionFunctorInterface<R, NDIM>> gfunctorT;
 
-    const double thresh=1.e-7;
-    Tensor<double> cell(NDIM,2);
-    for (std::size_t i=0; i<NDIM; ++i) {
-        cell(i,0) = -11.0-2*i;  // Deliberately asymmetric bounding box
-        cell(i,1) =  10.0+i;
+    const double thresh = 1.e-7;
+    Tensor<double> cell(NDIM, 2);
+    for (std::size_t i = 0; i < NDIM; ++i) {
+        cell(i, 0) = -11.0 - 2 * i;  // Deliberately asymmetric bounding box
+        cell(i, 1) =  10.0 + i;
     }
     FunctionDefaults<NDIM>::set_cell(cell);
     FunctionDefaults<NDIM>::set_k(8);
@@ -209,58 +223,60 @@ void test_dot(World& world) {
     FunctionDefaults<NDIM>::set_initial_level(3);
     FunctionDefaults<NDIM>::set_truncate_mode(1);
 
-    const int nleft=95, nright=sym ? nleft : 94;
+    const int nleft = 95, nright = sym ? nleft : 94;
 
     if (world.rank() == 0)
-        print("testing matrix_dot<",archive::get_type_name<T>(),",",archive::get_type_name<R>(),">","sym =",sym);
+        print("testing matrix_dot<", archive::get_type_name<T>(), ", ", archive::get_type_name<R>(), ">", "sym  = ", sym);
 
     START_TIMER;
-    std::vector< Function<T,NDIM> > left(nleft);
-    for (int i=0; i<nleft; ++i) {
-        ffunctorT f(RandomGaussian<T,NDIM>(FunctionDefaults<NDIM>::get_cell(),0.5));
-        left[i] = FunctionFactory<T,NDIM>(world).functor(f);
+    std::vector<Function<T, NDIM>> left(nleft);
+    for (int i = 0; i < nleft; ++i) {
+        ffunctorT f(RandomGaussian<T, NDIM>(FunctionDefaults<NDIM>::get_cell(), 0.5));
+        left[i] = FunctionFactory<T, NDIM>(world).functor(f);
     }
-    std::vector< Function<R,NDIM> > right(nright);
-    std::vector< Function<R,NDIM> >* pright = &right;
+    std::vector<Function<R, NDIM>> right(nright);
+    std::vector<Function<R, NDIM>>* pright = &right;
     if (sym) {
-        pright = (std::vector< Function<R,NDIM> >*)(&left);
+        pright = (std::vector< Function<R, NDIM>>*)(&left);
     }
     else {
-        for (int i=0; i<nright; ++i) {
-            gfunctorT f(RandomGaussian<R,NDIM>(FunctionDefaults<NDIM>::get_cell(),0.5));
-            right[i] = FunctionFactory<R,NDIM>(world).functor(f);
+        for (int i = 0; i < nright; ++i) {
+            gfunctorT f(RandomGaussian<R, NDIM>(FunctionDefaults<NDIM>::get_cell(), 0.5));
+            right[i] = FunctionFactory<R, NDIM>(world).functor(f);
         }
     }
     END_TIMER("project");
 
     START_TIMER;
-    compress(world,left);
-    compress(world,right);
+    compress(world, left);
+    compress(world, right);
     END_TIMER("compress");
 
     START_TIMER;
-    Tensor<TENSOR_RESULT_TYPE(T,R)> rnew = matrix_dot(world,left,*pright,sym);
+    Tensor<TENSOR_RESULT_TYPE(T, R)> rnew = matrix_dot(world, left, *pright, sym);
     END_TIMER("new");
     START_TIMER;
-    Tensor<TENSOR_RESULT_TYPE(T,R)> rold = matrix_dot_old(world,left,*pright,sym);
+    Tensor<TENSOR_RESULT_TYPE(T, R)> rold = matrix_inner(world,
+                                                         madness::conj(world, left),
+                                                         *pright, sym);
     END_TIMER("old");
 
     if (world.rank() == 0) 
-        print("error norm",(rold-rnew).normf(),"\n");
+        print("error norm", (rold - rnew).normf(), "\n");
+    MADNESS_CHECK((rold - rnew).normf() < FunctionDefaults<NDIM>::get_thresh());
 }
 
 template<typename T, std::size_t NDIM>
 int test_transform(World& world) {
     test_output to("testing transform");
     to.set_cout_to_terminal();
-    typedef std::shared_ptr< FunctionFunctorInterface<T,NDIM> > ffunctorT;
+    typedef std::shared_ptr<FunctionFunctorInterface<T, NDIM>> ffunctorT;
 
-
-    const double thresh=1.e-7;
-    Tensor<double> cell(NDIM,2);
-    for (std::size_t i=0; i<NDIM; ++i) {
-        cell(i,0) = -11.0-2*i;  // Deliberately asymmetric bounding box
-        cell(i,1) =  10.0+i;
+    const double thresh = 1.e-7;
+    Tensor<double> cell(NDIM, 2);
+    for (std::size_t i = 0; i < NDIM; ++i) {
+        cell(i, 0) = -11.0 - 2 * i;  // Deliberately asymmetric bounding box
+        cell(i, 1) =  10.0 + i;
     }
     FunctionDefaults<NDIM>::set_cell(cell);
     FunctionDefaults<NDIM>::set_k(8);
@@ -269,55 +285,50 @@ int test_transform(World& world) {
     FunctionDefaults<NDIM>::set_initial_level(3);
     FunctionDefaults<NDIM>::set_truncate_mode(1);
 
-
-    const int nleft=RandomValue<int>()%10;
-    const int nright=RandomValue<int>()%10;
-    print("nleft, nright",nleft,nright);
+    const int nleft = RandomValue<int>()%10;
+    const int nright = RandomValue<int>()%10;
+    print("nleft, nright", nleft, nright);
 
     START_TIMER;
-    std::vector< Function<T,NDIM> > left(nleft);
-    for (int i=0; i<nleft; ++i) {
-        ffunctorT f(RandomGaussian<T,NDIM>(FunctionDefaults<NDIM>::get_cell(),0.5));
-        left[i] = FunctionFactory<T,NDIM>(world).functor(f);
+    std::vector<Function<T, NDIM>> left(nleft);
+    for (int i = 0; i < nleft; ++i) {
+        ffunctorT f(RandomGaussian<T, NDIM>(FunctionDefaults<NDIM>::get_cell(), 0.5));
+        left[i] = FunctionFactory<T, NDIM>(world).functor(f);
     }
     END_TIMER("project");
-    to.checkpoint(true,"initial projection");
+    to.checkpoint(true, "initial projection");
 
-    Tensor<T> c(nleft,nright);
-    auto result1=transform(world,left,c);
-    to.checkpoint(true,"reference transform");
+    Tensor<T> c(nleft, nright);
+    auto result1 = transform(world, left, c);
+    to.checkpoint(true, "reference transform");
 
-    change_tree_state(left,reconstructed);
-    auto result2=transform_reconstructed(world,left,c,false);
+    change_tree_state(left, reconstructed);
+    auto result2 = transform_reconstructed(world, left, c, false);
     world.gop.fence();
-    for (auto& r : result2) MADNESS_CHECK(r.get_impl()->get_tree_state()==redundant_after_merge);
-    change_tree_state(result2,reconstructed);
-    double err1=norm2(world, result1-result2);
-    to.checkpoint(err1,thresh,"reference transform");
+    for (auto& r : result2)
+        MADNESS_CHECK(r.get_impl()->get_tree_state() == redundant_after_merge);
+    change_tree_state(result2, reconstructed);
+    double err1 = norm2(world, result1 - result2);
+    to.checkpoint(err1, thresh, "reference transform");
 
-    change_tree_state(left,compressed);
-    auto result3=transform_reconstructed(world,left,c);
-    double err2=norm2(world, result1-result3);
-    to.checkpoint(err2,thresh,"reference transform");
-
+    change_tree_state(left, compressed);
+    auto result3 = transform_reconstructed(world, left, c);
+    double err2 = norm2(world, result1 - result3);
+    to.checkpoint(err2, thresh, "reference transform");
 
     return to.end();
 }
 
-
-
-
-
 template <typename T, typename R, int NDIM>
 void test_cross(World& world) {
-    typedef std::shared_ptr< FunctionFunctorInterface<T,NDIM> > ffunctorT;
-    typedef std::shared_ptr< FunctionFunctorInterface<R,NDIM> > gfunctorT;
+    typedef std::shared_ptr<FunctionFunctorInterface<T, NDIM>> ffunctorT;
+    typedef std::shared_ptr<FunctionFunctorInterface<R, NDIM>> gfunctorT;
 
-    const double thresh=1.e-7;
-    Tensor<double> cell(NDIM,2);
-    for (std::size_t i=0; i<NDIM; ++i) {
-        cell(i,0) = -11.0-2*i;  // Deliberately asymmetric bounding box
-        cell(i,1) =  10.0+i;
+    const double thresh = 1.e-7;
+    Tensor<double> cell(NDIM, 2);
+    for (std::size_t i = 0; i < NDIM; ++i) {
+        cell(i, 0) = -11.0 - 2 * i;  // Deliberately asymmetric bounding box
+        cell(i, 1) =  10.0 + i;
     }
     FunctionDefaults<NDIM>::set_cell(cell);
     FunctionDefaults<NDIM>::set_k(8);
@@ -326,61 +337,63 @@ void test_cross(World& world) {
     FunctionDefaults<NDIM>::set_initial_level(3);
     FunctionDefaults<NDIM>::set_truncate_mode(1);
 
-    const int nleft=3, nright=3;
+    const int nleft = 3, nright = 3;
 
     if (world.rank() == 0)
-        print("testing  cross product<",archive::get_type_name<T>(),",",archive::get_type_name<R>(),">");
+        print("testing  cross product<", archive::get_type_name<T>(), ", ", archive::get_type_name<R>(), ">");
 
     START_TIMER;
-    std::vector< Function<T,NDIM> > left(nleft);
-    for (int i=0; i<nleft; ++i) {
-        ffunctorT f(RandomGaussian<T,NDIM>(FunctionDefaults<NDIM>::get_cell(),0.5));
-        left[i] = FunctionFactory<T,NDIM>(world).functor(f);
+    std::vector<Function<T, NDIM>> left(nleft);
+    for (int i = 0; i < nleft; ++i) {
+        ffunctorT f(RandomGaussian<T, NDIM>(FunctionDefaults<NDIM>::get_cell(), 0.5));
+        left[i] = FunctionFactory<T, NDIM>(world).functor(f);
     }
-    std::vector< Function<R,NDIM> > right(nright);
-    for (int i=0; i<nright; ++i) {
-    	gfunctorT f(RandomGaussian<R,NDIM>(FunctionDefaults<NDIM>::get_cell(),0.5));
-    	right[i] = FunctionFactory<R,NDIM>(world).functor(f);
+    std::vector<Function<R, NDIM>> right(nright);
+    for (int i = 0; i<nright; ++i) {
+    	gfunctorT f(RandomGaussian<R, NDIM>(FunctionDefaults<NDIM>::get_cell(), 0.5));
+    	right[i] = FunctionFactory<R, NDIM>(world).functor(f);
     }
     END_TIMER("project");
 
     START_TIMER;
-    compress(world,left);
-    compress(world,right);
+    compress(world, left);
+    compress(world, right);
     END_TIMER("compress");
 
     // cross product is anti-commuting
-    std::vector<Function<TENSOR_RESULT_TYPE(T,R),NDIM> > result1=cross(left,right)+cross(right,left);
-    double err1=norm2(world,result1);
-    if (world.rank() == 0) print("error norm1",err1,"\n");
+    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>> result1 = cross(left, right) + cross(right, left);
+    double err1 = norm2(world, result1);
+    if (world.rank() == 0) print("error norm1", err1, "\n");
+    MADNESS_CHECK(err1 < FunctionDefaults<NDIM>::get_thresh());
 
     // cross product with self vanishes
-    std::vector<Function<TENSOR_RESULT_TYPE(T,R),NDIM> > result2=cross(left,left);
-    double err2=norm2(world,result2);
-    if (world.rank() == 0) print("error norm2",err2,"\n");
+    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>> result2 = cross(left, left);
+    double err2 = norm2(world, result2);
+    if (world.rank() == 0) print("error norm2", err2, "\n");
+    MADNESS_CHECK(err2 < FunctionDefaults<NDIM>::get_thresh());
 
     // cross product with self vanishes
-    std::vector<Function<TENSOR_RESULT_TYPE(T,R),NDIM> > result3=cross(left,right);
-    Function<TENSOR_RESULT_TYPE(T,R), NDIM> reference0=left[1]*right[2] - left[2]*right[1];
+    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>> result3 = cross(left, right);
+    Function<TENSOR_RESULT_TYPE(T, R), NDIM> reference0 = left[1] * right[2] - left[2] * right[1];
 
-    double err3=(reference0-result3[0]).norm2();
-    if (world.rank() == 0) print("error norm3",err3,"\n");
+    double err3 = (reference0 - result3[0]).norm2();
+    if (world.rank() == 0) print("error norm3", err3, "\n");
+    MADNESS_CHECK(err3 < FunctionDefaults<NDIM>::get_thresh());
 
-    double err4=(result3[0]).norm2();
-    if (world.rank() == 0) print("error norm4",err4," (should not be zero)\n");
-
+    double err4 = (result3[0]).norm2();
+    if (world.rank() == 0) print("norm of i-component", err4, " (should not be zero)\n");
 }
 
 
 template <typename T, int NDIM>
 void test_rot(World& world) {
-    typedef std::shared_ptr< FunctionFunctorInterface<T,NDIM> > ffunctorT;
+    typedef std::shared_ptr<FunctionFunctorInterface<T, NDIM>> ffunctorT;
 
-    const double thresh=1.e-7;
-    Tensor<double> cell(NDIM,2);
-    for (std::size_t i=0; i<NDIM; ++i) {
-        cell(i,0) = -11.0-2*i;  // Deliberately asymmetric bounding box
-        cell(i,1) =  10.0+i;
+    const double thresh = 1.e-7;
+    Tensor<double> cell(NDIM, 2);
+    for (std::size_t i = 0; i < NDIM; ++i) {
+        cell(i, 0) = -11.0 - 2 * i;  // Deliberately asymmetric bounding box
+        cell(i, 1) =  10.0 + i;
     }
     FunctionDefaults<NDIM>::set_cell(cell);
     FunctionDefaults<NDIM>::set_k(8);
@@ -389,41 +402,39 @@ void test_rot(World& world) {
     FunctionDefaults<NDIM>::set_initial_level(3);
     FunctionDefaults<NDIM>::set_truncate_mode(1);
 
-    const int nleft=3;
+    const int nleft = 3;
 
     if (world.rank() == 0)
-        print("testing rot operator<",archive::get_type_name<T>(),",",archive::get_type_name<T>(),">");
+        print("testing rot operator<", archive::get_type_name<T>(), ", ", archive::get_type_name<T>(), ">");
 
     START_TIMER;
-    std::vector< Function<T,NDIM> > left(nleft);
-    for (int i=0; i<nleft; ++i) {
-        ffunctorT f(RandomGaussian<T,NDIM>(FunctionDefaults<NDIM>::get_cell(),0.5));
-        left[i] = FunctionFactory<T,NDIM>(world).functor(f);
+    std::vector< Function<T, NDIM>> left(nleft);
+    for (int i = 0; i < nleft; ++i) {
+        ffunctorT f(RandomGaussian<T, NDIM>(FunctionDefaults<NDIM>::get_cell(), 0.5));
+        left[i] = FunctionFactory<T, NDIM>(world).functor(f);
     }
     END_TIMER("project");
 
     START_TIMER;
-    compress(world,left);
+    compress(world, left);
     END_TIMER("compress");
 
     // rot grad v vanishes
-    std::vector<Function<T,NDIM> > result1=rot(grad(left[0]));
-    double err1=norm2(world,result1);
-    if (world.rank() == 0) print("error norm1",err1,"\n");
+    std::vector<Function<T, NDIM>> result1 = rot(grad(left[0]));
+    double err1 = norm2(world, result1);
+    if (world.rank() == 0) print("error norm1", err1, "\n");
 
     // div rot v vanishes
-    Function<T,NDIM> result2=div(rot(left));
-    double err2=result2.norm2();
-    if (world.rank() == 0) print("error norm2",err2,"\n");
-
-
+    Function<T, NDIM> result2 = div(rot(left));
+    double err2 = result2.norm2();
+    if (world.rank() == 0) print("error norm2", err2, "\n");
 }
 
 template<typename T, int NDIM>
 void test_matrix_mul_sparse(World &world) {
-    typedef std::shared_ptr<FunctionFunctorInterface<T, NDIM> > ffunctorT;
+    typedef std::shared_ptr<FunctionFunctorInterface<T, NDIM>> ffunctorT;
 
-    if (world.rank()==0) print("entering test_mul_sparse");
+    if (world.rank() == 0) print("entering test_mul_sparse");
     const double thresh = 1.e-7;
     Tensor<double> cell(NDIM, 2);
     for (std::size_t i = 0; i < NDIM; ++i) {
@@ -440,12 +451,12 @@ void test_matrix_mul_sparse(World &world) {
     START_TIMER;
     const long nrow = 3;
     const long ncolumn = 4;
-    std::vector<Function<T, NDIM> > row(nrow);
+    std::vector<Function<T, NDIM>> row(nrow);
     for (long i = 0; i < nrow; ++i) {
         ffunctorT f(RandomGaussian<T, NDIM>(FunctionDefaults<NDIM>::get_cell(), 0.5));
         row[i] = FunctionFactory<T, NDIM>(world).functor(f);
     }
-    std::vector<Function<T, NDIM> > column(ncolumn);
+    std::vector<Function<T, NDIM>> column(ncolumn);
     for (long i = 0; i < ncolumn; ++i) {
         ffunctorT f(RandomGaussian<T, NDIM>(FunctionDefaults<NDIM>::get_cell(), 0.5));
         column[i] = FunctionFactory<T, NDIM>(world).functor(f);
@@ -456,36 +467,30 @@ void test_matrix_mul_sparse(World &world) {
     auto result = matrix_mul_sparse<T, T, NDIM>(world, row, column, 0.0);
     END_TIMER("matrix_mul_sparse");
 
-
-
-    MADNESS_CHECK(result.size()==nrow);
+    MADNESS_CHECK(result.size() == nrow);
     for (long i = 0; i < nrow; ++i) {
-        MADNESS_CHECK(result[i].size()==ncolumn);
+        MADNESS_CHECK(result[i].size() == ncolumn);
         for (long j = 0; j < ncolumn; ++j) {
             Function<T, NDIM> tmp = row[i] * column[j];
-            double err=(tmp-result[i][j]).norm2();
-            MADNESS_CHECK(err<1.e-10);
+            double err = (tmp-result[i][j]).norm2();
+            MADNESS_CHECK(err < 1.e-10);
         }
     }
 
-    if (world.rank()==0) print("leaving test_mul_sparse");
+    if (world.rank() == 0) print("leaving test_mul_sparse");
 }
-
-
-
 
 template <std::size_t NDIM>
 void test_multi_to_multi_op(World& world) {
+    typedef Function<double, NDIM> functionT;
+    typedef std::vector<Function<double, NDIM>> vecfuncT;
+    typedef std::shared_ptr<FunctionFunctorInterface<double, NDIM>> ffunctorT;
 
-    typedef Function<double,NDIM> functionT;
-    typedef std::vector<Function<double,NDIM> > vecfuncT;
-    typedef std::shared_ptr< FunctionFunctorInterface<double,NDIM> > ffunctorT;
-
-    const double thresh=1.e-7;
-    Tensor<double> cell(NDIM,2);
-    for (std::size_t i=0; i<NDIM; ++i) {
-        cell(i,0) = -11.0-2*i;  // Deliberately asymmetric bounding box
-        cell(i,1) =  10.0+i;
+    const double thresh = 1.e-7;
+    Tensor<double> cell(NDIM, 2);
+    for (std::size_t i = 0; i < NDIM; ++i) {
+        cell(i, 0) = -11.0 - 2 * i;  // Deliberately asymmetric bounding box
+        cell(i, 1) =  10.0 + i;
     }
     FunctionDefaults<NDIM>::set_cell(cell);
     FunctionDefaults<NDIM>::set_k(8);
@@ -494,74 +499,84 @@ void test_multi_to_multi_op(World& world) {
     FunctionDefaults<NDIM>::set_initial_level(3);
     FunctionDefaults<NDIM>::set_truncate_mode(1);
 
-
     many_to_many_op<NDIM> op;
     vecfuncT vin(3);
 
     for (functionT& in : vin) {
-        ffunctorT f(RandomGaussian<double,NDIM>(FunctionDefaults<NDIM>::get_cell(),0.5));
-        in=FunctionFactory<double,NDIM>(world).functor(f);
+        ffunctorT f(RandomGaussian<double, NDIM>(FunctionDefaults<NDIM>::get_cell(), 0.5));
+        in = FunctionFactory<double, NDIM>(world).functor(f);
     }
-    refine_to_common_level(world,vin);
+    refine_to_common_level(world, vin);
 
-    vecfuncT vout=multi_to_multi_op_values(op, vin);
+    vecfuncT vout = multi_to_multi_op_values(op, vin);
 
     std::vector<functionT> result(2);
-    result[0]=2.0*vin[0]-vout[0];
-    result[1]=vout[1]-vin[1]-vin[2];
+    result[0] = 2.0 * vin[0] - vout[0];
+    result[1] = vout[1] - vin[1] - vin[2];
 
-    double norm_in=norm2(world,vin);
-    double norm_out=norm2(world,vout);
-    double error=norm2(world,result);
-    if (world.rank()==0) print("error in multi_to_multi ",error,norm_in,norm_out);
-
+    double norm_in = norm2(world, vin);
+    double norm_out = norm2(world, vout);
+    double error = norm2(world, result);
+    if (world.rank() == 0) print("error in multi_to_multi ", error, norm_in, norm_out);
+    MADNESS_CHECK(error < FunctionDefaults<NDIM>::get_thresh());
 }
+
 
 int main(int argc, char**argv) {
     initialize(argc, argv);
     World world(SafeMPI::COMM_WORLD);
 
     bool smalltest = false;
-    if (getenv("MAD_SMALL_TESTS")) smalltest=true;
-    for (int iarg=1; iarg<argc; iarg++) if (strcmp(argv[iarg],"--small")==0) smalltest=true;
+    if (getenv("MAD_SMALL_TESTS")) smalltest = true;
+    for (int iarg = 1; iarg < argc; iarg++) if (strcmp(argv[iarg], "--small") == 0) smalltest = true;
     std::cout << "small test : " << smalltest << std::endl;
     if (smalltest) return 0;
-    madness::default_random_generator.setstate(int(cpu_time()*1000)%4149);
-
+    madness::default_random_generator.setstate(int(cpu_time() * 1000) % 4149);
 
     try {
-        startup(world,argc,argv);
+        startup(world, argc, argv);
 
-        // test_add<double,3>(world);
-        // test_add<std::complex<double>,3 >(world);
+        // test_add<double, 3>(world);
+        // test_add<std::complex<double>, 3 >(world);
 
-        test_inner<double,double,1,false>(world);
-        test_inner<double,double,1,true>(world);
+        test_inner<double, double, 1, false>(world);
+        test_inner<double, double, 1, true>(world);
+
+        test_dot<double, double, 1, false>(world);
+        test_dot<double, double, 1, true>(world);
+
         test_multi_to_multi_op<1>(world);
         test_multi_to_multi_op<2>(world);
 
-        test_cross<double,double,2>(world);
-        test_cross<std::complex<double>,double,2>(world);
-        test_cross<std::complex<double>,std::complex<double>,2>(world);
+        test_cross<double, double, 2>(world);
+        test_cross<std::complex<double>, double, 2>(world);
+        test_cross<std::complex<double>, std::complex<double>, 2>(world);
 
-        test_transform<double,2>(world);
-        test_transform<double,2>(world);
-        test_transform<double,2>(world);
-        test_transform<double,2>(world);
+        test_transform<double, 2>(world);
+        test_transform<double, 2>(world);
+        test_transform<double, 2>(world);
+        test_transform<double, 2>(world);
 
-        test_rot<double,3>(world);
-        test_rot<std::complex<double>,3>(world);
+        test_rot<double, 3>(world);
+        test_rot<std::complex<double>, 3>(world);
 
-        test_matrix_mul_sparse<double,2>(world);
-        test_matrix_mul_sparse<double,3>(world);
+        test_matrix_mul_sparse<double, 2>(world);
+        test_matrix_mul_sparse<double, 3>(world);
 
         if (!smalltest) test_multi_to_multi_op<3>(world);
 #if !HAVE_GENTENSOR
-        test_inner<double,std::complex<double>,1,false>(world);
+        test_inner<double, std::complex<double>, 1, false>(world);
         if (!smalltest) {
-            test_inner<std::complex<double>,double,1,false>(world);
-            test_inner<std::complex<double>,std::complex<double>,1,false>(world);
-            test_inner<std::complex<double>,std::complex<double>,1,true>(world);
+            test_inner<std::complex<double>, double, 1, false>(world);
+            test_inner<std::complex<double>, std::complex<double>, 1, false>(world);
+            test_inner<std::complex<double>, std::complex<double>, 1, true>(world);
+        }
+
+        test_dot<double, std::complex<double>, 1, false>(world);
+        if (!smalltest) {
+            test_dot<std::complex<double>, double, 1, false>(world);
+            test_dot<std::complex<double>, std::complex<double>, 1, false>(world);
+            test_dot<std::complex<double>, std::complex<double>, 1, true>(world);
         }
 #endif
     }

--- a/src/madness/mra/testvmra.cc
+++ b/src/madness/mra/testvmra.cc
@@ -128,7 +128,12 @@ void test_add(World& world) {
     	error6+=(r6[i]-diff[i]).norm2();
     }
     print("errors in add", error1,error3,error5,error2,error4,error6);
-
+    MADNESS_CHECK(error1 < FunctionDefaults<NDIM>::get_thresh());
+    MADNESS_CHECK(error3 < FunctionDefaults<NDIM>::get_thresh());
+    MADNESS_CHECK(error5 < FunctionDefaults<NDIM>::get_thresh());
+    MADNESS_CHECK(error2 < FunctionDefaults<NDIM>::get_thresh());
+    MADNESS_CHECK(error4 < FunctionDefaults<NDIM>::get_thresh());
+    MADNESS_CHECK(error6 < FunctionDefaults<NDIM>::get_thresh());
 }
 
 
@@ -189,18 +194,22 @@ void test_inner(World& world) {
 
     if (world.rank() == 0) 
         print("error norm",(rold-rnew).normf(),"\n");
+
+    // With sym = true, the error is larger on the order of 2.0e-6
+    auto check_thresh = (sym) ? 50 * thresh : thresh;
+    MADNESS_CHECK((rold - rnew).normf() < check_thresh);
 }
 
 template <typename T, typename R, int NDIM, bool sym>
 void test_dot(World& world) {
-    typedef std::shared_ptr< FunctionFunctorInterface<T,NDIM> > ffunctorT;
-    typedef std::shared_ptr< FunctionFunctorInterface<R,NDIM> > gfunctorT;
+    typedef std::shared_ptr<FunctionFunctorInterface<T, NDIM>> ffunctorT;
+    typedef std::shared_ptr<FunctionFunctorInterface<R, NDIM>> gfunctorT;
 
-    const double thresh=1.e-7;
-    Tensor<double> cell(NDIM,2);
-    for (std::size_t i=0; i<NDIM; ++i) {
-        cell(i,0) = -11.0-2*i;  // Deliberately asymmetric bounding box
-        cell(i,1) =  10.0+i;
+    const double thresh = 1.e-7;
+    Tensor<double> cell(NDIM, 2);
+    for (std::size_t i = 0; i < NDIM; ++i) {
+        cell(i, 0) = -11.0 - 2 * i;  // Deliberately asymmetric bounding box
+        cell(i, 1) =  10.0 + i;
     }
     FunctionDefaults<NDIM>::set_cell(cell);
     FunctionDefaults<NDIM>::set_k(8);
@@ -209,16 +218,16 @@ void test_dot(World& world) {
     FunctionDefaults<NDIM>::set_initial_level(3);
     FunctionDefaults<NDIM>::set_truncate_mode(1);
 
-    const int nleft=95, nright=sym ? nleft : 94;
+    const int nleft = 95, nright = sym ? nleft : 94;
 
     if (world.rank() == 0)
-        print("testing matrix_dot<",archive::get_type_name<T>(),",",archive::get_type_name<R>(),">","sym =",sym);
+        print("testing matrix_dot<", archive::get_type_name<T>(), ",", archive::get_type_name<R>(), ">", "sym =", sym);
 
     START_TIMER;
     std::vector< Function<T,NDIM> > left(nleft);
-    for (int i=0; i<nleft; ++i) {
-        ffunctorT f(RandomGaussian<T,NDIM>(FunctionDefaults<NDIM>::get_cell(),0.5));
-        left[i] = FunctionFactory<T,NDIM>(world).functor(f);
+    for (int i = 0; i < nleft; ++i) {
+        ffunctorT f(RandomGaussian<T, NDIM>(FunctionDefaults<NDIM>::get_cell(), 0.5));
+        left[i] = FunctionFactory<T, NDIM>(world).functor(f);
     }
     std::vector< Function<R,NDIM> > right(nright);
     std::vector< Function<R,NDIM> >* pright = &right;
@@ -226,27 +235,30 @@ void test_dot(World& world) {
         pright = (std::vector< Function<R,NDIM> >*)(&left);
     }
     else {
-        for (int i=0; i<nright; ++i) {
-            gfunctorT f(RandomGaussian<R,NDIM>(FunctionDefaults<NDIM>::get_cell(),0.5));
+        for (int i = 0; i < nright; ++i) {
+            gfunctorT f(RandomGaussian<R,NDIM>(FunctionDefaults<NDIM>::get_cell(), 0.5));
             right[i] = FunctionFactory<R,NDIM>(world).functor(f);
         }
     }
     END_TIMER("project");
 
     START_TIMER;
-    compress(world,left);
-    compress(world,right);
+    compress(world, left);
+    compress(world, right);
     END_TIMER("compress");
 
     START_TIMER;
-    Tensor<TENSOR_RESULT_TYPE(T,R)> rnew = matrix_dot(world,left,*pright,sym);
+    Tensor<TENSOR_RESULT_TYPE(T, R)> rnew = matrix_dot(world, left, *pright, sym);
     END_TIMER("new");
     START_TIMER;
-    Tensor<TENSOR_RESULT_TYPE(T,R)> rold = matrix_dot_old(world,left,*pright,sym);
+    Tensor<TENSOR_RESULT_TYPE(T, R)> rold = matrix_inner(world,
+                                                        conj(world, left),
+                                                        *pright, sym);
     END_TIMER("old");
 
     if (world.rank() == 0) 
-        print("error norm",(rold-rnew).normf(),"\n");
+        print("error norm", (rold - rnew).normf(), "\n");
+    MADNESS_CHECK((rold - rnew).normf() < FunctionDefaults<NDIM>::get_thresh());
 }
 
 template<typename T, std::size_t NDIM>
@@ -353,11 +365,13 @@ void test_cross(World& world) {
     std::vector<Function<TENSOR_RESULT_TYPE(T,R),NDIM> > result1=cross(left,right)+cross(right,left);
     double err1=norm2(world,result1);
     if (world.rank() == 0) print("error norm1",err1,"\n");
+    MADNESS_CHECK(err1 < FunctionDefaults<NDIM>::get_thresh());
 
     // cross product with self vanishes
     std::vector<Function<TENSOR_RESULT_TYPE(T,R),NDIM> > result2=cross(left,left);
     double err2=norm2(world,result2);
     if (world.rank() == 0) print("error norm2",err2,"\n");
+    MADNESS_CHECK(err2 < FunctionDefaults<NDIM>::get_thresh());
 
     // cross product with self vanishes
     std::vector<Function<TENSOR_RESULT_TYPE(T,R),NDIM> > result3=cross(left,right);
@@ -365,9 +379,10 @@ void test_cross(World& world) {
 
     double err3=(reference0-result3[0]).norm2();
     if (world.rank() == 0) print("error norm3",err3,"\n");
+    MADNESS_CHECK(err3 < FunctionDefaults<NDIM>::get_thresh());
 
     double err4=(result3[0]).norm2();
-    if (world.rank() == 0) print("error norm4",err4," (should not be zero)\n");
+    if (world.rank() == 0) print("norm of i-component", err4, " (should not be zero)\n");
 
 }
 
@@ -514,6 +529,7 @@ void test_multi_to_multi_op(World& world) {
     double norm_out=norm2(world,vout);
     double error=norm2(world,result);
     if (world.rank()==0) print("error in multi_to_multi ",error,norm_in,norm_out);
+    MADNESS_CHECK(error < FunctionDefaults<NDIM>::get_thresh());
 
 }
 
@@ -537,6 +553,8 @@ int main(int argc, char**argv) {
 
         test_inner<double,double,1,false>(world);
         test_inner<double,double,1,true>(world);
+        test_dot<double, double, 1, false>(world);
+        test_dot<double, double, 1, true>(world);
         test_multi_to_multi_op<1>(world);
         test_multi_to_multi_op<2>(world);
 
@@ -562,6 +580,12 @@ int main(int argc, char**argv) {
             test_inner<std::complex<double>,double,1,false>(world);
             test_inner<std::complex<double>,std::complex<double>,1,false>(world);
             test_inner<std::complex<double>,std::complex<double>,1,true>(world);
+        }
+        test_dot<double, std::complex<double>, 1, false>(world);
+        if (!smalltest) {
+            test_dot<std::complex<double>, double, 1, false>(world);
+            test_dot<std::complex<double>, std::complex<double>, 1, false>(world);
+            test_dot<std::complex<double>, std::complex<double>, 1, true>(world);
         }
 #endif
     }

--- a/src/madness/mra/testvmra.cc
+++ b/src/madness/mra/testvmra.cc
@@ -1,5 +1,3 @@
-#include "funcdefaults.h"
-#include "madness_exception.h"
 #define NO_GENTENSOR
 #include <madness/mra/mra.h>
 #include <madness/mra/vmra.h>
@@ -11,12 +9,8 @@ const double PI = 3.1415926535897932384;
 using namespace madness;
 
 double ttt, sss;
-#define START_TIMER world.gop.fence(); \
-                    ttt = wall_time(); \
-                    sss = cpu_time()
-#define END_TIMER(msg) ttt = wall_time() - ttt; \
-                       sss = cpu_time() - sss;  \
-                       if (world.rank() == 0) printf("timer: %20.20s %8.2fs %8.2fs\n", msg, sss, ttt)
+#define START_TIMER world.gop.fence(); ttt=wall_time(); sss=cpu_time()
+#define END_TIMER(msg) ttt=wall_time()-ttt; sss=cpu_time()-sss; if (world.rank()==0) printf("timer: %20.20s %8.2fs %8.2fs\n", msg, sss, ttt)
 
 template <typename T>
 T complexify(T c) {
@@ -24,11 +18,11 @@ T complexify(T c) {
 }
 
 template <> double_complex complexify<double_complex>(double_complex c) {
-    return double_complex(c.real(), c.real() * c.real());
+    return double_complex(c.real(),c.real()*c.real());
 }
 
 template <> float_complex complexify<float_complex>(float_complex c) {
-    return c * float_complex(c.real(), c.real() * c.real());
+    return c*float_complex(c.real(),c.real()*c.real());
 }
 
 /// struct to test the multi_to_multi_op_values
@@ -40,20 +34,20 @@ struct many_to_many_op {
     std::size_t result_size;
     std::size_t get_result_size() const {return result_size;}
 
-    std::vector<madness::Tensor<double>> operator()(const madness::Key<NDIM> & key,
-            const std::vector< madness::Tensor<double>>& t) const {
-        std::vector<madness::Tensor<double>> result(result_size);
-        result[0] = 2.0 * t[0];
-        result[1] = t[1] + t[2];
+    std::vector<madness::Tensor<double> > operator()(const madness::Key<NDIM> & key,
+            const std::vector< madness::Tensor<double> >& t) const {
+        std::vector<madness::Tensor<double> > result(result_size);
+        result[0]=2.0*t[0];
+        result[1]=t[1]+t[2];
         return result;
     }
 };
 
 
 template <typename T, std::size_t NDIM>
-class Gaussian : public FunctionFunctorInterface<T, NDIM> {
+class Gaussian : public FunctionFunctorInterface<T,NDIM> {
 public:
-    typedef Vector<double, NDIM> coordT;
+    typedef Vector<double,NDIM> coordT;
     const coordT center;
     const double exponent;
     const T coefficient;
@@ -63,9 +57,9 @@ public:
 
     T operator()(const coordT& x) const {
         double sum = 0.0;
-        for (std::size_t i = 0; i < NDIM; ++i) {
-            double xx = center[i] - x[i];
-            sum += xx * xx;
+        for (std::size_t i=0; i<NDIM; ++i) {
+            double xx = center[i]-x[i];
+            sum += xx*xx;
         };
         return coefficient*exp(-exponent*sum);
     };
@@ -73,29 +67,30 @@ public:
 
 /// Makes a square-normalized Gaussian with random origin and exponent
 template <typename T, std::size_t NDIM>
-Gaussian<T, NDIM>*
-RandomGaussian(const Tensor<double> cell, double expntmax = 1e5) {
-    typedef Vector<double, NDIM> coordT;
+Gaussian<T,NDIM>*
+RandomGaussian(const Tensor<double> cell, double expntmax=1e5) {
+    typedef Vector<double,NDIM> coordT;
     coordT origin;
-    for (std::size_t i = 0; i < NDIM; ++i) {
-        origin[i] = RandomValue<double>() * (cell(i, 1) - cell(i, 0)) + cell(i, 0);
+    for (std::size_t i=0; i<NDIM; ++i) {
+        origin[i] = RandomValue<double>()*(cell(i,1)-cell(i,0)) + cell(i,0);
     }
     double lo = log(0.01);
     double hi = log(expntmax);
-    double expnt = exp(RandomValue<double>() * (hi - lo) + lo);
-    T coeff = pow(2.0 * expnt / PI, 0.25 * NDIM);
+    double expnt = exp(RandomValue<double>()*(hi-lo) + lo);
+    T coeff = pow(2.0*expnt/PI,0.25*NDIM);
     //print("RandomGaussian: origin", origin, "expnt", expnt, "coeff", coeff);
-    return new Gaussian<T, NDIM>(origin, expnt, coeff);
+    return new Gaussian<T,NDIM>(origin,expnt,coeff);
 }
+
 
 template <typename T, std::size_t NDIM>
 void test_add(World& world) {
 
-    const double thresh = 1.e-7;
-    Tensor<double> cell(NDIM, 2);
-    for (std::size_t i = 0; i < NDIM; ++i) {
-        cell(i, 0) = -11.0 - 2 * i;  // Deliberately asymmetric bounding box
-        cell(i, 1) =  10.0 + i;
+    const double thresh=1.e-7;
+    Tensor<double> cell(NDIM,2);
+    for (std::size_t i=0; i<NDIM; ++i) {
+        cell(i,0) = -11.0-2*i;  // Deliberately asymmetric bounding box
+        cell(i,1) =  10.0+i;
     }
     FunctionDefaults<NDIM>::set_cell(cell);
     FunctionDefaults<NDIM>::set_k(8);
@@ -104,54 +99,50 @@ void test_add(World& world) {
     FunctionDefaults<NDIM>::set_initial_level(3);
     FunctionDefaults<NDIM>::set_truncate_mode(1);
 
-    std::size_t nvec = 5;
-    std::vector<Function<T, NDIM>> add1(nvec), add2(nvec), sum(nvec), diff(nvec);
+    std::size_t nvec=5;
+    std::vector<Function<T,NDIM> > add1(nvec), add2(nvec), sum(nvec), diff(nvec);
 
-    for (int i = 0; i<nvec; ++i) {
-        add1[i] = FunctionFactory<T, NDIM>(world).functor([] (const Vector<double, 3>& r) {return r.normf();});
-        add2[i] = FunctionFactory<T, NDIM>(world).functor([] (const Vector<double, 3>& r) {return 2.0 * r.normf();});
-        sum[i] = FunctionFactory<T, NDIM>(world).functor([] (const Vector<double, 3>& r) {return 3.0 * r.normf();});
-        diff[i] = FunctionFactory<T, NDIM>(world).functor([] (const Vector<double, 3>& r) {return -1.0 * r.normf();});
+    for (int i=0; i<nvec; ++i) {
+        add1[i]=FunctionFactory<T,NDIM>(world).functor([] (const Vector<double,3>& r) {return r.normf();});
+        add2[i]=FunctionFactory<T,NDIM>(world).functor([] (const Vector<double,3>& r) {return 2.0*r.normf();});
+        sum[i]=FunctionFactory<T,NDIM>(world).functor([] (const Vector<double,3>& r) {return 3.0*r.normf();});
+        diff[i]=FunctionFactory<T,NDIM>(world).functor([] (const Vector<double,3>& r) {return -1.0*r.normf();});
     }
 
-    std::vector<Function<T, NDIM>> r1 = add1 + add2;
-    std::vector<Function<T, NDIM>> r3 = add1 + add2[0];
-    std::vector<Function<T, NDIM>> r5 = add1[0] + add2;
+    std::vector<Function<T,NDIM> > r1=add1+add2;
+    std::vector<Function<T,NDIM> > r3=add1+add2[0];
+    std::vector<Function<T,NDIM> > r5=add1[0]+add2;
 
-    std::vector<Function<T, NDIM>> r2 = add1 - add2;
-    std::vector<Function<T, NDIM>> r4 = add1 - add2[0];
-    std::vector<Function<T, NDIM>> r6 = add1[0] - add2;
+    std::vector<Function<T,NDIM> > r2=add1-add2;
+    std::vector<Function<T,NDIM> > r4=add1-add2[0];
+    std::vector<Function<T,NDIM> > r6=add1[0]-add2;
 
-    double error1 = 0.0, error2 = 0.0, error3 = 0.0, error4 = 0.0, error5 = 0.0, error6 = 0.0;
-    for (int i = 0; i < nvec; ++i) {
-    	error1 += (r1[i] - sum[i]).norm2();
-    	error3 += (r3[i] - sum[i]).norm2();
-    	error5 += (r5[i] - sum[i]).norm2();
+    double error1=0.0,error2=0.0,error3=0.0,error4=0.0,error5=0.0,error6=0.0;
+    for (int i=0; i<nvec; ++i) {
+    	error1+=(r1[i]-sum[i]).norm2();
+    	error3+=(r3[i]-sum[i]).norm2();
+    	error5+=(r5[i]-sum[i]).norm2();
 
-     	error2 += (r2[i] - diff[i]).norm2();
-    	error4 += (r4[i] - diff[i]).norm2();
-    	error6 += (r6[i] - diff[i]).norm2();
+    	error2+=(r2[i]-diff[i]).norm2();
+    	error4+=(r4[i]-diff[i]).norm2();
+    	error6+=(r6[i]-diff[i]).norm2();
     }
-    print("errors in add", error1, error3, error5, error2, error4, error6);
-    MADNESS_CHECK(error1 < FunctionDefaults<NDIM>::get_thresh());
-    MADNESS_CHECK(error3 < FunctionDefaults<NDIM>::get_thresh());
-    MADNESS_CHECK(error5 < FunctionDefaults<NDIM>::get_thresh());
-    MADNESS_CHECK(error2 < FunctionDefaults<NDIM>::get_thresh());
-    MADNESS_CHECK(error4 < FunctionDefaults<NDIM>::get_thresh());
-    MADNESS_CHECK(error6 < FunctionDefaults<NDIM>::get_thresh());
+    print("errors in add", error1,error3,error5,error2,error4,error6);
 
 }
 
+
+
 template <typename T, typename R, int NDIM, bool sym>
 void test_inner(World& world) {
-    typedef std::shared_ptr<FunctionFunctorInterface<T, NDIM>> ffunctorT;
-    typedef std::shared_ptr<FunctionFunctorInterface<R, NDIM>> gfunctorT;
+    typedef std::shared_ptr< FunctionFunctorInterface<T,NDIM> > ffunctorT;
+    typedef std::shared_ptr< FunctionFunctorInterface<R,NDIM> > gfunctorT;
 
-    const double thresh = 1.e-7;
-    Tensor<double> cell(NDIM, 2);
-    for (std::size_t i = 0; i < NDIM; ++i) {
-        cell(i, 0) = -11.0 - 2 * i;  // Deliberately asymmetric bounding box
-        cell(i, 1) =  10.0 + i;
+    const double thresh=1.e-7;
+    Tensor<double> cell(NDIM,2);
+    for (std::size_t i=0; i<NDIM; ++i) {
+        cell(i,0) = -11.0-2*i;  // Deliberately asymmetric bounding box
+        cell(i,1) =  10.0+i;
     }
     FunctionDefaults<NDIM>::set_cell(cell);
     FunctionDefaults<NDIM>::set_k(8);
@@ -163,58 +154,53 @@ void test_inner(World& world) {
     const int nleft=95, nright=sym ? nleft : 94;
 
     if (world.rank() == 0) 
-        print("testing matrix_inner<", archive::get_type_name<T>(), ", ", archive::get_type_name<R>(), ">", "sym  = ", sym);
+        print("testing matrix_inner<",archive::get_type_name<T>(),",",archive::get_type_name<R>(),">","sym =",sym);
 
     START_TIMER;
-    std::vector<Function<T, NDIM>> left(nleft);
-    for (int i = 0; i < nleft; ++i) {
-        ffunctorT f(RandomGaussian<T, NDIM>(FunctionDefaults<NDIM>::get_cell(), 0.5));
-        left[i] = FunctionFactory<T, NDIM>(world).functor(f);
+    std::vector< Function<T,NDIM> > left(nleft);
+    for (int i=0; i<nleft; ++i) {
+        ffunctorT f(RandomGaussian<T,NDIM>(FunctionDefaults<NDIM>::get_cell(),0.5));
+        left[i] = FunctionFactory<T,NDIM>(world).functor(f);
     }
-    std::vector<Function<R, NDIM>> right(nright);
-    std::vector<Function<R, NDIM>>* pright = &right;
+    std::vector< Function<R,NDIM> > right(nright);
+    std::vector< Function<R,NDIM> >* pright = &right;
     if (sym) {
-        pright = (std::vector<Function<R, NDIM>>*)(&left);
+        pright = (std::vector< Function<R,NDIM> >*)(&left);
     }
     else {
-        for (int i = 0; i < nright; ++i) {
-            gfunctorT f(RandomGaussian<R, NDIM>(FunctionDefaults<NDIM>::get_cell(), 0.5));
-            right[i] = FunctionFactory<R, NDIM>(world).functor(f);
+        for (int i=0; i<nright; ++i) {
+            gfunctorT f(RandomGaussian<R,NDIM>(FunctionDefaults<NDIM>::get_cell(),0.5));
+            right[i] = FunctionFactory<R,NDIM>(world).functor(f);
         }
     }
     END_TIMER("project");
 
     START_TIMER;
-    compress(world, left);
-    compress(world, right);
+    compress(world,left);
+    compress(world,right);
     END_TIMER("compress");
     
     START_TIMER;
-    Tensor<TENSOR_RESULT_TYPE(T, R)> rnew = matrix_inner(world, left, *pright, sym);
+    Tensor<TENSOR_RESULT_TYPE(T,R)> rnew = matrix_inner(world,left,*pright,sym);
     END_TIMER("new");
-
     START_TIMER;
-    Tensor<TENSOR_RESULT_TYPE(T, R)> rold = matrix_inner_old(world, left, *pright, sym);
+    Tensor<TENSOR_RESULT_TYPE(T,R)> rold = matrix_inner_old(world,left,*pright,sym);
     END_TIMER("old");
 
     if (world.rank() == 0) 
-        print("error norm", (rold - rnew).normf(), "\n");
-    
-    // With sym = true, the error is larger on the order of 2.0e-6
-    auto check_thresh = (sym) ? 50 * thresh : thresh;
-    MADNESS_CHECK((rold - rnew).normf() < check_thresh);
+        print("error norm",(rold-rnew).normf(),"\n");
 }
 
 template <typename T, typename R, int NDIM, bool sym>
 void test_dot(World& world) {
-    typedef std::shared_ptr<FunctionFunctorInterface<T, NDIM>> ffunctorT;
-    typedef std::shared_ptr<FunctionFunctorInterface<R, NDIM>> gfunctorT;
+    typedef std::shared_ptr< FunctionFunctorInterface<T,NDIM> > ffunctorT;
+    typedef std::shared_ptr< FunctionFunctorInterface<R,NDIM> > gfunctorT;
 
-    const double thresh = 1.e-7;
-    Tensor<double> cell(NDIM, 2);
-    for (std::size_t i = 0; i < NDIM; ++i) {
-        cell(i, 0) = -11.0 - 2 * i;  // Deliberately asymmetric bounding box
-        cell(i, 1) =  10.0 + i;
+    const double thresh=1.e-7;
+    Tensor<double> cell(NDIM,2);
+    for (std::size_t i=0; i<NDIM; ++i) {
+        cell(i,0) = -11.0-2*i;  // Deliberately asymmetric bounding box
+        cell(i,1) =  10.0+i;
     }
     FunctionDefaults<NDIM>::set_cell(cell);
     FunctionDefaults<NDIM>::set_k(8);
@@ -223,60 +209,58 @@ void test_dot(World& world) {
     FunctionDefaults<NDIM>::set_initial_level(3);
     FunctionDefaults<NDIM>::set_truncate_mode(1);
 
-    const int nleft = 95, nright = sym ? nleft : 94;
+    const int nleft=95, nright=sym ? nleft : 94;
 
     if (world.rank() == 0)
-        print("testing matrix_dot<", archive::get_type_name<T>(), ", ", archive::get_type_name<R>(), ">", "sym  = ", sym);
+        print("testing matrix_dot<",archive::get_type_name<T>(),",",archive::get_type_name<R>(),">","sym =",sym);
 
     START_TIMER;
-    std::vector<Function<T, NDIM>> left(nleft);
-    for (int i = 0; i < nleft; ++i) {
-        ffunctorT f(RandomGaussian<T, NDIM>(FunctionDefaults<NDIM>::get_cell(), 0.5));
-        left[i] = FunctionFactory<T, NDIM>(world).functor(f);
+    std::vector< Function<T,NDIM> > left(nleft);
+    for (int i=0; i<nleft; ++i) {
+        ffunctorT f(RandomGaussian<T,NDIM>(FunctionDefaults<NDIM>::get_cell(),0.5));
+        left[i] = FunctionFactory<T,NDIM>(world).functor(f);
     }
-    std::vector<Function<R, NDIM>> right(nright);
-    std::vector<Function<R, NDIM>>* pright = &right;
+    std::vector< Function<R,NDIM> > right(nright);
+    std::vector< Function<R,NDIM> >* pright = &right;
     if (sym) {
-        pright = (std::vector< Function<R, NDIM>>*)(&left);
+        pright = (std::vector< Function<R,NDIM> >*)(&left);
     }
     else {
-        for (int i = 0; i < nright; ++i) {
-            gfunctorT f(RandomGaussian<R, NDIM>(FunctionDefaults<NDIM>::get_cell(), 0.5));
-            right[i] = FunctionFactory<R, NDIM>(world).functor(f);
+        for (int i=0; i<nright; ++i) {
+            gfunctorT f(RandomGaussian<R,NDIM>(FunctionDefaults<NDIM>::get_cell(),0.5));
+            right[i] = FunctionFactory<R,NDIM>(world).functor(f);
         }
     }
     END_TIMER("project");
 
     START_TIMER;
-    compress(world, left);
-    compress(world, right);
+    compress(world,left);
+    compress(world,right);
     END_TIMER("compress");
 
     START_TIMER;
-    Tensor<TENSOR_RESULT_TYPE(T, R)> rnew = matrix_dot(world, left, *pright, sym);
+    Tensor<TENSOR_RESULT_TYPE(T,R)> rnew = matrix_dot(world,left,*pright,sym);
     END_TIMER("new");
     START_TIMER;
-    Tensor<TENSOR_RESULT_TYPE(T, R)> rold = matrix_inner(world,
-                                                         madness::conj(world, left),
-                                                         *pright, sym);
+    Tensor<TENSOR_RESULT_TYPE(T,R)> rold = matrix_dot_old(world,left,*pright,sym);
     END_TIMER("old");
 
     if (world.rank() == 0) 
-        print("error norm", (rold - rnew).normf(), "\n");
-    MADNESS_CHECK((rold - rnew).normf() < FunctionDefaults<NDIM>::get_thresh());
+        print("error norm",(rold-rnew).normf(),"\n");
 }
 
 template<typename T, std::size_t NDIM>
 int test_transform(World& world) {
     test_output to("testing transform");
     to.set_cout_to_terminal();
-    typedef std::shared_ptr<FunctionFunctorInterface<T, NDIM>> ffunctorT;
+    typedef std::shared_ptr< FunctionFunctorInterface<T,NDIM> > ffunctorT;
 
-    const double thresh = 1.e-7;
-    Tensor<double> cell(NDIM, 2);
-    for (std::size_t i = 0; i < NDIM; ++i) {
-        cell(i, 0) = -11.0 - 2 * i;  // Deliberately asymmetric bounding box
-        cell(i, 1) =  10.0 + i;
+
+    const double thresh=1.e-7;
+    Tensor<double> cell(NDIM,2);
+    for (std::size_t i=0; i<NDIM; ++i) {
+        cell(i,0) = -11.0-2*i;  // Deliberately asymmetric bounding box
+        cell(i,1) =  10.0+i;
     }
     FunctionDefaults<NDIM>::set_cell(cell);
     FunctionDefaults<NDIM>::set_k(8);
@@ -285,50 +269,55 @@ int test_transform(World& world) {
     FunctionDefaults<NDIM>::set_initial_level(3);
     FunctionDefaults<NDIM>::set_truncate_mode(1);
 
-    const int nleft = RandomValue<int>()%10;
-    const int nright = RandomValue<int>()%10;
-    print("nleft, nright", nleft, nright);
+
+    const int nleft=RandomValue<int>()%10;
+    const int nright=RandomValue<int>()%10;
+    print("nleft, nright",nleft,nright);
 
     START_TIMER;
-    std::vector<Function<T, NDIM>> left(nleft);
-    for (int i = 0; i < nleft; ++i) {
-        ffunctorT f(RandomGaussian<T, NDIM>(FunctionDefaults<NDIM>::get_cell(), 0.5));
-        left[i] = FunctionFactory<T, NDIM>(world).functor(f);
+    std::vector< Function<T,NDIM> > left(nleft);
+    for (int i=0; i<nleft; ++i) {
+        ffunctorT f(RandomGaussian<T,NDIM>(FunctionDefaults<NDIM>::get_cell(),0.5));
+        left[i] = FunctionFactory<T,NDIM>(world).functor(f);
     }
     END_TIMER("project");
-    to.checkpoint(true, "initial projection");
+    to.checkpoint(true,"initial projection");
 
-    Tensor<T> c(nleft, nright);
-    auto result1 = transform(world, left, c);
-    to.checkpoint(true, "reference transform");
+    Tensor<T> c(nleft,nright);
+    auto result1=transform(world,left,c);
+    to.checkpoint(true,"reference transform");
 
-    change_tree_state(left, reconstructed);
-    auto result2 = transform_reconstructed(world, left, c, false);
+    change_tree_state(left,reconstructed);
+    auto result2=transform_reconstructed(world,left,c,false);
     world.gop.fence();
-    for (auto& r : result2)
-        MADNESS_CHECK(r.get_impl()->get_tree_state() == redundant_after_merge);
-    change_tree_state(result2, reconstructed);
-    double err1 = norm2(world, result1 - result2);
-    to.checkpoint(err1, thresh, "reference transform");
+    for (auto& r : result2) MADNESS_CHECK(r.get_impl()->get_tree_state()==redundant_after_merge);
+    change_tree_state(result2,reconstructed);
+    double err1=norm2(world, result1-result2);
+    to.checkpoint(err1,thresh,"reference transform");
 
-    change_tree_state(left, compressed);
-    auto result3 = transform_reconstructed(world, left, c);
-    double err2 = norm2(world, result1 - result3);
-    to.checkpoint(err2, thresh, "reference transform");
+    change_tree_state(left,compressed);
+    auto result3=transform_reconstructed(world,left,c);
+    double err2=norm2(world, result1-result3);
+    to.checkpoint(err2,thresh,"reference transform");
+
 
     return to.end();
 }
 
+
+
+
+
 template <typename T, typename R, int NDIM>
 void test_cross(World& world) {
-    typedef std::shared_ptr<FunctionFunctorInterface<T, NDIM>> ffunctorT;
-    typedef std::shared_ptr<FunctionFunctorInterface<R, NDIM>> gfunctorT;
+    typedef std::shared_ptr< FunctionFunctorInterface<T,NDIM> > ffunctorT;
+    typedef std::shared_ptr< FunctionFunctorInterface<R,NDIM> > gfunctorT;
 
-    const double thresh = 1.e-7;
-    Tensor<double> cell(NDIM, 2);
-    for (std::size_t i = 0; i < NDIM; ++i) {
-        cell(i, 0) = -11.0 - 2 * i;  // Deliberately asymmetric bounding box
-        cell(i, 1) =  10.0 + i;
+    const double thresh=1.e-7;
+    Tensor<double> cell(NDIM,2);
+    for (std::size_t i=0; i<NDIM; ++i) {
+        cell(i,0) = -11.0-2*i;  // Deliberately asymmetric bounding box
+        cell(i,1) =  10.0+i;
     }
     FunctionDefaults<NDIM>::set_cell(cell);
     FunctionDefaults<NDIM>::set_k(8);
@@ -337,63 +326,61 @@ void test_cross(World& world) {
     FunctionDefaults<NDIM>::set_initial_level(3);
     FunctionDefaults<NDIM>::set_truncate_mode(1);
 
-    const int nleft = 3, nright = 3;
+    const int nleft=3, nright=3;
 
     if (world.rank() == 0)
-        print("testing  cross product<", archive::get_type_name<T>(), ", ", archive::get_type_name<R>(), ">");
+        print("testing  cross product<",archive::get_type_name<T>(),",",archive::get_type_name<R>(),">");
 
     START_TIMER;
-    std::vector<Function<T, NDIM>> left(nleft);
-    for (int i = 0; i < nleft; ++i) {
-        ffunctorT f(RandomGaussian<T, NDIM>(FunctionDefaults<NDIM>::get_cell(), 0.5));
-        left[i] = FunctionFactory<T, NDIM>(world).functor(f);
+    std::vector< Function<T,NDIM> > left(nleft);
+    for (int i=0; i<nleft; ++i) {
+        ffunctorT f(RandomGaussian<T,NDIM>(FunctionDefaults<NDIM>::get_cell(),0.5));
+        left[i] = FunctionFactory<T,NDIM>(world).functor(f);
     }
-    std::vector<Function<R, NDIM>> right(nright);
-    for (int i = 0; i<nright; ++i) {
-    	gfunctorT f(RandomGaussian<R, NDIM>(FunctionDefaults<NDIM>::get_cell(), 0.5));
-    	right[i] = FunctionFactory<R, NDIM>(world).functor(f);
+    std::vector< Function<R,NDIM> > right(nright);
+    for (int i=0; i<nright; ++i) {
+    	gfunctorT f(RandomGaussian<R,NDIM>(FunctionDefaults<NDIM>::get_cell(),0.5));
+    	right[i] = FunctionFactory<R,NDIM>(world).functor(f);
     }
     END_TIMER("project");
 
     START_TIMER;
-    compress(world, left);
-    compress(world, right);
+    compress(world,left);
+    compress(world,right);
     END_TIMER("compress");
 
     // cross product is anti-commuting
-    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>> result1 = cross(left, right) + cross(right, left);
-    double err1 = norm2(world, result1);
-    if (world.rank() == 0) print("error norm1", err1, "\n");
-    MADNESS_CHECK(err1 < FunctionDefaults<NDIM>::get_thresh());
+    std::vector<Function<TENSOR_RESULT_TYPE(T,R),NDIM> > result1=cross(left,right)+cross(right,left);
+    double err1=norm2(world,result1);
+    if (world.rank() == 0) print("error norm1",err1,"\n");
 
     // cross product with self vanishes
-    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>> result2 = cross(left, left);
-    double err2 = norm2(world, result2);
-    if (world.rank() == 0) print("error norm2", err2, "\n");
-    MADNESS_CHECK(err2 < FunctionDefaults<NDIM>::get_thresh());
+    std::vector<Function<TENSOR_RESULT_TYPE(T,R),NDIM> > result2=cross(left,left);
+    double err2=norm2(world,result2);
+    if (world.rank() == 0) print("error norm2",err2,"\n");
 
     // cross product with self vanishes
-    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>> result3 = cross(left, right);
-    Function<TENSOR_RESULT_TYPE(T, R), NDIM> reference0 = left[1] * right[2] - left[2] * right[1];
+    std::vector<Function<TENSOR_RESULT_TYPE(T,R),NDIM> > result3=cross(left,right);
+    Function<TENSOR_RESULT_TYPE(T,R), NDIM> reference0=left[1]*right[2] - left[2]*right[1];
 
-    double err3 = (reference0 - result3[0]).norm2();
-    if (world.rank() == 0) print("error norm3", err3, "\n");
-    MADNESS_CHECK(err3 < FunctionDefaults<NDIM>::get_thresh());
+    double err3=(reference0-result3[0]).norm2();
+    if (world.rank() == 0) print("error norm3",err3,"\n");
 
-    double err4 = (result3[0]).norm2();
-    if (world.rank() == 0) print("norm of i-component", err4, " (should not be zero)\n");
+    double err4=(result3[0]).norm2();
+    if (world.rank() == 0) print("error norm4",err4," (should not be zero)\n");
+
 }
 
 
 template <typename T, int NDIM>
 void test_rot(World& world) {
-    typedef std::shared_ptr<FunctionFunctorInterface<T, NDIM>> ffunctorT;
+    typedef std::shared_ptr< FunctionFunctorInterface<T,NDIM> > ffunctorT;
 
-    const double thresh = 1.e-7;
-    Tensor<double> cell(NDIM, 2);
-    for (std::size_t i = 0; i < NDIM; ++i) {
-        cell(i, 0) = -11.0 - 2 * i;  // Deliberately asymmetric bounding box
-        cell(i, 1) =  10.0 + i;
+    const double thresh=1.e-7;
+    Tensor<double> cell(NDIM,2);
+    for (std::size_t i=0; i<NDIM; ++i) {
+        cell(i,0) = -11.0-2*i;  // Deliberately asymmetric bounding box
+        cell(i,1) =  10.0+i;
     }
     FunctionDefaults<NDIM>::set_cell(cell);
     FunctionDefaults<NDIM>::set_k(8);
@@ -402,39 +389,41 @@ void test_rot(World& world) {
     FunctionDefaults<NDIM>::set_initial_level(3);
     FunctionDefaults<NDIM>::set_truncate_mode(1);
 
-    const int nleft = 3;
+    const int nleft=3;
 
     if (world.rank() == 0)
-        print("testing rot operator<", archive::get_type_name<T>(), ", ", archive::get_type_name<T>(), ">");
+        print("testing rot operator<",archive::get_type_name<T>(),",",archive::get_type_name<T>(),">");
 
     START_TIMER;
-    std::vector< Function<T, NDIM>> left(nleft);
-    for (int i = 0; i < nleft; ++i) {
-        ffunctorT f(RandomGaussian<T, NDIM>(FunctionDefaults<NDIM>::get_cell(), 0.5));
-        left[i] = FunctionFactory<T, NDIM>(world).functor(f);
+    std::vector< Function<T,NDIM> > left(nleft);
+    for (int i=0; i<nleft; ++i) {
+        ffunctorT f(RandomGaussian<T,NDIM>(FunctionDefaults<NDIM>::get_cell(),0.5));
+        left[i] = FunctionFactory<T,NDIM>(world).functor(f);
     }
     END_TIMER("project");
 
     START_TIMER;
-    compress(world, left);
+    compress(world,left);
     END_TIMER("compress");
 
     // rot grad v vanishes
-    std::vector<Function<T, NDIM>> result1 = rot(grad(left[0]));
-    double err1 = norm2(world, result1);
-    if (world.rank() == 0) print("error norm1", err1, "\n");
+    std::vector<Function<T,NDIM> > result1=rot(grad(left[0]));
+    double err1=norm2(world,result1);
+    if (world.rank() == 0) print("error norm1",err1,"\n");
 
     // div rot v vanishes
-    Function<T, NDIM> result2 = div(rot(left));
-    double err2 = result2.norm2();
-    if (world.rank() == 0) print("error norm2", err2, "\n");
+    Function<T,NDIM> result2=div(rot(left));
+    double err2=result2.norm2();
+    if (world.rank() == 0) print("error norm2",err2,"\n");
+
+
 }
 
 template<typename T, int NDIM>
 void test_matrix_mul_sparse(World &world) {
-    typedef std::shared_ptr<FunctionFunctorInterface<T, NDIM>> ffunctorT;
+    typedef std::shared_ptr<FunctionFunctorInterface<T, NDIM> > ffunctorT;
 
-    if (world.rank() == 0) print("entering test_mul_sparse");
+    if (world.rank()==0) print("entering test_mul_sparse");
     const double thresh = 1.e-7;
     Tensor<double> cell(NDIM, 2);
     for (std::size_t i = 0; i < NDIM; ++i) {
@@ -451,12 +440,12 @@ void test_matrix_mul_sparse(World &world) {
     START_TIMER;
     const long nrow = 3;
     const long ncolumn = 4;
-    std::vector<Function<T, NDIM>> row(nrow);
+    std::vector<Function<T, NDIM> > row(nrow);
     for (long i = 0; i < nrow; ++i) {
         ffunctorT f(RandomGaussian<T, NDIM>(FunctionDefaults<NDIM>::get_cell(), 0.5));
         row[i] = FunctionFactory<T, NDIM>(world).functor(f);
     }
-    std::vector<Function<T, NDIM>> column(ncolumn);
+    std::vector<Function<T, NDIM> > column(ncolumn);
     for (long i = 0; i < ncolumn; ++i) {
         ffunctorT f(RandomGaussian<T, NDIM>(FunctionDefaults<NDIM>::get_cell(), 0.5));
         column[i] = FunctionFactory<T, NDIM>(world).functor(f);
@@ -467,30 +456,36 @@ void test_matrix_mul_sparse(World &world) {
     auto result = matrix_mul_sparse<T, T, NDIM>(world, row, column, 0.0);
     END_TIMER("matrix_mul_sparse");
 
-    MADNESS_CHECK(result.size() == nrow);
+
+
+    MADNESS_CHECK(result.size()==nrow);
     for (long i = 0; i < nrow; ++i) {
-        MADNESS_CHECK(result[i].size() == ncolumn);
+        MADNESS_CHECK(result[i].size()==ncolumn);
         for (long j = 0; j < ncolumn; ++j) {
             Function<T, NDIM> tmp = row[i] * column[j];
-            double err = (tmp-result[i][j]).norm2();
-            MADNESS_CHECK(err < 1.e-10);
+            double err=(tmp-result[i][j]).norm2();
+            MADNESS_CHECK(err<1.e-10);
         }
     }
 
-    if (world.rank() == 0) print("leaving test_mul_sparse");
+    if (world.rank()==0) print("leaving test_mul_sparse");
 }
+
+
+
 
 template <std::size_t NDIM>
 void test_multi_to_multi_op(World& world) {
-    typedef Function<double, NDIM> functionT;
-    typedef std::vector<Function<double, NDIM>> vecfuncT;
-    typedef std::shared_ptr<FunctionFunctorInterface<double, NDIM>> ffunctorT;
 
-    const double thresh = 1.e-7;
-    Tensor<double> cell(NDIM, 2);
-    for (std::size_t i = 0; i < NDIM; ++i) {
-        cell(i, 0) = -11.0 - 2 * i;  // Deliberately asymmetric bounding box
-        cell(i, 1) =  10.0 + i;
+    typedef Function<double,NDIM> functionT;
+    typedef std::vector<Function<double,NDIM> > vecfuncT;
+    typedef std::shared_ptr< FunctionFunctorInterface<double,NDIM> > ffunctorT;
+
+    const double thresh=1.e-7;
+    Tensor<double> cell(NDIM,2);
+    for (std::size_t i=0; i<NDIM; ++i) {
+        cell(i,0) = -11.0-2*i;  // Deliberately asymmetric bounding box
+        cell(i,1) =  10.0+i;
     }
     FunctionDefaults<NDIM>::set_cell(cell);
     FunctionDefaults<NDIM>::set_k(8);
@@ -499,84 +494,74 @@ void test_multi_to_multi_op(World& world) {
     FunctionDefaults<NDIM>::set_initial_level(3);
     FunctionDefaults<NDIM>::set_truncate_mode(1);
 
+
     many_to_many_op<NDIM> op;
     vecfuncT vin(3);
 
     for (functionT& in : vin) {
-        ffunctorT f(RandomGaussian<double, NDIM>(FunctionDefaults<NDIM>::get_cell(), 0.5));
-        in = FunctionFactory<double, NDIM>(world).functor(f);
+        ffunctorT f(RandomGaussian<double,NDIM>(FunctionDefaults<NDIM>::get_cell(),0.5));
+        in=FunctionFactory<double,NDIM>(world).functor(f);
     }
-    refine_to_common_level(world, vin);
+    refine_to_common_level(world,vin);
 
-    vecfuncT vout = multi_to_multi_op_values(op, vin);
+    vecfuncT vout=multi_to_multi_op_values(op, vin);
 
     std::vector<functionT> result(2);
-    result[0] = 2.0 * vin[0] - vout[0];
-    result[1] = vout[1] - vin[1] - vin[2];
+    result[0]=2.0*vin[0]-vout[0];
+    result[1]=vout[1]-vin[1]-vin[2];
 
-    double norm_in = norm2(world, vin);
-    double norm_out = norm2(world, vout);
-    double error = norm2(world, result);
-    if (world.rank() == 0) print("error in multi_to_multi ", error, norm_in, norm_out);
-    MADNESS_CHECK(error < FunctionDefaults<NDIM>::get_thresh());
+    double norm_in=norm2(world,vin);
+    double norm_out=norm2(world,vout);
+    double error=norm2(world,result);
+    if (world.rank()==0) print("error in multi_to_multi ",error,norm_in,norm_out);
+
 }
-
 
 int main(int argc, char**argv) {
     initialize(argc, argv);
     World world(SafeMPI::COMM_WORLD);
 
     bool smalltest = false;
-    if (getenv("MAD_SMALL_TESTS")) smalltest = true;
-    for (int iarg = 1; iarg < argc; iarg++) if (strcmp(argv[iarg], "--small") == 0) smalltest = true;
+    if (getenv("MAD_SMALL_TESTS")) smalltest=true;
+    for (int iarg=1; iarg<argc; iarg++) if (strcmp(argv[iarg],"--small")==0) smalltest=true;
     std::cout << "small test : " << smalltest << std::endl;
     if (smalltest) return 0;
-    madness::default_random_generator.setstate(int(cpu_time() * 1000) % 4149);
+    madness::default_random_generator.setstate(int(cpu_time()*1000)%4149);
+
 
     try {
-        startup(world, argc, argv);
+        startup(world,argc,argv);
 
-        // test_add<double, 3>(world);
-        // test_add<std::complex<double>, 3 >(world);
+        // test_add<double,3>(world);
+        // test_add<std::complex<double>,3 >(world);
 
-        test_inner<double, double, 1, false>(world);
-        test_inner<double, double, 1, true>(world);
-
-        test_dot<double, double, 1, false>(world);
-        test_dot<double, double, 1, true>(world);
-
+        test_inner<double,double,1,false>(world);
+        test_inner<double,double,1,true>(world);
         test_multi_to_multi_op<1>(world);
         test_multi_to_multi_op<2>(world);
 
-        test_cross<double, double, 2>(world);
-        test_cross<std::complex<double>, double, 2>(world);
-        test_cross<std::complex<double>, std::complex<double>, 2>(world);
+        test_cross<double,double,2>(world);
+        test_cross<std::complex<double>,double,2>(world);
+        test_cross<std::complex<double>,std::complex<double>,2>(world);
 
-        test_transform<double, 2>(world);
-        test_transform<double, 2>(world);
-        test_transform<double, 2>(world);
-        test_transform<double, 2>(world);
+        test_transform<double,2>(world);
+        test_transform<double,2>(world);
+        test_transform<double,2>(world);
+        test_transform<double,2>(world);
 
-        test_rot<double, 3>(world);
-        test_rot<std::complex<double>, 3>(world);
+        test_rot<double,3>(world);
+        test_rot<std::complex<double>,3>(world);
 
-        test_matrix_mul_sparse<double, 2>(world);
-        test_matrix_mul_sparse<double, 3>(world);
+        test_matrix_mul_sparse<double,2>(world);
+        test_matrix_mul_sparse<double,3>(world);
 
         if (!smalltest) test_multi_to_multi_op<3>(world);
 #if !HAVE_GENTENSOR
-        test_inner<double, std::complex<double>, 1, false>(world);
+        test_inner<double,std::complex<double>,1,false>(world);
         if (!smalltest) {
-            test_inner<std::complex<double>, double, 1, false>(world);
-            test_inner<std::complex<double>, std::complex<double>, 1, false>(world);
-            test_inner<std::complex<double>, std::complex<double>, 1, true>(world);
-        }
-
-        test_dot<double, std::complex<double>, 1, false>(world);
-        if (!smalltest) {
-            test_dot<std::complex<double>, double, 1, false>(world);
-            test_dot<std::complex<double>, std::complex<double>, 1, false>(world);
-            test_dot<std::complex<double>, std::complex<double>, 1, true>(world);
+            test_inner<std::complex<double>,double,1,false>(world);
+            test_inner<std::complex<double>,std::complex<double>,1,false>(world);
+            test_inner<std::complex<double>,std::complex<double>,1,true>(world);
         }
 #endif
     }

--- a/src/madness/mra/testvmra.cc
+++ b/src/madness/mra/testvmra.cc
@@ -252,8 +252,8 @@ void test_dot(World& world) {
     END_TIMER("new");
     START_TIMER;
     Tensor<TENSOR_RESULT_TYPE(T, R)> rold = matrix_inner(world,
-                                                        conj(world, left),
-                                                        *pright, sym);
+                                                         conj(world, left),
+                                                         *pright, sym);
     END_TIMER("old");
 
     if (world.rank() == 0) 

--- a/src/madness/mra/vmra.h
+++ b/src/madness/mra/vmra.h
@@ -924,7 +924,7 @@ namespace madness {
                 int64_t jhi = std::min(jlo + jchunk, m);
                 std::vector< Function<T,NDIM> > jvec(g.begin()+jlo, g.begin()+jhi);
 
-               Tensor<T> P = matrix_inner(A.get_world(), ivec, jvec);
+                Tensor<T> P = matrix_inner(A.get_world(), ivec, jvec);
                 A.copy_from_replicated_patch(ilo, ihi - 1, jlo, jhi - 1, P);
             }
         }
@@ -946,7 +946,6 @@ namespace madness {
         compress(world, f);
 //        if ((void*)(&f) != (void*)(&g)) compress(world, g);
         compress(world, g);
-
 
 
         std::vector<const FunctionImpl<T,NDIM>*> left(f.size());

--- a/src/madness/mra/vmra.h
+++ b/src/madness/mra/vmra.h
@@ -89,7 +89,7 @@
 
 	*) set_thresh: setting a finite thresh-hold for a vector of functions
 	\code
-	void set_thresh(World& world, std::vector< Function<T,NDIM> >& v, double thresh, bool fence=true);
+	void set_thresh(World& world, std::vector<Function<T, NDIM>>& v, double thresh, bool fence=true);
 	\endcode
 
 	Arithmetic Operations on arrays of functions
@@ -114,9 +114,6 @@
 	    - norm2s
 	*) scale(world, v, alpha);
 
-
-
-
 */
 
 #include <madness/mra/mra.h>
@@ -131,13 +128,13 @@ namespace madness {
     /// Compress a vector of functions
     template <typename T, std::size_t NDIM>
     void compress(World& world,
-                  const std::vector< Function<T,NDIM> >& v,
+                  const std::vector<Function<T, NDIM>>& v,
                   bool fence=true) {
 
         PROFILE_BLOCK(Vcompress);
         change_tree_state(v, TreeState::compressed, fence);
 //        bool must_fence = false;
-//        for (unsigned int i=0; i<v.size(); ++i) {
+//        for (unsigned int i = 0; i < v.size(); ++i) {
 //            if (!v[i].is_compressed()) {
 //                v[i].compress(false);
 //                must_fence = true;
@@ -153,7 +150,7 @@ namespace madness {
     /// implies fence
     /// return v for chaining
     template <typename T, std::size_t NDIM>
-    const std::vector< Function<T,NDIM> >& reconstruct(const std::vector< Function<T,NDIM> >& v) {
+    const std::vector<Function<T, NDIM>>& reconstruct(const std::vector<Function<T, NDIM>>& v) {
         return change_tree_state(v, TreeState::reconstructed, true);
     }
 
@@ -162,50 +159,50 @@ namespace madness {
     /// implies fence
     /// return v for chaining
     template <typename T, std::size_t NDIM>
-    const std::vector< Function<T,NDIM> >& compress(const std::vector< Function<T,NDIM> >& v) {
+    const std::vector<Function<T, NDIM>>& compress(const std::vector<Function<T, NDIM>>& v) {
         return change_tree_state(v, TreeState::compressed, true);
     }
 
     /// Reconstruct a vector of functions
     template <typename T, std::size_t NDIM>
     void reconstruct(World& world,
-                     const std::vector< Function<T,NDIM> >& v,
+                     const std::vector<Function<T, NDIM>>& v,
                      bool fence=true) {
         PROFILE_BLOCK(Vreconstruct);
-//        bool must_fence = false;
+        // bool must_fence = false;
         change_tree_state(v, TreeState::reconstructed, fence);
-//        for (unsigned int i=0; i<v.size(); ++i) {
-//            if (v[i].is_compressed() or v[i].is_nonstandard()) {
-//                v[i].reconstruct(false);
-//                must_fence = true;
-//            }
-//        }
-//
-//        if (fence && must_fence) world.gop.fence();
+        // for (unsigned int i = 0; i < v.size(); ++i) {
+        //     if (v[i].is_compressed() or v[i].is_nonstandard()) {
+        //         v[i].reconstruct(false);
+        //         must_fence = true;
+        //     }
+        // }
+
+        // if (fence && must_fence) world.gop.fence();
     }
 
     /// change tree_state of a vector of functions to redundant
     template <typename T, std::size_t NDIM>
     void make_redundant(World& world,
-                  const std::vector< Function<T,NDIM> >& v,
-                  bool fence=true) {
+                        const std::vector<Function<T, NDIM>>& v,
+                        bool fence=true) {
 
         PROFILE_BLOCK(Vcompress);
         change_tree_state(v, TreeState::redundant, fence);
-//        bool must_fence = false;
-//        for (unsigned int i=0; i<v.size(); ++i) {
-//            if (!v[i].get_impl()->is_redundant()) {
-//                v[i].get_impl()->make_redundant(false);
-//                must_fence = true;
-//            }
-//        }
-//
-//        if (fence && must_fence) world.gop.fence();
+        // bool must_fence = false;
+        // for (unsigned int i = 0; i < v.size(); ++i) {
+        //     if (!v[i].get_impl()->is_redundant()) {
+        //         v[i].get_impl()->make_redundant(false);
+        //         must_fence = true;
+        //     }
+        // }
+
+        // if (fence && must_fence) world.gop.fence();
     }
 
     /// refine the functions according to the autorefine criteria
     template <typename T, std::size_t NDIM>
-    void refine(World& world, const std::vector<Function<T,NDIM> >& vf,
+    void refine(World& world, const std::vector<Function<T, NDIM>>& vf,
             bool fence=true) {
         for (const auto& f : vf) f.refine(false);
         if (fence) world.gop.fence();
@@ -215,57 +212,57 @@ namespace madness {
 
     /// if functions are not initialized (impl==NULL) they are ignored
     template <typename T, std::size_t NDIM>
-    void refine_to_common_level(World& world, std::vector<Function<T,NDIM> >& vf,
+    void refine_to_common_level(World& world, std::vector<Function<T, NDIM>>& vf,
             bool fence=true) {
 
         reconstruct(world,vf);
         Key<NDIM> key0(0, Vector<Translation, NDIM> (0));
-        std::vector<FunctionImpl<T,NDIM>*> v_ptr;
+        std::vector<FunctionImpl<T, NDIM>*> v_ptr;
 
         // push initialized function pointers into the vector v_ptr
-        for (unsigned int i=0; i<vf.size(); ++i) {
+        for (unsigned int i = 0; i < vf.size(); ++i) {
             if (vf[i].is_initialized()) v_ptr.push_back(vf[i].get_impl().get());
         }
 
         // sort and remove duplicates to not confuse the refining function
-        std::sort(v_ptr.begin(),v_ptr.end());
+        std::sort(v_ptr.begin(), v_ptr.end());
         typename std::vector<FunctionImpl<T, NDIM>*>::iterator it;
         it = std::unique(v_ptr.begin(), v_ptr.end());
         v_ptr.resize( std::distance(v_ptr.begin(),it) );
 
-        std::vector< Tensor<T> > c(v_ptr.size());
+        std::vector<Tensor<T>> c(v_ptr.size());
         v_ptr[0]->refine_to_common_level(v_ptr, c, key0);
         if (fence) v_ptr[0]->world.gop.fence();
         if (VERIFY_TREE)
-            for (unsigned int i=0; i<vf.size(); i++) vf[i].verify_tree();
+            for (unsigned int i = 0; i < vf.size(); i++) vf[i].verify_tree();
     }
 
     /// Generates non-standard form of a vector of functions
     template <typename T, std::size_t NDIM>
     void make_nonstandard(World& world,
-                          std::vector< Function<T,NDIM> >& v,
-                          bool fence= true) {
+                          std::vector<Function<T, NDIM>>& v,
+                          bool fence=true) {
         PROFILE_BLOCK(Vnonstandard);
         change_tree_state(v, TreeState::nonstandard, fence);
-//        reconstruct(world, v);
-//        for (unsigned int i=0; i<v.size(); ++i) {
-//            v[i].make_nonstandard(false, false);
-//        }
-//        if (fence) world.gop.fence();
+        // reconstruct(world, v);
+        // for (unsigned int i = 0; i < v.size(); ++i) {
+        //     v[i].make_nonstandard(false, false);
+        // }
+        // if (fence) world.gop.fence();
     }
 
 
     /// Generates standard form of a vector of functions
     template <typename T, std::size_t NDIM>
     void standard(World& world,
-                  std::vector< Function<T,NDIM> >& v,
+                  std::vector<Function<T, NDIM>>& v,
                   bool fence=true) {
         PROFILE_BLOCK(Vstandard);
         change_tree_state(v, TreeState::compressed, fence);
-//        for (unsigned int i=0; i<v.size(); ++i) {
-//            v[i].standard(false);
-//        }
-//        if (fence) world.gop.fence();
+        // for (unsigned int i = 0; i < v.size(); ++i) {
+        //     v[i].standard(false);
+        // }
+        // if (fence) world.gop.fence();
     }
 
 
@@ -274,56 +271,57 @@ namespace madness {
     /// will respect fence
     /// @return v   for chaining
     template <typename T, std::size_t NDIM>
-    const std::vector<Function<T,NDIM>>& change_tree_state(const std::vector<Function<T,NDIM>>& v,
-                                                     const TreeState finalstate,
-                                                     const bool fence=true) {
-        if (v.size()==0) return v;
+    const std::vector<Function<T, NDIM>>& change_tree_state(
+        const std::vector<Function<T, NDIM>>& v,
+        const TreeState finalstate,
+        const bool fence=true) {
+
+        if (v.size() == 0) return v;
         // find initialized function with world
-        Function<T,NDIM> dummy;
+       Function<T, NDIM> dummy;
         for (const auto& f : v)
             if (f.is_initialized()) {
-                dummy=f;
+                dummy = f;
                 break;
             }
         if (not dummy.is_initialized()) return v;
-        World& world=dummy.world();
-
+        World& world = dummy.world();
 
         // if a tree state cannot directly be changed to finalstate, we need to go via intermediate
-        auto change_initial_to_intermediate =[](const std::vector<Function<T,NDIM>>& v,
-                                                  const TreeState initialstate,
-                                                  const TreeState intermediatestate) {
+        auto change_initial_to_intermediate = [](const std::vector<Function<T, NDIM>>& v,
+                                                 const TreeState initialstate,
+                                                 const TreeState intermediatestate) {
             int must_fence=0;
             for (auto& f : v) {
                 if (f.is_initialized() and f.get_impl()->get_tree_state()==initialstate) {
                     f.change_tree_state(intermediatestate,false);
-                    must_fence=1;
+                    must_fence = 1;
                 }
             }
             return must_fence;
         };
 
-        int do_fence=0;
-        if (finalstate==compressed) {
-            do_fence+=change_initial_to_intermediate(v,redundant,TreeState::reconstructed);
+        int do_fence = 0;
+        if (finalstate == compressed) {
+            do_fence += change_initial_to_intermediate(v, redundant, TreeState::reconstructed);
         }
         if (finalstate==nonstandard) {
-            do_fence+=change_initial_to_intermediate(v,compressed,TreeState::reconstructed);
-            do_fence+=change_initial_to_intermediate(v,redundant,TreeState::reconstructed);
+            do_fence += change_initial_to_intermediate(v, compressed, TreeState::reconstructed);
+            do_fence += change_initial_to_intermediate(v, redundant, TreeState::reconstructed);
         }
         if (finalstate==nonstandard_with_leaves) {
-            do_fence+=change_initial_to_intermediate(v,compressed,TreeState::reconstructed);
-            do_fence+=change_initial_to_intermediate(v,nonstandard,TreeState::reconstructed);
-            do_fence+=change_initial_to_intermediate(v,redundant,TreeState::reconstructed);
+            do_fence += change_initial_to_intermediate(v, compressed, TreeState::reconstructed);
+            do_fence += change_initial_to_intermediate(v, nonstandard, TreeState::reconstructed);
+            do_fence += change_initial_to_intermediate(v, redundant, TreeState::reconstructed);
         }
         if (finalstate==redundant) {
-            do_fence+=change_initial_to_intermediate(v,compressed,TreeState::reconstructed);
-            do_fence+=change_initial_to_intermediate(v,nonstandard,TreeState::reconstructed);
-            do_fence+=change_initial_to_intermediate(v,nonstandard_with_leaves,TreeState::reconstructed);
+            do_fence += change_initial_to_intermediate(v, compressed, TreeState::reconstructed);
+            do_fence += change_initial_to_intermediate(v, nonstandard, TreeState::reconstructed);
+            do_fence += change_initial_to_intermediate(v, nonstandard_with_leaves, TreeState::reconstructed);
         }
-        if (do_fence>0) world.gop.fence();
+        if (do_fence > 0) world.gop.fence();
 
-        for (unsigned int i=0; i<v.size(); ++i) v[i].change_tree_state(finalstate,fence);
+        for (unsigned int i = 0; i < v.size(); ++i) v[i].change_tree_state(finalstate,fence);
         if (fence) world.gop.fence();
 
         return v;
@@ -333,16 +331,16 @@ namespace madness {
     /// Truncates a vector of functions
     template <typename T, std::size_t NDIM>
     void truncate(World& world,
-                  std::vector< Function<T,NDIM> >& v,
+                  std::vector<Function<T, NDIM>>& v,
                   double tol=0.0,
                   bool fence=true) {
         PROFILE_BLOCK(Vtruncate);
 
         // truncate in compressed form only for low-dimensional functions
         // compression is very expensive if low-rank tensor approximations are used
-        if (NDIM<4) compress(world, v);
+        if (NDIM < 4) compress(world, v);
 
-        for (unsigned int i=0; i<v.size(); ++i) {
+        for (unsigned int i = 0; i < v.size(); ++i) {
             v[i].truncate(tol, false);
         }
 
@@ -353,9 +351,9 @@ namespace madness {
 
     /// @return the truncated vector for chaining
     template <typename T, std::size_t NDIM>
-    std::vector< Function<T,NDIM> > truncate(std::vector< Function<T,NDIM> > v,
+    std::vector<Function<T, NDIM>> truncate(std::vector<Function<T, NDIM>> v,
                   double tol=0.0, bool fence=true) {
-        if (v.size()>0) truncate(v[0].world(),v,tol,fence);
+        if (v.size() > 0) truncate(v[0].world(), v, tol, fence);
         return v;
     }
 
@@ -363,10 +361,10 @@ namespace madness {
 
     /// @return the vector for chaining
     template <typename T, std::size_t NDIM>
-    std::vector< Function<T,NDIM> > reduce_rank(std::vector< Function<T,NDIM> > v,
+    std::vector<Function<T, NDIM>> reduce_rank(std::vector<Function<T, NDIM>> v,
                   double thresh=0.0, bool fence=true) {
-    	if (v.size()==0) return v;
-    	for (auto& vv : v) vv.reduce_rank(thresh,false);
+    	if (v.size() == 0) return v;
+    	for (auto& vv : v) vv.reduce_rank(thresh, false);
     	if (fence) v[0].world().gop.fence();
 		return v;
     }
@@ -374,15 +372,15 @@ namespace madness {
 
     /// Applies a derivative operator to a vector of functions
     template <typename T, std::size_t NDIM>
-    std::vector< Function<T,NDIM> >
+    std::vector<Function<T, NDIM>>
     apply(World& world,
-          const Derivative<T,NDIM>& D,
-          const std::vector< Function<T,NDIM> >& v,
+          const Derivative<T, NDIM>& D,
+          const std::vector<Function<T, NDIM>>& v,
           bool fence=true)
     {
         reconstruct(world, v);
-        std::vector< Function<T,NDIM> > df(v.size());
-        for (unsigned int i=0; i<v.size(); ++i) {
+        std::vector<Function<T, NDIM>> df(v.size());
+        for (unsigned int i = 0; i < v.size(); ++i) {
             df[i] = D(v[i],false);
         }
         if (fence) world.gop.fence();
@@ -391,26 +389,26 @@ namespace madness {
 
     /// Generates a vector of zero functions (reconstructed)
     template <typename T, std::size_t NDIM>
-    std::vector< Function<T,NDIM> >
+    std::vector<Function<T, NDIM>>
     zero_functions(World& world, int n, bool fence=true) {
         PROFILE_BLOCK(Vzero_functions);
-        std::vector< Function<T,NDIM> > r(n);
-        for (int i=0; i<n; ++i)
-  	    r[i] = Function<T,NDIM>(FunctionFactory<T,NDIM>(world).fence(false));
+        std::vector<Function<T, NDIM>> r(n);
+        for (int i = 0; i < n; ++i)
+  	        r[i] = Function<T, NDIM>(FunctionFactory<T, NDIM>(world).fence(false));
 
-	if (n && fence) world.gop.fence();
-
+	    if (n && fence) world.gop.fence();
         return r;
     }
 
     /// Generates a vector of zero functions (compressed)
     template <typename T, std::size_t NDIM>
-    std::vector< Function<T,NDIM> >
+    std::vector<Function<T, NDIM>>
     zero_functions_compressed(World& world, int n, bool fence=true) {
         PROFILE_BLOCK(Vzero_functions);
-        std::vector< Function<T,NDIM> > r(n);
-        for (int i=0; i<n; ++i)
-  	    r[i] = Function<T,NDIM>(FunctionFactory<T,NDIM>(world).fence(false).compressed(true).initial_level(1));
+        std::vector<Function<T, NDIM>> r(n);
+        for (int i = 0; i < n; ++i)
+  	        r[i] = Function<T, NDIM>(FunctionFactory<T, NDIM>(world).fence(false).compressed(true).initial_level(1));
+
     	if (n && fence) world.gop.fence();
         return r;
     }
@@ -418,31 +416,32 @@ namespace madness {
 
     /// orthonormalize the vectors
     template<typename T, std::size_t NDIM>
-    std::vector<Function<T,NDIM>> orthonormalize(const std::vector<Function<T,NDIM> >& vf_in) {
-        if (vf_in.size()==0) return std::vector<Function<T,NDIM>>();
-        World& world=vf_in.front().world();
-        auto vf=copy(world,vf_in);
-        normalize(world,vf);
-        if (vf.size()==1) return copy(world,vf_in);
+    std::vector<Function<T, NDIM>> orthonormalize(
+            const std::vector<Function<T, NDIM>>& vf_in) {
+        if (vf_in.size() == 0) return std::vector<Function<T, NDIM>>();
+        World& world = vf_in.front().world();
+        auto vf = copy(world, vf_in);
+        normalize(world, vf);
+        if (vf.size() == 1) return copy(world, vf_in);
         double maxq;
-        double trantol=0.0;
-        auto Q2=[](const Tensor<T>& s) {
-            Tensor<T> Q = -0.5*s;
-            for (int i=0; i<s.dim(0); ++i) Q(i,i) += 1.5;
+        double trantol = 0.0;
+        auto Q2 = [](const Tensor<T>& s) {
+           Tensor<T>Q = -0.5 * s;
+            for (int i = 0; i < s.dim(0); ++i) Q(i, i) += 1.5;
             return Q;
         };
 
         do {
-            Tensor<T> Q = Q2(matrix_inner(world, vf, vf));
-            maxq=0.0;
-            for (int i=0; i<Q.dim(0); ++i)
-                for (int j=0; j<i; ++j)
+           Tensor<T>Q = Q2(matrix_inner(world, vf, vf));
+            maxq = 0.0;
+            for (int i = 0; i < Q.dim(0); ++i)
+                for (int j = 0; j <i; ++j)
                     maxq = std::max(maxq,std::abs(Q(i,j)));
 
             vf = transform(world, vf, Q, trantol, true);
             truncate(world, vf);
 
-        } while (maxq>0.01);
+        } while (maxq > 0.01);
         normalize(world,vf);
         return vf;
     }
@@ -453,44 +452,44 @@ namespace madness {
     /// @param[in] the vector to orthonormalize
     /// @param[in] overlap matrix
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T,NDIM> > orthonormalize_symmetric(
-    		const std::vector<Function<T,NDIM> >& v,
+    std::vector<Function<T, NDIM>> orthonormalize_symmetric(
+    		const std::vector<Function<T, NDIM>>& v,
 			  const Tensor<T>& ovlp) {
     	if(v.empty()) return v;
 
     	Tensor<T> U;
-    	Tensor< typename Tensor<T>::scalar_type > s;
-    	syev(ovlp,U,s);
+    	Tensor<typename Tensor<T>::scalar_type> s;
+    	syev(ovlp, U, s);
 
     	// transform s to s^{-1}
-    	for(size_t i=0;i<v.size();++i) s(i)=1.0/(sqrt(s(i)));
+    	for(size_t i = 0; i < v.size(); ++i) s(i) = 1.0 / sqrt(s(i));
 
     	// save Ut before U gets modified with s^{-1}
-    	const Tensor<T> Ut=transpose(U);
-    	for(size_t i=0;i<v.size();++i){
-    		for(size_t j=0;j<v.size();++j){
-    			U(i,j)=U(i,j)*s(j);
+    	const Tensor<T> Ut = transpose(U);
+    	for(size_t i = 0; i < v.size(); ++i){
+    		for(size_t j = 0; j < v.size(); ++j){
+    			U(i, j) = U(i, j) * s(j);
     		}
     	}
 
-    	Tensor<T> X=inner(U,Ut,1,0);
+    	Tensor<T> X = inner(U, Ut, 1,0);
 
-    	World& world=v.front().world();
-    	return transform(world,v,X);
+    	World& world = v.front().world();
+    	return transform(world, v, X);
 
     }
     /// convenience routine for symmetric orthonormalization (see e.g. Szabo/Ostlund)
     /// overlap matrix is calculated
     /// @param[in] the vector to orthonormalize
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T,NDIM> > orthonormalize_symmetric(const std::vector<Function<T,NDIM> >& v){
+    std::vector<Function<T, NDIM>> orthonormalize_symmetric(
+            const std::vector<Function<T, NDIM>>& v){
     	if(v.empty()) return v;
 
-
-    	World& world=v.front().world();
+    	World& world = v.front().world();
     	Tensor<T> ovlp = matrix_inner(world, v, v);
 
-    	return orthonormalize_symmetric(v,ovlp);
+    	return orthonormalize_symmetric(v, ovlp);
     }
 
     /// canonical orthonormalization (see e.g. Szabo/Ostlund)
@@ -498,8 +497,8 @@ namespace madness {
     /// @param[in] overlap matrix
     /// @param[in]	lindep	linear dependency threshold relative to largest eigenvalue
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T,NDIM> > orthonormalize_canonical(
-    		const std::vector<Function<T,NDIM> >& v,
+    std::vector<Function<T, NDIM>> orthonormalize_canonical(
+    		const std::vector<Function<T, NDIM>>& v,
 			const Tensor<T>& ovlp,
 			double lindep) {
 
@@ -507,57 +506,58 @@ namespace madness {
 
     	Tensor<T> U;
     	Tensor< typename Tensor<T>::scalar_type > s;
-    	syev(ovlp,U,s);
-    	lindep*=s(s.size()-1);	// eigenvalues are in ascending order
+    	syev(ovlp, U, s);
+    	lindep *= s(s.size() - 1);	// eigenvalues are in ascending order
 
     	// transform s to s^{-1}
-    	int rank=0,lo=0;
-    	Tensor< typename Tensor<T>::scalar_type > sqrts(v.size());
-    	for(size_t i=0;i<v.size();++i) {
-    		if (s(i)>lindep) {
-    			sqrts(i)=1.0/(sqrt(s(i)));
+    	int rank = 0, lo = 0;
+    	Tensor<typename Tensor<T>::scalar_type> sqrts(v.size());
+    	for(size_t i = 0; i < v.size(); ++i) {
+    		if (s(i) > lindep) {
+    			sqrts(i) = 1.0 / sqrt(s(i));
         		rank++;
     		} else {
-    			sqrts(i)=0.0;
+    			sqrts(i) = 0.0;
     			lo++;
     		}
     	}
-    	MADNESS_ASSERT(size_t(lo+rank)==v.size());
+    	MADNESS_ASSERT(size_t(lo + rank) == v.size());
 
-    	for(size_t i=0;i<v.size();++i){
-    		for(size_t j=0;j<v.size();++j){
-    			U(i,j)=U(i,j)*(sqrts(j));
+    	for(size_t i = 0; i < v.size(); ++i){
+    		for(size_t j = 0; j < v.size(); ++j){
+    			U(i, j) = U(i, j) * sqrts(j);
     		}
     	}
-    	Tensor<T> X=U(_,Slice(lo,-1));
+    	Tensor<T> X = U(_, Slice(lo, -1));
 
-    	World& world=v.front().world();
-    	return transform(world,v,X);
+    	World& world = v.front().world();
+    	return transform(world, v, X);
 
     }
 
-    /// convenience routine for canonical routine for symmetric orthonormalization (see e.g. Szabo/Ostlund)
+    /// convenience routine for canonical routine for 
+    /// symmetric orthonormalization (see e.g. Szabo/Ostlund)
     /// overlap matrix is calculated
     /// @param[in] the vector to orthonormalize
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T,NDIM> > orthonormalize_canonical(const std::vector<Function<T,NDIM> >& v,
+    std::vector<Function<T, NDIM>> orthonormalize_canonical(
+            const std::vector<Function<T, NDIM>>& v,
     		const double lindep){
     	if(v.empty()) return v;
 
     	World& world=v.front().world();
     	Tensor<T> ovlp = matrix_inner(world, v, v);
 
-    	return orthonormalize_canonical(v,ovlp,lindep);
+    	return orthonormalize_canonical(v, ovlp, lindep);
     }
 
     /// cholesky orthonormalization without pivoting
     /// @param[in] the vector to orthonormalize
     /// @param[in] overlap matrix, destroyed on return!
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T,NDIM> > orthonormalize_cd(
-    		const std::vector<Function<T,NDIM> >& v,
+    std::vector<Function<T, NDIM>> orthonormalize_cd(
+    		const std::vector<Function<T, NDIM>>& v,
 			Tensor<T>& ovlp) {
-
     	if (v.empty()) return v;
 
     	cholesky(ovlp); // destroys ovlp and gives back Upper ∆ Matrix from CD
@@ -568,20 +568,20 @@ namespace madness {
 
     	World& world=v.front().world();
     	return transform(world, v, U);
-
     }
 
     /// convenience routine for cholesky orthonormalization without pivoting
     /// @param[in] the vector to orthonormalize
     /// @param[in] overlap matrix
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T,NDIM> > orthonormalize_cd(const std::vector<Function<T,NDIM> >& v){
+    std::vector<Function<T, NDIM>> orthonormalize_cd(
+            const std::vector<Function<T, NDIM>>& v){
     	if(v.empty()) return v;
 
     	World& world=v.front().world();
     	Tensor<T> ovlp = matrix_inner(world, v, v);
 
-    	return orthonormalize_cd(v,ovlp);
+    	return orthonormalize_cd(v, ovlp);
     }
 
     /// @param[in] the vector to orthonormalize
@@ -591,8 +591,8 @@ namespace madness {
     /// @param[out] rank
     /// @return orthonrormalized vector (may or may not be truncated)
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T,NDIM> > orthonormalize_rrcd(
-    		const std::vector<Function<T,NDIM> >& v,
+    std::vector<Function<T, NDIM>> orthonormalize_rrcd(
+    		const std::vector<Function<T, NDIM>>& v,
 			Tensor<T>& ovlp,
 			const double tol,
 			Tensor<integer>& piv,
@@ -602,14 +602,14 @@ namespace madness {
     		return v;
     	}
 
-    	rr_cholesky(ovlp,tol,piv,rank); // destroys ovlp and gives back Upper ∆ Matrix from CCD
+    	rr_cholesky(ovlp, tol, piv, rank);  // destroys ovlp and gives back Upper ∆ Matrix from CCD
 
     	// rearrange and truncate the functions according to the pivoting of the rr_cholesky
-    	std::vector<Function<T,NDIM> > pv(rank);
-    	for(integer i=0;i<rank;++i){
-    		pv[i]=v[piv[i]];
+    	std::vector<Function<T, NDIM>> pv(rank);
+    	for(integer i = 0; i < rank; ++i){
+    		pv[i] = v[piv[i]];
     	}
-    	ovlp=ovlp(Slice(0,rank-1),Slice(0,rank-1));
+    	ovlp = ovlp(Slice(0, rank - 1), Slice(0, rank - 1));
 
     	Tensor<T> L = transpose(ovlp);
     	Tensor<T> Linv = inverse(L);
@@ -619,90 +619,100 @@ namespace madness {
     	return transform(world, pv, U);
     }
 
-    /// convenience routine for orthonromalize_cholesky: orthonromalize_cholesky without information on pivoting and rank
+    /// convenience routine for orthonromalize_cholesky:
+    /// orthonromalize_cholesky without information on pivoting and rank
     /// @param[in] the vector to orthonormalize
     /// @param[in] overlap matrix
     /// @param[in] tolerance for numerical rank reduction
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T,NDIM> > orthonormalize_rrcd(const std::vector<Function<T,NDIM> >& v, Tensor<T> ovlp , const double tol) {
+    std::vector<Function<T, NDIM>> orthonormalize_rrcd(
+            const std::vector<Function<T, NDIM>>& v,
+            Tensor<T> ovlp,
+            const double tol) {
     	Tensor<integer> piv;
     	int rank;
-    	return orthonormalize_rrcd(v,ovlp,tol,piv,rank);
+    	return orthonormalize_rrcd(v, ovlp, tol, piv,rank);
     }
 
-    /// convenience routine for orthonromalize_cholesky: computes the overlap matrix and then calls orthonromalize_cholesky
+    /// convenience routine for orthonromalize_cholesky:
+    /// computes the overlap matrix and then calls orthonromalize_cholesky
     /// @param[in] the vector to orthonormalize
     /// @param[in] tolerance for numerical rank reduction
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T,NDIM> > orthonormalize_rrcd(const std::vector<Function<T,NDIM> >& v, const double tol) {
+    std::vector<Function<T, NDIM>> orthonormalize_rrcd(
+            const std::vector<Function<T, NDIM>>& v,
+            const double tol) {
     	if (v.empty()) {
     		return v;
     	}
     	// compute overlap
-    	World& world=v.front().world();
+    	World& world = v.front().world();
     	Tensor<T> ovlp = matrix_inner(world, v, v);
-    	return orthonormalize_rrcd(v,ovlp,tol);
+    	return orthonormalize_rrcd(v, ovlp, tol);
     }
 
     /// combine two vectors
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T,NDIM> > append(const std::vector<Function<T,NDIM> > & lhs, const std::vector<Function<T,NDIM> > & rhs){
-    	std::vector<Function<T,NDIM> >  v=lhs;
+    std::vector<Function<T, NDIM>> append(const std::vector<Function<T, NDIM>> & lhs,
+            const std::vector<Function<T, NDIM>> & rhs){
+    	std::vector<Function<T, NDIM>> v = lhs;
     	for (std::size_t i = 0; i < rhs.size(); ++i) v.push_back(rhs[i]);
     	return v;
     }
 
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T,NDIM> > flatten(const std::vector< std::vector<Function<T,NDIM> > >& vv){
-    	std::vector<Function<T,NDIM> >result;
-    	for(const auto& x:vv) result=append(result,x);
+    std::vector<Function<T, NDIM>> flatten(const std::vector<std::vector<Function<T, NDIM>>>& vv){
+    	std::vector<Function<T, NDIM>> result;
+    	for (const auto& x : vv) result = append(result, x);
     	return result;
     }
 
     template<typename T, std::size_t NDIM>
-    std::vector<std::shared_ptr<FunctionImpl<T,NDIM>>> get_impl(const std::vector<Function<T,NDIM>>& v) {
-        std::vector<std::shared_ptr<FunctionImpl<T,NDIM>>> result;
+    std::vector<std::shared_ptr<FunctionImpl<T, NDIM>>> get_impl(
+            const std::vector<Function<T, NDIM>>& v) {
+        std::vector<std::shared_ptr<FunctionImpl<T, NDIM>>> result;
         for (auto& f : v) result.push_back(f.get_impl());
         return result;
     }
 
     template<typename T, std::size_t NDIM>
-    void set_impl(std::vector<Function<T,NDIM>>& v, const std::vector<std::shared_ptr<FunctionImpl<T,NDIM>>> vimpl) {
+    void set_impl(std::vector<Function<T, NDIM>>& v, 
+                  const std::vector<std::shared_ptr<FunctionImpl<T, NDIM>>> vimpl) {
         MADNESS_CHECK(vimpl.size()==v.size());
-        for (std::size_t i=0; i<vimpl.size(); ++i) v[i].set_impl(vimpl[i]);
+        for (std::size_t i = 0; i < vimpl.size(); ++i) v[i].set_impl(vimpl[i]);
     }
 
     template<typename T, std::size_t NDIM>
-    std::vector<Function<T,NDIM>> impl2function(const std::vector<std::shared_ptr<FunctionImpl<T,NDIM>>> vimpl) {
-        std::vector<Function<T,NDIM>> v(vimpl.size());
-        for (std::size_t i=0; i<vimpl.size(); ++i) v[i].set_impl(vimpl[i]);
+    std::vector<Function<T, NDIM>> impl2function(
+            const std::vector<std::shared_ptr<FunctionImpl<T, NDIM>>> vimpl) {
+        std::vector<Function<T, NDIM>> v(vimpl.size());
+        for (std::size_t i = 0; i < vimpl.size(); ++i) v[i].set_impl(vimpl[i]);
         return v;
     }
-
 
     /// Transforms a vector of functions according to new[i] = sum[j] old[j]*c[j,i]
 
     /// Uses sparsity in the transformation matrix --- set small elements to
     /// zero to take advantage of this.
     template <typename T, typename R, std::size_t NDIM>
-    std::vector< Function<TENSOR_RESULT_TYPE(T,R),NDIM> >
+    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>>
     transform(World& world,
-              const std::vector< Function<T,NDIM> >& v,
+              const std::vector<Function<T, NDIM>>& v,
               const Tensor<R>& c,
               bool fence=true) {
 
         PROFILE_BLOCK(Vtransformsp);
-        typedef TENSOR_RESULT_TYPE(T,R) resultT;
+        typedef TENSOR_RESULT_TYPE(T, R) resultT;
         int n = v.size();  // n is the old dimension
         int m = c.dim(1);  // m is the new dimension
-        MADNESS_ASSERT(n==c.dim(0));
+        MADNESS_ASSERT(n == c.dim(0));
 
-        std::vector< Function<resultT,NDIM> > vc = zero_functions_compressed<resultT,NDIM>(world, m);
+        std::vector<Function<resultT, NDIM>> vc = zero_functions_compressed<resultT, NDIM>(world, m);
         compress(world, v);
 
-        for (int i=0; i<m; ++i) {
-            for (int j=0; j<n; ++j) {
-                if (c(j,i) != R(0.0)) vc[i].gaxpy(resultT(1.0),v[j],resultT(c(j,i)),false);
+        for (int i = 0; i < m; ++i) {
+            for (int j = 0; j < n; ++j) {
+                if (c(j, i) != R(0.0)) vc[i].gaxpy(resultT(1.0), v[j], resultT(c(j, i)), false);
             }
         }
 
@@ -714,29 +724,29 @@ namespace madness {
 
     /// all trees are in reconstructed state, final trees have to be summed down if no fence is present
     template <typename T, typename R, std::size_t NDIM>
-    std::vector< Function<TENSOR_RESULT_TYPE(T,R),NDIM> >
+    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>>
     transform_reconstructed(World& world,
-              const std::vector< Function<T,NDIM> >& v,
+              const std::vector<Function<T, NDIM>>& v,
               const Tensor<R>& c,
               bool fence=true) {
 
         PROFILE_BLOCK(Vtransformsp);
-        typedef TENSOR_RESULT_TYPE(T,R) resultT;
+        typedef TENSOR_RESULT_TYPE(T, R) resultT;
         int n = v.size();  // n is the old dimension
         int m = c.dim(1);  // m is the new dimension
-        MADNESS_CHECK(n==c.dim(0));
+        MADNESS_CHECK(n == c.dim(0));
 
         // if we fence set the right tree state here, otherwise it has to be correct from the start.
-        if (fence) change_tree_state(v,reconstructed);
+        if (fence) change_tree_state(v, reconstructed);
         for (const auto& vv : v) MADNESS_CHECK_THROW(
-            vv.get_impl()->get_tree_state()==reconstructed,"trees have to be reconstructed in transform_reconstructed");
+            vv.get_impl()->get_tree_state() == reconstructed, "trees have to be reconstructed in transform_reconstructed");
 
-        std::vector< Function<resultT,NDIM> > result = zero_functions<resultT,NDIM>(world, m);
+        std::vector<Function<resultT, NDIM>> result = zero_functions<resultT, NDIM>(world, m);
 
-        for (int i=0; i<m; ++i) {
+        for (int i = 0; i < m; ++i) {
             result[i].get_impl()->set_tree_state(redundant_after_merge);
-            for (int j=0; j<n; ++j) {
-                if (c(j,i) != R(0.0)) v[j].get_impl()->accumulate_trees(*(result[i].get_impl()),resultT(c(j,i)),true);
+            for (int j = 0; j < n; ++j) {
+                if (c(j, i) != R(0.0)) v[j].get_impl()->accumulate_trees(*(result[i].get_impl()), resultT(c(j, i)), true);
             }
         }
 
@@ -753,14 +763,14 @@ namespace madness {
     /// this version of transform uses Function::vtransform and screens
     /// using both elements of `c` and `v`
     template <typename L, typename R, std::size_t NDIM>
-    std::vector< Function<TENSOR_RESULT_TYPE(L,R),NDIM> >
-    transform(World& world,  const std::vector< Function<L,NDIM> >& v,
+    std::vector<Function<TENSOR_RESULT_TYPE(L, R), NDIM>>
+    transform(World& world, const std::vector<Function<L, NDIM>>& v,
             const Tensor<R>& c, double tol, bool fence) {
         PROFILE_BLOCK(Vtransform);
         MADNESS_ASSERT(v.size() == (unsigned int)(c.dim(0)));
 
-        std::vector< Function<TENSOR_RESULT_TYPE(L,R),NDIM> > vresult
-            = zero_functions_compressed<TENSOR_RESULT_TYPE(L,R),NDIM>(world, c.dim(1));
+        std::vector<Function<TENSOR_RESULT_TYPE(L, R), NDIM>> vresult
+            = zero_functions_compressed<TENSOR_RESULT_TYPE(L, R), NDIM>(world, c.dim(1));
 
         compress(world, v, true);
         vresult[0].vtransform(v, c, vresult, tol, fence);
@@ -768,30 +778,30 @@ namespace madness {
     }
 
     template <typename T, typename R, std::size_t NDIM>
-    std::vector< Function<TENSOR_RESULT_TYPE(T,R),NDIM> >
+    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>>
     transform(World& world,
-              const std::vector< Function<T,NDIM> >& v,
+              const std::vector<Function<T, NDIM>>& v,
               const DistributedMatrix<R>& c,
               bool fence=true) {
         PROFILE_FUNC;
 
-        typedef TENSOR_RESULT_TYPE(T,R) resultT;
+        typedef TENSOR_RESULT_TYPE(T, R) resultT;
         long n = v.size();    // n is the old dimension
         long m = c.rowdim();  // m is the new dimension
         MADNESS_ASSERT(n==c.coldim());
 
         // new(i) = sum(j) old(j) c(j,i)
 
-        Tensor<T> tmp(n,m);
+       Tensor<T>tmp(n,m);
         c.copy_to_replicated(tmp); // for debugging
         tmp = transpose(tmp);
 
-        std::vector< Function<resultT,NDIM> > vc = zero_functions_compressed<resultT,NDIM>(world, m);
+        std::vector<Function<resultT, NDIM>> vc = zero_functions_compressed<resultT, NDIM>(world, m);
         compress(world, v);
 
-        for (int i=0; i<m; ++i) {
-            for (int j=0; j<n; ++j) {
-                if (tmp(j,i) != R(0.0)) vc[i].gaxpy(1.0,v[j],tmp(j,i),false);
+        for (int i = 0; i < m; ++i) {
+            for (int j = 0; j < n; ++j) {
+                if (tmp(j, i) != R(0.0)) vc[i].gaxpy(1.0, v[j], tmp(j, i), false);
             }
         }
 
@@ -803,34 +813,34 @@ namespace madness {
     /// Scales inplace a vector of functions by distinct values
     template <typename T, typename Q, std::size_t NDIM>
     void scale(World& world,
-               std::vector< Function<T,NDIM> >& v,
+               std::vector<Function<T, NDIM>>& v,
                const std::vector<Q>& factors,
                bool fence=true) {
         PROFILE_BLOCK(Vscale);
-        for (unsigned int i=0; i<v.size(); ++i) v[i].scale(factors[i],false);
+        for (unsigned int i = 0; i < v.size(); ++i) v[i].scale(factors[i], false);
         if (fence) world.gop.fence();
     }
 
     /// Scales inplace a vector of functions by the same
     template <typename T, typename Q, std::size_t NDIM>
     void scale(World& world,
-               std::vector< Function<T,NDIM> >& v,
-	       const Q factor,
+               std::vector<Function<T, NDIM>>& v,
+	           const Q factor,
                bool fence=true) {
         PROFILE_BLOCK(Vscale);
-        for (unsigned int i=0; i<v.size(); ++i) v[i].scale(factor,false);
+        for (unsigned int i = 0; i < v.size(); ++i) v[i].scale(factor, false);
         if (fence) world.gop.fence();
     }
 
     /// Computes the 2-norms of a vector of functions
     template <typename T, std::size_t NDIM>
     std::vector<double> norm2s(World& world,
-                              const std::vector< Function<T,NDIM> >& v) {
+                               const std::vector<Function<T, NDIM>>& v) {
         PROFILE_BLOCK(Vnorm2);
         std::vector<double> norms(v.size());
-        for (unsigned int i=0; i<v.size(); ++i) norms[i] = v[i].norm2sq_local();
+        for (unsigned int i = 0; i < v.size(); ++i) norms[i] = v[i].norm2sq_local();
         world.gop.sum(&norms[0], norms.size());
-        for (unsigned int i=0; i<v.size(); ++i) norms[i] = sqrt(norms[i]);
+        for (unsigned int i = 0; i < v.size(); ++i) norms[i] = sqrt(norms[i]);
         world.gop.fence();
         return norms;
     }
@@ -848,13 +858,13 @@ namespace madness {
 
     /// Computes the 2-norm of a vector of functions
     template <typename T, std::size_t NDIM>
-    double norm2(World& world,const std::vector< Function<T,NDIM> >& v) {
+    double norm2(World& world,const std::vector<Function<T, NDIM>>& v) {
         PROFILE_BLOCK(Vnorm2);
-        if (v.size()==0) return 0.0;
+        if (v.size() == 0) return 0.0;
         std::vector<double> norms(v.size());
-        for (unsigned int i=0; i<v.size(); ++i) norms[i] = v[i].norm2sq_local();
+        for (unsigned int i = 0; i < v.size(); ++i) norms[i] = v[i].norm2sq_local();
         world.gop.sum(&norms[0], norms.size());
-        for (unsigned int i=1; i<v.size(); ++i) norms[0] += norms[i];
+        for (unsigned int i = 1; i < v.size(); ++i) norms[0] += norms[i];
         world.gop.fence();
         return sqrt(norms[0]);
     }
@@ -874,19 +884,19 @@ namespace madness {
 //
 //    template <typename T, typename R, std::size_t NDIM>
 //    struct MatrixInnerTask : public TaskInterface {
-//        Tensor<TENSOR_RESULT_TYPE(T,R)> result; // Must be a copy
-//        const Function<T,NDIM>& f;
-//        const std::vector< Function<R,NDIM> >& g;
+//        Tensor<TENSOR_RESULT_TYPE(T, R)> result; // Must be a copy
+//        const Function<T, NDIM>& f;
+//        const std::vector<Function<R, NDIM>>& g;
 //        long jtop;
 //
-//        MatrixInnerTask(const Tensor<TENSOR_RESULT_TYPE(T,R)>& result,
-//                        const Function<T,NDIM>& f,
-//                        const std::vector< Function<R,NDIM> >& g,
+//        MatrixInnerTask(const Tensor<TENSOR_RESULT_TYPE(T, R)>& result,
+//                        const Function<T, NDIM>& f,
+//                        const std::vector<Function<R, NDIM>>& g,
 //                        long jtop)
 //                : result(result), f(f), g(g), jtop(jtop) {}
 //
 //        void run(World& world) {
-//            for (long j=0; j<jtop; ++j) {
+//            for (long j = 0; j < jtop; ++j) {
 //                result(j) = f.inner_local(g[j]);
 //            }
 //        }
@@ -904,8 +914,8 @@ namespace madness {
 
     template <typename T, std::size_t NDIM>
     DistributedMatrix<T> matrix_inner(const DistributedMatrixDistribution& d,
-                                      const std::vector< Function<T,NDIM> >& f,
-                                      const std::vector< Function<T,NDIM> >& g,
+                                      const std::vector<Function<T, NDIM>>& f,
+                                      const std::vector<Function<T, NDIM>>& g,
                                       bool sym=false)
     {
         PROFILE_FUNC;
@@ -917,15 +927,15 @@ namespace madness {
         // Assume we can always create an ichunk*jchunk matrix locally
         const int ichunk = 1000;
         const int jchunk = 1000; // 1000*1000*8 = 8 MBytes
-        for (int64_t ilo=0; ilo<n; ilo+=ichunk) {
+        for (int64_t ilo = 0; ilo < n; ilo += ichunk) {
             int64_t ihi = std::min(ilo + ichunk, n);
-            std::vector< Function<T,NDIM> > ivec(f.begin()+ilo, f.begin()+ihi);
-            for (int64_t jlo=0; jlo<m; jlo+=jchunk) {
+            std::vector<Function<T, NDIM>> ivec(f.begin() + ilo, f.begin() + ihi);
+            for (int64_t jlo = 0; jlo < m; jlo += jchunk) {
                 int64_t jhi = std::min(jlo + jchunk, m);
-                std::vector< Function<T,NDIM> > jvec(g.begin()+jlo, g.begin()+jhi);
+                std::vector<Function<T, NDIM>> jvec(g.begin() + jlo, g.begin() + jhi);
 
-                Tensor<T> P = matrix_inner(A.get_world(),ivec,jvec);
-                A.copy_from_replicated_patch(ilo, ihi-1, jlo, jhi-1, P);
+               Tensor<T> P = matrix_inner(A.get_world(), ivec, jvec);
+                A.copy_from_replicated_patch(ilo, ihi - 1, jlo, jhi - 1, P);
             }
         }
         return A;
@@ -937,23 +947,23 @@ namespace madness {
     ///
     /// The current parallel loop is non-optimal but functional.
     template <typename T, typename R, std::size_t NDIM>
-    Tensor< TENSOR_RESULT_TYPE(T,R) > matrix_inner(World& world,
-                                                   const std::vector< Function<T,NDIM> >& f,
-                                                   const std::vector< Function<R,NDIM> >& g,
+    Tensor<TENSOR_RESULT_TYPE(T, R)> matrix_inner(World& world,
+                                                   const std::vector<Function<T, NDIM>>& f,
+                                                   const std::vector<Function<R, NDIM>>& g,
                                                    bool sym=false)
     {
         world.gop.fence();
         compress(world, f);
-//        if ((void*)(&f) != (void*)(&g)) compress(world, g);
+        // if ((void*)(&f) != (void*)(&g)) compress(world, g);
         compress(world, g);
 
 
-        std::vector<const FunctionImpl<T,NDIM>*> left(f.size());
-        std::vector<const FunctionImpl<R,NDIM>*> right(g.size());
-        for (unsigned int i=0; i<f.size(); i++) left[i] = f[i].get_impl().get();
-        for (unsigned int i=0; i<g.size(); i++) right[i]= g[i].get_impl().get();
+        std::vector<const FunctionImpl<T, NDIM>*> left(f.size());
+        std::vector<const FunctionImpl<R, NDIM>*> right(g.size());
+        for (unsigned int i = 0; i < f.size(); i++) left[i] = f[i].get_impl().get();
+        for (unsigned int i = 0; i < g.size(); i++) right[i]= g[i].get_impl().get();
 
-        Tensor< TENSOR_RESULT_TYPE(T,R) > r= FunctionImpl<T,NDIM>::inner_local(left, right, sym);
+        Tensor<TENSOR_RESULT_TYPE(T, R)> r = FunctionImpl<T, NDIM>::inner_local(left, right, sym);
 
         world.gop.fence();
         world.gop.sum(r.ptr(),f.size()*g.size());
@@ -967,65 +977,66 @@ namespace madness {
     ///
     /// The current parallel loop is non-optimal but functional.
     template <typename T, typename R, std::size_t NDIM>
-    Tensor< TENSOR_RESULT_TYPE(T,R) > matrix_inner_old(World& world,
-            const std::vector< Function<T,NDIM> >& f,
-            const std::vector< Function<R,NDIM> >& g,
+    Tensor<TENSOR_RESULT_TYPE(T, R)> matrix_inner_old(
+            World& world,
+            const std::vector<Function<T, NDIM>>& f,
+            const std::vector<Function<R, NDIM>>& g,
             bool sym=false) {
         PROFILE_BLOCK(Vmatrix_inner);
-        long n=f.size(), m=g.size();
-        Tensor< TENSOR_RESULT_TYPE(T,R) > r(n,m);
-        if (sym) MADNESS_ASSERT(n==m);
+        long n = f.size(), m = g.size();
+        Tensor<TENSOR_RESULT_TYPE(T, R)> r(n, m);
+        if (sym) MADNESS_ASSERT(n == m);
 
         world.gop.fence();
         compress(world, f);
         if ((void*)(&f) != (void*)(&g)) compress(world, g);
 
-        for (long i=0; i<n; ++i) {
+        for (long i = 0; i < n; ++i) {
             long jtop = m;
-            if (sym) jtop = i+1;
-            for (long j=0; j<jtop; ++j) {
+            if (sym) jtop = i + 1;
+            for (long j = 0; j < jtop; ++j) {
                 r(i,j) = f[i].inner_local(g[j]);
-                if (sym) r(j,i) = conj(r(i,j));
+                if (sym) r(j, i) = conj(r(i, j));
             }
          }
 
-//        for (long i=n-1; i>=0; --i) {
-//            long jtop = m;
-//            if (sym) jtop = i+1;
-//            world.taskq.add(new MatrixInnerTask<T,R,NDIM>(r(i,_), f[i], g, jtop));
-//        }
+        // for (long i = n - 1; i >= 0; --i) {
+        //     long jtop = m;
+        //     if (sym) jtop = i + 1;
+        //     world.taskq.add(new MatrixInnerTask<T, R, NDIM>(r(i, _), f[i], g, jtop));
+        // }
         world.gop.fence();
-        world.gop.sum(r.ptr(),n*m);
+        world.gop.sum(r.ptr(), n * m);
 
-//        if (sym) {
-//            for (int i=0; i<n; ++i) {
-//                for (int j=0; j<i; ++j) {
-//                    r(j,i) = conj(r(i,j));
-//                }
-//            }
-//        }
+        // if (sym) {
+        //     for (int i = 0; i < n; ++i) {
+        //         for (int j = 0; j < i; ++j) {
+        //             r(j,i) = conj(r(i, j));
+        //         }
+        //     }
+        // }
         return r;
     }
 
     /// Computes the element-wise inner product of two function vectors - q(i) = inner(f[i],g[i])
     template <typename T, typename R, std::size_t NDIM>
-    Tensor< TENSOR_RESULT_TYPE(T,R) > inner(World& world,
-                                            const std::vector< Function<T,NDIM> >& f,
-                                            const std::vector< Function<R,NDIM> >& g) {
+    Tensor<TENSOR_RESULT_TYPE(T, R)> inner(World& world,
+                                           const std::vector<Function<T, NDIM>>& f,
+                                           const std::vector<Function<R, NDIM>>& g) {
         PROFILE_BLOCK(Vinnervv);
-        long n=f.size(), m=g.size();
-        MADNESS_CHECK(n==m);
-        Tensor< TENSOR_RESULT_TYPE(T,R) > r(n);
+        long n = f.size(), m = g.size();
+        MADNESS_CHECK(n == m);
+        Tensor<TENSOR_RESULT_TYPE(T, R)> r(n);
 
         compress(world, f);
         compress(world, g);
 
-        for (long i=0; i<n; ++i) {
+        for (long i = 0; i < n; ++i) {
             r(i) = f[i].inner_local(g[i]);
         }
 
         world.taskq.fence();
-        world.gop.sum(r.ptr(),n);
+        world.gop.sum(r.ptr(), n);
         world.gop.fence();
         return r;
     }
@@ -1033,22 +1044,22 @@ namespace madness {
 
     /// Computes the inner product of a function with a function vector - q(i) = inner(f,g[i])
     template <typename T, typename R, std::size_t NDIM>
-    Tensor< TENSOR_RESULT_TYPE(T,R) > inner(World& world,
-                                            const Function<T,NDIM>& f,
-                                            const std::vector< Function<R,NDIM> >& g) {
+    Tensor<TENSOR_RESULT_TYPE(T, R)> inner(World& world,
+                                            const Function<T, NDIM>& f,
+                                            const std::vector<Function<R, NDIM>>& g) {
         PROFILE_BLOCK(Vinner);
-        long n=g.size();
-        Tensor< TENSOR_RESULT_TYPE(T,R) > r(n);
+        long n = g.size();
+        Tensor<TENSOR_RESULT_TYPE(T, R)> r(n);
 
         f.compress();
         compress(world, g);
 
-        for (long i=0; i<n; ++i) {
+        for (long i = 0; i < n; ++i) {
             r(i) = f.inner_local(g[i]);
         }
 
         world.taskq.fence();
-        world.gop.sum(r.ptr(),n);
+        world.gop.sum(r.ptr(), n);
         world.gop.fence();
         return r;
     }
@@ -1056,20 +1067,20 @@ namespace madness {
     /// inner function with right signature for the nonlinear solver
     /// this is needed for the KAIN solvers and other functions
     template <typename T, typename R, std::size_t NDIM>
-    TENSOR_RESULT_TYPE(T,R) inner( const std::vector< Function<T,NDIM> >& f,
-	                                            const std::vector< Function<R,NDIM> >& g){
-      MADNESS_ASSERT(f.size()==g.size());
+    TENSOR_RESULT_TYPE(T, R) inner(const std::vector<Function<T, NDIM>>& f,
+	                               const std::vector<Function<R, NDIM>>& g){
+      MADNESS_ASSERT(f.size() == g.size());
       if(f.empty()) return 0.0;
-      else return inner(f[0].world(),f,g).sum();
+      else return inner(f[0].world(), f, g).sum();
     }
 
 
     /// Multiplies a function against a vector of functions --- q[i] = a * v[i]
     template <typename T, typename R, std::size_t NDIM>
-    std::vector< Function<TENSOR_RESULT_TYPE(T,R), NDIM> >
+    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>>
     mul(World& world,
-        const Function<T,NDIM>& a,
-        const std::vector< Function<R,NDIM> >& v,
+        const Function<T, NDIM>& a,
+        const std::vector<Function<R, NDIM>>& v,
         bool fence=true) {
         PROFILE_BLOCK(Vmul);
         a.reconstruct(false);
@@ -1080,17 +1091,17 @@ namespace madness {
 
     /// Multiplies a function against a vector of functions using sparsity of a and v[i] --- q[i] = a * v[i]
     template <typename T, typename R, std::size_t NDIM>
-    std::vector< Function<TENSOR_RESULT_TYPE(T,R), NDIM> >
+    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>>
     mul_sparse(World& world,
-               const Function<T,NDIM>& a,
-               const std::vector< Function<R,NDIM> >& v,
+               const Function<T, NDIM>& a,
+               const std::vector<Function<R, NDIM>>& v,
                double tol,
                bool fence=true) {
         PROFILE_BLOCK(Vmulsp);
         a.reconstruct(false);
         reconstruct(world, v, false);
         world.gop.fence();
-        for (unsigned int i=0; i<v.size(); ++i) {
+        for (unsigned int i = 0; i < v.size(); ++i) {
             v[i].norm_tree(false);
         }
         a.norm_tree();
@@ -1111,15 +1122,15 @@ namespace madness {
     /// \param symm     if true, only compute f(i) * g(j) for j<=i
     /// \return         fg(i,j) = f(i) * g(j), as a vector of vectors
     template <typename T, typename R, std::size_t NDIM>
-    std::vector<std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM> > >
+    std::vector<std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>>>
     matrix_mul_sparse(World &world,
-                      const std::vector<Function<R, NDIM> > &f,
-                      const std::vector<Function<R, NDIM> > &g,
+                      const std::vector<Function<R, NDIM>> &f,
+                      const std::vector<Function<R, NDIM>> &g,
                       double tol,
-                      bool fence = true,
-                      bool symm = false) {
+                      bool fence=true,
+                      bool symm=false) {
         PROFILE_BLOCK(Vmulsp);
-        bool same=(&f == &g);
+        bool same = (&f == &g);
         reconstruct(world, f, false);
         if (not same) reconstruct(world, g, false);
         world.gop.fence();
@@ -1127,15 +1138,15 @@ namespace madness {
         if (not same) for (auto& gg : g) gg.norm_tree(false);
         world.gop.fence();
 
-        std::vector<std::vector<Function<R,NDIM> > >result(f.size());
+        std::vector<std::vector<Function<R,NDIM>>> result(f.size());
         std::vector<Function<R,NDIM>> g_i;
-        for (int64_t i=f.size()-1; i>=0; --i) {
+        for (int64_t i = f.size()-1; i>=0; --i) {
           if (!symm)
             result[i]= vmulXX(f[i], g, tol, false);
           else {
             if (g_i.empty()) g_i = g;
-            g_i.resize(i+1);  // this shrinks g_i down to single function for i=0
-            result[i]= vmulXX(f[i], g_i, tol, false);
+            g_i.resize(i + 1);  // this shrinks g_i down to single function for i=0
+            result[i] = vmulXX(f[i], g_i, tol, false);
           }
         }
         if (fence) world.gop.fence();
@@ -1145,11 +1156,11 @@ namespace madness {
     /// Makes the norm tree for all functions in a vector
     template <typename T, std::size_t NDIM>
     void norm_tree(World& world,
-                   const std::vector< Function<T,NDIM> >& v,
+                   const std::vector<Function<T, NDIM>>& v,
                    bool fence=true)
     {
         PROFILE_BLOCK(Vnorm_tree);
-        for (unsigned int i=0; i<v.size(); ++i) {
+        for (unsigned int i = 0; i < v.size(); ++i) {
             v[i].norm_tree(false);
         }
         if (fence) world.gop.fence();
@@ -1157,18 +1168,18 @@ namespace madness {
 
     /// Multiplies two vectors of functions q[i] = a[i] * b[i]
     template <typename T, typename R, std::size_t NDIM>
-    std::vector< Function<TENSOR_RESULT_TYPE(T,R), NDIM> >
+    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>>
     mul(World& world,
-        const std::vector< Function<T,NDIM> >& a,
-        const std::vector< Function<R,NDIM> >& b,
+        const std::vector<Function<T, NDIM>>& a,
+        const std::vector<Function<R, NDIM>>& b,
         bool fence=true) {
         PROFILE_BLOCK(Vmulvv);
         reconstruct(world, a, true);
         reconstruct(world, b, true);
-//        if (&a != &b) reconstruct(world, b, true); // fails if type(a) != type(b)
+        // if (&a != &b) reconstruct(world, b, true); // fails if type(a) != type(b)
 
-        std::vector< Function<TENSOR_RESULT_TYPE(T,R),NDIM> > q(a.size());
-        for (unsigned int i=0; i<a.size(); ++i) {
+        std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>> q(a.size());
+        for (unsigned int i = 0; i < a.size(); ++i) {
             q[i] = mul(a[i], b[i], false);
         }
         if (fence) world.gop.fence();
@@ -1183,22 +1194,22 @@ namespace madness {
     /// @param[in]  v   dimension indices of f to multiply
     /// @return     h[i](0,1,2,3) = f(0,1,2,3) * g[i](1,2,3) for v={1,2,3}
     template<typename T, std::size_t NDIM, std::size_t LDIM>
-    std::vector<Function<T,NDIM> > partial_mul(const Function<T,NDIM> f, const std::vector<Function<T,LDIM> > g,
+    std::vector<Function<T, NDIM>> partial_mul(const Function<T, NDIM> f, const std::vector<Function<T,LDIM>> g,
                                  const int particle) {
 
-        World& world=f.world();
-        std::vector<Function<T,NDIM> > result(g.size());
+        World& world = f.world();
+        std::vector<Function<T, NDIM>> result(g.size());
         for (auto& r : result) r.set_impl(f, false);
 
-        FunctionImpl<T,NDIM>* fimpl=f.get_impl().get();
+        FunctionImpl<T, NDIM>* fimpl = f.get_impl().get();
 //        fimpl->make_redundant(false);
-        fimpl->change_tree_state(redundant,false);
-        make_redundant(world,g,false);
+        fimpl->change_tree_state(redundant, false);
+        make_redundant(world, g, false);
         world.gop.fence();
 
-        for (std::size_t i=0; i<result.size(); ++i) {
-            FunctionImpl<T,LDIM>* gimpl=g[i].get_impl().get();
-            result[i].get_impl()->multiply(fimpl,gimpl,particle);     // stupid naming inconsistency
+        for (std::size_t i = 0; i < result.size(); ++i) {
+            FunctionImpl<T, LDIM>* gimpl = g[i].get_impl().get();
+            result[i].get_impl()->multiply(fimpl, gimpl, particle);  // stupid naming inconsistency
         }
         world.gop.fence();
 
@@ -1209,38 +1220,38 @@ namespace madness {
     }
 
     template<typename T, std::size_t NDIM, std::size_t LDIM>
-    std::vector<Function<T,NDIM> > multiply(const Function<T,NDIM> f, const std::vector<Function<T,LDIM> > g,
+    std::vector<Function<T, NDIM>> multiply(const Function<T, NDIM> f, const std::vector<Function<T, LDIM>> g,
                               const std::tuple<int,int,int> v) {
-        return partial_mul<T,NDIM,LDIM>(f,g,std::array<int,3>({std::get<0>(v),std::get<1>(v),std::get<2>(v)}));
+        return partial_mul<T, NDIM, LDIM>(f, g, std::array<int,3>({std::get<0>(v), std::get<1>(v), std::get<2>(v)}));
     }
 
 
 /// Computes the square of a vector of functions --- q[i] = v[i]**2
     template <typename T, std::size_t NDIM>
-    std::vector< Function<T,NDIM> >
+    std::vector<Function<T, NDIM>>
     square(World& world,
-           const std::vector< Function<T,NDIM> >& v,
+           const std::vector<Function<T, NDIM>>& v,
            bool fence=true) {
-        return mul<T,T,NDIM>(world, v, v, fence);
-//         std::vector< Function<T,NDIM> > vsq(v.size());
-//         for (unsigned int i=0; i<v.size(); ++i) {
-//             vsq[i] = square(v[i], false);
-//         }
-//         if (fence) world.gop.fence();
-//         return vsq;
+        return mul<T, T, NDIM>(world, v, v, fence);
+        // std::vector<Function<T, NDIM>> vsq(v.size());
+        // for (unsigned int i = 0; i < v.size(); ++i) {
+        //     vsq[i] = square(v[i], false);
+        // }
+        // if (fence) world.gop.fence();
+        // return vsq;
     }
 
 
     /// Computes the square of a vector of functions --- q[i] = abs(v[i])**2
     template <typename T, std::size_t NDIM>
-    std::vector< Function<typename Tensor<T>::scalar_type,NDIM> >
+    std::vector<Function<typename Tensor<T>::scalar_type, NDIM>>
     abssq(World& world,
-           const std::vector< Function<T,NDIM> >& v,
+           const std::vector<Function<T, NDIM>>& v,
            bool fence=true) {
     	typedef typename Tensor<T>::scalar_type scalartype;
-    	reconstruct(world,v);
-    	std::vector<Function<scalartype,NDIM> > result(v.size());
-    	for (size_t i=0; i<v.size(); ++i) result[i]=abs_square(v[i],false);
+    	reconstruct(world, v);
+    	std::vector<Function<scalartype, NDIM>> result(v.size());
+    	for (size_t i = 0; i < v.size(); ++i) result[i] = abs_square(v[i], false);
     	if (fence) world.gop.fence();
         return result;
     }
@@ -1248,8 +1259,8 @@ namespace madness {
 
     /// Sets the threshold in a vector of functions
     template <typename T, std::size_t NDIM>
-    void set_thresh(World& world, std::vector< Function<T,NDIM> >& v, double thresh, bool fence=true) {
-        for (unsigned int j=0; j<v.size(); ++j) {
+    void set_thresh(World& world, std::vector<Function<T, NDIM>>& v, double thresh, bool fence=true) {
+        for (unsigned int j = 0; j < v.size(); ++j) {
             v[j].set_thresh(thresh,false);
         }
         if (fence) world.gop.fence();
@@ -1257,13 +1268,13 @@ namespace madness {
 
     /// Returns the complex conjugate of the vector of functions
     template <typename T, std::size_t NDIM>
-    std::vector< Function<T,NDIM> >
+    std::vector<Function<T, NDIM>>
     conj(World& world,
-         const std::vector< Function<T,NDIM> >& v,
+         const std::vector<Function<T, NDIM>>& v,
          bool fence=true) {
         PROFILE_BLOCK(Vconj);
-        std::vector< Function<T,NDIM> > r = copy(world, v); // Currently don't have oop conj
-        for (unsigned int i=0; i<v.size(); ++i) {
+        std::vector<Function<T, NDIM>> r = copy(world, v); // Currently don't have oop conj
+        for (unsigned int i = 0; i < v.size(); ++i) {
             r[i].conj(false);
         }
         if (fence) world.gop.fence();
@@ -1272,12 +1283,12 @@ namespace madness {
 
     /// Returns a deep copy of a vector of functions
     template <typename T, typename R, std::size_t NDIM>
-    std::vector< Function<R,NDIM> > convert(World& world,
-    		const std::vector< Function<T,NDIM> >& v, bool fence=true) {
+    std::vector<Function<R, NDIM>> convert(World& world,
+    		const std::vector<Function<T, NDIM>>& v, bool fence=true) {
         PROFILE_BLOCK(Vcopy);
-        std::vector< Function<R,NDIM> > r(v.size());
-        for (unsigned int i=0; i<v.size(); ++i) {
-            r[i] = convert<T,R,NDIM>(v[i], false);
+        std::vector<Function<R, NDIM>> r(v.size());
+        for (unsigned int i = 0; i < v.size(); ++i) {
+            r[i] = convert<T, R, NDIM>(v[i], false);
         }
         if (fence) world.gop.fence();
         return r;
@@ -1286,13 +1297,13 @@ namespace madness {
 
     /// Returns a deep copy of a vector of functions
     template <typename T, std::size_t NDIM>
-    std::vector< Function<T,NDIM> >
+    std::vector<Function<T, NDIM>>
     copy(World& world,
-         const std::vector< Function<T,NDIM> >& v,
+         const std::vector<Function<T, NDIM>>& v,
          bool fence=true) {
         PROFILE_BLOCK(Vcopy);
-        std::vector< Function<T,NDIM> > r(v.size());
-        for (unsigned int i=0; i<v.size(); ++i) {
+        std::vector<Function<T, NDIM>> r(v.size());
+        for (unsigned int i = 0; i < v.size(); ++i) {
             r[i] = copy(v[i], false);
         }
         if (fence) world.gop.fence();
@@ -1302,24 +1313,24 @@ namespace madness {
 
     /// Returns a deep copy of a vector of functions
     template <typename T, std::size_t NDIM>
-    std::vector< Function<T,NDIM> >
-    copy(const std::vector< Function<T,NDIM> >& v, bool fence=true) {
+    std::vector<Function<T, NDIM>>
+    copy(const std::vector<Function<T, NDIM>>& v, bool fence=true) {
         PROFILE_BLOCK(Vcopy);
-        std::vector< Function<T,NDIM> > r(v.size());
-        if (v.size()>0) r=copy(v.front().world(),v,fence);
+        std::vector<Function<T, NDIM>> r(v.size());
+        if (v.size() > 0) r = copy(v.front().world(), v, fence);
         return r;
     }
 
     /// Returns a vector of `n` deep copies of a function
     template <typename T, std::size_t NDIM>
-    std::vector< Function<T,NDIM> >
+    std::vector<Function<T, NDIM>>
     copy(World& world,
-         const Function<T,NDIM>& v,
+         const Function<T, NDIM>& v,
          const unsigned int n,
          bool fence=true) {
         PROFILE_BLOCK(Vcopy1);
-        std::vector< Function<T,NDIM> > r(n);
-        for (unsigned int i=0; i<n; ++i) {
+        std::vector<Function<T, NDIM>> r(n);
+        for (unsigned int i = 0; i < n; ++i) {
             r[i] = copy(v, false);
         }
         if (fence) world.gop.fence();
@@ -1339,7 +1350,7 @@ namespace madness {
     std::vector<Function<T, NDIM>> copy(World& world,
                                         const std::vector<Function<T, NDIM>>& v,
                                         const std::shared_ptr<WorldDCPmapInterface<Key<NDIM>>>& pmap,
-                                        bool fence = true) {
+                                        bool fence=true) {
       PROFILE_BLOCK(Vcopy);
       std::vector<Function<T, NDIM>> r(v.size());
       for (unsigned int i = 0; i < v.size(); ++i) {
@@ -1351,18 +1362,18 @@ namespace madness {
 
     /// Returns new vector of functions --- q[i] = a[i] + b[i]
     template <typename T, typename R, std::size_t NDIM>
-    std::vector< Function<TENSOR_RESULT_TYPE(T,R), NDIM> >
+    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>>
     add(World& world,
-        const std::vector< Function<T,NDIM> >& a,
-        const std::vector< Function<R,NDIM> >& b,
+        const std::vector<Function<T, NDIM>>& a,
+        const std::vector<Function<R, NDIM>>& b,
         bool fence=true) {
         PROFILE_BLOCK(Vadd);
         MADNESS_ASSERT(a.size() == b.size());
         compress(world, a);
         compress(world, b);
 
-        std::vector< Function<TENSOR_RESULT_TYPE(T,R),NDIM> > r(a.size());
-        for (unsigned int i=0; i<a.size(); ++i) {
+        std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>> r(a.size());
+        for (unsigned int i = 0; i < a.size(); ++i) {
             r[i] = add(a[i], b[i], false);
         }
         if (fence) world.gop.fence();
@@ -1371,45 +1382,45 @@ namespace madness {
 
      /// Returns new vector of functions --- q[i] = a + b[i]
     template <typename T, typename R, std::size_t NDIM>
-    std::vector< Function<TENSOR_RESULT_TYPE(T,R), NDIM> >
+    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>>
     add(World& world,
-        const Function<T,NDIM> & a,
-        const std::vector< Function<R,NDIM> >& b,
+        const Function<T, NDIM>& a,
+        const std::vector<Function<R, NDIM>>& b,
         bool fence=true) {
         PROFILE_BLOCK(Vadd1);
         a.compress();
         compress(world, b);
 
-        std::vector< Function<TENSOR_RESULT_TYPE(T,R),NDIM> > r(b.size());
-        for (unsigned int i=0; i<b.size(); ++i) {
+        std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>> r(b.size());
+        for (unsigned int i = 0; i < b.size(); ++i) {
             r[i] = add(a, b[i], false);
         }
         if (fence) world.gop.fence();
         return r;
     }
     template <typename T, typename R, std::size_t NDIM>
-    inline std::vector< Function<TENSOR_RESULT_TYPE(T,R), NDIM> >
+    inline std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>>
     add(World& world,
-        const std::vector< Function<R,NDIM> >& b,
-        const Function<T,NDIM> & a,
+        const std::vector<Function<R, NDIM>>& b,
+        const Function<T, NDIM>& a,
         bool fence=true) {
         return add(world, a, b, fence);
     }
 
     /// Returns new vector of functions --- q[i] = a[i] - b[i]
     template <typename T, typename R, std::size_t NDIM>
-    std::vector< Function<TENSOR_RESULT_TYPE(T,R), NDIM> >
+    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>>
     sub(World& world,
-        const std::vector< Function<T,NDIM> >& a,
-        const std::vector< Function<R,NDIM> >& b,
+        const std::vector<Function<T, NDIM>>& a,
+        const std::vector<Function<R, NDIM>>& b,
         bool fence=true) {
         PROFILE_BLOCK(Vsub);
         MADNESS_ASSERT(a.size() == b.size());
         compress(world, a);
         compress(world, b);
 
-        std::vector< Function<TENSOR_RESULT_TYPE(T,R),NDIM> > r(a.size());
-        for (unsigned int i=0; i<a.size(); ++i) {
+        std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>> r(a.size());
+        for (unsigned int i = 0; i < a.size(); ++i) {
             r[i] = sub(a[i], b[i], false);
         }
         if (fence) world.gop.fence();
@@ -1418,48 +1429,47 @@ namespace madness {
 
     /// Returns new function --- q = sum_i f[i]
     template <typename T, std::size_t NDIM>
-    Function<T, NDIM> sum(World& world, const std::vector<Function<T,NDIM> >& f,
-        bool fence=true) {
+    Function<T, NDIM> sum(World& world, const std::vector<Function<T, NDIM>>& f,
+            bool fence=true) {
 
         compress(world, f);
-        Function<T,NDIM> r=FunctionFactory<T,NDIM>(world).compressed();
+        Function<T, NDIM> r = FunctionFactory<T, NDIM>(world).compressed();
 
-        for (unsigned int i=0; i<f.size(); ++i) r.gaxpy(1.0,f[i],1.0,false);
+        for (unsigned int i = 0; i < f.size(); ++i) r.gaxpy(1.0, f[i], 1.0, false);
         if (fence) world.gop.fence();
         return r;
     }
 
-
     /// Multiplies and sums two vectors of functions r = \sum_i a[i] * b[i]
     template <typename T, typename R, std::size_t NDIM>
-    Function<TENSOR_RESULT_TYPE(T,R), NDIM>
+    Function<TENSOR_RESULT_TYPE(T, R), NDIM>
     dot(World& world,
-        const std::vector< Function<T,NDIM> >& a,
-        const std::vector< Function<R,NDIM> >& b,
+        const std::vector<Function<T, NDIM>>& a,
+        const std::vector<Function<R, NDIM>>& b,
         bool fence=true) {
         MADNESS_CHECK(a.size()==b.size());
-        return sum(world,mul(world,a,b,true),fence);
+        return sum(world, mul(world, a, b,true), fence);
     }
 
 
     /// out-of-place gaxpy for two vectors: result[i] = alpha * a[i] + beta * b[i]
     template <typename T, typename Q, typename R, std::size_t NDIM>
-    std::vector<Function<TENSOR_RESULT_TYPE(Q,TENSOR_RESULT_TYPE(T,R)),NDIM> >
+    std::vector<Function<TENSOR_RESULT_TYPE(Q, TENSOR_RESULT_TYPE(T, R)), NDIM>>
     gaxpy_oop(Q alpha,
-               const std::vector< Function<T,NDIM> >& a,
-               Q beta,
-               const std::vector< Function<R,NDIM> >& b,
-               bool fence=true) {
+              const std::vector<Function<T, NDIM>>& a,
+              Q beta,
+              const std::vector<Function<R, NDIM>>& b,
+              bool fence=true) {
 
         MADNESS_ASSERT(a.size() == b.size());
-        typedef TENSOR_RESULT_TYPE(Q,TENSOR_RESULT_TYPE(T,R)) resultT;
-        if (a.size()==0) return std::vector<Function<resultT,NDIM> >();
+        typedef TENSOR_RESULT_TYPE(Q, TENSOR_RESULT_TYPE(T, R)) resultT;
+        if (a.size() == 0) return std::vector<Function<resultT, NDIM>>();
 
-        World& world=a[0].world();
-        compress(world,a);
-    	compress(world,b);
-    	std::vector<Function<resultT,NDIM> > result(a.size());
-        for (unsigned int i=0; i<a.size(); ++i) {
+        World& world = a[0].world();
+        compress(world, a);
+    	compress(world, b);
+    	std::vector<Function<resultT, NDIM>> result(a.size());
+        for (unsigned int i = 0; i < a.size(); ++i) {
             result[i]=gaxpy_oop(alpha, a[i], beta, b[i], false);
         }
         if (fence) world.gop.fence();
@@ -1469,22 +1479,22 @@ namespace madness {
 
     /// out-of-place gaxpy for a vectors and a function: result[i] = alpha * a[i] + beta * b
     template <typename T, typename Q, typename R, std::size_t NDIM>
-    std::vector<Function<TENSOR_RESULT_TYPE(Q,TENSOR_RESULT_TYPE(T,R)),NDIM> >
+    std::vector<Function<TENSOR_RESULT_TYPE(Q, TENSOR_RESULT_TYPE(T, R)), NDIM> >
     gaxpy_oop(Q alpha,
-               const std::vector< Function<T,NDIM> >& a,
-               Q beta,
-               const Function<R,NDIM>& b,
-               bool fence=true) {
+              const std::vector<Function<T, NDIM>>& a,
+              Q beta,
+              const Function<R,NDIM>& b,
+              bool fence=true) {
 
-        typedef TENSOR_RESULT_TYPE(Q,TENSOR_RESULT_TYPE(T,R)) resultT;
-        if (a.size()==0) return std::vector<Function<resultT,NDIM> >();
+        typedef TENSOR_RESULT_TYPE(Q, TENSOR_RESULT_TYPE(T, R)) resultT;
+        if (a.size() == 0) return std::vector<Function<resultT, NDIM>>();
 
-        World& world=a[0].world();
-        compress(world,a);
+        World& world = a[0].world();
+        compress(world, a);
     	b.compress();
-    	std::vector<Function<resultT,NDIM> > result(a.size());
-        for (unsigned int i=0; i<a.size(); ++i) {
-            result[i]=gaxpy_oop(alpha, a[i], beta, b, false);
+    	std::vector<Function<resultT, NDIM>> result(a.size());
+        for (unsigned int i = 0; i < a.size(); ++i) {
+            result[i] = gaxpy_oop(alpha, a[i], beta, b, false);
         }
         if (fence) world.gop.fence();
         return result;
@@ -1493,19 +1503,23 @@ namespace madness {
 
     /// Generalized A*X+Y for vectors of functions ---- a[i] = alpha*a[i] + beta*b[i]
     template <typename T, typename Q, typename R, std::size_t NDIM>
-	void gaxpy(Q alpha, std::vector<Function<T,NDIM>>& a, Q beta, const std::vector<Function<R,NDIM>>& b, const bool fence) {
+	void gaxpy(Q alpha,
+               std::vector<Function<T, NDIM>>& a,
+               Q beta,
+               const std::vector<Function<R,NDIM>>& b,
+               const bool fence) {
 	    if (a.size() == 0) return;
-    	World& world=a.front().world();
-    	gaxpy(world,alpha,a,beta,b,fence);
+    	World& world = a.front().world();
+    	gaxpy(world, alpha, a, beta, b, fence);
     }
 
     /// Generalized A*X+Y for vectors of functions ---- a[i] = alpha*a[i] + beta*b[i]
     template <typename T, typename Q, typename R, std::size_t NDIM>
     void gaxpy(World& world,
                Q alpha,
-               std::vector< Function<T,NDIM> >& a,
+               std::vector<Function<T, NDIM>>& a,
                Q beta,
-               const std::vector< Function<R,NDIM> >& b,
+               const std::vector<Function<R, NDIM>>& b,
                bool fence=true) {
         PROFILE_BLOCK(Vgaxpy);
         MADNESS_ASSERT(a.size() == b.size());
@@ -1513,10 +1527,10 @@ namespace madness {
 			compress(a.front().world(), a);
 			compress(b.front().world(), b);
     	}
-    	for (const auto& aa : a) MADNESS_CHECK_THROW(aa.is_compressed(),"vector-gaxpy requires compressed functions");
-    	for (const auto& bb : b) MADNESS_CHECK_THROW(bb.is_compressed(),"vector-gaxpy requires compressed functions");
+    	for (const auto& aa : a) MADNESS_CHECK_THROW(aa.is_compressed(), "vector-gaxpy requires compressed functions");
+    	for (const auto& bb : b) MADNESS_CHECK_THROW(bb.is_compressed(), "vector-gaxpy requires compressed functions");
 
-        for (unsigned int i=0; i<a.size(); ++i) {
+        for (unsigned int i = 0; i < a.size(); ++i) {
             a[i].gaxpy(alpha, b[i], beta, false);
         }
         if (fence) world.gop.fence();
@@ -1525,21 +1539,21 @@ namespace madness {
 
     /// Applies a vector of operators to a vector of functions --- q[i] = apply(op[i],f[i])
     template <typename opT, typename R, std::size_t NDIM>
-    std::vector< Function<TENSOR_RESULT_TYPE(typename opT::opT,R), NDIM> >
+    std::vector<Function<TENSOR_RESULT_TYPE(typename opT::opT, R), NDIM>>
     apply(World& world,
-          const std::vector< std::shared_ptr<opT> >& op,
-          const std::vector< Function<R,NDIM> > f) {
+          const std::vector<std::shared_ptr<opT>>& op,
+          const std::vector<Function<R, NDIM>> f) {
 
         PROFILE_BLOCK(Vapplyv);
-        MADNESS_ASSERT(f.size()==op.size());
+        MADNESS_ASSERT(f.size() == op.size());
 
-        std::vector< Function<R,NDIM> >& ncf = *const_cast< std::vector< Function<R,NDIM> >* >(&f);
+        std::vector<Function<R, NDIM>>& ncf = *const_cast<std::vector<Function<R, NDIM>>*>(&f);
 
 //        reconstruct(world, f);
         make_nonstandard(world, ncf);
 
-        std::vector< Function<TENSOR_RESULT_TYPE(typename opT::opT,R), NDIM> > result(f.size());
-        for (unsigned int i=0; i<f.size(); ++i) {
+        std::vector<Function<TENSOR_RESULT_TYPE(typename opT::opT, R), NDIM>> result(f.size());
+        for (unsigned int i = 0; i < f.size(); ++i) {
             result[i] = apply_only(*op[i], f[i], false);
             result[i].get_impl()->set_tree_state(nonstandard_after_apply);
         }
@@ -1556,32 +1570,32 @@ namespace madness {
 
     /// Applies an operator to a vector of functions --- q[i] = apply(op,f[i])
     template <typename T, typename R, std::size_t NDIM, std::size_t KDIM>
-    std::vector< Function<TENSOR_RESULT_TYPE(T,R), NDIM> >
+    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>>
     apply(const SeparatedConvolution<T,KDIM>& op,
-          const std::vector< Function<R,NDIM> > f) {
+          const std::vector<Function<R, NDIM>> f) {
         return apply(op.get_world(),op,f);
     }
 
 
     /// Applies an operator to a vector of functions --- q[i] = apply(op,f[i])
     template <typename T, typename R, std::size_t NDIM, std::size_t KDIM>
-    std::vector< Function<TENSOR_RESULT_TYPE(T,R), NDIM> >
+    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>>
     apply(World& world,
           const SeparatedConvolution<T,KDIM>& op,
-          const std::vector< Function<R,NDIM> > f) {
+          const std::vector<Function<R, NDIM>> f) {
         PROFILE_BLOCK(Vapply);
 
-        std::vector< Function<R,NDIM> >& ncf = *const_cast< std::vector< Function<R,NDIM> >* >(&f);
-        bool print_timings=(NDIM==6) and (world.rank()==0) and op.print_timings;
+        std::vector<Function<R, NDIM>>& ncf = *const_cast<std::vector<Function<R, NDIM>>*>(&f);
+        bool print_timings = (NDIM == 6) and (world.rank() == 0) and op.print_timings;
 
-        double wall0=wall_time();
-//        reconstruct(world, f);
+        double wall0 = wall_time();
+        // reconstruct(world, f);
         make_nonstandard(world, ncf);
-        double wall1=wall_time();
-        if (print_timings) printf("timer: %20.20s %8.2fs\n", "make_nonstandard", wall1-wall0);
+        double wall1 = wall_time();
+        if (print_timings) printf("timer: %20.20s %8.2fs\n", "make_nonstandard", wall1 - wall0);
 
-        std::vector< Function<TENSOR_RESULT_TYPE(T,R), NDIM> > result(f.size());
-        for (unsigned int i=0; i<f.size(); ++i) {
+        std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>> result(f.size());
+        for (unsigned int i = 0; i < f.size(); ++i) {
             result[i] = apply_only(op, f[i], false);
         }
 
@@ -1596,7 +1610,7 @@ namespace madness {
         }
 
         // svd-tensor requires some cleanup after apply
-        if (result[0].get_impl()->get_tensor_type()==TT_2D) {
+        if (result[0].get_impl()->get_tensor_type() == TT_2D) {
             for (auto& r : result) r.get_impl()->finalize_apply();
         }
 
@@ -1611,20 +1625,20 @@ namespace madness {
 
     /// Normalizes a vector of functions --- v[i] = v[i].scale(1.0/v[i].norm2())
     template <typename T, std::size_t NDIM>
-    void normalize(World& world, std::vector< Function<T,NDIM> >& v, bool fence=true) {
+    void normalize(World& world, std::vector<Function<T, NDIM>>& v, bool fence=true) {
         PROFILE_BLOCK(Vnormalize);
         std::vector<double> nn = norm2s(world, v);
-        for (unsigned int i=0; i<v.size(); ++i) v[i].scale(1.0/nn[i],false);
+        for (unsigned int i = 0; i < v.size(); ++i) v[i].scale(1.0 / nn[i], false);
         if (fence) world.gop.fence();
     }
 
     template <typename T, std::size_t NDIM>
-    void print_size(World &world, const std::vector<Function<T,NDIM> > &v, const std::string &msg = "vectorfunction" ){
-    	if(v.empty()){
-    		if(world.rank()==0) std::cout << "print_size: " << msg << " is empty" << std::endl;
-    	}else if(v.size()==1){
+    void print_size(World &world, const std::vector<Function<T, NDIM>> &v, const std::string &msg = "vectorfunction"){
+    	if (v.empty()){
+    		if(world.rank() == 0) std::cout << "print_size: " << msg << " is empty" << std::endl;
+    	} else if (v.size() == 1){
     		v.front().print_size(msg);
-    	}else{
+    	} else {
     		for(auto x:v){
     			x.print_size(msg);
     		}
@@ -1633,16 +1647,15 @@ namespace madness {
 
     // gives back the size in GB
     template <typename T, std::size_t NDIM>
-    double get_size(World& world, const std::vector< Function<T,NDIM> >& v){
-
+    double get_size(World& world, const std::vector<Function<T, NDIM>>& v){
     	if (v.empty()) return 0.0;
 
-    	const double d=sizeof(T);
-        const double fac=1024*1024*1024;
+    	const double d = sizeof(T);
+        const double fac = 1024 * 1024 * 1024;
 
-        double size=0.0;
-        for(unsigned int i=0;i<v.size();i++){
-            if (v[i].is_initialized()) size+=v[i].size();
+        double size = 0.0;
+        for(unsigned int i = 0; i < v.size(); i++){
+            if (v[i].is_initialized()) size += v[i].size();
         }
 
         return size/fac*d;
@@ -1651,11 +1664,11 @@ namespace madness {
 
     // gives back the size in GB
     template <typename T, std::size_t NDIM>
-    double get_size(const Function<T,NDIM> & f){
-    	const double d=sizeof(T);
-        const double fac=1024*1024*1024;
-        double size=f.size();
-        return size/fac*d;
+    double get_size(const Function<T, NDIM>& f){
+    	const double d = sizeof(T);
+        const double fac = 1024 * 1024 * 1024;
+        double size = f.size();
+        return size / fac * d;
     }
 
     /// apply op on the input vector yielding an output vector of functions
@@ -1664,16 +1677,16 @@ namespace madness {
     /// @param[in]  vin  vector of input Functions; needs to be refined to common level!
     /// @return vector of output Functions vout = op(vin)
     template <typename T, typename opT, std::size_t NDIM>
-    std::vector<Function<T,NDIM> > multi_to_multi_op_values(const opT& op,
-            const std::vector< Function<T,NDIM> >& vin,
+    std::vector<Function<T, NDIM>> multi_to_multi_op_values(const opT& op,
+            const std::vector<Function<T, NDIM>>& vin,
             const bool fence=true) {
-        MADNESS_ASSERT(vin.size()>0);
+        MADNESS_ASSERT(vin.size() > 0);
         MADNESS_ASSERT(vin[0].is_initialized()); // might be changed
-        World& world=vin[0].world();
-        Function<T,NDIM> dummy;
+        World& world = vin[0].world();
+        Function<T, NDIM> dummy;
         dummy.set_impl(vin[0], false);
-        std::vector<Function<T,NDIM> > vout=zero_functions<T,NDIM>(world, op.get_result_size());
-        for (auto& out : vout) out.set_impl(vin[0],false);
+        std::vector<Function<T, NDIM>> vout = zero_functions<T, NDIM>(world, op.get_result_size());
+        for (auto& out : vout) out.set_impl(vin[0], false);
         dummy.multi_to_multi_op_values(op, vin, vout, fence);
         return vout;
     }
@@ -1685,114 +1698,114 @@ namespace madness {
 
     /// result[i] = a[i] + b[i]
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T,NDIM> > operator+(const std::vector<Function<T,NDIM> >& lhs,
-            const std::vector<Function<T,NDIM>>& rhs) {
+    std::vector<Function<T, NDIM>> operator+(const std::vector<Function<T, NDIM>>& lhs,
+            const std::vector<Function<T, NDIM>>& rhs) {
         MADNESS_CHECK(lhs.size() == rhs.size());
-        return gaxpy_oop(1.0,lhs,1.0,rhs);
+        return gaxpy_oop(1.0, lhs, 1.0, rhs);
     }
 
     /// result[i] = a[i] - b[i]
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T,NDIM> > operator-(const std::vector<Function<T,NDIM> >& lhs,
-            const std::vector<Function<T,NDIM> >& rhs) {
+    std::vector<Function<T, NDIM>> operator-(const std::vector<Function<T, NDIM>>& lhs,
+            const std::vector<Function<T, NDIM>>& rhs) {
         MADNESS_CHECK(lhs.size() == rhs.size());
-        return gaxpy_oop(1.0,lhs,-1.0,rhs);
+        return gaxpy_oop(1.0, lhs, -1.0, rhs);
     }
 
     /// result[i] = a[i] + b
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T,NDIM> > operator+(const std::vector<Function<T,NDIM> >& lhs,
-            const Function<T,NDIM>& rhs) {
+    std::vector<Function<T, NDIM>> operator+(const std::vector<Function<T, NDIM>>& lhs,
+            const Function<T, NDIM>& rhs) {
         // MADNESS_CHECK(lhs.size() == rhs.size()); // no!!
-        return gaxpy_oop(1.0,lhs,1.0,rhs);
+        return gaxpy_oop(1.0, lhs, 1.0, rhs);
     }
 
     /// result[i] = a[i] - b
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T,NDIM> > operator-(const std::vector<Function<T,NDIM> >& lhs,
-            const Function<T,NDIM>& rhs) {
+    std::vector<Function<T, NDIM>> operator-(const std::vector<Function<T, NDIM>>& lhs,
+            const Function<T, NDIM>& rhs) {
         // MADNESS_CHECK(lhs.size() == rhs.size());  // no
-        return gaxpy_oop(1.0,lhs,-1.0,rhs);
+        return gaxpy_oop(1.0, lhs, -1.0, rhs);
     }
 
     /// result[i] = a + b[i]
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T,NDIM> > operator+(const Function<T,NDIM>& lhs,
-            const std::vector<Function<T,NDIM> >& rhs) {
+    std::vector<Function<T, NDIM>> operator+(const Function<T, NDIM>& lhs,
+            const std::vector<Function<T, NDIM>>& rhs) {
         // MADNESS_CHECK(lhs.size() == rhs.size());   // no
-        return gaxpy_oop(1.0,rhs,1.0,lhs);
+        return gaxpy_oop(1.0, rhs, 1.0, lhs);
     }
 
     /// result[i] = a - b[i]
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T,NDIM> > operator-(const Function<T,NDIM>& lhs,
-            const std::vector<Function<T,NDIM> >& rhs) {
-//         MADNESS_CHECK(lhs.size() == rhs.size());  // no
-        return gaxpy_oop(-1.0,rhs,1.0,lhs);
+    std::vector<Function<T, NDIM>> operator-(const Function<T, NDIM>& lhs,
+            const std::vector<Function<T, NDIM>>& rhs) {
+        // MADNESS_CHECK(lhs.size() == rhs.size());  // no
+        return gaxpy_oop(-1.0, rhs, 1.0, lhs);
     }
 
 
     template <typename T, typename R, std::size_t NDIM>
-    std::vector<Function<TENSOR_RESULT_TYPE(T,R),NDIM> > operator*(const R fac,
-            const std::vector<Function<T,NDIM> >& rhs) {
+    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM> > operator*(const R fac,
+            const std::vector<Function<T, NDIM>>& rhs) {
     	if (rhs.size()>0) {
-			std::vector<Function<T,NDIM> > tmp=copy(rhs[0].world(),rhs);
-			scale(tmp[0].world(),tmp,TENSOR_RESULT_TYPE(T,R)(fac));
+			std::vector<Function<T, NDIM>> tmp = copy(rhs[0].world(), rhs);
+			scale(tmp[0].world(), tmp, TENSOR_RESULT_TYPE(T, R)(fac));
 			return tmp;
     	}
-		return std::vector<Function<TENSOR_RESULT_TYPE(T,R),NDIM> >();
+		return std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>>();
     }
 
     template <typename T, typename R, std::size_t NDIM>
-    std::vector<Function<T,NDIM> > operator*(const std::vector<Function<T,NDIM> >& rhs,
+    std::vector<Function<T, NDIM>> operator*(const std::vector<Function<T, NDIM>>& rhs,
             const R fac) {
     	if (rhs.size()>0) {
-            std::vector<Function<TENSOR_RESULT_TYPE(T,R),NDIM> > tmp=copy(rhs[0].world(),rhs);
-            scale(tmp[0].world(),tmp,TENSOR_RESULT_TYPE(T,R)(fac));
+            std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM> > tmp = copy(rhs[0].world(), rhs);
+            scale(tmp[0].world(), tmp, TENSOR_RESULT_TYPE(T, R)(fac));
             return tmp;
     	}
-		return std::vector<Function<TENSOR_RESULT_TYPE(T,R),NDIM> >();
+		return std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM> >();
     }
 
     /// multiply a vector of functions with a function: r[i] = v[i] * a
     template <typename T, typename R, std::size_t NDIM>
-    std::vector<Function<TENSOR_RESULT_TYPE(T,R),NDIM> > operator*(const Function<T,NDIM>& a,
-            const std::vector<Function<R,NDIM> >& v) {
-        if (v.size()>0) return mul(v[0].world(),a,v,true);
-        return std::vector<Function<TENSOR_RESULT_TYPE(T,R),NDIM> >();
+    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>> operator*(const Function<T, NDIM>& a,
+            const std::vector<Function<R,NDIM>>& v) {
+        if (v.size() > 0) return mul(v[0].world(), a, v, true);
+        return std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>>();
     }
 
 
     /// multiply a vector of functions with a function: r[i] = a * v[i]
     template <typename T, typename R, std::size_t NDIM>
-    std::vector<Function<TENSOR_RESULT_TYPE(T,R),NDIM> > operator*(const std::vector<Function<T,NDIM> >& v,
-            const Function<R,NDIM>& a) {
-        if (v.size()>0) return mul(v[0].world(),a,v,true);
-        return std::vector<Function<TENSOR_RESULT_TYPE(T,R),NDIM> >();
+    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>> operator*(const std::vector<Function<T, NDIM>>& v,
+            const Function<R, NDIM>& a) {
+        if (v.size() > 0) return mul(v[0].world(), a, v, true);
+        return std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>>();
     }
 
 
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T,NDIM> > operator+=(std::vector<Function<T,NDIM> >& lhs, const std::vector<Function<T,NDIM> >& rhs) {
+    std::vector<Function<T, NDIM>> operator+=(std::vector<Function<T, NDIM>>& lhs, const std::vector<Function<T, NDIM>>& rhs) {
         MADNESS_CHECK(lhs.size() == rhs.size());
         if (lhs.size() > 0) gaxpy(lhs.front().world(), 1.0, lhs, 1.0, rhs);
-	return lhs;
+	    return lhs;
     }
 
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T,NDIM> > operator-=(std::vector<Function<T,NDIM> >& lhs,
-            const std::vector<Function<T,NDIM> >& rhs) {
+    std::vector<Function<T, NDIM>> operator-=(std::vector<Function<T, NDIM>>& lhs,
+            const std::vector<Function<T, NDIM>>& rhs) {
         MADNESS_CHECK(lhs.size() == rhs.size());
         if (lhs.size() > 0) gaxpy(lhs.front().world(), 1.0, lhs, -1.0, rhs);
-	return lhs;
+	    return lhs;
     }
 
     /// return the real parts of the vector's function (if complex)
     template <typename T, std::size_t NDIM>
     std::vector<Function<typename Tensor<T>::scalar_type,NDIM> >
-    real(const std::vector<Function<T,NDIM> >& v, bool fence=true) {
-    	std::vector<Function<typename Tensor<T>::scalar_type,NDIM> > result(v.size());
-    	for (std::size_t i=0; i<v.size(); ++i) result[i]=real(v[i],false);
+    real(const std::vector<Function<T, NDIM>>& v, bool fence=true) {
+    	std::vector<Function<typename Tensor<T>::scalar_type, NDIM>> result(v.size());
+    	for (std::size_t i = 0; i < v.size(); ++i) result[i] = real(v[i], false);
         if (fence and result.size()>0) result[0].world().gop.fence();
         return result;
     }
@@ -1800,10 +1813,10 @@ namespace madness {
     /// return the imaginary parts of the vector's function (if complex)
     template <typename T, std::size_t NDIM>
     std::vector<Function<typename Tensor<T>::scalar_type,NDIM> >
-    imag(const std::vector<Function<T,NDIM> >& v, bool fence=true) {
-    	std::vector<Function<typename Tensor<T>::scalar_type,NDIM> > result(v.size());
-    	for (std::size_t i=0; i<v.size(); ++i) result[i]=imag(v[i],false);
-        if (fence and result.size()>0) result[0].world().gop.fence();
+    imag(const std::vector<Function<T, NDIM>>& v, bool fence=true) {
+    	std::vector<Function<typename Tensor<T>::scalar_type, NDIM>> result(v.size());
+    	for (std::size_t i = 0; i < v.size(); ++i) result[i] = imag(v[i], false);
+        if (fence and result.size() > 0) result[0].world().gop.fence();
         return result;
     }
 
@@ -1815,123 +1828,123 @@ namespace madness {
     /// @param[in]  fence   fence after completion; if reconstruction is needed always fence
     /// @return     the vector \frac{\partial}{\partial x_i} f
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T,NDIM> > grad(const Function<T,NDIM>& f,
+    std::vector<Function<T, NDIM>> grad(const Function<T, NDIM>& f,
             bool refine=false, bool fence=true) {
 
-        World& world=f.world();
+        World& world = f.world();
         f.reconstruct();
         if (refine) f.refine();      // refine to make result more precise
 
-        std::vector< std::shared_ptr< Derivative<T,NDIM> > > grad=
-                gradient_operator<T,NDIM>(world);
+        std::vector<std::shared_ptr< Derivative<T, NDIM>>> grad =
+                gradient_operator<T, NDIM>(world);
 
-        std::vector<Function<T,NDIM> > result(NDIM);
-        for (size_t i=0; i<NDIM; ++i) result[i]=apply(*(grad[i]),f,false);
+        std::vector<Function<T, NDIM>> result(NDIM);
+        for (size_t i = 0; i < NDIM; ++i) result[i] = apply(*(grad[i]), f, false);
         if (fence) world.gop.fence();
         return result;
     }
 
     // BLM first derivative
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T,NDIM> > grad_ble_one(const Function<T,NDIM>& f,
+    std::vector<Function<T, NDIM>> grad_ble_one(const Function<T, NDIM>& f,
             bool refine=false, bool fence=true) {
 
-        World& world=f.world();
+        World& world = f.world();
         f.reconstruct();
         if (refine) f.refine();      // refine to make result more precise
 
-        std::vector< std::shared_ptr< Derivative<T,NDIM> > > grad=
-                gradient_operator<T,NDIM>(world);
+        std::vector<std::shared_ptr<Derivative<T, NDIM>>> grad=
+                gradient_operator<T, NDIM>(world);
 
         // Read in new coeff for each operator
-        for (unsigned int i=0; i<NDIM; ++i) (*grad[i]).set_ble1();
+        for (unsigned int i = 0; i < NDIM; ++i) (*grad[i]).set_ble1();
 
-        std::vector<Function<T,NDIM> > result(NDIM);
-        for (unsigned int i=0; i<NDIM; ++i) result[i]=apply(*(grad[i]),f,false);
+        std::vector<Function<T, NDIM>> result(NDIM);
+        for (unsigned int i = 0; i < NDIM; ++i) result[i] = apply(*(grad[i]), f, false);
         if (fence) world.gop.fence();
         return result;
     }
 
     // BLM second derivative
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T,NDIM> > grad_ble_two(const Function<T,NDIM>& f,
+    std::vector<Function<T, NDIM>> grad_ble_two(const Function<T, NDIM>& f,
             bool refine=false, bool fence=true) {
 
-        World& world=f.world();
+        World& world = f.world();
         f.reconstruct();
         if (refine) f.refine();      // refine to make result more precise
 
-        std::vector< std::shared_ptr< Derivative<T,NDIM> > > grad=
-                gradient_operator<T,NDIM>(world);
+        std::vector<std::shared_ptr< Derivative<T, NDIM>>> grad =
+                gradient_operator<T, NDIM>(world);
 
         // Read in new coeff for each operator
-        for (unsigned int i=0; i<NDIM; ++i) (*grad[i]).set_ble2();
+        for (unsigned int i = 0; i < NDIM; ++i) (*grad[i]).set_ble2();
 
-        std::vector<Function<T,NDIM> > result(NDIM);
-        for (unsigned int i=0; i<NDIM; ++i) result[i]=apply(*(grad[i]),f,false);
+        std::vector<Function<T, NDIM>> result(NDIM);
+        for (unsigned int i = 0; i < NDIM; ++i) result[i]=apply(*(grad[i]), f, false);
         if (fence) world.gop.fence();
         return result;
     }
 
     // Bspline first derivative
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T,NDIM> > grad_bspline_one(const Function<T,NDIM>& f,
+    std::vector<Function<T, NDIM>> grad_bspline_one(const Function<T, NDIM>& f,
             bool refine=false, bool fence=true) {
 
-        World& world=f.world();
+        World& world = f.world();
         f.reconstruct();
         if (refine) f.refine();      // refine to make result more precise
 
-        std::vector< std::shared_ptr< Derivative<T,NDIM> > > grad=
-                gradient_operator<T,NDIM>(world);
+        std::vector<std::shared_ptr< Derivative<T, NDIM>>> grad=
+                gradient_operator<T, NDIM>(world);
 
         // Read in new coeff for each operator
-        for (unsigned int i=0; i<NDIM; ++i) (*grad[i]).set_bspline1();
+        for (unsigned int i = 0; i < NDIM; ++i) (*grad[i]).set_bspline1();
 
-        std::vector<Function<T,NDIM> > result(NDIM);
-        for (unsigned int i=0; i<NDIM; ++i) result[i]=apply(*(grad[i]),f,false);
+        std::vector<Function<T, NDIM>> result(NDIM);
+        for (unsigned int i = 0; i < NDIM; ++i) result[i] = apply(*(grad[i]), f, false);
         if (fence) world.gop.fence();
         return result;
     }
 
     // Bpsline second derivative
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T,NDIM> > grad_bpsline_two(const Function<T,NDIM>& f,
+    std::vector<Function<T, NDIM>> grad_bpsline_two(const Function<T, NDIM>& f,
             bool refine=false, bool fence=true) {
 
-        World& world=f.world();
+        World& world = f.world();
         f.reconstruct();
-        if (refine) f.refine();      // refine to make result more precise
+        if (refine) f.refine();  // refine to make result more precise
 
-        std::vector< std::shared_ptr< Derivative<T,NDIM> > > grad=
-                gradient_operator<T,NDIM>(world);
+        std::vector<std::shared_ptr< Derivative<T, NDIM>>> grad =
+                gradient_operator<T, NDIM>(world);
 
         // Read in new coeff for each operator
-        for (unsigned int i=0; i<NDIM; ++i) (*grad[i]).set_bspline2();
+        for (unsigned int i = 0; i < NDIM; ++i) (*grad[i]).set_bspline2();
 
-        std::vector<Function<T,NDIM> > result(NDIM);
-        for (unsigned int i=0; i<NDIM; ++i) result[i]=apply(*(grad[i]),f,false);
+        std::vector<Function<T, NDIM>> result(NDIM);
+        for (unsigned int i = 0; i < NDIM; ++i) result[i] = apply(*(grad[i]), f, false);
         if (fence) world.gop.fence();
         return result;
     }
 
     // Bspline third derivative
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T,NDIM> > grad_bspline_three(const Function<T,NDIM>& f,
+    std::vector<Function<T, NDIM>> grad_bspline_three(const Function<T, NDIM>& f,
             bool refine=false, bool fence=true) {
 
-        World& world=f.world();
+        World& world = f.world();
         f.reconstruct();
         if (refine) f.refine();      // refine to make result more precise
 
-        std::vector< std::shared_ptr< Derivative<T,NDIM> > > grad=
-                gradient_operator<T,NDIM>(world);
+        std::vector<std::shared_ptr< Derivative<T, NDIM>>> grad =
+                gradient_operator<T, NDIM>(world);
 
         // Read in new coeff for each operator
-        for (unsigned int i=0; i<NDIM; ++i) (*grad[i]).set_bspline3();
+        for (unsigned int i = 0; i < NDIM; ++i) (*grad[i]).set_bspline3();
 
-        std::vector<Function<T,NDIM> > result(NDIM);
-        for (unsigned int i=0; i<NDIM; ++i) result[i]=apply(*(grad[i]),f,false);
+        std::vector<Function<T, NDIM>> result(NDIM);
+        for (unsigned int i = 0; i < NDIM; ++i) result[i] = apply(*(grad[i]), f, false);
         if (fence) world.gop.fence();
         return result;
     }
@@ -1947,19 +1960,19 @@ namespace madness {
     /// @return     the vector \frac{\partial}{\partial x_i} f
     /// TODO: add this to operator fusion
     template <typename T, std::size_t NDIM>
-    Function<T,NDIM> div(const std::vector<Function<T,NDIM> >& v,
+    Function<T, NDIM> div(const std::vector<Function<T, NDIM>>& v,
             bool do_refine=false, bool fence=true) {
 
-        MADNESS_ASSERT(v.size()>0);
-        World& world=v[0].world();
-        reconstruct(world,v);
-        if (do_refine) refine(world,v);      // refine to make result more precise
+        MADNESS_ASSERT(v.size() > 0);
+        World& world = v[0].world();
+        reconstruct(world, v);
+        if (do_refine) refine(world, v);      // refine to make result more precise
 
-        std::vector< std::shared_ptr< Derivative<T,NDIM> > > grad=
-                gradient_operator<T,NDIM>(world);
+        std::vector<std::shared_ptr< Derivative<T, NDIM>>> grad =
+                gradient_operator<T, NDIM>(world);
 
-        std::vector<Function<T,NDIM> > result(NDIM);
-        for (size_t i=0; i<NDIM; ++i) result[i]=apply(*(grad[i]),v[i],false);
+        std::vector<Function<T, NDIM>> result(NDIM);
+        for (size_t i = 0; i < NDIM; ++i) result[i] = apply(*(grad[i]), v[i], false);
         world.gop.fence();
         return sum(world,result,fence);
     }
@@ -1973,29 +1986,29 @@ namespace madness {
     /// @return     the vector \frac{\partial}{\partial x_i} f
     /// TODO: add this to operator fusion
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T,NDIM> > rot(const std::vector<Function<T,NDIM> >& v,
+    std::vector<Function<T, NDIM>> rot(const std::vector<Function<T, NDIM>>& v,
             bool do_refine=false, bool fence=true) {
 
-        MADNESS_ASSERT(v.size()==3);
-        World& world=v[0].world();
-        reconstruct(world,v);
-        if (do_refine) refine(world,v);      // refine to make result more precise
+        MADNESS_ASSERT(v.size() == 3);
+        World& world = v[0].world();
+        reconstruct(world, v);
+        if (do_refine) refine(world, v);      // refine to make result more precise
 
-        std::vector< std::shared_ptr< Derivative<T,NDIM> > > grad=
-                gradient_operator<T,NDIM>(world);
+        std::vector<std::shared_ptr< Derivative<T, NDIM>>> grad =
+                gradient_operator<T, NDIM>(world);
 
-        std::vector<Function<T,NDIM> > d(NDIM),dd(NDIM);
-        d[0]=apply(*(grad[1]),v[2],false);	// Dy z
-        d[1]=apply(*(grad[2]),v[0],false);	// Dz x
-        d[2]=apply(*(grad[0]),v[1],false);	// Dx y
-        dd[0]=apply(*(grad[2]),v[1],false);	// Dz y
-        dd[1]=apply(*(grad[0]),v[2],false);	// Dx z
-        dd[2]=apply(*(grad[1]),v[0],false);	// Dy x
+        std::vector<Function<T, NDIM>> d(NDIM), dd(NDIM);
+        d[0] = apply(*(grad[1]), v[2], false);	// Dy z
+        d[1] = apply(*(grad[2]), v[0], false);	// Dz x
+        d[2] = apply(*(grad[0]), v[1], false);	// Dx y
+        dd[0] = apply(*(grad[2]), v[1], false);	// Dz y
+        dd[1] = apply(*(grad[0]), v[2], false);	// Dx z
+        dd[2] = apply(*(grad[1]), v[0], false);	// Dy x
         world.gop.fence();
 
-        d[0].gaxpy(1.0,dd[0],-1.0,false);
-        d[1].gaxpy(1.0,dd[1],-1.0,false);
-        d[2].gaxpy(1.0,dd[2],-1.0,false);
+        d[0].gaxpy(1.0, dd[0], -1.0, false);
+        d[1].gaxpy(1.0, dd[1], -1.0, false);
+        d[2].gaxpy(1.0, dd[2], -1.0, false);
 
         world.gop.fence();
         return d;
@@ -2010,33 +2023,33 @@ namespace madness {
     /// @return     the vector \frac{\partial}{\partial x_i} f
     /// TODO: add this to operator fusion
     template <typename T, typename R, std::size_t NDIM>
-    std::vector<Function<TENSOR_RESULT_TYPE(T,R),NDIM> > cross(const std::vector<Function<T,NDIM> >& f,
+    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM> > cross(const std::vector<Function<T, NDIM>>& f,
     		const std::vector<Function<R,NDIM> >& g,
             bool do_refine=false, bool fence=true) {
 
-        MADNESS_ASSERT(f.size()==3);
-        MADNESS_ASSERT(g.size()==3);
-        World& world=f[0].world();
-        reconstruct(world,f,false);
-        reconstruct(world,g);
+        MADNESS_ASSERT(f.size() == 3);
+        MADNESS_ASSERT(g.size() == 3);
+        World& world = f[0].world();
+        reconstruct(world, f, false);
+        reconstruct(world, g);
 
-        std::vector<Function<TENSOR_RESULT_TYPE(T,R),NDIM> > d(f.size()),dd(f.size());
+        std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>> d(f.size()), dd(f.size());
 
-        d[0]=mul(f[1],g[2],false);
-        d[1]=mul(f[2],g[0],false);
-        d[2]=mul(f[0],g[1],false);
+        d[0] = mul(f[1], g[2], false);
+        d[1] = mul(f[2], g[0], false);
+        d[2] = mul(f[0], g[1], false);
 
-        dd[0]=mul(f[2],g[1],false);
-        dd[1]=mul(f[0],g[2],false);
-        dd[2]=mul(f[1],g[0],false);
+        dd[0] = mul(f[2], g[1], false);
+        dd[1] = mul(f[0], g[2], false);
+        dd[2] = mul(f[1], g[0], false);
         world.gop.fence();
 
-        compress(world,d,false);
-        compress(world,dd);
+        compress(world, d, false);
+        compress(world, dd);
 
-        d[0].gaxpy(1.0,dd[0],-1.0,false);
-        d[1].gaxpy(1.0,dd[1],-1.0,false);
-        d[2].gaxpy(1.0,dd[2],-1.0,false);
+        d[0].gaxpy(1.0, dd[0], -1.0, false);
+        d[1].gaxpy(1.0, dd[1], -1.0, false);
+        d[2].gaxpy(1.0, dd[2], -1.0, false);
 
         world.gop.fence();
         return d;
@@ -2045,26 +2058,26 @@ namespace madness {
 
     /// load a vector of functions
     template<typename T, size_t NDIM>
-    void load_function(World& world, std::vector<Function<T,NDIM> >& f,
+    void load_function(World& world, std::vector<Function<T, NDIM>>& f,
             const std::string name) {
-        if (world.rank()==0) print("loading vector of functions",name);
+        if (world.rank() == 0) print("loading vector of functions", name);
         archive::ParallelInputArchive<archive::BinaryFstreamInputArchive> ar(world, name.c_str(), 1);
-        std::size_t fsize=0;
+        std::size_t fsize = 0;
         ar & fsize;
         f.resize(fsize);
-        for (std::size_t i=0; i<fsize; ++i) ar & f[i];
+        for (std::size_t i = 0; i < fsize; ++i) ar & f[i];
     }
 
     /// save a vector of functions
     template<typename T, size_t NDIM>
-    void save_function(const std::vector<Function<T,NDIM> >& f, const std::string name) {
-        if (f.size()>0) {
-            World& world=f.front().world();
-            if (world.rank()==0) print("saving vector of functions",name);
+    void save_function(const std::vector<Function<T, NDIM>>& f, const std::string name) {
+        if (f.size() > 0) {
+            World& world = f.front().world();
+            if (world.rank() == 0) print("saving vector of functions", name);
             archive::ParallelOutputArchive<archive::BinaryFstreamOutputArchive> ar(world, name.c_str(), 1);
-            std::size_t fsize=f.size();
+            std::size_t fsize = f.size();
             ar & fsize;
-            for (std::size_t i=0; i<fsize; ++i) ar & f[i];
+            for (std::size_t i = 0; i < fsize; ++i) ar & f[i];
         }
     }
 

--- a/src/madness/mra/vmra.h
+++ b/src/madness/mra/vmra.h
@@ -89,7 +89,7 @@
 
 	*) set_thresh: setting a finite thresh-hold for a vector of functions
 	\code
-	void set_thresh(World& world, std::vector<Function<T, NDIM>>& v, double thresh, bool fence=true);
+	void set_thresh(World& world, std::vector< Function<T,NDIM> >& v, double thresh, bool fence=true);
 	\endcode
 
 	Arithmetic Operations on arrays of functions
@@ -114,6 +114,9 @@
 	    - norm2s
 	*) scale(world, v, alpha);
 
+
+
+
 */
 
 #include <madness/mra/mra.h>
@@ -128,13 +131,13 @@ namespace madness {
     /// Compress a vector of functions
     template <typename T, std::size_t NDIM>
     void compress(World& world,
-                  const std::vector<Function<T, NDIM>>& v,
+                  const std::vector< Function<T,NDIM> >& v,
                   bool fence=true) {
 
         PROFILE_BLOCK(Vcompress);
         change_tree_state(v, TreeState::compressed, fence);
 //        bool must_fence = false;
-//        for (unsigned int i = 0; i < v.size(); ++i) {
+//        for (unsigned int i=0; i<v.size(); ++i) {
 //            if (!v[i].is_compressed()) {
 //                v[i].compress(false);
 //                must_fence = true;
@@ -150,7 +153,7 @@ namespace madness {
     /// implies fence
     /// return v for chaining
     template <typename T, std::size_t NDIM>
-    const std::vector<Function<T, NDIM>>& reconstruct(const std::vector<Function<T, NDIM>>& v) {
+    const std::vector< Function<T,NDIM> >& reconstruct(const std::vector< Function<T,NDIM> >& v) {
         return change_tree_state(v, TreeState::reconstructed, true);
     }
 
@@ -159,50 +162,50 @@ namespace madness {
     /// implies fence
     /// return v for chaining
     template <typename T, std::size_t NDIM>
-    const std::vector<Function<T, NDIM>>& compress(const std::vector<Function<T, NDIM>>& v) {
+    const std::vector< Function<T,NDIM> >& compress(const std::vector< Function<T,NDIM> >& v) {
         return change_tree_state(v, TreeState::compressed, true);
     }
 
     /// Reconstruct a vector of functions
     template <typename T, std::size_t NDIM>
     void reconstruct(World& world,
-                     const std::vector<Function<T, NDIM>>& v,
+                     const std::vector< Function<T,NDIM> >& v,
                      bool fence=true) {
         PROFILE_BLOCK(Vreconstruct);
-        // bool must_fence = false;
+//        bool must_fence = false;
         change_tree_state(v, TreeState::reconstructed, fence);
-        // for (unsigned int i = 0; i < v.size(); ++i) {
-        //     if (v[i].is_compressed() or v[i].is_nonstandard()) {
-        //         v[i].reconstruct(false);
-        //         must_fence = true;
-        //     }
-        // }
-
-        // if (fence && must_fence) world.gop.fence();
+//        for (unsigned int i=0; i<v.size(); ++i) {
+//            if (v[i].is_compressed() or v[i].is_nonstandard()) {
+//                v[i].reconstruct(false);
+//                must_fence = true;
+//            }
+//        }
+//
+//        if (fence && must_fence) world.gop.fence();
     }
 
     /// change tree_state of a vector of functions to redundant
     template <typename T, std::size_t NDIM>
     void make_redundant(World& world,
-                        const std::vector<Function<T, NDIM>>& v,
-                        bool fence=true) {
+                  const std::vector< Function<T,NDIM> >& v,
+                  bool fence=true) {
 
         PROFILE_BLOCK(Vcompress);
         change_tree_state(v, TreeState::redundant, fence);
-        // bool must_fence = false;
-        // for (unsigned int i = 0; i < v.size(); ++i) {
-        //     if (!v[i].get_impl()->is_redundant()) {
-        //         v[i].get_impl()->make_redundant(false);
-        //         must_fence = true;
-        //     }
-        // }
-
-        // if (fence && must_fence) world.gop.fence();
+//        bool must_fence = false;
+//        for (unsigned int i=0; i<v.size(); ++i) {
+//            if (!v[i].get_impl()->is_redundant()) {
+//                v[i].get_impl()->make_redundant(false);
+//                must_fence = true;
+//            }
+//        }
+//
+//        if (fence && must_fence) world.gop.fence();
     }
 
     /// refine the functions according to the autorefine criteria
     template <typename T, std::size_t NDIM>
-    void refine(World& world, const std::vector<Function<T, NDIM>>& vf,
+    void refine(World& world, const std::vector<Function<T,NDIM> >& vf,
             bool fence=true) {
         for (const auto& f : vf) f.refine(false);
         if (fence) world.gop.fence();
@@ -212,57 +215,57 @@ namespace madness {
 
     /// if functions are not initialized (impl==NULL) they are ignored
     template <typename T, std::size_t NDIM>
-    void refine_to_common_level(World& world, std::vector<Function<T, NDIM>>& vf,
+    void refine_to_common_level(World& world, std::vector<Function<T,NDIM> >& vf,
             bool fence=true) {
 
         reconstruct(world,vf);
         Key<NDIM> key0(0, Vector<Translation, NDIM> (0));
-        std::vector<FunctionImpl<T, NDIM>*> v_ptr;
+        std::vector<FunctionImpl<T,NDIM>*> v_ptr;
 
         // push initialized function pointers into the vector v_ptr
-        for (unsigned int i = 0; i < vf.size(); ++i) {
+        for (unsigned int i=0; i<vf.size(); ++i) {
             if (vf[i].is_initialized()) v_ptr.push_back(vf[i].get_impl().get());
         }
 
         // sort and remove duplicates to not confuse the refining function
-        std::sort(v_ptr.begin(), v_ptr.end());
+        std::sort(v_ptr.begin(),v_ptr.end());
         typename std::vector<FunctionImpl<T, NDIM>*>::iterator it;
         it = std::unique(v_ptr.begin(), v_ptr.end());
         v_ptr.resize( std::distance(v_ptr.begin(),it) );
 
-        std::vector<Tensor<T>> c(v_ptr.size());
+        std::vector< Tensor<T> > c(v_ptr.size());
         v_ptr[0]->refine_to_common_level(v_ptr, c, key0);
         if (fence) v_ptr[0]->world.gop.fence();
         if (VERIFY_TREE)
-            for (unsigned int i = 0; i < vf.size(); i++) vf[i].verify_tree();
+            for (unsigned int i=0; i<vf.size(); i++) vf[i].verify_tree();
     }
 
     /// Generates non-standard form of a vector of functions
     template <typename T, std::size_t NDIM>
     void make_nonstandard(World& world,
-                          std::vector<Function<T, NDIM>>& v,
-                          bool fence=true) {
+                          std::vector< Function<T,NDIM> >& v,
+                          bool fence= true) {
         PROFILE_BLOCK(Vnonstandard);
         change_tree_state(v, TreeState::nonstandard, fence);
-        // reconstruct(world, v);
-        // for (unsigned int i = 0; i < v.size(); ++i) {
-        //     v[i].make_nonstandard(false, false);
-        // }
-        // if (fence) world.gop.fence();
+//        reconstruct(world, v);
+//        for (unsigned int i=0; i<v.size(); ++i) {
+//            v[i].make_nonstandard(false, false);
+//        }
+//        if (fence) world.gop.fence();
     }
 
 
     /// Generates standard form of a vector of functions
     template <typename T, std::size_t NDIM>
     void standard(World& world,
-                  std::vector<Function<T, NDIM>>& v,
+                  std::vector< Function<T,NDIM> >& v,
                   bool fence=true) {
         PROFILE_BLOCK(Vstandard);
         change_tree_state(v, TreeState::compressed, fence);
-        // for (unsigned int i = 0; i < v.size(); ++i) {
-        //     v[i].standard(false);
-        // }
-        // if (fence) world.gop.fence();
+//        for (unsigned int i=0; i<v.size(); ++i) {
+//            v[i].standard(false);
+//        }
+//        if (fence) world.gop.fence();
     }
 
 
@@ -271,57 +274,56 @@ namespace madness {
     /// will respect fence
     /// @return v   for chaining
     template <typename T, std::size_t NDIM>
-    const std::vector<Function<T, NDIM>>& change_tree_state(
-        const std::vector<Function<T, NDIM>>& v,
-        const TreeState finalstate,
-        const bool fence=true) {
-
-        if (v.size() == 0) return v;
+    const std::vector<Function<T,NDIM>>& change_tree_state(const std::vector<Function<T,NDIM>>& v,
+                                                     const TreeState finalstate,
+                                                     const bool fence=true) {
+        if (v.size()==0) return v;
         // find initialized function with world
-       Function<T, NDIM> dummy;
+        Function<T,NDIM> dummy;
         for (const auto& f : v)
             if (f.is_initialized()) {
-                dummy = f;
+                dummy=f;
                 break;
             }
         if (not dummy.is_initialized()) return v;
-        World& world = dummy.world();
+        World& world=dummy.world();
+
 
         // if a tree state cannot directly be changed to finalstate, we need to go via intermediate
-        auto change_initial_to_intermediate = [](const std::vector<Function<T, NDIM>>& v,
-                                                 const TreeState initialstate,
-                                                 const TreeState intermediatestate) {
+        auto change_initial_to_intermediate =[](const std::vector<Function<T,NDIM>>& v,
+                                                  const TreeState initialstate,
+                                                  const TreeState intermediatestate) {
             int must_fence=0;
             for (auto& f : v) {
                 if (f.is_initialized() and f.get_impl()->get_tree_state()==initialstate) {
                     f.change_tree_state(intermediatestate,false);
-                    must_fence = 1;
+                    must_fence=1;
                 }
             }
             return must_fence;
         };
 
-        int do_fence = 0;
-        if (finalstate == compressed) {
-            do_fence += change_initial_to_intermediate(v, redundant, TreeState::reconstructed);
+        int do_fence=0;
+        if (finalstate==compressed) {
+            do_fence+=change_initial_to_intermediate(v,redundant,TreeState::reconstructed);
         }
         if (finalstate==nonstandard) {
-            do_fence += change_initial_to_intermediate(v, compressed, TreeState::reconstructed);
-            do_fence += change_initial_to_intermediate(v, redundant, TreeState::reconstructed);
+            do_fence+=change_initial_to_intermediate(v,compressed,TreeState::reconstructed);
+            do_fence+=change_initial_to_intermediate(v,redundant,TreeState::reconstructed);
         }
         if (finalstate==nonstandard_with_leaves) {
-            do_fence += change_initial_to_intermediate(v, compressed, TreeState::reconstructed);
-            do_fence += change_initial_to_intermediate(v, nonstandard, TreeState::reconstructed);
-            do_fence += change_initial_to_intermediate(v, redundant, TreeState::reconstructed);
+            do_fence+=change_initial_to_intermediate(v,compressed,TreeState::reconstructed);
+            do_fence+=change_initial_to_intermediate(v,nonstandard,TreeState::reconstructed);
+            do_fence+=change_initial_to_intermediate(v,redundant,TreeState::reconstructed);
         }
         if (finalstate==redundant) {
-            do_fence += change_initial_to_intermediate(v, compressed, TreeState::reconstructed);
-            do_fence += change_initial_to_intermediate(v, nonstandard, TreeState::reconstructed);
-            do_fence += change_initial_to_intermediate(v, nonstandard_with_leaves, TreeState::reconstructed);
+            do_fence+=change_initial_to_intermediate(v,compressed,TreeState::reconstructed);
+            do_fence+=change_initial_to_intermediate(v,nonstandard,TreeState::reconstructed);
+            do_fence+=change_initial_to_intermediate(v,nonstandard_with_leaves,TreeState::reconstructed);
         }
-        if (do_fence > 0) world.gop.fence();
+        if (do_fence>0) world.gop.fence();
 
-        for (unsigned int i = 0; i < v.size(); ++i) v[i].change_tree_state(finalstate,fence);
+        for (unsigned int i=0; i<v.size(); ++i) v[i].change_tree_state(finalstate,fence);
         if (fence) world.gop.fence();
 
         return v;
@@ -331,16 +333,16 @@ namespace madness {
     /// Truncates a vector of functions
     template <typename T, std::size_t NDIM>
     void truncate(World& world,
-                  std::vector<Function<T, NDIM>>& v,
+                  std::vector< Function<T,NDIM> >& v,
                   double tol=0.0,
                   bool fence=true) {
         PROFILE_BLOCK(Vtruncate);
 
         // truncate in compressed form only for low-dimensional functions
         // compression is very expensive if low-rank tensor approximations are used
-        if (NDIM < 4) compress(world, v);
+        if (NDIM<4) compress(world, v);
 
-        for (unsigned int i = 0; i < v.size(); ++i) {
+        for (unsigned int i=0; i<v.size(); ++i) {
             v[i].truncate(tol, false);
         }
 
@@ -351,9 +353,9 @@ namespace madness {
 
     /// @return the truncated vector for chaining
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T, NDIM>> truncate(std::vector<Function<T, NDIM>> v,
+    std::vector< Function<T,NDIM> > truncate(std::vector< Function<T,NDIM> > v,
                   double tol=0.0, bool fence=true) {
-        if (v.size() > 0) truncate(v[0].world(), v, tol, fence);
+        if (v.size()>0) truncate(v[0].world(),v,tol,fence);
         return v;
     }
 
@@ -361,10 +363,10 @@ namespace madness {
 
     /// @return the vector for chaining
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T, NDIM>> reduce_rank(std::vector<Function<T, NDIM>> v,
+    std::vector< Function<T,NDIM> > reduce_rank(std::vector< Function<T,NDIM> > v,
                   double thresh=0.0, bool fence=true) {
-    	if (v.size() == 0) return v;
-    	for (auto& vv : v) vv.reduce_rank(thresh, false);
+    	if (v.size()==0) return v;
+    	for (auto& vv : v) vv.reduce_rank(thresh,false);
     	if (fence) v[0].world().gop.fence();
 		return v;
     }
@@ -372,15 +374,15 @@ namespace madness {
 
     /// Applies a derivative operator to a vector of functions
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T, NDIM>>
+    std::vector< Function<T,NDIM> >
     apply(World& world,
-          const Derivative<T, NDIM>& D,
-          const std::vector<Function<T, NDIM>>& v,
+          const Derivative<T,NDIM>& D,
+          const std::vector< Function<T,NDIM> >& v,
           bool fence=true)
     {
         reconstruct(world, v);
-        std::vector<Function<T, NDIM>> df(v.size());
-        for (unsigned int i = 0; i < v.size(); ++i) {
+        std::vector< Function<T,NDIM> > df(v.size());
+        for (unsigned int i=0; i<v.size(); ++i) {
             df[i] = D(v[i],false);
         }
         if (fence) world.gop.fence();
@@ -389,26 +391,26 @@ namespace madness {
 
     /// Generates a vector of zero functions (reconstructed)
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T, NDIM>>
+    std::vector< Function<T,NDIM> >
     zero_functions(World& world, int n, bool fence=true) {
         PROFILE_BLOCK(Vzero_functions);
-        std::vector<Function<T, NDIM>> r(n);
-        for (int i = 0; i < n; ++i)
-  	        r[i] = Function<T, NDIM>(FunctionFactory<T, NDIM>(world).fence(false));
+        std::vector< Function<T,NDIM> > r(n);
+        for (int i=0; i<n; ++i)
+  	    r[i] = Function<T,NDIM>(FunctionFactory<T,NDIM>(world).fence(false));
 
-	    if (n && fence) world.gop.fence();
+	if (n && fence) world.gop.fence();
+
         return r;
     }
 
     /// Generates a vector of zero functions (compressed)
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T, NDIM>>
+    std::vector< Function<T,NDIM> >
     zero_functions_compressed(World& world, int n, bool fence=true) {
         PROFILE_BLOCK(Vzero_functions);
-        std::vector<Function<T, NDIM>> r(n);
-        for (int i = 0; i < n; ++i)
-  	        r[i] = Function<T, NDIM>(FunctionFactory<T, NDIM>(world).fence(false).compressed(true).initial_level(1));
-
+        std::vector< Function<T,NDIM> > r(n);
+        for (int i=0; i<n; ++i)
+  	    r[i] = Function<T,NDIM>(FunctionFactory<T,NDIM>(world).fence(false).compressed(true).initial_level(1));
     	if (n && fence) world.gop.fence();
         return r;
     }
@@ -416,32 +418,31 @@ namespace madness {
 
     /// orthonormalize the vectors
     template<typename T, std::size_t NDIM>
-    std::vector<Function<T, NDIM>> orthonormalize(
-            const std::vector<Function<T, NDIM>>& vf_in) {
-        if (vf_in.size() == 0) return std::vector<Function<T, NDIM>>();
-        World& world = vf_in.front().world();
-        auto vf = copy(world, vf_in);
-        normalize(world, vf);
-        if (vf.size() == 1) return copy(world, vf_in);
+    std::vector<Function<T,NDIM>> orthonormalize(const std::vector<Function<T,NDIM> >& vf_in) {
+        if (vf_in.size()==0) return std::vector<Function<T,NDIM>>();
+        World& world=vf_in.front().world();
+        auto vf=copy(world,vf_in);
+        normalize(world,vf);
+        if (vf.size()==1) return copy(world,vf_in);
         double maxq;
-        double trantol = 0.0;
-        auto Q2 = [](const Tensor<T>& s) {
-           Tensor<T>Q = -0.5 * s;
-            for (int i = 0; i < s.dim(0); ++i) Q(i, i) += 1.5;
+        double trantol=0.0;
+        auto Q2=[](const Tensor<T>& s) {
+            Tensor<T> Q = -0.5*s;
+            for (int i=0; i<s.dim(0); ++i) Q(i,i) += 1.5;
             return Q;
         };
 
         do {
-           Tensor<T>Q = Q2(matrix_inner(world, vf, vf));
-            maxq = 0.0;
-            for (int i = 0; i < Q.dim(0); ++i)
-                for (int j = 0; j <i; ++j)
+            Tensor<T> Q = Q2(matrix_inner(world, vf, vf));
+            maxq=0.0;
+            for (int i=0; i<Q.dim(0); ++i)
+                for (int j=0; j<i; ++j)
                     maxq = std::max(maxq,std::abs(Q(i,j)));
 
             vf = transform(world, vf, Q, trantol, true);
             truncate(world, vf);
 
-        } while (maxq > 0.01);
+        } while (maxq>0.01);
         normalize(world,vf);
         return vf;
     }
@@ -452,44 +453,44 @@ namespace madness {
     /// @param[in] the vector to orthonormalize
     /// @param[in] overlap matrix
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T, NDIM>> orthonormalize_symmetric(
-    		const std::vector<Function<T, NDIM>>& v,
+    std::vector<Function<T,NDIM> > orthonormalize_symmetric(
+    		const std::vector<Function<T,NDIM> >& v,
 			  const Tensor<T>& ovlp) {
     	if(v.empty()) return v;
 
     	Tensor<T> U;
-    	Tensor<typename Tensor<T>::scalar_type> s;
-    	syev(ovlp, U, s);
+    	Tensor< typename Tensor<T>::scalar_type > s;
+    	syev(ovlp,U,s);
 
     	// transform s to s^{-1}
-    	for(size_t i = 0; i < v.size(); ++i) s(i) = 1.0 / sqrt(s(i));
+    	for(size_t i=0;i<v.size();++i) s(i)=1.0/(sqrt(s(i)));
 
     	// save Ut before U gets modified with s^{-1}
-    	const Tensor<T> Ut = transpose(U);
-    	for(size_t i = 0; i < v.size(); ++i){
-    		for(size_t j = 0; j < v.size(); ++j){
-    			U(i, j) = U(i, j) * s(j);
+    	const Tensor<T> Ut=transpose(U);
+    	for(size_t i=0;i<v.size();++i){
+    		for(size_t j=0;j<v.size();++j){
+    			U(i,j)=U(i,j)*s(j);
     		}
     	}
 
-    	Tensor<T> X = inner(U, Ut, 1,0);
+    	Tensor<T> X=inner(U,Ut,1,0);
 
-    	World& world = v.front().world();
-    	return transform(world, v, X);
+    	World& world=v.front().world();
+    	return transform(world,v,X);
 
     }
     /// convenience routine for symmetric orthonormalization (see e.g. Szabo/Ostlund)
     /// overlap matrix is calculated
     /// @param[in] the vector to orthonormalize
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T, NDIM>> orthonormalize_symmetric(
-            const std::vector<Function<T, NDIM>>& v){
+    std::vector<Function<T,NDIM> > orthonormalize_symmetric(const std::vector<Function<T,NDIM> >& v){
     	if(v.empty()) return v;
 
-    	World& world = v.front().world();
+
+    	World& world=v.front().world();
     	Tensor<T> ovlp = matrix_inner(world, v, v);
 
-    	return orthonormalize_symmetric(v, ovlp);
+    	return orthonormalize_symmetric(v,ovlp);
     }
 
     /// canonical orthonormalization (see e.g. Szabo/Ostlund)
@@ -497,8 +498,8 @@ namespace madness {
     /// @param[in] overlap matrix
     /// @param[in]	lindep	linear dependency threshold relative to largest eigenvalue
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T, NDIM>> orthonormalize_canonical(
-    		const std::vector<Function<T, NDIM>>& v,
+    std::vector<Function<T,NDIM> > orthonormalize_canonical(
+    		const std::vector<Function<T,NDIM> >& v,
 			const Tensor<T>& ovlp,
 			double lindep) {
 
@@ -506,58 +507,57 @@ namespace madness {
 
     	Tensor<T> U;
     	Tensor< typename Tensor<T>::scalar_type > s;
-    	syev(ovlp, U, s);
-    	lindep *= s(s.size() - 1);	// eigenvalues are in ascending order
+    	syev(ovlp,U,s);
+    	lindep*=s(s.size()-1);	// eigenvalues are in ascending order
 
     	// transform s to s^{-1}
-    	int rank = 0, lo = 0;
-    	Tensor<typename Tensor<T>::scalar_type> sqrts(v.size());
-    	for(size_t i = 0; i < v.size(); ++i) {
-    		if (s(i) > lindep) {
-    			sqrts(i) = 1.0 / sqrt(s(i));
+    	int rank=0,lo=0;
+    	Tensor< typename Tensor<T>::scalar_type > sqrts(v.size());
+    	for(size_t i=0;i<v.size();++i) {
+    		if (s(i)>lindep) {
+    			sqrts(i)=1.0/(sqrt(s(i)));
         		rank++;
     		} else {
-    			sqrts(i) = 0.0;
+    			sqrts(i)=0.0;
     			lo++;
     		}
     	}
-    	MADNESS_ASSERT(size_t(lo + rank) == v.size());
+    	MADNESS_ASSERT(size_t(lo+rank)==v.size());
 
-    	for(size_t i = 0; i < v.size(); ++i){
-    		for(size_t j = 0; j < v.size(); ++j){
-    			U(i, j) = U(i, j) * sqrts(j);
+    	for(size_t i=0;i<v.size();++i){
+    		for(size_t j=0;j<v.size();++j){
+    			U(i,j)=U(i,j)*(sqrts(j));
     		}
     	}
-    	Tensor<T> X = U(_, Slice(lo, -1));
+    	Tensor<T> X=U(_,Slice(lo,-1));
 
-    	World& world = v.front().world();
-    	return transform(world, v, X);
+    	World& world=v.front().world();
+    	return transform(world,v,X);
 
     }
 
-    /// convenience routine for canonical routine for 
-    /// symmetric orthonormalization (see e.g. Szabo/Ostlund)
+    /// convenience routine for canonical routine for symmetric orthonormalization (see e.g. Szabo/Ostlund)
     /// overlap matrix is calculated
     /// @param[in] the vector to orthonormalize
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T, NDIM>> orthonormalize_canonical(
-            const std::vector<Function<T, NDIM>>& v,
+    std::vector<Function<T,NDIM> > orthonormalize_canonical(const std::vector<Function<T,NDIM> >& v,
     		const double lindep){
     	if(v.empty()) return v;
 
     	World& world=v.front().world();
     	Tensor<T> ovlp = matrix_inner(world, v, v);
 
-    	return orthonormalize_canonical(v, ovlp, lindep);
+    	return orthonormalize_canonical(v,ovlp,lindep);
     }
 
     /// cholesky orthonormalization without pivoting
     /// @param[in] the vector to orthonormalize
     /// @param[in] overlap matrix, destroyed on return!
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T, NDIM>> orthonormalize_cd(
-    		const std::vector<Function<T, NDIM>>& v,
+    std::vector<Function<T,NDIM> > orthonormalize_cd(
+    		const std::vector<Function<T,NDIM> >& v,
 			Tensor<T>& ovlp) {
+
     	if (v.empty()) return v;
 
     	cholesky(ovlp); // destroys ovlp and gives back Upper ∆ Matrix from CD
@@ -568,20 +568,20 @@ namespace madness {
 
     	World& world=v.front().world();
     	return transform(world, v, U);
+
     }
 
     /// convenience routine for cholesky orthonormalization without pivoting
     /// @param[in] the vector to orthonormalize
     /// @param[in] overlap matrix
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T, NDIM>> orthonormalize_cd(
-            const std::vector<Function<T, NDIM>>& v){
+    std::vector<Function<T,NDIM> > orthonormalize_cd(const std::vector<Function<T,NDIM> >& v){
     	if(v.empty()) return v;
 
     	World& world=v.front().world();
     	Tensor<T> ovlp = matrix_inner(world, v, v);
 
-    	return orthonormalize_cd(v, ovlp);
+    	return orthonormalize_cd(v,ovlp);
     }
 
     /// @param[in] the vector to orthonormalize
@@ -591,8 +591,8 @@ namespace madness {
     /// @param[out] rank
     /// @return orthonrormalized vector (may or may not be truncated)
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T, NDIM>> orthonormalize_rrcd(
-    		const std::vector<Function<T, NDIM>>& v,
+    std::vector<Function<T,NDIM> > orthonormalize_rrcd(
+    		const std::vector<Function<T,NDIM> >& v,
 			Tensor<T>& ovlp,
 			const double tol,
 			Tensor<integer>& piv,
@@ -602,14 +602,14 @@ namespace madness {
     		return v;
     	}
 
-    	rr_cholesky(ovlp, tol, piv, rank);  // destroys ovlp and gives back Upper ∆ Matrix from CCD
+    	rr_cholesky(ovlp,tol,piv,rank); // destroys ovlp and gives back Upper ∆ Matrix from CCD
 
     	// rearrange and truncate the functions according to the pivoting of the rr_cholesky
-    	std::vector<Function<T, NDIM>> pv(rank);
-    	for(integer i = 0; i < rank; ++i){
-    		pv[i] = v[piv[i]];
+    	std::vector<Function<T,NDIM> > pv(rank);
+    	for(integer i=0;i<rank;++i){
+    		pv[i]=v[piv[i]];
     	}
-    	ovlp = ovlp(Slice(0, rank - 1), Slice(0, rank - 1));
+    	ovlp=ovlp(Slice(0,rank-1),Slice(0,rank-1));
 
     	Tensor<T> L = transpose(ovlp);
     	Tensor<T> Linv = inverse(L);
@@ -619,100 +619,90 @@ namespace madness {
     	return transform(world, pv, U);
     }
 
-    /// convenience routine for orthonromalize_cholesky:
-    /// orthonromalize_cholesky without information on pivoting and rank
+    /// convenience routine for orthonromalize_cholesky: orthonromalize_cholesky without information on pivoting and rank
     /// @param[in] the vector to orthonormalize
     /// @param[in] overlap matrix
     /// @param[in] tolerance for numerical rank reduction
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T, NDIM>> orthonormalize_rrcd(
-            const std::vector<Function<T, NDIM>>& v,
-            Tensor<T> ovlp,
-            const double tol) {
+    std::vector<Function<T,NDIM> > orthonormalize_rrcd(const std::vector<Function<T,NDIM> >& v, Tensor<T> ovlp , const double tol) {
     	Tensor<integer> piv;
     	int rank;
-    	return orthonormalize_rrcd(v, ovlp, tol, piv,rank);
+    	return orthonormalize_rrcd(v,ovlp,tol,piv,rank);
     }
 
-    /// convenience routine for orthonromalize_cholesky:
-    /// computes the overlap matrix and then calls orthonromalize_cholesky
+    /// convenience routine for orthonromalize_cholesky: computes the overlap matrix and then calls orthonromalize_cholesky
     /// @param[in] the vector to orthonormalize
     /// @param[in] tolerance for numerical rank reduction
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T, NDIM>> orthonormalize_rrcd(
-            const std::vector<Function<T, NDIM>>& v,
-            const double tol) {
+    std::vector<Function<T,NDIM> > orthonormalize_rrcd(const std::vector<Function<T,NDIM> >& v, const double tol) {
     	if (v.empty()) {
     		return v;
     	}
     	// compute overlap
-    	World& world = v.front().world();
+    	World& world=v.front().world();
     	Tensor<T> ovlp = matrix_inner(world, v, v);
-    	return orthonormalize_rrcd(v, ovlp, tol);
+    	return orthonormalize_rrcd(v,ovlp,tol);
     }
 
     /// combine two vectors
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T, NDIM>> append(const std::vector<Function<T, NDIM>> & lhs,
-            const std::vector<Function<T, NDIM>> & rhs){
-    	std::vector<Function<T, NDIM>> v = lhs;
+    std::vector<Function<T,NDIM> > append(const std::vector<Function<T,NDIM> > & lhs, const std::vector<Function<T,NDIM> > & rhs){
+    	std::vector<Function<T,NDIM> >  v=lhs;
     	for (std::size_t i = 0; i < rhs.size(); ++i) v.push_back(rhs[i]);
     	return v;
     }
 
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T, NDIM>> flatten(const std::vector<std::vector<Function<T, NDIM>>>& vv){
-    	std::vector<Function<T, NDIM>> result;
-    	for (const auto& x : vv) result = append(result, x);
+    std::vector<Function<T,NDIM> > flatten(const std::vector< std::vector<Function<T,NDIM> > >& vv){
+    	std::vector<Function<T,NDIM> >result;
+    	for(const auto& x:vv) result=append(result,x);
     	return result;
     }
 
     template<typename T, std::size_t NDIM>
-    std::vector<std::shared_ptr<FunctionImpl<T, NDIM>>> get_impl(
-            const std::vector<Function<T, NDIM>>& v) {
-        std::vector<std::shared_ptr<FunctionImpl<T, NDIM>>> result;
+    std::vector<std::shared_ptr<FunctionImpl<T,NDIM>>> get_impl(const std::vector<Function<T,NDIM>>& v) {
+        std::vector<std::shared_ptr<FunctionImpl<T,NDIM>>> result;
         for (auto& f : v) result.push_back(f.get_impl());
         return result;
     }
 
     template<typename T, std::size_t NDIM>
-    void set_impl(std::vector<Function<T, NDIM>>& v, 
-                  const std::vector<std::shared_ptr<FunctionImpl<T, NDIM>>> vimpl) {
+    void set_impl(std::vector<Function<T,NDIM>>& v, const std::vector<std::shared_ptr<FunctionImpl<T,NDIM>>> vimpl) {
         MADNESS_CHECK(vimpl.size()==v.size());
-        for (std::size_t i = 0; i < vimpl.size(); ++i) v[i].set_impl(vimpl[i]);
+        for (std::size_t i=0; i<vimpl.size(); ++i) v[i].set_impl(vimpl[i]);
     }
 
     template<typename T, std::size_t NDIM>
-    std::vector<Function<T, NDIM>> impl2function(
-            const std::vector<std::shared_ptr<FunctionImpl<T, NDIM>>> vimpl) {
-        std::vector<Function<T, NDIM>> v(vimpl.size());
-        for (std::size_t i = 0; i < vimpl.size(); ++i) v[i].set_impl(vimpl[i]);
+    std::vector<Function<T,NDIM>> impl2function(const std::vector<std::shared_ptr<FunctionImpl<T,NDIM>>> vimpl) {
+        std::vector<Function<T,NDIM>> v(vimpl.size());
+        for (std::size_t i=0; i<vimpl.size(); ++i) v[i].set_impl(vimpl[i]);
         return v;
     }
+
 
     /// Transforms a vector of functions according to new[i] = sum[j] old[j]*c[j,i]
 
     /// Uses sparsity in the transformation matrix --- set small elements to
     /// zero to take advantage of this.
     template <typename T, typename R, std::size_t NDIM>
-    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>>
+    std::vector< Function<TENSOR_RESULT_TYPE(T,R),NDIM> >
     transform(World& world,
-              const std::vector<Function<T, NDIM>>& v,
+              const std::vector< Function<T,NDIM> >& v,
               const Tensor<R>& c,
               bool fence=true) {
 
         PROFILE_BLOCK(Vtransformsp);
-        typedef TENSOR_RESULT_TYPE(T, R) resultT;
+        typedef TENSOR_RESULT_TYPE(T,R) resultT;
         int n = v.size();  // n is the old dimension
         int m = c.dim(1);  // m is the new dimension
-        MADNESS_ASSERT(n == c.dim(0));
+        MADNESS_ASSERT(n==c.dim(0));
 
-        std::vector<Function<resultT, NDIM>> vc = zero_functions_compressed<resultT, NDIM>(world, m);
+        std::vector< Function<resultT,NDIM> > vc = zero_functions_compressed<resultT,NDIM>(world, m);
         compress(world, v);
 
-        for (int i = 0; i < m; ++i) {
-            for (int j = 0; j < n; ++j) {
-                if (c(j, i) != R(0.0)) vc[i].gaxpy(resultT(1.0), v[j], resultT(c(j, i)), false);
+        for (int i=0; i<m; ++i) {
+            for (int j=0; j<n; ++j) {
+                if (c(j,i) != R(0.0)) vc[i].gaxpy(resultT(1.0),v[j],resultT(c(j,i)),false);
             }
         }
 
@@ -724,29 +714,29 @@ namespace madness {
 
     /// all trees are in reconstructed state, final trees have to be summed down if no fence is present
     template <typename T, typename R, std::size_t NDIM>
-    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>>
+    std::vector< Function<TENSOR_RESULT_TYPE(T,R),NDIM> >
     transform_reconstructed(World& world,
-              const std::vector<Function<T, NDIM>>& v,
+              const std::vector< Function<T,NDIM> >& v,
               const Tensor<R>& c,
               bool fence=true) {
 
         PROFILE_BLOCK(Vtransformsp);
-        typedef TENSOR_RESULT_TYPE(T, R) resultT;
+        typedef TENSOR_RESULT_TYPE(T,R) resultT;
         int n = v.size();  // n is the old dimension
         int m = c.dim(1);  // m is the new dimension
-        MADNESS_CHECK(n == c.dim(0));
+        MADNESS_CHECK(n==c.dim(0));
 
         // if we fence set the right tree state here, otherwise it has to be correct from the start.
-        if (fence) change_tree_state(v, reconstructed);
+        if (fence) change_tree_state(v,reconstructed);
         for (const auto& vv : v) MADNESS_CHECK_THROW(
-            vv.get_impl()->get_tree_state() == reconstructed, "trees have to be reconstructed in transform_reconstructed");
+            vv.get_impl()->get_tree_state()==reconstructed,"trees have to be reconstructed in transform_reconstructed");
 
-        std::vector<Function<resultT, NDIM>> result = zero_functions<resultT, NDIM>(world, m);
+        std::vector< Function<resultT,NDIM> > result = zero_functions<resultT,NDIM>(world, m);
 
-        for (int i = 0; i < m; ++i) {
+        for (int i=0; i<m; ++i) {
             result[i].get_impl()->set_tree_state(redundant_after_merge);
-            for (int j = 0; j < n; ++j) {
-                if (c(j, i) != R(0.0)) v[j].get_impl()->accumulate_trees(*(result[i].get_impl()), resultT(c(j, i)), true);
+            for (int j=0; j<n; ++j) {
+                if (c(j,i) != R(0.0)) v[j].get_impl()->accumulate_trees(*(result[i].get_impl()),resultT(c(j,i)),true);
             }
         }
 
@@ -763,14 +753,14 @@ namespace madness {
     /// this version of transform uses Function::vtransform and screens
     /// using both elements of `c` and `v`
     template <typename L, typename R, std::size_t NDIM>
-    std::vector<Function<TENSOR_RESULT_TYPE(L, R), NDIM>>
-    transform(World& world, const std::vector<Function<L, NDIM>>& v,
+    std::vector< Function<TENSOR_RESULT_TYPE(L,R),NDIM> >
+    transform(World& world,  const std::vector< Function<L,NDIM> >& v,
             const Tensor<R>& c, double tol, bool fence) {
         PROFILE_BLOCK(Vtransform);
         MADNESS_ASSERT(v.size() == (unsigned int)(c.dim(0)));
 
-        std::vector<Function<TENSOR_RESULT_TYPE(L, R), NDIM>> vresult
-            = zero_functions_compressed<TENSOR_RESULT_TYPE(L, R), NDIM>(world, c.dim(1));
+        std::vector< Function<TENSOR_RESULT_TYPE(L,R),NDIM> > vresult
+            = zero_functions_compressed<TENSOR_RESULT_TYPE(L,R),NDIM>(world, c.dim(1));
 
         compress(world, v, true);
         vresult[0].vtransform(v, c, vresult, tol, fence);
@@ -778,30 +768,30 @@ namespace madness {
     }
 
     template <typename T, typename R, std::size_t NDIM>
-    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>>
+    std::vector< Function<TENSOR_RESULT_TYPE(T,R),NDIM> >
     transform(World& world,
-              const std::vector<Function<T, NDIM>>& v,
+              const std::vector< Function<T,NDIM> >& v,
               const DistributedMatrix<R>& c,
               bool fence=true) {
         PROFILE_FUNC;
 
-        typedef TENSOR_RESULT_TYPE(T, R) resultT;
+        typedef TENSOR_RESULT_TYPE(T,R) resultT;
         long n = v.size();    // n is the old dimension
         long m = c.rowdim();  // m is the new dimension
         MADNESS_ASSERT(n==c.coldim());
 
         // new(i) = sum(j) old(j) c(j,i)
 
-       Tensor<T>tmp(n,m);
+        Tensor<T> tmp(n,m);
         c.copy_to_replicated(tmp); // for debugging
         tmp = transpose(tmp);
 
-        std::vector<Function<resultT, NDIM>> vc = zero_functions_compressed<resultT, NDIM>(world, m);
+        std::vector< Function<resultT,NDIM> > vc = zero_functions_compressed<resultT,NDIM>(world, m);
         compress(world, v);
 
-        for (int i = 0; i < m; ++i) {
-            for (int j = 0; j < n; ++j) {
-                if (tmp(j, i) != R(0.0)) vc[i].gaxpy(1.0, v[j], tmp(j, i), false);
+        for (int i=0; i<m; ++i) {
+            for (int j=0; j<n; ++j) {
+                if (tmp(j,i) != R(0.0)) vc[i].gaxpy(1.0,v[j],tmp(j,i),false);
             }
         }
 
@@ -813,34 +803,34 @@ namespace madness {
     /// Scales inplace a vector of functions by distinct values
     template <typename T, typename Q, std::size_t NDIM>
     void scale(World& world,
-               std::vector<Function<T, NDIM>>& v,
+               std::vector< Function<T,NDIM> >& v,
                const std::vector<Q>& factors,
                bool fence=true) {
         PROFILE_BLOCK(Vscale);
-        for (unsigned int i = 0; i < v.size(); ++i) v[i].scale(factors[i], false);
+        for (unsigned int i=0; i<v.size(); ++i) v[i].scale(factors[i],false);
         if (fence) world.gop.fence();
     }
 
     /// Scales inplace a vector of functions by the same
     template <typename T, typename Q, std::size_t NDIM>
     void scale(World& world,
-               std::vector<Function<T, NDIM>>& v,
-	           const Q factor,
+               std::vector< Function<T,NDIM> >& v,
+	       const Q factor,
                bool fence=true) {
         PROFILE_BLOCK(Vscale);
-        for (unsigned int i = 0; i < v.size(); ++i) v[i].scale(factor, false);
+        for (unsigned int i=0; i<v.size(); ++i) v[i].scale(factor,false);
         if (fence) world.gop.fence();
     }
 
     /// Computes the 2-norms of a vector of functions
     template <typename T, std::size_t NDIM>
     std::vector<double> norm2s(World& world,
-                               const std::vector<Function<T, NDIM>>& v) {
+                              const std::vector< Function<T,NDIM> >& v) {
         PROFILE_BLOCK(Vnorm2);
         std::vector<double> norms(v.size());
-        for (unsigned int i = 0; i < v.size(); ++i) norms[i] = v[i].norm2sq_local();
+        for (unsigned int i=0; i<v.size(); ++i) norms[i] = v[i].norm2sq_local();
         world.gop.sum(&norms[0], norms.size());
-        for (unsigned int i = 0; i < v.size(); ++i) norms[i] = sqrt(norms[i]);
+        for (unsigned int i=0; i<v.size(); ++i) norms[i] = sqrt(norms[i]);
         world.gop.fence();
         return norms;
     }
@@ -858,13 +848,13 @@ namespace madness {
 
     /// Computes the 2-norm of a vector of functions
     template <typename T, std::size_t NDIM>
-    double norm2(World& world,const std::vector<Function<T, NDIM>>& v) {
+    double norm2(World& world,const std::vector< Function<T,NDIM> >& v) {
         PROFILE_BLOCK(Vnorm2);
-        if (v.size() == 0) return 0.0;
+        if (v.size()==0) return 0.0;
         std::vector<double> norms(v.size());
-        for (unsigned int i = 0; i < v.size(); ++i) norms[i] = v[i].norm2sq_local();
+        for (unsigned int i=0; i<v.size(); ++i) norms[i] = v[i].norm2sq_local();
         world.gop.sum(&norms[0], norms.size());
-        for (unsigned int i = 1; i < v.size(); ++i) norms[0] += norms[i];
+        for (unsigned int i=1; i<v.size(); ++i) norms[0] += norms[i];
         world.gop.fence();
         return sqrt(norms[0]);
     }
@@ -884,19 +874,19 @@ namespace madness {
 //
 //    template <typename T, typename R, std::size_t NDIM>
 //    struct MatrixInnerTask : public TaskInterface {
-//        Tensor<TENSOR_RESULT_TYPE(T, R)> result; // Must be a copy
-//        const Function<T, NDIM>& f;
-//        const std::vector<Function<R, NDIM>>& g;
+//        Tensor<TENSOR_RESULT_TYPE(T,R)> result; // Must be a copy
+//        const Function<T,NDIM>& f;
+//        const std::vector< Function<R,NDIM> >& g;
 //        long jtop;
 //
-//        MatrixInnerTask(const Tensor<TENSOR_RESULT_TYPE(T, R)>& result,
-//                        const Function<T, NDIM>& f,
-//                        const std::vector<Function<R, NDIM>>& g,
+//        MatrixInnerTask(const Tensor<TENSOR_RESULT_TYPE(T,R)>& result,
+//                        const Function<T,NDIM>& f,
+//                        const std::vector< Function<R,NDIM> >& g,
 //                        long jtop)
 //                : result(result), f(f), g(g), jtop(jtop) {}
 //
 //        void run(World& world) {
-//            for (long j = 0; j < jtop; ++j) {
+//            for (long j=0; j<jtop; ++j) {
 //                result(j) = f.inner_local(g[j]);
 //            }
 //        }
@@ -914,8 +904,8 @@ namespace madness {
 
     template <typename T, std::size_t NDIM>
     DistributedMatrix<T> matrix_inner(const DistributedMatrixDistribution& d,
-                                      const std::vector<Function<T, NDIM>>& f,
-                                      const std::vector<Function<T, NDIM>>& g,
+                                      const std::vector< Function<T,NDIM> >& f,
+                                      const std::vector< Function<T,NDIM> >& g,
                                       bool sym=false)
     {
         PROFILE_FUNC;
@@ -927,15 +917,15 @@ namespace madness {
         // Assume we can always create an ichunk*jchunk matrix locally
         const int ichunk = 1000;
         const int jchunk = 1000; // 1000*1000*8 = 8 MBytes
-        for (int64_t ilo = 0; ilo < n; ilo += ichunk) {
+        for (int64_t ilo=0; ilo<n; ilo+=ichunk) {
             int64_t ihi = std::min(ilo + ichunk, n);
-            std::vector<Function<T, NDIM>> ivec(f.begin() + ilo, f.begin() + ihi);
-            for (int64_t jlo = 0; jlo < m; jlo += jchunk) {
+            std::vector< Function<T,NDIM> > ivec(f.begin()+ilo, f.begin()+ihi);
+            for (int64_t jlo=0; jlo<m; jlo+=jchunk) {
                 int64_t jhi = std::min(jlo + jchunk, m);
-                std::vector<Function<T, NDIM>> jvec(g.begin() + jlo, g.begin() + jhi);
+                std::vector< Function<T,NDIM> > jvec(g.begin()+jlo, g.begin()+jhi);
 
-                Tensor<T> P = matrix_inner(A.get_world(), ivec, jvec, sym);
-                A.copy_from_replicated_patch(ilo, ihi - 1, jlo, jhi - 1, P);
+                Tensor<T> P = matrix_inner(A.get_world(),ivec,jvec);
+                A.copy_from_replicated_patch(ilo, ihi-1, jlo, jhi-1, P);
             }
         }
         return A;
@@ -947,23 +937,22 @@ namespace madness {
     ///
     /// The current parallel loop is non-optimal but functional.
     template <typename T, typename R, std::size_t NDIM>
-    Tensor<TENSOR_RESULT_TYPE(T, R)> matrix_inner(
-            World& world,
-            const std::vector<Function<T, NDIM>>& f,
-            const std::vector<Function<R, NDIM>>& g,
-            bool sym=false)
+    Tensor< TENSOR_RESULT_TYPE(T,R) > matrix_inner(World& world,
+                                                   const std::vector< Function<T,NDIM> >& f,
+                                                   const std::vector< Function<R,NDIM> >& g,
+                                                   bool sym=false)
     {
         world.gop.fence();
         compress(world, f);
-        // if ((void*)(&f) != (void*)(&g)) compress(world, g);
+//        if ((void*)(&f) != (void*)(&g)) compress(world, g);
         compress(world, g);
 
-        std::vector<const FunctionImpl<T, NDIM>*> left(f.size());
-        std::vector<const FunctionImpl<R, NDIM>*> right(g.size());
-        for (unsigned int i = 0; i < f.size(); i++) left[i] = f[i].get_impl().get();
-        for (unsigned int i = 0; i < g.size(); i++) right[i] = g[i].get_impl().get();
+        std::vector<const FunctionImpl<T,NDIM>*> left(f.size());
+        std::vector<const FunctionImpl<R,NDIM>*> right(g.size());
+        for (unsigned int i=0; i<f.size(); i++) left[i] = f[i].get_impl().get();
+        for (unsigned int i=0; i<g.size(); i++) right[i]= g[i].get_impl().get();
 
-        Tensor<TENSOR_RESULT_TYPE(T, R)> r = FunctionImpl<T, NDIM>::inner_local(left, right, sym);
+        Tensor< TENSOR_RESULT_TYPE(T,R) > r= FunctionImpl<T,NDIM>::inner_local(left, right, sym);
 
         world.gop.fence();
         world.gop.sum(r.ptr(), f.size() * g.size());
@@ -977,66 +966,65 @@ namespace madness {
     ///
     /// The current parallel loop is non-optimal but functional.
     template <typename T, typename R, std::size_t NDIM>
-    Tensor<TENSOR_RESULT_TYPE(T, R)> matrix_inner_old(
-            World& world,
-            const std::vector<Function<T, NDIM>>& f,
-            const std::vector<Function<R, NDIM>>& g,
+    Tensor< TENSOR_RESULT_TYPE(T,R) > matrix_inner_old(World& world,
+            const std::vector< Function<T,NDIM> >& f,
+            const std::vector< Function<R,NDIM> >& g,
             bool sym=false) {
         PROFILE_BLOCK(Vmatrix_inner);
-        long n = f.size(), m = g.size();
-        Tensor<TENSOR_RESULT_TYPE(T, R)> r(n, m);
-        if (sym) MADNESS_ASSERT(n == m);
+        long n=f.size(), m=g.size();
+        Tensor< TENSOR_RESULT_TYPE(T,R) > r(n,m);
+        if (sym) MADNESS_ASSERT(n==m);
 
         world.gop.fence();
         compress(world, f);
         if ((void*)(&f) != (void*)(&g)) compress(world, g);
 
-        for (long i = 0; i < n; ++i) {
+        for (long i=0; i<n; ++i) {
             long jtop = m;
-            if (sym) jtop = i + 1;
-            for (long j = 0; j < jtop; ++j) {
-                r(i, j) = f[i].inner_local(g[j]);
-                if (sym) r(j, i) = conj(r(i, j));
+            if (sym) jtop = i+1;
+            for (long j=0; j<jtop; ++j) {
+                r(i,j) = f[i].inner_local(g[j]);
+                if (sym) r(j,i) = conj(r(i,j));
             }
          }
 
-        // for (long i = n - 1; i >= 0; --i) {
-        //     long jtop = m;
-        //     if (sym) jtop = i + 1;
-        //     world.taskq.add(new MatrixInnerTask<T, R, NDIM>(r(i, _), f[i], g, jtop));
-        // }
+//        for (long i=n-1; i>=0; --i) {
+//            long jtop = m;
+//            if (sym) jtop = i+1;
+//            world.taskq.add(new MatrixInnerTask<T,R,NDIM>(r(i,_), f[i], g, jtop));
+//        }
         world.gop.fence();
-        world.gop.sum(r.ptr(), n * m);
+        world.gop.sum(r.ptr(),n*m);
 
-        // if (sym) {
-        //     for (int i = 0; i < n; ++i) {
-        //         for (int j = 0; j < i; ++j) {
-        //             r(j, i) = conj(r(i, j));
-        //         }
-        //     }
-        // }
+//        if (sym) {
+//            for (int i=0; i<n; ++i) {
+//                for (int j=0; j<i; ++j) {
+//                    r(j,i) = conj(r(i,j));
+//                }
+//            }
+//        }
         return r;
     }
 
     /// Computes the element-wise inner product of two function vectors - q(i) = inner(f[i],g[i])
     template <typename T, typename R, std::size_t NDIM>
-    Tensor<TENSOR_RESULT_TYPE(T, R)> inner(World& world,
-                                           const std::vector<Function<T, NDIM>>& f,
-                                           const std::vector<Function<R, NDIM>>& g) {
+    Tensor< TENSOR_RESULT_TYPE(T,R) > inner(World& world,
+                                            const std::vector< Function<T,NDIM> >& f,
+                                            const std::vector< Function<R,NDIM> >& g) {
         PROFILE_BLOCK(Vinnervv);
-        long n = f.size(), m = g.size();
-        MADNESS_CHECK(n == m);
-        Tensor<TENSOR_RESULT_TYPE(T, R)> r(n);
+        long n=f.size(), m=g.size();
+        MADNESS_CHECK(n==m);
+        Tensor< TENSOR_RESULT_TYPE(T,R) > r(n);
 
         compress(world, f);
         compress(world, g);
 
-        for (long i = 0; i < n; ++i) {
+        for (long i=0; i<n; ++i) {
             r(i) = f[i].inner_local(g[i]);
         }
 
         world.taskq.fence();
-        world.gop.sum(r.ptr(), n);
+        world.gop.sum(r.ptr(),n);
         world.gop.fence();
         return r;
     }
@@ -1044,22 +1032,22 @@ namespace madness {
 
     /// Computes the inner product of a function with a function vector - q(i) = inner(f,g[i])
     template <typename T, typename R, std::size_t NDIM>
-    Tensor<TENSOR_RESULT_TYPE(T, R)> inner(World& world,
-                                            const Function<T, NDIM>& f,
-                                            const std::vector<Function<R, NDIM>>& g) {
+    Tensor< TENSOR_RESULT_TYPE(T,R) > inner(World& world,
+                                            const Function<T,NDIM>& f,
+                                            const std::vector< Function<R,NDIM> >& g) {
         PROFILE_BLOCK(Vinner);
-        long n = g.size();
-        Tensor<TENSOR_RESULT_TYPE(T, R)> r(n);
+        long n=g.size();
+        Tensor< TENSOR_RESULT_TYPE(T,R) > r(n);
 
         f.compress();
         compress(world, g);
 
-        for (long i = 0; i < n; ++i) {
+        for (long i=0; i<n; ++i) {
             r(i) = f.inner_local(g[i]);
         }
 
         world.taskq.fence();
-        world.gop.sum(r.ptr(), n);
+        world.gop.sum(r.ptr(),n);
         world.gop.fence();
         return r;
     }
@@ -1067,20 +1055,20 @@ namespace madness {
     /// inner function with right signature for the nonlinear solver
     /// this is needed for the KAIN solvers and other functions
     template <typename T, typename R, std::size_t NDIM>
-    TENSOR_RESULT_TYPE(T, R) inner(const std::vector<Function<T, NDIM>>& f,
-	                               const std::vector<Function<R, NDIM>>& g){
-      MADNESS_ASSERT(f.size() == g.size());
+    TENSOR_RESULT_TYPE(T,R) inner( const std::vector< Function<T,NDIM> >& f,
+	                                            const std::vector< Function<R,NDIM> >& g){
+      MADNESS_ASSERT(f.size()==g.size());
       if(f.empty()) return 0.0;
-      else return inner(f[0].world(), f, g).sum();
+      else return inner(f[0].world(),f,g).sum();
     }
 
 
     /// Multiplies a function against a vector of functions --- q[i] = a * v[i]
     template <typename T, typename R, std::size_t NDIM>
-    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>>
+    std::vector< Function<TENSOR_RESULT_TYPE(T,R), NDIM> >
     mul(World& world,
-        const Function<T, NDIM>& a,
-        const std::vector<Function<R, NDIM>>& v,
+        const Function<T,NDIM>& a,
+        const std::vector< Function<R,NDIM> >& v,
         bool fence=true) {
         PROFILE_BLOCK(Vmul);
         a.reconstruct(false);
@@ -1091,17 +1079,17 @@ namespace madness {
 
     /// Multiplies a function against a vector of functions using sparsity of a and v[i] --- q[i] = a * v[i]
     template <typename T, typename R, std::size_t NDIM>
-    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>>
+    std::vector< Function<TENSOR_RESULT_TYPE(T,R), NDIM> >
     mul_sparse(World& world,
-               const Function<T, NDIM>& a,
-               const std::vector<Function<R, NDIM>>& v,
+               const Function<T,NDIM>& a,
+               const std::vector< Function<R,NDIM> >& v,
                double tol,
                bool fence=true) {
         PROFILE_BLOCK(Vmulsp);
         a.reconstruct(false);
         reconstruct(world, v, false);
         world.gop.fence();
-        for (unsigned int i = 0; i < v.size(); ++i) {
+        for (unsigned int i=0; i<v.size(); ++i) {
             v[i].norm_tree(false);
         }
         a.norm_tree();
@@ -1122,15 +1110,15 @@ namespace madness {
     /// \param symm     if true, only compute f(i) * g(j) for j<=i
     /// \return         fg(i,j) = f(i) * g(j), as a vector of vectors
     template <typename T, typename R, std::size_t NDIM>
-    std::vector<std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>>>
+    std::vector<std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM> > >
     matrix_mul_sparse(World &world,
-                      const std::vector<Function<R, NDIM>> &f,
-                      const std::vector<Function<R, NDIM>> &g,
+                      const std::vector<Function<R, NDIM> > &f,
+                      const std::vector<Function<R, NDIM> > &g,
                       double tol,
-                      bool fence=true,
-                      bool symm=false) {
+                      bool fence = true,
+                      bool symm = false) {
         PROFILE_BLOCK(Vmulsp);
-        bool same = (&f == &g);
+        bool same=(&f == &g);
         reconstruct(world, f, false);
         if (not same) reconstruct(world, g, false);
         world.gop.fence();
@@ -1138,15 +1126,15 @@ namespace madness {
         if (not same) for (auto& gg : g) gg.norm_tree(false);
         world.gop.fence();
 
-        std::vector<std::vector<Function<R,NDIM>>> result(f.size());
+        std::vector<std::vector<Function<R,NDIM> > >result(f.size());
         std::vector<Function<R,NDIM>> g_i;
-        for (int64_t i = f.size()-1; i>=0; --i) {
+        for (int64_t i=f.size()-1; i>=0; --i) {
           if (!symm)
             result[i]= vmulXX(f[i], g, tol, false);
           else {
             if (g_i.empty()) g_i = g;
-            g_i.resize(i + 1);  // this shrinks g_i down to single function for i=0
-            result[i] = vmulXX(f[i], g_i, tol, false);
+            g_i.resize(i+1);  // this shrinks g_i down to single function for i=0
+            result[i]= vmulXX(f[i], g_i, tol, false);
           }
         }
         if (fence) world.gop.fence();
@@ -1156,11 +1144,11 @@ namespace madness {
     /// Makes the norm tree for all functions in a vector
     template <typename T, std::size_t NDIM>
     void norm_tree(World& world,
-                   const std::vector<Function<T, NDIM>>& v,
+                   const std::vector< Function<T,NDIM> >& v,
                    bool fence=true)
     {
         PROFILE_BLOCK(Vnorm_tree);
-        for (unsigned int i = 0; i < v.size(); ++i) {
+        for (unsigned int i=0; i<v.size(); ++i) {
             v[i].norm_tree(false);
         }
         if (fence) world.gop.fence();
@@ -1168,18 +1156,18 @@ namespace madness {
 
     /// Multiplies two vectors of functions q[i] = a[i] * b[i]
     template <typename T, typename R, std::size_t NDIM>
-    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>>
+    std::vector< Function<TENSOR_RESULT_TYPE(T,R), NDIM> >
     mul(World& world,
-        const std::vector<Function<T, NDIM>>& a,
-        const std::vector<Function<R, NDIM>>& b,
+        const std::vector< Function<T,NDIM> >& a,
+        const std::vector< Function<R,NDIM> >& b,
         bool fence=true) {
         PROFILE_BLOCK(Vmulvv);
         reconstruct(world, a, true);
         reconstruct(world, b, true);
-        // if (&a != &b) reconstruct(world, b, true); // fails if type(a) != type(b)
+//        if (&a != &b) reconstruct(world, b, true); // fails if type(a) != type(b)
 
-        std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>> q(a.size());
-        for (unsigned int i = 0; i < a.size(); ++i) {
+        std::vector< Function<TENSOR_RESULT_TYPE(T,R),NDIM> > q(a.size());
+        for (unsigned int i=0; i<a.size(); ++i) {
             q[i] = mul(a[i], b[i], false);
         }
         if (fence) world.gop.fence();
@@ -1194,22 +1182,22 @@ namespace madness {
     /// @param[in]  v   dimension indices of f to multiply
     /// @return     h[i](0,1,2,3) = f(0,1,2,3) * g[i](1,2,3) for v={1,2,3}
     template<typename T, std::size_t NDIM, std::size_t LDIM>
-    std::vector<Function<T, NDIM>> partial_mul(const Function<T, NDIM> f, const std::vector<Function<T,LDIM>> g,
+    std::vector<Function<T,NDIM> > partial_mul(const Function<T,NDIM> f, const std::vector<Function<T,LDIM> > g,
                                  const int particle) {
 
-        World& world = f.world();
-        std::vector<Function<T, NDIM>> result(g.size());
+        World& world=f.world();
+        std::vector<Function<T,NDIM> > result(g.size());
         for (auto& r : result) r.set_impl(f, false);
 
-        FunctionImpl<T, NDIM>* fimpl = f.get_impl().get();
+        FunctionImpl<T,NDIM>* fimpl=f.get_impl().get();
 //        fimpl->make_redundant(false);
-        fimpl->change_tree_state(redundant, false);
-        make_redundant(world, g, false);
+        fimpl->change_tree_state(redundant,false);
+        make_redundant(world,g,false);
         world.gop.fence();
 
-        for (std::size_t i = 0; i < result.size(); ++i) {
-            FunctionImpl<T, LDIM>* gimpl = g[i].get_impl().get();
-            result[i].get_impl()->multiply(fimpl, gimpl, particle);  // stupid naming inconsistency
+        for (std::size_t i=0; i<result.size(); ++i) {
+            FunctionImpl<T,LDIM>* gimpl=g[i].get_impl().get();
+            result[i].get_impl()->multiply(fimpl,gimpl,particle);     // stupid naming inconsistency
         }
         world.gop.fence();
 
@@ -1220,38 +1208,38 @@ namespace madness {
     }
 
     template<typename T, std::size_t NDIM, std::size_t LDIM>
-    std::vector<Function<T, NDIM>> multiply(const Function<T, NDIM> f, const std::vector<Function<T, LDIM>> g,
+    std::vector<Function<T,NDIM> > multiply(const Function<T,NDIM> f, const std::vector<Function<T,LDIM> > g,
                               const std::tuple<int,int,int> v) {
-        return partial_mul<T, NDIM, LDIM>(f, g, std::array<int,3>({std::get<0>(v), std::get<1>(v), std::get<2>(v)}));
+        return partial_mul<T,NDIM,LDIM>(f,g,std::array<int,3>({std::get<0>(v),std::get<1>(v),std::get<2>(v)}));
     }
 
 
 /// Computes the square of a vector of functions --- q[i] = v[i]**2
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T, NDIM>>
+    std::vector< Function<T,NDIM> >
     square(World& world,
-           const std::vector<Function<T, NDIM>>& v,
+           const std::vector< Function<T,NDIM> >& v,
            bool fence=true) {
-        return mul<T, T, NDIM>(world, v, v, fence);
-        // std::vector<Function<T, NDIM>> vsq(v.size());
-        // for (unsigned int i = 0; i < v.size(); ++i) {
-        //     vsq[i] = square(v[i], false);
-        // }
-        // if (fence) world.gop.fence();
-        // return vsq;
+        return mul<T,T,NDIM>(world, v, v, fence);
+//         std::vector< Function<T,NDIM> > vsq(v.size());
+//         for (unsigned int i=0; i<v.size(); ++i) {
+//             vsq[i] = square(v[i], false);
+//         }
+//         if (fence) world.gop.fence();
+//         return vsq;
     }
 
 
     /// Computes the square of a vector of functions --- q[i] = abs(v[i])**2
     template <typename T, std::size_t NDIM>
-    std::vector<Function<typename Tensor<T>::scalar_type, NDIM>>
+    std::vector< Function<typename Tensor<T>::scalar_type,NDIM> >
     abssq(World& world,
-           const std::vector<Function<T, NDIM>>& v,
+           const std::vector< Function<T,NDIM> >& v,
            bool fence=true) {
     	typedef typename Tensor<T>::scalar_type scalartype;
-    	reconstruct(world, v);
-    	std::vector<Function<scalartype, NDIM>> result(v.size());
-    	for (size_t i = 0; i < v.size(); ++i) result[i] = abs_square(v[i], false);
+    	reconstruct(world,v);
+    	std::vector<Function<scalartype,NDIM> > result(v.size());
+    	for (size_t i=0; i<v.size(); ++i) result[i]=abs_square(v[i],false);
     	if (fence) world.gop.fence();
         return result;
     }
@@ -1259,8 +1247,8 @@ namespace madness {
 
     /// Sets the threshold in a vector of functions
     template <typename T, std::size_t NDIM>
-    void set_thresh(World& world, std::vector<Function<T, NDIM>>& v, double thresh, bool fence=true) {
-        for (unsigned int j = 0; j < v.size(); ++j) {
+    void set_thresh(World& world, std::vector< Function<T,NDIM> >& v, double thresh, bool fence=true) {
+        for (unsigned int j=0; j<v.size(); ++j) {
             v[j].set_thresh(thresh,false);
         }
         if (fence) world.gop.fence();
@@ -1268,13 +1256,13 @@ namespace madness {
 
     /// Returns the complex conjugate of the vector of functions
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T, NDIM>>
+    std::vector< Function<T,NDIM> >
     conj(World& world,
-         const std::vector<Function<T, NDIM>>& v,
+         const std::vector< Function<T,NDIM> >& v,
          bool fence=true) {
         PROFILE_BLOCK(Vconj);
-        std::vector<Function<T, NDIM>> r = copy(world, v); // Currently don't have oop conj
-        for (unsigned int i = 0; i < v.size(); ++i) {
+        std::vector< Function<T,NDIM> > r = copy(world, v); // Currently don't have oop conj
+        for (unsigned int i=0; i<v.size(); ++i) {
             r[i].conj(false);
         }
         if (fence) world.gop.fence();
@@ -1283,12 +1271,12 @@ namespace madness {
 
     /// Returns a deep copy of a vector of functions
     template <typename T, typename R, std::size_t NDIM>
-    std::vector<Function<R, NDIM>> convert(World& world,
-    		const std::vector<Function<T, NDIM>>& v, bool fence=true) {
+    std::vector< Function<R,NDIM> > convert(World& world,
+    		const std::vector< Function<T,NDIM> >& v, bool fence=true) {
         PROFILE_BLOCK(Vcopy);
-        std::vector<Function<R, NDIM>> r(v.size());
-        for (unsigned int i = 0; i < v.size(); ++i) {
-            r[i] = convert<T, R, NDIM>(v[i], false);
+        std::vector< Function<R,NDIM> > r(v.size());
+        for (unsigned int i=0; i<v.size(); ++i) {
+            r[i] = convert<T,R,NDIM>(v[i], false);
         }
         if (fence) world.gop.fence();
         return r;
@@ -1297,13 +1285,13 @@ namespace madness {
 
     /// Returns a deep copy of a vector of functions
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T, NDIM>>
+    std::vector< Function<T,NDIM> >
     copy(World& world,
-         const std::vector<Function<T, NDIM>>& v,
+         const std::vector< Function<T,NDIM> >& v,
          bool fence=true) {
         PROFILE_BLOCK(Vcopy);
-        std::vector<Function<T, NDIM>> r(v.size());
-        for (unsigned int i = 0; i < v.size(); ++i) {
+        std::vector< Function<T,NDIM> > r(v.size());
+        for (unsigned int i=0; i<v.size(); ++i) {
             r[i] = copy(v[i], false);
         }
         if (fence) world.gop.fence();
@@ -1313,24 +1301,24 @@ namespace madness {
 
     /// Returns a deep copy of a vector of functions
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T, NDIM>>
-    copy(const std::vector<Function<T, NDIM>>& v, bool fence=true) {
+    std::vector< Function<T,NDIM> >
+    copy(const std::vector< Function<T,NDIM> >& v, bool fence=true) {
         PROFILE_BLOCK(Vcopy);
-        std::vector<Function<T, NDIM>> r(v.size());
-        if (v.size() > 0) r = copy(v.front().world(), v, fence);
+        std::vector< Function<T,NDIM> > r(v.size());
+        if (v.size()>0) r=copy(v.front().world(),v,fence);
         return r;
     }
 
     /// Returns a vector of `n` deep copies of a function
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T, NDIM>>
+    std::vector< Function<T,NDIM> >
     copy(World& world,
-         const Function<T, NDIM>& v,
+         const Function<T,NDIM>& v,
          const unsigned int n,
          bool fence=true) {
         PROFILE_BLOCK(Vcopy1);
-        std::vector<Function<T, NDIM>> r(n);
-        for (unsigned int i = 0; i < n; ++i) {
+        std::vector< Function<T,NDIM> > r(n);
+        for (unsigned int i=0; i<n; ++i) {
             r[i] = copy(v, false);
         }
         if (fence) world.gop.fence();
@@ -1350,7 +1338,7 @@ namespace madness {
     std::vector<Function<T, NDIM>> copy(World& world,
                                         const std::vector<Function<T, NDIM>>& v,
                                         const std::shared_ptr<WorldDCPmapInterface<Key<NDIM>>>& pmap,
-                                        bool fence=true) {
+                                        bool fence = true) {
       PROFILE_BLOCK(Vcopy);
       std::vector<Function<T, NDIM>> r(v.size());
       for (unsigned int i = 0; i < v.size(); ++i) {
@@ -1362,18 +1350,18 @@ namespace madness {
 
     /// Returns new vector of functions --- q[i] = a[i] + b[i]
     template <typename T, typename R, std::size_t NDIM>
-    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>>
+    std::vector< Function<TENSOR_RESULT_TYPE(T,R), NDIM> >
     add(World& world,
-        const std::vector<Function<T, NDIM>>& a,
-        const std::vector<Function<R, NDIM>>& b,
+        const std::vector< Function<T,NDIM> >& a,
+        const std::vector< Function<R,NDIM> >& b,
         bool fence=true) {
         PROFILE_BLOCK(Vadd);
         MADNESS_ASSERT(a.size() == b.size());
         compress(world, a);
         compress(world, b);
 
-        std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>> r(a.size());
-        for (unsigned int i = 0; i < a.size(); ++i) {
+        std::vector< Function<TENSOR_RESULT_TYPE(T,R),NDIM> > r(a.size());
+        for (unsigned int i=0; i<a.size(); ++i) {
             r[i] = add(a[i], b[i], false);
         }
         if (fence) world.gop.fence();
@@ -1382,45 +1370,45 @@ namespace madness {
 
      /// Returns new vector of functions --- q[i] = a + b[i]
     template <typename T, typename R, std::size_t NDIM>
-    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>>
+    std::vector< Function<TENSOR_RESULT_TYPE(T,R), NDIM> >
     add(World& world,
-        const Function<T, NDIM>& a,
-        const std::vector<Function<R, NDIM>>& b,
+        const Function<T,NDIM> & a,
+        const std::vector< Function<R,NDIM> >& b,
         bool fence=true) {
         PROFILE_BLOCK(Vadd1);
         a.compress();
         compress(world, b);
 
-        std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>> r(b.size());
-        for (unsigned int i = 0; i < b.size(); ++i) {
+        std::vector< Function<TENSOR_RESULT_TYPE(T,R),NDIM> > r(b.size());
+        for (unsigned int i=0; i<b.size(); ++i) {
             r[i] = add(a, b[i], false);
         }
         if (fence) world.gop.fence();
         return r;
     }
     template <typename T, typename R, std::size_t NDIM>
-    inline std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>>
+    inline std::vector< Function<TENSOR_RESULT_TYPE(T,R), NDIM> >
     add(World& world,
-        const std::vector<Function<R, NDIM>>& b,
-        const Function<T, NDIM>& a,
+        const std::vector< Function<R,NDIM> >& b,
+        const Function<T,NDIM> & a,
         bool fence=true) {
         return add(world, a, b, fence);
     }
 
     /// Returns new vector of functions --- q[i] = a[i] - b[i]
     template <typename T, typename R, std::size_t NDIM>
-    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>>
+    std::vector< Function<TENSOR_RESULT_TYPE(T,R), NDIM> >
     sub(World& world,
-        const std::vector<Function<T, NDIM>>& a,
-        const std::vector<Function<R, NDIM>>& b,
+        const std::vector< Function<T,NDIM> >& a,
+        const std::vector< Function<R,NDIM> >& b,
         bool fence=true) {
         PROFILE_BLOCK(Vsub);
         MADNESS_ASSERT(a.size() == b.size());
         compress(world, a);
         compress(world, b);
 
-        std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>> r(a.size());
-        for (unsigned int i = 0; i < a.size(); ++i) {
+        std::vector< Function<TENSOR_RESULT_TYPE(T,R),NDIM> > r(a.size());
+        for (unsigned int i=0; i<a.size(); ++i) {
             r[i] = sub(a[i], b[i], false);
         }
         if (fence) world.gop.fence();
@@ -1429,13 +1417,13 @@ namespace madness {
 
     /// Returns new function --- q = sum_i f[i]
     template <typename T, std::size_t NDIM>
-    Function<T, NDIM> sum(World& world, const std::vector<Function<T, NDIM>>& f,
-            bool fence=true) {
+    Function<T, NDIM> sum(World& world, const std::vector<Function<T,NDIM> >& f,
+        bool fence=true) {
 
         compress(world, f);
-        Function<T, NDIM> r = FunctionFactory<T, NDIM>(world).compressed();
+        Function<T,NDIM> r=FunctionFactory<T,NDIM>(world).compressed();
 
-        for (unsigned int i = 0; i < f.size(); ++i) r.gaxpy(1.0, f[i], 1.0, false);
+        for (unsigned int i=0; i<f.size(); ++i) r.gaxpy(1.0,f[i],1.0,false);
         if (fence) world.gop.fence();
         return r;
     }
@@ -1500,34 +1488,34 @@ namespace madness {
 
     /// Multiplies and sums two vectors of functions r = \sum_i a[i] * b[i]
     template <typename T, typename R, std::size_t NDIM>
-    Function<TENSOR_RESULT_TYPE(T, R), NDIM>
+    Function<TENSOR_RESULT_TYPE(T,R), NDIM>
     dot(World& world,
-        const std::vector<Function<T, NDIM>>& a,
-        const std::vector<Function<R, NDIM>>& b,
+        const std::vector< Function<T,NDIM> >& a,
+        const std::vector< Function<R,NDIM> >& b,
         bool fence=true) {
         MADNESS_CHECK(a.size()==b.size());
-        return sum(world, mul(world, a, b,true), fence);
+        return sum(world,mul(world,a,b,true),fence);
     }
 
 
     /// out-of-place gaxpy for two vectors: result[i] = alpha * a[i] + beta * b[i]
     template <typename T, typename Q, typename R, std::size_t NDIM>
-    std::vector<Function<TENSOR_RESULT_TYPE(Q, TENSOR_RESULT_TYPE(T, R)), NDIM>>
+    std::vector<Function<TENSOR_RESULT_TYPE(Q,TENSOR_RESULT_TYPE(T,R)),NDIM> >
     gaxpy_oop(Q alpha,
-              const std::vector<Function<T, NDIM>>& a,
-              Q beta,
-              const std::vector<Function<R, NDIM>>& b,
-              bool fence=true) {
+               const std::vector< Function<T,NDIM> >& a,
+               Q beta,
+               const std::vector< Function<R,NDIM> >& b,
+               bool fence=true) {
 
         MADNESS_ASSERT(a.size() == b.size());
-        typedef TENSOR_RESULT_TYPE(Q, TENSOR_RESULT_TYPE(T, R)) resultT;
-        if (a.size() == 0) return std::vector<Function<resultT, NDIM>>();
+        typedef TENSOR_RESULT_TYPE(Q,TENSOR_RESULT_TYPE(T,R)) resultT;
+        if (a.size()==0) return std::vector<Function<resultT,NDIM> >();
 
-        World& world = a[0].world();
-        compress(world, a);
-    	compress(world, b);
-    	std::vector<Function<resultT, NDIM>> result(a.size());
-        for (unsigned int i = 0; i < a.size(); ++i) {
+        World& world=a[0].world();
+        compress(world,a);
+    	compress(world,b);
+    	std::vector<Function<resultT,NDIM> > result(a.size());
+        for (unsigned int i=0; i<a.size(); ++i) {
             result[i]=gaxpy_oop(alpha, a[i], beta, b[i], false);
         }
         if (fence) world.gop.fence();
@@ -1537,22 +1525,22 @@ namespace madness {
 
     /// out-of-place gaxpy for a vectors and a function: result[i] = alpha * a[i] + beta * b
     template <typename T, typename Q, typename R, std::size_t NDIM>
-    std::vector<Function<TENSOR_RESULT_TYPE(Q, TENSOR_RESULT_TYPE(T, R)), NDIM> >
+    std::vector<Function<TENSOR_RESULT_TYPE(Q,TENSOR_RESULT_TYPE(T,R)),NDIM> >
     gaxpy_oop(Q alpha,
-              const std::vector<Function<T, NDIM>>& a,
-              Q beta,
-              const Function<R,NDIM>& b,
-              bool fence=true) {
+               const std::vector< Function<T,NDIM> >& a,
+               Q beta,
+               const Function<R,NDIM>& b,
+               bool fence=true) {
 
-        typedef TENSOR_RESULT_TYPE(Q, TENSOR_RESULT_TYPE(T, R)) resultT;
-        if (a.size() == 0) return std::vector<Function<resultT, NDIM>>();
+        typedef TENSOR_RESULT_TYPE(Q,TENSOR_RESULT_TYPE(T,R)) resultT;
+        if (a.size()==0) return std::vector<Function<resultT,NDIM> >();
 
-        World& world = a[0].world();
-        compress(world, a);
+        World& world=a[0].world();
+        compress(world,a);
     	b.compress();
-    	std::vector<Function<resultT, NDIM>> result(a.size());
-        for (unsigned int i = 0; i < a.size(); ++i) {
-            result[i] = gaxpy_oop(alpha, a[i], beta, b, false);
+    	std::vector<Function<resultT,NDIM> > result(a.size());
+        for (unsigned int i=0; i<a.size(); ++i) {
+            result[i]=gaxpy_oop(alpha, a[i], beta, b, false);
         }
         if (fence) world.gop.fence();
         return result;
@@ -1561,23 +1549,19 @@ namespace madness {
 
     /// Generalized A*X+Y for vectors of functions ---- a[i] = alpha*a[i] + beta*b[i]
     template <typename T, typename Q, typename R, std::size_t NDIM>
-	void gaxpy(Q alpha,
-               std::vector<Function<T, NDIM>>& a,
-               Q beta,
-               const std::vector<Function<R,NDIM>>& b,
-               const bool fence) {
+	void gaxpy(Q alpha, std::vector<Function<T,NDIM>>& a, Q beta, const std::vector<Function<R,NDIM>>& b, const bool fence) {
 	    if (a.size() == 0) return;
-    	World& world = a.front().world();
-    	gaxpy(world, alpha, a, beta, b, fence);
+    	World& world=a.front().world();
+    	gaxpy(world,alpha,a,beta,b,fence);
     }
 
     /// Generalized A*X+Y for vectors of functions ---- a[i] = alpha*a[i] + beta*b[i]
     template <typename T, typename Q, typename R, std::size_t NDIM>
     void gaxpy(World& world,
                Q alpha,
-               std::vector<Function<T, NDIM>>& a,
+               std::vector< Function<T,NDIM> >& a,
                Q beta,
-               const std::vector<Function<R, NDIM>>& b,
+               const std::vector< Function<R,NDIM> >& b,
                bool fence=true) {
         PROFILE_BLOCK(Vgaxpy);
         MADNESS_ASSERT(a.size() == b.size());
@@ -1585,10 +1569,10 @@ namespace madness {
 			compress(a.front().world(), a);
 			compress(b.front().world(), b);
     	}
-    	for (const auto& aa : a) MADNESS_CHECK_THROW(aa.is_compressed(), "vector-gaxpy requires compressed functions");
-    	for (const auto& bb : b) MADNESS_CHECK_THROW(bb.is_compressed(), "vector-gaxpy requires compressed functions");
+    	for (const auto& aa : a) MADNESS_CHECK_THROW(aa.is_compressed(),"vector-gaxpy requires compressed functions");
+    	for (const auto& bb : b) MADNESS_CHECK_THROW(bb.is_compressed(),"vector-gaxpy requires compressed functions");
 
-        for (unsigned int i = 0; i < a.size(); ++i) {
+        for (unsigned int i=0; i<a.size(); ++i) {
             a[i].gaxpy(alpha, b[i], beta, false);
         }
         if (fence) world.gop.fence();
@@ -1597,21 +1581,21 @@ namespace madness {
 
     /// Applies a vector of operators to a vector of functions --- q[i] = apply(op[i],f[i])
     template <typename opT, typename R, std::size_t NDIM>
-    std::vector<Function<TENSOR_RESULT_TYPE(typename opT::opT, R), NDIM>>
+    std::vector< Function<TENSOR_RESULT_TYPE(typename opT::opT,R), NDIM> >
     apply(World& world,
-          const std::vector<std::shared_ptr<opT>>& op,
-          const std::vector<Function<R, NDIM>> f) {
+          const std::vector< std::shared_ptr<opT> >& op,
+          const std::vector< Function<R,NDIM> > f) {
 
         PROFILE_BLOCK(Vapplyv);
-        MADNESS_ASSERT(f.size() == op.size());
+        MADNESS_ASSERT(f.size()==op.size());
 
-        std::vector<Function<R, NDIM>>& ncf = *const_cast<std::vector<Function<R, NDIM>>*>(&f);
+        std::vector< Function<R,NDIM> >& ncf = *const_cast< std::vector< Function<R,NDIM> >* >(&f);
 
 //        reconstruct(world, f);
         make_nonstandard(world, ncf);
 
-        std::vector<Function<TENSOR_RESULT_TYPE(typename opT::opT, R), NDIM>> result(f.size());
-        for (unsigned int i = 0; i < f.size(); ++i) {
+        std::vector< Function<TENSOR_RESULT_TYPE(typename opT::opT,R), NDIM> > result(f.size());
+        for (unsigned int i=0; i<f.size(); ++i) {
             result[i] = apply_only(*op[i], f[i], false);
             result[i].get_impl()->set_tree_state(nonstandard_after_apply);
         }
@@ -1628,32 +1612,32 @@ namespace madness {
 
     /// Applies an operator to a vector of functions --- q[i] = apply(op,f[i])
     template <typename T, typename R, std::size_t NDIM, std::size_t KDIM>
-    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>>
+    std::vector< Function<TENSOR_RESULT_TYPE(T,R), NDIM> >
     apply(const SeparatedConvolution<T,KDIM>& op,
-          const std::vector<Function<R, NDIM>> f) {
+          const std::vector< Function<R,NDIM> > f) {
         return apply(op.get_world(),op,f);
     }
 
 
     /// Applies an operator to a vector of functions --- q[i] = apply(op,f[i])
     template <typename T, typename R, std::size_t NDIM, std::size_t KDIM>
-    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>>
+    std::vector< Function<TENSOR_RESULT_TYPE(T,R), NDIM> >
     apply(World& world,
           const SeparatedConvolution<T,KDIM>& op,
-          const std::vector<Function<R, NDIM>> f) {
+          const std::vector< Function<R,NDIM> > f) {
         PROFILE_BLOCK(Vapply);
 
-        std::vector<Function<R, NDIM>>& ncf = *const_cast<std::vector<Function<R, NDIM>>*>(&f);
-        bool print_timings = (NDIM == 6) and (world.rank() == 0) and op.print_timings;
+        std::vector< Function<R,NDIM> >& ncf = *const_cast< std::vector< Function<R,NDIM> >* >(&f);
+        bool print_timings=(NDIM==6) and (world.rank()==0) and op.print_timings;
 
-        double wall0 = wall_time();
-        // reconstruct(world, f);
+        double wall0=wall_time();
+//        reconstruct(world, f);
         make_nonstandard(world, ncf);
-        double wall1 = wall_time();
-        if (print_timings) printf("timer: %20.20s %8.2fs\n", "make_nonstandard", wall1 - wall0);
+        double wall1=wall_time();
+        if (print_timings) printf("timer: %20.20s %8.2fs\n", "make_nonstandard", wall1-wall0);
 
-        std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>> result(f.size());
-        for (unsigned int i = 0; i < f.size(); ++i) {
+        std::vector< Function<TENSOR_RESULT_TYPE(T,R), NDIM> > result(f.size());
+        for (unsigned int i=0; i<f.size(); ++i) {
             result[i] = apply_only(op, f[i], false);
         }
 
@@ -1668,7 +1652,7 @@ namespace madness {
         }
 
         // svd-tensor requires some cleanup after apply
-        if (result[0].get_impl()->get_tensor_type() == TT_2D) {
+        if (result[0].get_impl()->get_tensor_type()==TT_2D) {
             for (auto& r : result) r.get_impl()->finalize_apply();
         }
 
@@ -1683,20 +1667,20 @@ namespace madness {
 
     /// Normalizes a vector of functions --- v[i] = v[i].scale(1.0/v[i].norm2())
     template <typename T, std::size_t NDIM>
-    void normalize(World& world, std::vector<Function<T, NDIM>>& v, bool fence=true) {
+    void normalize(World& world, std::vector< Function<T,NDIM> >& v, bool fence=true) {
         PROFILE_BLOCK(Vnormalize);
         std::vector<double> nn = norm2s(world, v);
-        for (unsigned int i = 0; i < v.size(); ++i) v[i].scale(1.0 / nn[i], false);
+        for (unsigned int i=0; i<v.size(); ++i) v[i].scale(1.0/nn[i],false);
         if (fence) world.gop.fence();
     }
 
     template <typename T, std::size_t NDIM>
-    void print_size(World &world, const std::vector<Function<T, NDIM>> &v, const std::string &msg = "vectorfunction"){
-    	if (v.empty()){
-    		if(world.rank() == 0) std::cout << "print_size: " << msg << " is empty" << std::endl;
-    	} else if (v.size() == 1){
+    void print_size(World &world, const std::vector<Function<T,NDIM> > &v, const std::string &msg = "vectorfunction" ){
+    	if(v.empty()){
+    		if(world.rank()==0) std::cout << "print_size: " << msg << " is empty" << std::endl;
+    	}else if(v.size()==1){
     		v.front().print_size(msg);
-    	} else {
+    	}else{
     		for(auto x:v){
     			x.print_size(msg);
     		}
@@ -1705,15 +1689,16 @@ namespace madness {
 
     // gives back the size in GB
     template <typename T, std::size_t NDIM>
-    double get_size(World& world, const std::vector<Function<T, NDIM>>& v){
+    double get_size(World& world, const std::vector< Function<T,NDIM> >& v){
+
     	if (v.empty()) return 0.0;
 
-    	const double d = sizeof(T);
-        const double fac = 1024 * 1024 * 1024;
+    	const double d=sizeof(T);
+        const double fac=1024*1024*1024;
 
-        double size = 0.0;
-        for(unsigned int i = 0; i < v.size(); i++){
-            if (v[i].is_initialized()) size += v[i].size();
+        double size=0.0;
+        for(unsigned int i=0;i<v.size();i++){
+            if (v[i].is_initialized()) size+=v[i].size();
         }
 
         return size/fac*d;
@@ -1722,11 +1707,11 @@ namespace madness {
 
     // gives back the size in GB
     template <typename T, std::size_t NDIM>
-    double get_size(const Function<T, NDIM>& f){
-    	const double d = sizeof(T);
-        const double fac = 1024 * 1024 * 1024;
-        double size = f.size();
-        return size / fac * d;
+    double get_size(const Function<T,NDIM> & f){
+    	const double d=sizeof(T);
+        const double fac=1024*1024*1024;
+        double size=f.size();
+        return size/fac*d;
     }
 
     /// apply op on the input vector yielding an output vector of functions
@@ -1735,16 +1720,16 @@ namespace madness {
     /// @param[in]  vin  vector of input Functions; needs to be refined to common level!
     /// @return vector of output Functions vout = op(vin)
     template <typename T, typename opT, std::size_t NDIM>
-    std::vector<Function<T, NDIM>> multi_to_multi_op_values(const opT& op,
-            const std::vector<Function<T, NDIM>>& vin,
+    std::vector<Function<T,NDIM> > multi_to_multi_op_values(const opT& op,
+            const std::vector< Function<T,NDIM> >& vin,
             const bool fence=true) {
-        MADNESS_ASSERT(vin.size() > 0);
+        MADNESS_ASSERT(vin.size()>0);
         MADNESS_ASSERT(vin[0].is_initialized()); // might be changed
-        World& world = vin[0].world();
-        Function<T, NDIM> dummy;
+        World& world=vin[0].world();
+        Function<T,NDIM> dummy;
         dummy.set_impl(vin[0], false);
-        std::vector<Function<T, NDIM>> vout = zero_functions<T, NDIM>(world, op.get_result_size());
-        for (auto& out : vout) out.set_impl(vin[0], false);
+        std::vector<Function<T,NDIM> > vout=zero_functions<T,NDIM>(world, op.get_result_size());
+        for (auto& out : vout) out.set_impl(vin[0],false);
         dummy.multi_to_multi_op_values(op, vin, vout, fence);
         return vout;
     }
@@ -1756,114 +1741,114 @@ namespace madness {
 
     /// result[i] = a[i] + b[i]
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T, NDIM>> operator+(const std::vector<Function<T, NDIM>>& lhs,
-            const std::vector<Function<T, NDIM>>& rhs) {
+    std::vector<Function<T,NDIM> > operator+(const std::vector<Function<T,NDIM> >& lhs,
+            const std::vector<Function<T,NDIM>>& rhs) {
         MADNESS_CHECK(lhs.size() == rhs.size());
-        return gaxpy_oop(1.0, lhs, 1.0, rhs);
+        return gaxpy_oop(1.0,lhs,1.0,rhs);
     }
 
     /// result[i] = a[i] - b[i]
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T, NDIM>> operator-(const std::vector<Function<T, NDIM>>& lhs,
-            const std::vector<Function<T, NDIM>>& rhs) {
+    std::vector<Function<T,NDIM> > operator-(const std::vector<Function<T,NDIM> >& lhs,
+            const std::vector<Function<T,NDIM> >& rhs) {
         MADNESS_CHECK(lhs.size() == rhs.size());
-        return gaxpy_oop(1.0, lhs, -1.0, rhs);
+        return gaxpy_oop(1.0,lhs,-1.0,rhs);
     }
 
     /// result[i] = a[i] + b
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T, NDIM>> operator+(const std::vector<Function<T, NDIM>>& lhs,
-            const Function<T, NDIM>& rhs) {
+    std::vector<Function<T,NDIM> > operator+(const std::vector<Function<T,NDIM> >& lhs,
+            const Function<T,NDIM>& rhs) {
         // MADNESS_CHECK(lhs.size() == rhs.size()); // no!!
-        return gaxpy_oop(1.0, lhs, 1.0, rhs);
+        return gaxpy_oop(1.0,lhs,1.0,rhs);
     }
 
     /// result[i] = a[i] - b
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T, NDIM>> operator-(const std::vector<Function<T, NDIM>>& lhs,
-            const Function<T, NDIM>& rhs) {
+    std::vector<Function<T,NDIM> > operator-(const std::vector<Function<T,NDIM> >& lhs,
+            const Function<T,NDIM>& rhs) {
         // MADNESS_CHECK(lhs.size() == rhs.size());  // no
-        return gaxpy_oop(1.0, lhs, -1.0, rhs);
+        return gaxpy_oop(1.0,lhs,-1.0,rhs);
     }
 
     /// result[i] = a + b[i]
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T, NDIM>> operator+(const Function<T, NDIM>& lhs,
-            const std::vector<Function<T, NDIM>>& rhs) {
+    std::vector<Function<T,NDIM> > operator+(const Function<T,NDIM>& lhs,
+            const std::vector<Function<T,NDIM> >& rhs) {
         // MADNESS_CHECK(lhs.size() == rhs.size());   // no
-        return gaxpy_oop(1.0, rhs, 1.0, lhs);
+        return gaxpy_oop(1.0,rhs,1.0,lhs);
     }
 
     /// result[i] = a - b[i]
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T, NDIM>> operator-(const Function<T, NDIM>& lhs,
-            const std::vector<Function<T, NDIM>>& rhs) {
-        // MADNESS_CHECK(lhs.size() == rhs.size());  // no
-        return gaxpy_oop(-1.0, rhs, 1.0, lhs);
+    std::vector<Function<T,NDIM> > operator-(const Function<T,NDIM>& lhs,
+            const std::vector<Function<T,NDIM> >& rhs) {
+//         MADNESS_CHECK(lhs.size() == rhs.size());  // no
+        return gaxpy_oop(-1.0,rhs,1.0,lhs);
     }
 
 
     template <typename T, typename R, std::size_t NDIM>
-    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM> > operator*(const R fac,
-            const std::vector<Function<T, NDIM>>& rhs) {
+    std::vector<Function<TENSOR_RESULT_TYPE(T,R),NDIM> > operator*(const R fac,
+            const std::vector<Function<T,NDIM> >& rhs) {
     	if (rhs.size()>0) {
-			std::vector<Function<T, NDIM>> tmp = copy(rhs[0].world(), rhs);
-			scale(tmp[0].world(), tmp, TENSOR_RESULT_TYPE(T, R)(fac));
+			std::vector<Function<T,NDIM> > tmp=copy(rhs[0].world(),rhs);
+			scale(tmp[0].world(),tmp,TENSOR_RESULT_TYPE(T,R)(fac));
 			return tmp;
     	}
-		return std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>>();
+		return std::vector<Function<TENSOR_RESULT_TYPE(T,R),NDIM> >();
     }
 
     template <typename T, typename R, std::size_t NDIM>
-    std::vector<Function<T, NDIM>> operator*(const std::vector<Function<T, NDIM>>& rhs,
+    std::vector<Function<T,NDIM> > operator*(const std::vector<Function<T,NDIM> >& rhs,
             const R fac) {
     	if (rhs.size()>0) {
-            std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM> > tmp = copy(rhs[0].world(), rhs);
-            scale(tmp[0].world(), tmp, TENSOR_RESULT_TYPE(T, R)(fac));
+            std::vector<Function<TENSOR_RESULT_TYPE(T,R),NDIM> > tmp=copy(rhs[0].world(),rhs);
+            scale(tmp[0].world(),tmp,TENSOR_RESULT_TYPE(T,R)(fac));
             return tmp;
     	}
-		return std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM> >();
+		return std::vector<Function<TENSOR_RESULT_TYPE(T,R),NDIM> >();
     }
 
     /// multiply a vector of functions with a function: r[i] = v[i] * a
     template <typename T, typename R, std::size_t NDIM>
-    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>> operator*(const Function<T, NDIM>& a,
-            const std::vector<Function<R,NDIM>>& v) {
-        if (v.size() > 0) return mul(v[0].world(), a, v, true);
-        return std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>>();
+    std::vector<Function<TENSOR_RESULT_TYPE(T,R),NDIM> > operator*(const Function<T,NDIM>& a,
+            const std::vector<Function<R,NDIM> >& v) {
+        if (v.size()>0) return mul(v[0].world(),a,v,true);
+        return std::vector<Function<TENSOR_RESULT_TYPE(T,R),NDIM> >();
     }
 
 
     /// multiply a vector of functions with a function: r[i] = a * v[i]
     template <typename T, typename R, std::size_t NDIM>
-    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>> operator*(const std::vector<Function<T, NDIM>>& v,
-            const Function<R, NDIM>& a) {
-        if (v.size() > 0) return mul(v[0].world(), a, v, true);
-        return std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>>();
+    std::vector<Function<TENSOR_RESULT_TYPE(T,R),NDIM> > operator*(const std::vector<Function<T,NDIM> >& v,
+            const Function<R,NDIM>& a) {
+        if (v.size()>0) return mul(v[0].world(),a,v,true);
+        return std::vector<Function<TENSOR_RESULT_TYPE(T,R),NDIM> >();
     }
 
 
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T, NDIM>> operator+=(std::vector<Function<T, NDIM>>& lhs, const std::vector<Function<T, NDIM>>& rhs) {
+    std::vector<Function<T,NDIM> > operator+=(std::vector<Function<T,NDIM> >& lhs, const std::vector<Function<T,NDIM> >& rhs) {
         MADNESS_CHECK(lhs.size() == rhs.size());
         if (lhs.size() > 0) gaxpy(lhs.front().world(), 1.0, lhs, 1.0, rhs);
-	    return lhs;
+	return lhs;
     }
 
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T, NDIM>> operator-=(std::vector<Function<T, NDIM>>& lhs,
-            const std::vector<Function<T, NDIM>>& rhs) {
+    std::vector<Function<T,NDIM> > operator-=(std::vector<Function<T,NDIM> >& lhs,
+            const std::vector<Function<T,NDIM> >& rhs) {
         MADNESS_CHECK(lhs.size() == rhs.size());
         if (lhs.size() > 0) gaxpy(lhs.front().world(), 1.0, lhs, -1.0, rhs);
-	    return lhs;
+	return lhs;
     }
 
     /// return the real parts of the vector's function (if complex)
     template <typename T, std::size_t NDIM>
     std::vector<Function<typename Tensor<T>::scalar_type,NDIM> >
-    real(const std::vector<Function<T, NDIM>>& v, bool fence=true) {
-    	std::vector<Function<typename Tensor<T>::scalar_type, NDIM>> result(v.size());
-    	for (std::size_t i = 0; i < v.size(); ++i) result[i] = real(v[i], false);
+    real(const std::vector<Function<T,NDIM> >& v, bool fence=true) {
+    	std::vector<Function<typename Tensor<T>::scalar_type,NDIM> > result(v.size());
+    	for (std::size_t i=0; i<v.size(); ++i) result[i]=real(v[i],false);
         if (fence and result.size()>0) result[0].world().gop.fence();
         return result;
     }
@@ -1871,10 +1856,10 @@ namespace madness {
     /// return the imaginary parts of the vector's function (if complex)
     template <typename T, std::size_t NDIM>
     std::vector<Function<typename Tensor<T>::scalar_type,NDIM> >
-    imag(const std::vector<Function<T, NDIM>>& v, bool fence=true) {
-    	std::vector<Function<typename Tensor<T>::scalar_type, NDIM>> result(v.size());
-    	for (std::size_t i = 0; i < v.size(); ++i) result[i] = imag(v[i], false);
-        if (fence and result.size() > 0) result[0].world().gop.fence();
+    imag(const std::vector<Function<T,NDIM> >& v, bool fence=true) {
+    	std::vector<Function<typename Tensor<T>::scalar_type,NDIM> > result(v.size());
+    	for (std::size_t i=0; i<v.size(); ++i) result[i]=imag(v[i],false);
+        if (fence and result.size()>0) result[0].world().gop.fence();
         return result;
     }
 
@@ -1886,123 +1871,123 @@ namespace madness {
     /// @param[in]  fence   fence after completion; if reconstruction is needed always fence
     /// @return     the vector \frac{\partial}{\partial x_i} f
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T, NDIM>> grad(const Function<T, NDIM>& f,
+    std::vector<Function<T,NDIM> > grad(const Function<T,NDIM>& f,
             bool refine=false, bool fence=true) {
 
-        World& world = f.world();
+        World& world=f.world();
         f.reconstruct();
         if (refine) f.refine();      // refine to make result more precise
 
-        std::vector<std::shared_ptr< Derivative<T, NDIM>>> grad =
-                gradient_operator<T, NDIM>(world);
+        std::vector< std::shared_ptr< Derivative<T,NDIM> > > grad=
+                gradient_operator<T,NDIM>(world);
 
-        std::vector<Function<T, NDIM>> result(NDIM);
-        for (size_t i = 0; i < NDIM; ++i) result[i] = apply(*(grad[i]), f, false);
+        std::vector<Function<T,NDIM> > result(NDIM);
+        for (size_t i=0; i<NDIM; ++i) result[i]=apply(*(grad[i]),f,false);
         if (fence) world.gop.fence();
         return result;
     }
 
     // BLM first derivative
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T, NDIM>> grad_ble_one(const Function<T, NDIM>& f,
+    std::vector<Function<T,NDIM> > grad_ble_one(const Function<T,NDIM>& f,
             bool refine=false, bool fence=true) {
 
-        World& world = f.world();
+        World& world=f.world();
         f.reconstruct();
         if (refine) f.refine();      // refine to make result more precise
 
-        std::vector<std::shared_ptr<Derivative<T, NDIM>>> grad=
-                gradient_operator<T, NDIM>(world);
+        std::vector< std::shared_ptr< Derivative<T,NDIM> > > grad=
+                gradient_operator<T,NDIM>(world);
 
         // Read in new coeff for each operator
-        for (unsigned int i = 0; i < NDIM; ++i) (*grad[i]).set_ble1();
+        for (unsigned int i=0; i<NDIM; ++i) (*grad[i]).set_ble1();
 
-        std::vector<Function<T, NDIM>> result(NDIM);
-        for (unsigned int i = 0; i < NDIM; ++i) result[i] = apply(*(grad[i]), f, false);
+        std::vector<Function<T,NDIM> > result(NDIM);
+        for (unsigned int i=0; i<NDIM; ++i) result[i]=apply(*(grad[i]),f,false);
         if (fence) world.gop.fence();
         return result;
     }
 
     // BLM second derivative
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T, NDIM>> grad_ble_two(const Function<T, NDIM>& f,
+    std::vector<Function<T,NDIM> > grad_ble_two(const Function<T,NDIM>& f,
             bool refine=false, bool fence=true) {
 
-        World& world = f.world();
+        World& world=f.world();
         f.reconstruct();
         if (refine) f.refine();      // refine to make result more precise
 
-        std::vector<std::shared_ptr< Derivative<T, NDIM>>> grad =
-                gradient_operator<T, NDIM>(world);
+        std::vector< std::shared_ptr< Derivative<T,NDIM> > > grad=
+                gradient_operator<T,NDIM>(world);
 
         // Read in new coeff for each operator
-        for (unsigned int i = 0; i < NDIM; ++i) (*grad[i]).set_ble2();
+        for (unsigned int i=0; i<NDIM; ++i) (*grad[i]).set_ble2();
 
-        std::vector<Function<T, NDIM>> result(NDIM);
-        for (unsigned int i = 0; i < NDIM; ++i) result[i]=apply(*(grad[i]), f, false);
+        std::vector<Function<T,NDIM> > result(NDIM);
+        for (unsigned int i=0; i<NDIM; ++i) result[i]=apply(*(grad[i]),f,false);
         if (fence) world.gop.fence();
         return result;
     }
 
     // Bspline first derivative
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T, NDIM>> grad_bspline_one(const Function<T, NDIM>& f,
+    std::vector<Function<T,NDIM> > grad_bspline_one(const Function<T,NDIM>& f,
             bool refine=false, bool fence=true) {
 
-        World& world = f.world();
+        World& world=f.world();
         f.reconstruct();
         if (refine) f.refine();      // refine to make result more precise
 
-        std::vector<std::shared_ptr< Derivative<T, NDIM>>> grad=
-                gradient_operator<T, NDIM>(world);
+        std::vector< std::shared_ptr< Derivative<T,NDIM> > > grad=
+                gradient_operator<T,NDIM>(world);
 
         // Read in new coeff for each operator
-        for (unsigned int i = 0; i < NDIM; ++i) (*grad[i]).set_bspline1();
+        for (unsigned int i=0; i<NDIM; ++i) (*grad[i]).set_bspline1();
 
-        std::vector<Function<T, NDIM>> result(NDIM);
-        for (unsigned int i = 0; i < NDIM; ++i) result[i] = apply(*(grad[i]), f, false);
+        std::vector<Function<T,NDIM> > result(NDIM);
+        for (unsigned int i=0; i<NDIM; ++i) result[i]=apply(*(grad[i]),f,false);
         if (fence) world.gop.fence();
         return result;
     }
 
     // Bpsline second derivative
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T, NDIM>> grad_bpsline_two(const Function<T, NDIM>& f,
+    std::vector<Function<T,NDIM> > grad_bpsline_two(const Function<T,NDIM>& f,
             bool refine=false, bool fence=true) {
 
-        World& world = f.world();
+        World& world=f.world();
         f.reconstruct();
-        if (refine) f.refine();  // refine to make result more precise
+        if (refine) f.refine();      // refine to make result more precise
 
-        std::vector<std::shared_ptr< Derivative<T, NDIM>>> grad =
-                gradient_operator<T, NDIM>(world);
+        std::vector< std::shared_ptr< Derivative<T,NDIM> > > grad=
+                gradient_operator<T,NDIM>(world);
 
         // Read in new coeff for each operator
-        for (unsigned int i = 0; i < NDIM; ++i) (*grad[i]).set_bspline2();
+        for (unsigned int i=0; i<NDIM; ++i) (*grad[i]).set_bspline2();
 
-        std::vector<Function<T, NDIM>> result(NDIM);
-        for (unsigned int i = 0; i < NDIM; ++i) result[i] = apply(*(grad[i]), f, false);
+        std::vector<Function<T,NDIM> > result(NDIM);
+        for (unsigned int i=0; i<NDIM; ++i) result[i]=apply(*(grad[i]),f,false);
         if (fence) world.gop.fence();
         return result;
     }
 
     // Bspline third derivative
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T, NDIM>> grad_bspline_three(const Function<T, NDIM>& f,
+    std::vector<Function<T,NDIM> > grad_bspline_three(const Function<T,NDIM>& f,
             bool refine=false, bool fence=true) {
 
-        World& world = f.world();
+        World& world=f.world();
         f.reconstruct();
         if (refine) f.refine();      // refine to make result more precise
 
-        std::vector<std::shared_ptr< Derivative<T, NDIM>>> grad =
-                gradient_operator<T, NDIM>(world);
+        std::vector< std::shared_ptr< Derivative<T,NDIM> > > grad=
+                gradient_operator<T,NDIM>(world);
 
         // Read in new coeff for each operator
-        for (unsigned int i = 0; i < NDIM; ++i) (*grad[i]).set_bspline3();
+        for (unsigned int i=0; i<NDIM; ++i) (*grad[i]).set_bspline3();
 
-        std::vector<Function<T, NDIM>> result(NDIM);
-        for (unsigned int i = 0; i < NDIM; ++i) result[i] = apply(*(grad[i]), f, false);
+        std::vector<Function<T,NDIM> > result(NDIM);
+        for (unsigned int i=0; i<NDIM; ++i) result[i]=apply(*(grad[i]),f,false);
         if (fence) world.gop.fence();
         return result;
     }
@@ -2018,19 +2003,19 @@ namespace madness {
     /// @return     the vector \frac{\partial}{\partial x_i} f
     /// TODO: add this to operator fusion
     template <typename T, std::size_t NDIM>
-    Function<T, NDIM> div(const std::vector<Function<T, NDIM>>& v,
+    Function<T,NDIM> div(const std::vector<Function<T,NDIM> >& v,
             bool do_refine=false, bool fence=true) {
 
-        MADNESS_ASSERT(v.size() > 0);
-        World& world = v[0].world();
-        reconstruct(world, v);
-        if (do_refine) refine(world, v);      // refine to make result more precise
+        MADNESS_ASSERT(v.size()>0);
+        World& world=v[0].world();
+        reconstruct(world,v);
+        if (do_refine) refine(world,v);      // refine to make result more precise
 
-        std::vector<std::shared_ptr< Derivative<T, NDIM>>> grad =
-                gradient_operator<T, NDIM>(world);
+        std::vector< std::shared_ptr< Derivative<T,NDIM> > > grad=
+                gradient_operator<T,NDIM>(world);
 
-        std::vector<Function<T, NDIM>> result(NDIM);
-        for (size_t i = 0; i < NDIM; ++i) result[i] = apply(*(grad[i]), v[i], false);
+        std::vector<Function<T,NDIM> > result(NDIM);
+        for (size_t i=0; i<NDIM; ++i) result[i]=apply(*(grad[i]),v[i],false);
         world.gop.fence();
         return sum(world,result,fence);
     }
@@ -2044,29 +2029,29 @@ namespace madness {
     /// @return     the vector \frac{\partial}{\partial x_i} f
     /// TODO: add this to operator fusion
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T, NDIM>> rot(const std::vector<Function<T, NDIM>>& v,
+    std::vector<Function<T,NDIM> > rot(const std::vector<Function<T,NDIM> >& v,
             bool do_refine=false, bool fence=true) {
 
-        MADNESS_ASSERT(v.size() == 3);
-        World& world = v[0].world();
-        reconstruct(world, v);
-        if (do_refine) refine(world, v);      // refine to make result more precise
+        MADNESS_ASSERT(v.size()==3);
+        World& world=v[0].world();
+        reconstruct(world,v);
+        if (do_refine) refine(world,v);      // refine to make result more precise
 
-        std::vector<std::shared_ptr< Derivative<T, NDIM>>> grad =
-                gradient_operator<T, NDIM>(world);
+        std::vector< std::shared_ptr< Derivative<T,NDIM> > > grad=
+                gradient_operator<T,NDIM>(world);
 
-        std::vector<Function<T, NDIM>> d(NDIM), dd(NDIM);
-        d[0] = apply(*(grad[1]), v[2], false);	// Dy z
-        d[1] = apply(*(grad[2]), v[0], false);	// Dz x
-        d[2] = apply(*(grad[0]), v[1], false);	// Dx y
-        dd[0] = apply(*(grad[2]), v[1], false);	// Dz y
-        dd[1] = apply(*(grad[0]), v[2], false);	// Dx z
-        dd[2] = apply(*(grad[1]), v[0], false);	// Dy x
+        std::vector<Function<T,NDIM> > d(NDIM),dd(NDIM);
+        d[0]=apply(*(grad[1]),v[2],false);	// Dy z
+        d[1]=apply(*(grad[2]),v[0],false);	// Dz x
+        d[2]=apply(*(grad[0]),v[1],false);	// Dx y
+        dd[0]=apply(*(grad[2]),v[1],false);	// Dz y
+        dd[1]=apply(*(grad[0]),v[2],false);	// Dx z
+        dd[2]=apply(*(grad[1]),v[0],false);	// Dy x
         world.gop.fence();
 
-        d[0].gaxpy(1.0, dd[0], -1.0, false);
-        d[1].gaxpy(1.0, dd[1], -1.0, false);
-        d[2].gaxpy(1.0, dd[2], -1.0, false);
+        d[0].gaxpy(1.0,dd[0],-1.0,false);
+        d[1].gaxpy(1.0,dd[1],-1.0,false);
+        d[2].gaxpy(1.0,dd[2],-1.0,false);
 
         world.gop.fence();
         return d;
@@ -2081,33 +2066,33 @@ namespace madness {
     /// @return     the vector \frac{\partial}{\partial x_i} f
     /// TODO: add this to operator fusion
     template <typename T, typename R, std::size_t NDIM>
-    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM> > cross(const std::vector<Function<T, NDIM>>& f,
+    std::vector<Function<TENSOR_RESULT_TYPE(T,R),NDIM> > cross(const std::vector<Function<T,NDIM> >& f,
     		const std::vector<Function<R,NDIM> >& g,
             bool do_refine=false, bool fence=true) {
 
-        MADNESS_ASSERT(f.size() == 3);
-        MADNESS_ASSERT(g.size() == 3);
-        World& world = f[0].world();
-        reconstruct(world, f, false);
-        reconstruct(world, g);
+        MADNESS_ASSERT(f.size()==3);
+        MADNESS_ASSERT(g.size()==3);
+        World& world=f[0].world();
+        reconstruct(world,f,false);
+        reconstruct(world,g);
 
-        std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>> d(f.size()), dd(f.size());
+        std::vector<Function<TENSOR_RESULT_TYPE(T,R),NDIM> > d(f.size()),dd(f.size());
 
-        d[0] = mul(f[1], g[2], false);
-        d[1] = mul(f[2], g[0], false);
-        d[2] = mul(f[0], g[1], false);
+        d[0]=mul(f[1],g[2],false);
+        d[1]=mul(f[2],g[0],false);
+        d[2]=mul(f[0],g[1],false);
 
-        dd[0] = mul(f[2], g[1], false);
-        dd[1] = mul(f[0], g[2], false);
-        dd[2] = mul(f[1], g[0], false);
+        dd[0]=mul(f[2],g[1],false);
+        dd[1]=mul(f[0],g[2],false);
+        dd[2]=mul(f[1],g[0],false);
         world.gop.fence();
 
-        compress(world, d, false);
-        compress(world, dd);
+        compress(world,d,false);
+        compress(world,dd);
 
-        d[0].gaxpy(1.0, dd[0], -1.0, false);
-        d[1].gaxpy(1.0, dd[1], -1.0, false);
-        d[2].gaxpy(1.0, dd[2], -1.0, false);
+        d[0].gaxpy(1.0,dd[0],-1.0,false);
+        d[1].gaxpy(1.0,dd[1],-1.0,false);
+        d[2].gaxpy(1.0,dd[2],-1.0,false);
 
         world.gop.fence();
         return d;
@@ -2116,26 +2101,26 @@ namespace madness {
 
     /// load a vector of functions
     template<typename T, size_t NDIM>
-    void load_function(World& world, std::vector<Function<T, NDIM>>& f,
+    void load_function(World& world, std::vector<Function<T,NDIM> >& f,
             const std::string name) {
-        if (world.rank() == 0) print("loading vector of functions", name);
+        if (world.rank()==0) print("loading vector of functions",name);
         archive::ParallelInputArchive<archive::BinaryFstreamInputArchive> ar(world, name.c_str(), 1);
-        std::size_t fsize = 0;
+        std::size_t fsize=0;
         ar & fsize;
         f.resize(fsize);
-        for (std::size_t i = 0; i < fsize; ++i) ar & f[i];
+        for (std::size_t i=0; i<fsize; ++i) ar & f[i];
     }
 
     /// save a vector of functions
     template<typename T, size_t NDIM>
-    void save_function(const std::vector<Function<T, NDIM>>& f, const std::string name) {
-        if (f.size() > 0) {
-            World& world = f.front().world();
-            if (world.rank() == 0) print("saving vector of functions", name);
+    void save_function(const std::vector<Function<T,NDIM> >& f, const std::string name) {
+        if (f.size()>0) {
+            World& world=f.front().world();
+            if (world.rank()==0) print("saving vector of functions",name);
             archive::ParallelOutputArchive<archive::BinaryFstreamOutputArchive> ar(world, name.c_str(), 1);
-            std::size_t fsize = f.size();
+            std::size_t fsize=f.size();
             ar & fsize;
-            for (std::size_t i = 0; i < fsize; ++i) ar & f[i];
+            for (std::size_t i=0; i<fsize; ++i) ar & f[i];
         }
     }
 

--- a/src/madness/mra/vmra.h
+++ b/src/madness/mra/vmra.h
@@ -934,7 +934,7 @@ namespace madness {
                 int64_t jhi = std::min(jlo + jchunk, m);
                 std::vector<Function<T, NDIM>> jvec(g.begin() + jlo, g.begin() + jhi);
 
-               Tensor<T> P = matrix_inner(A.get_world(), ivec, jvec);
+                Tensor<T> P = matrix_inner(A.get_world(), ivec, jvec, sym);
                 A.copy_from_replicated_patch(ilo, ihi - 1, jlo, jhi - 1, P);
             }
         }
@@ -957,7 +957,6 @@ namespace madness {
         // if ((void*)(&f) != (void*)(&g)) compress(world, g);
         compress(world, g);
 
-
         std::vector<const FunctionImpl<T, NDIM>*> left(f.size());
         std::vector<const FunctionImpl<R, NDIM>*> right(g.size());
         for (unsigned int i = 0; i < f.size(); i++) left[i] = f[i].get_impl().get();
@@ -966,7 +965,7 @@ namespace madness {
         Tensor<TENSOR_RESULT_TYPE(T, R)> r = FunctionImpl<T, NDIM>::inner_local(left, right, sym);
 
         world.gop.fence();
-        world.gop.sum(r.ptr(),f.size()*g.size());
+        world.gop.sum(r.ptr(), f.size() * g.size());
 
         return r;
     }

--- a/src/madness/mra/vmra.h
+++ b/src/madness/mra/vmra.h
@@ -924,8 +924,8 @@ namespace madness {
                 int64_t jhi = std::min(jlo + jchunk, m);
                 std::vector< Function<T,NDIM> > jvec(g.begin()+jlo, g.begin()+jhi);
 
-                Tensor<T> P = matrix_inner(A.get_world(),ivec,jvec);
-                A.copy_from_replicated_patch(ilo, ihi-1, jlo, jhi-1, P);
+               Tensor<T> P = matrix_inner(A.get_world(), ivec, jvec);
+                A.copy_from_replicated_patch(ilo, ihi - 1, jlo, jhi - 1, P);
             }
         }
         return A;
@@ -947,6 +947,8 @@ namespace madness {
 //        if ((void*)(&f) != (void*)(&g)) compress(world, g);
         compress(world, g);
 
+
+
         std::vector<const FunctionImpl<T,NDIM>*> left(f.size());
         std::vector<const FunctionImpl<R,NDIM>*> right(g.size());
         for (unsigned int i=0; i<f.size(); i++) left[i] = f[i].get_impl().get();
@@ -955,7 +957,7 @@ namespace madness {
         Tensor< TENSOR_RESULT_TYPE(T,R) > r= FunctionImpl<T,NDIM>::inner_local(left, right, sym);
 
         world.gop.fence();
-        world.gop.sum(r.ptr(), f.size() * g.size());
+        world.gop.sum(r.ptr(),f.size()*g.size());
 
         return r;
     }

--- a/src/madness/mra/vmra1.h
+++ b/src/madness/mra/vmra1.h
@@ -90,7 +90,7 @@
 
 	*) set_thresh: setting a finite thresh-hold for a vector of functions
 	\code
-	void set_thresh(World& world, std::vector< Function<T,NDIM> >& v, double thresh, bool fence=true);
+	void set_thresh(World& world, std::vector<Function<T, NDIM>>& v, double thresh, bool fence=true);
 	\endcode
 
 	Arithmetic Operations on arrays of functions
@@ -129,22 +129,22 @@ namespace madness {
     /// Compress a vector of functions
     template <typename T, std::size_t NDIM>
     void compress(World& world,
-                  const std::vector< Function<T,NDIM> >& v,
-		  unsigned int blk=1,
+                  const std::vector<Function<T, NDIM>>& v,
+		          unsigned int blk=1,
                   bool fence=true){
 
         PROFILE_BLOCK(Vcompress);
         bool must_fence = false;
-	unsigned int vvsize = v.size();
-        for (unsigned int i=0; i<vvsize; i+= blk) {
-	  for (unsigned int j=i; j<std::min(vvsize,(i+1)*blk); ++j) {
-            if (!v[j].is_compressed()) {
-	      v[j].compress(false);
-	      must_fence = true;
-            }
-	  }
-	  if ( blk!=1 && must_fence && fence) world.gop.fence();
-	}
+        unsigned int vvsize = v.size();
+        for (unsigned int i = 0; i < vvsize; i += blk) {
+            for (unsigned int j = i; j < std::min(vvsize, (i + 1) * blk); ++j) {
+                if (!v[j].is_compressed()) {
+                    v[j].compress(false);
+                    must_fence = true;
+                }
+	        }
+	        if (blk != 1 && must_fence && fence) world.gop.fence();
+	    }
 
         if (fence && must_fence) world.gop.fence();
     }
@@ -153,121 +153,118 @@ namespace madness {
     /// Reconstruct a vector of functions
     template <typename T, std::size_t NDIM>
     void reconstruct(World& world,
-                     const std::vector< Function<T,NDIM> >& v,
-		     unsigned int blk=1,
+                     const std::vector<Function<T, NDIM>>& v,
+		             unsigned int blk=1,
                      bool fence=true){ // reconstr
-	PROFILE_BLOCK(Vreconstruct);
-	bool must_fence = false;
-	unsigned int vvsize = v.size();
-	for (unsigned int i=0; i<vvsize; i+= blk) {
-	  for (unsigned int j=i; j<std::min(vvsize,(i+1)*blk); ++j) {
-	    if (v[j].is_compressed()) {
-	      v[j].reconstruct(false);
-	      must_fence = true;
-	    }
-	  }
-	  if ( blk!=1 && must_fence && fence) world.gop.fence();
-	}
+        PROFILE_BLOCK(Vreconstruct);
+        bool must_fence = false;
+        unsigned int vvsize = v.size();
+        for (unsigned int i = 0; i < vvsize; i += blk) {
+            for (unsigned int j = i; j < std::min(vvsize, (i + 1) * blk); ++j) {
+                if (v[j].is_compressed()) {
+                    v[j].reconstruct(false);
+                    must_fence = true;
+                }
+            }
+            if ( blk != 1 && must_fence && fence) world.gop.fence();
+        }
 
-	if (fence && must_fence) world.gop.fence();
+        if (fence && must_fence) world.gop.fence();
     } // reconstr
 
     /// Generates non-standard form of a vector of functions
     template <typename T, std::size_t NDIM>
-      void nonstandard(World& world,
-		       std::vector< Function<T,NDIM> >& v,
-		       unsigned int blk=1,
-		       bool fence=true) { // nonstand
+    void nonstandard(World& world,
+		             std::vector<Function<T, NDIM>>& v,
+		             unsigned int blk=1,
+		             bool fence=true) { // nonstand
         PROFILE_BLOCK(Vnonstandard);
-	unsigned int vvsize = v.size();
+	    unsigned int vvsize = v.size();
         reconstruct(world, v, blk);
-	for (unsigned int i=0; i<vvsize; i+= blk) {
-	  for (unsigned int j=i; j<std::min(vvsize,(i+1)*blk); ++j) {
-          v[j].make_nonstandard(false, false);
-	  }
-	  if ( blk!=1 && fence) world.gop.fence();
-	}
-	if (fence) world.gop.fence();
+        for (unsigned int i = 0; i < vvsize; i += blk) {
+            for (unsigned int j = i; j < std::min(vvsize, (i + 1) * blk); ++j) {
+                v[j].make_nonstandard(false, false);
+            }
+            if ( blk!=1 && fence) world.gop.fence();
+        }
+        if (fence) world.gop.fence();
     } //nonstand
 
 
     /// Generates standard form of a vector of functions
 
     template <typename T, std::size_t NDIM>
-      void standard(World& world,
-		    std::vector< Function<T,NDIM> >& v,
-		    unsigned int blk=1,
-		    bool fence=true){ // standard
-	PROFILE_BLOCK(Vstandard);
-	unsigned int vvsize = v.size();
-	for (unsigned int i=0; i<vvsize; i+= blk) {
-	  for (unsigned int j=i; j<std::min(vvsize,(i+1)*blk); ++j) {
-	    v[j].standard(false);
-	  }
-	  if ( blk!=1 && fence) world.gop.fence();
-	}
-	if (fence) world.gop.fence();
+    void standard(World& world,
+		          std::vector<Function<T, NDIM>>& v,
+		          unsigned int blk=1,
+		          bool fence=true){ // standard
+        PROFILE_BLOCK(Vstandard);
+        unsigned int vvsize = v.size();
+        for (unsigned int i = 0; i < vvsize; i += blk) {
+            for (unsigned int j = i; j < std::min(vvsize, (i + 1) * blk); ++j) {
+                v[j].standard(false);
+            }
+            if ( blk!=1 && fence) world.gop.fence();
+        }
+        if (fence) world.gop.fence();
     } // standard
 
 
     /// Truncates a vector of functions
     template <typename T, std::size_t NDIM>
     void truncate(World& world,
-                  std::vector< Function<T,NDIM> >& v,
+                  std::vector<Function<T, NDIM>>& v,
                   double tol=0.0,
-		  unsigned int blk=1,
+		          unsigned int blk=1,
                   bool fence=true){ // truncate
-	PROFILE_BLOCK(Vtruncate);
+        PROFILE_BLOCK(Vtruncate);
 
-	compress(world, v, blk);
+        compress(world, v, blk);
 
-	unsigned int vvsize = v.size();
-	for (unsigned int i=0; i<vvsize; i+= blk) {
-	  for (unsigned int j=i; j<std::min(vvsize,(i+1)*blk); ++j) {
-	    v[j].truncate(tol, false);
-	  }
-	  if ( blk!=1 && fence) world.gop.fence();
-	}
+        unsigned int vvsize = v.size();
+        for (unsigned int i = 0; i < vvsize; i += blk) {
+            for (unsigned int j = i; j < std::min(vvsize, (i + 1) * blk); ++j) {
+                v[j].truncate(tol, false);
+            }
+            if ( blk!=1 && fence) world.gop.fence();
+        }
         if (fence) world.gop.fence();
     } //truncate
 
     /// Applies a derivative operator to a vector of functions
 
     template <typename T, std::size_t NDIM>
-      std::vector< Function<T,NDIM> >
-      apply(World& world,
-	     const Derivative<T,NDIM>& D,
-	     const std::vector< Function<T,NDIM> >& v,
-	     const unsigned int blk=1,
-	     const bool fence=true)
-      {
-	reconstruct(world, v, blk);
-	std::vector< Function<T,NDIM> > df(v.size());
+    std::vector<Function<T, NDIM>>
+    apply(World& world,
+	      const Derivative<T,NDIM>& D,
+	      const std::vector<Function<T, NDIM>>& v,
+	      const unsigned int blk=1,
+	      const bool fence=true) {
+        reconstruct(world, v, blk);
+        std::vector<Function<T, NDIM>> df(v.size());
 
-	unsigned int vvsize = v.size();
+        unsigned int vvsize = v.size();
 
-	for (unsigned int i=0; i<vvsize; i+= blk) {
-	  for (unsigned int j=i; j<std::min(vvsize,(i+1)*blk); ++j) {
-	    df[j] = D(v[j],false);
-	  }
-	  if (blk!= 1 && fence) world.gop.fence();
-	}
-	if (fence) world.gop.fence();
-
-	return df;
-      }
+        for (unsigned int i = 0; i < vvsize; i += blk) {
+            for (unsigned int j = i; j < std::min(vvsize, (i + 1) * blk); ++j) {
+                df[j] = D(v[j],false);
+            }
+            if (blk!= 1 && fence) world.gop.fence();
+        }
+        if (fence) world.gop.fence();
+        return df;
+    }
 
     /// Generates a vector of zero functions
 
     template <typename T, std::size_t NDIM>
-      std::vector< Function<T,NDIM> >
-      zero_functions(World& world, int n) {
-      PROFILE_BLOCK(Vzero_functions);
-      std::vector< Function<T,NDIM> > r(n);
-      for (int i=0; i<n; ++i)
-	r[i] = Function<T,NDIM>(FunctionFactory<T,NDIM>(world));
+    std::vector<Function<T, NDIM>> zero_functions(World& world, int n) {
+        PROFILE_BLOCK(Vzero_functions);
+        std::vector<Function<T, NDIM>> r(n);
+        for (int i = 0; i < n; ++i)
+            r[i] = Function<T,NDIM>(FunctionFactory<T,NDIM>(world));
 
-      return r;
+        return r;
     }
 
 
@@ -277,214 +274,205 @@ namespace madness {
     /// zero to take advantage of this.
 
     template <typename T, typename R, std::size_t NDIM>
-      std::vector< Function<TENSOR_RESULT_TYPE(T,R),NDIM> >
-      transform(World& world,
-		const std::vector< Function<T,NDIM> >& v,
-		const Tensor<R>& c,
-		unsigned int blki=1,
-		unsigned int blkj=1,
-		const bool fence=true){
+        std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>>
+        transform(World& world,
+            const std::vector<Function<T, NDIM>>& v,
+            const Tensor<R>& c,
+            unsigned int blki=1,
+            unsigned int blkj=1,
+            const bool fence=true){
 
-      PROFILE_BLOCK(Vtransformsp);
+        PROFILE_BLOCK(Vtransformsp);
 
-      typedef TENSOR_RESULT_TYPE(T,R) resultT;
+        typedef TENSOR_RESULT_TYPE(T,R) resultT;
 
-      unsigned int blk = min(blki, blkj);
-      unsigned int n = v.size();  // n is the old dimension
-      unsigned int m = c.dim(1);  // m is the new dimension
-      MADNESS_ASSERT(n==c.dim(0));
+        unsigned int blk = std::min(blki, blkj);
+        unsigned int n = v.size();  // n is the old dimension
+        unsigned int m = c.dim(1);  // m is the new dimension
+        MADNESS_ASSERT(n==c.dim(0));
 
-      std::vector< Function<resultT,NDIM> > vc = zero_functions_compressed<resultT,NDIM>(world, m);
-      compress(world, v, blk);
+        std::vector<Function<resultT,NDIM>> vc = zero_functions_compressed<resultT, NDIM>(world, m);
+        compress(world, v, blk);
 
-      for (unsigned int i=0; i<m; i+= blki) {
-	for (unsigned int ii=i; ii<std::min(m,(i+1)*blki); ii++) {
-	  for (unsigned int j=0; j<n; j+= blkj) {
-	    for (unsigned int jj=j; jj<std::min(n, (j+1)*blkj); jj++)
-	      if (c(jj,ii) != R(0.0)) vc[ii].gaxpy(1.0,v[jj],c(jj,ii),false);
-	    if (fence && (blkj!=1)) world.gop.fence();
-	  }
-	}
-	if (fence && (blki!=1)) world.gop.fence();  // a bit conservative
-      }
+        for (unsigned int i = 0; i < m; i += blki) {
+            for (unsigned int ii = i; ii < std::min(m, (i + 1) * blki); ii++) {
+                for (unsigned int j = 0; j < n; j += blkj) {
+                    for (unsigned int jj = j; jj < std::min(n, (j + 1) * blkj); jj++)
+                        if (c(jj, ii) != R(0.0)) vc[ii].gaxpy(1.0, v[jj], c(jj, ii), false);
+                    if (fence && (blkj != 1)) world.gop.fence();
+                }
+            }
+            if (fence && (blki != 1)) world.gop.fence();  // a bit conservative
+        }
 
+        // for (unsigned int i = 0; i < m; ++i) {
+        //     for (unsigned int j = 0; j < n; ++j) {
+        //         if (c(j,i) != R(0.0)) vc[i].gaxpy(1.0,v[j],c(j,i),false);
+        //     }
+        // }
 
-      //      for (unsigned int i=0; i<m; ++i) {
-      // for (unsigned int j=0; j<n; ++j) {
-      // if (c(j,i) != R(0.0)) vc[i].gaxpy(1.0,v[j],c(j,i),false);
-      // }
-      // }
-
-      if (fence) world.gop.fence();
-      return vc;
+        if (fence) world.gop.fence();
+        return vc;
     }
 
 
     template <typename L, typename R, std::size_t NDIM>
-      std::vector< Function<TENSOR_RESULT_TYPE(L,R),NDIM> >
-      transform(World& world,
-		const std::vector< Function<L,NDIM> >& v,
-		const Tensor<R>& c,
-		const double tol,
-		const unsigned int blki=1,
-		const bool fence)
-      {
+     std::vector< Function<TENSOR_RESULT_TYPE(L,R),NDIM> >
+     transform(World& world,
+               const std::vector< Function<L,NDIM> >& v,
+               const Tensor<R>& c,
+               const double tol,
+               const unsigned int blki=1,
+               const bool fence=true) {
         PROFILE_BLOCK(Vtransform);
         MADNESS_ASSERT(v.size() == (unsigned int)(c.dim(0)));
 
-        std::vector< Function<TENSOR_RESULT_TYPE(L,R),NDIM> > vresult(c.dim(1));
-	unsigned int m=c.dim(1);
+        std::vector<Function<TENSOR_RESULT_TYPE(L, R),NDIM>> vresult(c.dim(1));
+        unsigned int m = c.dim(1);
 
-	for (unsigned int i=0; i<m; i+= blki) {
-	  for (unsigned int ii=i; ii<std::min(m,(i+1)*blki); ii++) {
-	    vresult[ii] = Function<TENSOR_RESULT_TYPE(L,R),NDIM>(FunctionFactory<TENSOR_RESULT_TYPE(L,R),NDIM>(world));
-	  }
-	  if (fence && (blki!=1)) world.gop.fence();  // a bit conservative
-	}
+        for (unsigned int i = 0; i < m; i += blki) {
+            for (unsigned int ii = i; ii < std::min(m, (i + 1) * blki); ii++) {
+                vresult[ii] = Function<TENSOR_RESULT_TYPE(L, R), NDIM>(FunctionFactory<TENSOR_RESULT_TYPE(L, R), NDIM>(world));
+            }
+            if (fence && (blki != 1)) world.gop.fence();  // a bit conservative
+        }
 
-
-	//        for (unsigned int i=0; i<c.dim(1); ++i) {
-	// vresult[i] = Function<TENSOR_RESULT_TYPE(L,R),NDIM>(FunctionFactory<TENSOR_RESULT_TYPE(L,R),NDIM>(world));
-	// }
+        // for (unsigned int i = 0; i < c.dim(1); ++i) {
+        //        vresult[i] = Function<TENSOR_RESULT_TYPE(L,R),NDIM>(FunctionFactory<TENSOR_RESULT_TYPE(L,R),NDIM>(world));
+        // }
         compress(world, v, blki, false);
         compress(world, vresult, blki, false);
         world.gop.fence();
         vresult[0].vtransform(v, c, vresult, tol, fence);
         return vresult;
-      }
+    }
 
     /// Scales inplace a vector of functions by distinct values
 
     template <typename T, typename Q, std::size_t NDIM>
-      void scale(World& world,
-		 std::vector< Function<T,NDIM> >& v,
-		 const std::vector<Q>& factors,
-		 const unsigned int blk=1,
-		 const bool fence=true)
-      {
-	PROFILE_BLOCK(Vscale);
+    void scale(World& world,
+	           std::vector<Function<T, NDIM>>& v,
+	           const std::vector<Q>& factors,
+	           const unsigned int blk=1,
+	           const bool fence=true) {
+        PROFILE_BLOCK(Vscale);
 
-	unsigned int vvsize = v.size();
-	for (unsigned int i=0; i<vvsize; i+= blk) {
-	  for (unsigned int j=i; j<std::min(vvsize,(i+1)*blk); ++j) {
-	    v[j].scale(factors[j],false);
-	  }
-	  if (fence && blk!=1 ) world.gop.fence();
-	}
-	if (fence) world.gop.fence();
-      }
+        unsigned int vvsize = v.size();
+        for (unsigned int i = 0; i < vvsize; i += blk) {
+            for (unsigned int j = i; j < std::min(vvsize, (i + 1) * blk); ++j) {
+                v[j].scale(factors[j], false);
+            }
+            if (fence && blk != 1 ) world.gop.fence();
+        }
+        if (fence) world.gop.fence();
+    }
 
     /// Scales inplace a vector of functions by the same
 
     template <typename T, typename Q, std::size_t NDIM>
-      void scale(World& world,
-		 std::vector< Function<T,NDIM> >& v,
-		  const Q factor,
-		 const unsigned int blk=1,
-		 const bool fence=true){
+    void scale(World& world,
+		       std::vector<Function<T, NDIM>>& v,
+		       const Q factor,
+		       const unsigned int blk=1,
+		       const bool fence=true){
+        PROFILE_BLOCK(Vscale); // shouldn't need blocking since it is local
 
-	PROFILE_BLOCK(Vscale); // shouldn't need blocking since it is local
-
-	unsigned int vvsize = v.size();
-	for (unsigned int i=0; i<vvsize; i+= blk) {
-	  for (unsigned int j=i; j<std::min(vvsize,(i+1)*blk); ++j) {
-	    v[j].scale(factor,false);
-	  }
-	  if (fence && blk!=1 ) world.gop.fence();
-	}
-	if (fence) world.gop.fence();
-      }
+        unsigned int vvsize = v.size();
+        for (unsigned int i = 0; i < vvsize; i += blk) {
+            for (unsigned int j = i; j < std::min(vvsize, (i + 1) * blk); ++j) {
+                v[j].scale(factor, false);
+            }
+            if (fence && blk != 1 ) world.gop.fence();
+        }
+        if (fence) world.gop.fence();
+    }
 
     /// Computes the 2-norms of a vector of functions
     template <typename T, std::size_t NDIM>
-      std::vector<double> norm2s(World& world,
-				 const std::vector< Function<T,NDIM> >& v,
-				 const unsigned int blk=1,
-				 const bool fence=true){
+    std::vector<double> norm2s(World& world,
+				               const std::vector<Function<T, NDIM>>& v,
+				               const unsigned int blk=1,
+				               const bool fence=true) {
+        PROFILE_BLOCK(Vnorm2);
+        unsigned int vvsize = v.size();
+        std::vector<double> norms(vvsize);
 
-      PROFILE_BLOCK(Vnorm2);
-      unsigned int vvsize = v.size();
-      std::vector<double> norms(vvsize);
+        for (unsigned int i = 0; i < vvsize; i += blk) {
+            for (unsigned int j = i; j < std::min(vvsize, (i + 1) * blk); ++j) {
+                norms[j] = v[j].norm2sq_local();
+            }
+            if (fence && (blk!=1)) world.gop.fence();
+        }
+        if (fence ) world.gop.fence();
 
-      for (unsigned int i=0; i<vvsize; i+= blk) {
-	for (unsigned int j=i; j<std::min(vvsize,(i+1)*blk); ++j) {
-	  norms[j] = v[j].norm2sq_local();
-	}
-	if (fence && (blk!=1)) world.gop.fence();
-      }
-      if (fence ) world.gop.fence();
+        world.gop.sum(&norms[0], norms.size());
 
-      world.gop.sum(&norms[0], norms.size());
+        for (unsigned int i = 0; i < vvsize; i += blk) {
+            for (unsigned int j = i; j < std::min(vvsize, (i + 1) * blk); ++j)
+                norms[j] = sqrt(norms[j]);
+            if (fence && (blk != 1)) world.gop.fence();
+        }
 
-      for (unsigned int i=0; i<vvsize; i+= blk) {
-	for (unsigned int j=i; j<std::min(vvsize,(i+1)*blk); ++j)
-	  norms[j] = sqrt(norms[j]);
-	if (fence && (blk!=1)) world.gop.fence();
-      }
-
-      world.gop.fence();
-      return norms;
+        world.gop.fence();
+        return norms;
     }
 
     /// Computes the 2-norm of a vector of functions
     // should be local; norms[0] contains the result
 
     template <typename T, std::size_t NDIM>
-      double norm2(World& world,
-		   const std::vector< Function<T,NDIM> >& v)
-      {
+    double norm2(World& world,
+	             const std::vector<Function<T, NDIM>>& v) {
+        PROFILE_BLOCK(Vnorm2);
+        std::vector<double> norms(v.size());
 
-	PROFILE_BLOCK(Vnorm2);
+        for (unsigned int i = 0; i < v.size(); ++i)
+            norms[i] = v[i].norm2sq_local();
 
-	std::vector<double> norms(v.size());
+        world.gop.sum(&norms[0], norms.size());
 
-	for (unsigned int i=0; i<v.size(); ++i)
-	  norms[i] = v[i].norm2sq_local();
+        for (unsigned int i = 1; i < v.size(); ++i)
+            norms[0] += norms[i];
 
-	world.gop.sum(&norms[0], norms.size());
-
-	for (unsigned int i=1; i<v.size(); ++i)
-	  norms[0] += norms[i];
-
-	world.gop.fence();
-	return sqrt(norms[0]);
-      }
+        world.gop.fence();
+        return sqrt(norms[0]);
+    }
 
     inline double conj(double x) {
-      return x;
+        return x;
     }
 
     inline double conj(float x) {
-      return x;
+        return x;
     }
 
 
     template <typename T, typename R, std::size_t NDIM>
     struct MatrixInnerTask : public TaskInterface {
-        Tensor<TENSOR_RESULT_TYPE(T,R)> result; // Must be a copy
-        const Function<T,NDIM>& f;
-        const std::vector< Function<R,NDIM> >& g;
+        Tensor<TENSOR_RESULT_TYPE(T, R)> result; // Must be a copy
+        const Function<T, NDIM>& f;
+        const std::vector< Function<R, NDIM> >& g;
         long jtop;
 
-        MatrixInnerTask(const Tensor<TENSOR_RESULT_TYPE(T,R)>& result,
-                const Function<T,NDIM>& f,
-                const std::vector< Function<R,NDIM> >& g,
-                long jtop)
-        : result(result), f(f), g(g), jtop(jtop) {}
+        MatrixInnerTask(const Tensor<TENSOR_RESULT_TYPE(T, R)>& result,
+                        const Function<T, NDIM>& f,
+                        const std::vector<Function<R, NDIM>>& g,
+                        long jtop)
+            : result(result), f(f), g(g), jtop(jtop) {}
 
         void run(World& world) {
-            for (long j=0; j<jtop; ++j) {
+            for (long j = 0; j < jtop; ++j) {
                 result(j) = f.inner_local(g[j]);
             }
         }
 
-    private:
-        /// Get the task id
+        private:
+            /// Get the task id
 
-        /// \param id The id to set for this task
-        virtual void get_id(std::pair<void*,unsigned short>& id) const {
-            PoolTaskInterface::make_id(id, *this);
-        }
+            /// \param id The id to set for this task
+            virtual void get_id(std::pair<void*,unsigned short>& id) const {
+                PoolTaskInterface::make_id(id, *this);
+            }
     }; // struct MatrixInnerTask
 
     /// Computes the matrix inner product of two function vectors - q(i,j) = inner(f[i],g[j])
@@ -494,467 +482,456 @@ namespace madness {
     /// The current parallel loop is non-optimal but functional.
 
     template <typename T, typename R, std::size_t NDIM>
-      Tensor< TENSOR_RESULT_TYPE(T,R) > matrix_inner(World& world,
-						     const std::vector< Function<T,NDIM> >& f,
-						     const std::vector< Function<R,NDIM> >& g,
-						     bool sym=false) {
-      PROFILE_BLOCK(Vmatrix_inner);
-      unsigned int n=f.size(), m=g.size();
-      Tensor< TENSOR_RESULT_TYPE(T,R) > r(n,m);
-      if (sym) MADNESS_ASSERT(n==m);
+    Tensor<TENSOR_RESULT_TYPE(T, R)> matrix_inner(
+            World& world,
+            const std::vector<Function<T, NDIM>>& f,
+            const std::vector<Function<R, NDIM>>& g,
+            bool sym=false) {
+        PROFILE_BLOCK(Vmatrix_inner);
+        unsigned int n = f.size(), m = g.size();
+        Tensor< TENSOR_RESULT_TYPE(T, R) > r(n, m);
+        if (sym) MADNESS_ASSERT(n == m);
 
-      world.gop.fence();
-      compress(world, f);
-      if (&f != &g) compress(world, g);
+        world.gop.fence();
+        compress(world, f);
+        if (&f != &g) compress(world, g);
 
-      //         for (long i=0; i<n; ++i) {
-      //             long jtop = m;
-      //             if (sym) jtop = i+1;
-      //             for (long j=0; j<jtop; ++j) {
-      //                 r(i,j) = f[i].inner_local(g[j]);
-      //                 if (sym) r(j,i) = conj(r(i,j));
-      //             }
-      //         }
+        // for (long i = 0; i < n; ++i) {
+        //     long jtop = m;
+        //     if (sym) jtop = i + 1;
+        //     for (long j = 0; j < jtop; ++j) {
+        //         r(i, j) = f[i].inner_local(g[j]);
+        //         if (sym) r(j, i) = conj(r(i, j));
+        //     }
+        // }
 
-      for (unsigned int i=n-1; i>=0; --i) {
-	unsigned int jtop = m;
-	if (sym) jtop = i+1;
-	world.taskq.add(new MatrixInnerTask<T,R,NDIM>(r(i,_), f[i], g, jtop));
-      }
-      world.gop.fence();
-      world.gop.sum(r.ptr(),n*m);
+        for (unsigned int i = n - 1; i >= 0; --i) {
+            unsigned int jtop = m;
+            if (sym) jtop = i + 1;
+                world.taskq.add(new MatrixInnerTask<T,R,NDIM>(r(i,_), f[i], g, jtop));
+        }
+        world.gop.fence();
+        world.gop.sum(r.ptr(),n*m);
 
-      if (sym) {
-	for (unsigned int i=0; i<n; ++i) {
-	  for (unsigned int j=0; j<i; ++j) {
-	    r(j,i) = conj(r(i,j));
-	  }
-	}
-      }
-      return r;
+        if (sym) {
+            for (unsigned int i = 0; i < n; ++i) {
+                for (unsigned int j = 0; j < i; ++j) {
+                    r(j, i) = conj(r(i, j));
+                }
+            }
+        }
+        return r;
     }
 
     /// Computes the element-wise inner product of two function vectors - q(i) = inner(f[i],g[i])
 
     template <typename T, typename R, std::size_t NDIM>
-      Tensor< TENSOR_RESULT_TYPE(T,R) > inner(World& world,
-					      const std::vector< Function<T,NDIM> >& f,
-					      const std::vector< Function<R,NDIM> >& g) {
-      PROFILE_BLOCK(Vinnervv);
-      long n=f.size(), m=g.size();
-      MADNESS_ASSERT(n==m);
-      Tensor< TENSOR_RESULT_TYPE(T,R) > r(n);
+    Tensor<TENSOR_RESULT_TYPE(T, R)> inner(
+            World& world,
+            const std::vector<Function<T, NDIM>>& f,
+            const std::vector<Function<R, NDIM>>& g) {
+        PROFILE_BLOCK(Vinnervv);
+        long n = f.size(), m = g.size();
+        MADNESS_ASSERT(n == m);
+        Tensor<TENSOR_RESULT_TYPE(T, R)> r(n);
 
-      compress(world, f);
-      compress(world, g);
+        compress(world, f);
+        compress(world, g);
 
-      for (long i=0; i<n; ++i) {
-	r(i) = f[i].inner_local(g[i]);
-      }
+        for (long i = 0; i < n; ++i) {
+            r(i) = f[i].inner_local(g[i]);
+        }
 
-      world.taskq.fence();
-      world.gop.sum(r.ptr(),n);
-      world.gop.fence();
-      return r;
+        world.taskq.fence();
+        world.gop.sum(r.ptr(), n);
+        world.gop.fence();
+        return r;
     }
 
 
     /// Computes the inner product of a function with a function vector - q(i) = inner(f,g[i])
 
     template <typename T, typename R, std::size_t NDIM>
-      Tensor< TENSOR_RESULT_TYPE(T,R) > inner(World& world,
-					      const Function<T,NDIM>& f,
-					      const std::vector< Function<R,NDIM> >& g) {
-      PROFILE_BLOCK(Vinner);
-      long n=g.size();
-      Tensor< TENSOR_RESULT_TYPE(T,R) > r(n);
+    Tensor<TENSOR_RESULT_TYPE(T, R)> inner(
+            World& world,
+            const Function<T,NDIM>& f,
+            const std::vector<Function<R, NDIM>>& g) {
+        PROFILE_BLOCK(Vinner);
+        long n = g.size();
+        Tensor<TENSOR_RESULT_TYPE(T, R)> r(n);
 
-      f.compress();
-      compress(world, g);
+        f.compress();
+        compress(world, g);
 
-      for (long i=0; i<n; ++i) {
-	r(i) = f.inner_local(g[i]);
-      }
+        for (long i = 0; i < n; ++i) {
+            r(i) = f.inner_local(g[i]);
+        }
 
-      world.taskq.fence();
-      world.gop.sum(r.ptr(),n);
-      world.gop.fence();
-      return r;
+        world.taskq.fence();
+        world.gop.sum(r.ptr(),n);
+        world.gop.fence();
+        return r;
     }
 
 
     /// Multiplies a function against a vector of functions --- q[i] = a * v[i]
 
     template <typename T, typename R, std::size_t NDIM>
-      std::vector< Function<TENSOR_RESULT_TYPE(T,R), NDIM> >
-      mul(World& world,
-	  const Function<T,NDIM>& a,
-	  const std::vector< Function<R,NDIM> >& v,
-	  const unsigned int blk=1,
-	  const bool fence=true) {
-
-      PROFILE_BLOCK(Vmul);
-      a.reconstruct(false);
-      reconstruct(world, v, blk, false);
-      world.gop.fence();
-      return vmulXX(a, v, 0.0, fence);
+    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>> mul(
+            World& world,
+            const Function<T,NDIM>& a,
+            const std::vector<Function<R, NDIM>>& v,
+            const unsigned int blk=1,
+            const bool fence=true) {
+        PROFILE_BLOCK(Vmul);
+        a.reconstruct(false);
+        reconstruct(world, v, blk, false);
+        world.gop.fence();
+        return vmulXX(a, v, 0.0, fence);
     }
 
     /// Multiplies a function against a vector of functions using sparsity of a and v[i] --- q[i] = a * v[i]
     template <typename T, typename R, std::size_t NDIM>
-      std::vector< Function<TENSOR_RESULT_TYPE(T,R), NDIM> >
-      mul_sparse(World& world,
-		 const Function<T,NDIM>& a,
-		 const std::vector< Function<R,NDIM> >& v,
-		 const double tol,
-		 const bool fence=true,
-		 const unsigned int blk=1)
- {
-      PROFILE_BLOCK(Vmulsp);
-      a.reconstruct(false);
-      reconstruct(world, v, blk, false);
-      world.gop.fence();
+    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>> mul_sparse(
+            World& world,
+            const Function<T, NDIM>& a,
+            const std::vector<Function<R, NDIM>>& v,
+            const double tol,
+            const bool fence=true,
+            const unsigned int blk=1) {
+        PROFILE_BLOCK(Vmulsp);
+        a.reconstruct(false);
+        reconstruct(world, v, blk, false);
+        world.gop.fence();
 
-      unsigned int vvsize = v.size();
-      for (unsigned int i=0; i<vvsize; i+= blk) {
-	for (unsigned int j=i; j<std::min(vvsize,(i+1)*blk); ++j)
-	  v[j].norm_tree(false);
-	if ( fence && (blk == 1)) world.gop.fence();
-      }
-      a.norm_tree();
-      return vmulXX(a, v, tol, fence);
+        unsigned int vvsize = v.size();
+        for (unsigned int i = 0; i < vvsize; i += blk) {
+            for (unsigned int j = i; j < std::min(vvsize,(i+1)*blk); ++j)
+                v[j].norm_tree(false);
+            if ( fence && (blk == 1)) world.gop.fence();
+        }
+        a.norm_tree();
+        return vmulXX(a, v, tol, fence);
     }
 
     /// Makes the norm tree for all functions in a vector
     template <typename T, std::size_t NDIM>
-      void norm_tree(World& world,
-		     const std::vector< Function<T,NDIM> >& v,
-		     bool fence=true,
-		     unsigned int blk=1){
+    void norm_tree(World& world,
+            const std::vector<Function<T, NDIM>>& v,
+            bool fence=true,
+            unsigned int blk=1){
         PROFILE_BLOCK(Vnorm_tree);
 
-      unsigned int vvsize = v.size();
-      for (unsigned int i=0; i<vvsize; i+= blk) {
-	for (unsigned int j=i; j<std::min(vvsize,(i+1)*blk); ++j)
-	  v[j].norm_tree(false);
-        if (fence && blk!=1 ) world.gop.fence();
-      }
-      if (fence) world.gop.fence();
+        unsigned int vvsize = v.size();
+        for (unsigned int i = 0; i < vvsize; i += blk) {
+            for (unsigned int j = i; j < std::min(vvsize,(i+1)*blk); ++j)
+                v[j].norm_tree(false);
+            if (fence && blk!=1 ) world.gop.fence();
+        }
+        if (fence) world.gop.fence();
     }
 
     /// Multiplies two vectors of functions q[i] = a[i] * b[i]
 
     template <typename T, typename R, std::size_t NDIM>
-      std::vector< Function<TENSOR_RESULT_TYPE(T,R), NDIM> >
-      mul(World& world,
-	  const std::vector< Function<T,NDIM> >& a,
-	  const std::vector< Function<R,NDIM> >& b,
-	  bool fence=true,
-	  unsigned int blk=1){
-      PROFILE_BLOCK(Vmulvv);
-      reconstruct(world, a, blk, false);
-      if (&a != &b) reconstruct(world, b, blk, false);
-      world.gop.fence();
+    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>> mul(
+            World& world,
+            const std::vector<Function<T, NDIM>>& a,
+            const std::vector<Function<R, NDIM>>& b,
+            bool fence=true,
+            unsigned int blk=1) {
+        PROFILE_BLOCK(Vmulvv);
+        reconstruct(world, a, blk, false);
+        if (&a != &b) reconstruct(world, b, blk, false);
+        world.gop.fence();
 
-      std::vector< Function<TENSOR_RESULT_TYPE(T,R),NDIM> > q(a.size());
+        std::vector<Function<TENSOR_RESULT_TYPE(T, R),NDIM>> q(a.size());
 
-      unsigned int vvsize = a.size();
-      for (unsigned int i=0; i<vvsize; i+= blk) {
-	for (unsigned int j=i; j<std::min(vvsize,(i+1)*blk); ++j)
-	  q[j] = mul(a[j], b[j], false);
-	if (fence && (blk !=1 )) world.gop.fence();
-      }
-      if (fence) world.gop.fence();
-      return q;
+        unsigned int vvsize = a.size();
+        for (unsigned int i = 0; i < vvsize; i += blk) {
+            for (unsigned int j = i; j < std::min(vvsize, (i + 1) * blk); ++j)
+                q[j] = mul(a[j], b[j], false);
+            if (fence && (blk != 1)) world.gop.fence();
+        }
+        if (fence) world.gop.fence();
+        return q;
     }
 
 
     /// Computes the square of a vector of functions --- q[i] = v[i]**2
 
     template <typename T, std::size_t NDIM>
-      std::vector< Function<T,NDIM> >
-      square(World& world,
-	     const std::vector< Function<T,NDIM> >& v,
-	     bool fence=true) {
-      return mul<T,T,NDIM>(world, v, v, fence);
-      //         std::vector< Function<T,NDIM> > vsq(v.size());
-      //         for (unsigned int i=0; i<v.size(); ++i) {
-      //             vsq[i] = square(v[i], false);
-      //         }
-      //         if (fence) world.gop.fence();
-      //         return vsq;
+    std::vector<Function<T, NDIM>> square(World& world,
+                                          const std::vector<Function<T, NDIM>>& v,
+                                          bool fence=true) {
+        return mul<T,T,NDIM>(world, v, v, fence);
+        // std::vector<Function<T, NDIM>> vsq(v.size());
+        // for (unsigned int i = 0; i < v.size(); ++i) {
+        //     vsq[i] = square(v[i], false);
+        // }
+        // if (fence) world.gop.fence();
+        // return vsq;
     }
 
     /// Sets the threshold in a vector of functions
 
     template <typename T, std::size_t NDIM>
-      void set_thresh(World& world,
-		      std::vector< Function<T,NDIM> >& v,
-		      double thresh,
-		      bool fence=true) {
-      for (unsigned int j=0; j<v.size(); ++j) {
-	v[j].set_thresh(thresh,false);
-      }
-      if (fence) world.gop.fence();
+    void set_thresh(World& world,
+                    std::vector<Function<T, NDIM>>& v,
+                    double thresh,
+                    bool fence=true) {
+        for (unsigned int j = 0; j < v.size(); ++j) {
+            v[j].set_thresh(thresh,false);
+        }
+        if (fence) world.gop.fence();
     }
 
     /// Returns the complex conjugate of the vector of functions
 
     template <typename T, std::size_t NDIM>
-      std::vector< Function<T,NDIM> >
-      conj(World& world,
-	   const std::vector< Function<T,NDIM> >& v,
-	   bool fence=true){
-      PROFILE_BLOCK(Vconj);
-      std::vector< Function<T,NDIM> > r = copy(world, v); // Currently don't have oop conj
-      for (unsigned int i=0; i<v.size(); ++i) {
-	r[i].conj(false);
-      }
-      if (fence) world.gop.fence();
-      return r;
+    std::vector<Function<T, NDIM>> conj(World& world,
+                                        const std::vector<Function<T, NDIM>>& v,
+                                        bool fence=true) {
+        PROFILE_BLOCK(Vconj);
+        std::vector<Function<T, NDIM>> r = copy(world, v); // Currently don't have oop conj
+        for (unsigned int i = 0; i < v.size(); ++i) {
+            r[i].conj(false);
+        }
+        if (fence) world.gop.fence();
+        return r;
     }
 
 
     /// Returns a deep copy of a vector of functions
 
     template <typename T, std::size_t NDIM>
-      std::vector< Function<T,NDIM> >
-      copy(World& world,
-	   const std::vector< Function<T,NDIM> >& v,
-	   bool fence=true) {
-      PROFILE_BLOCK(Vcopy);
-      std::vector< Function<T,NDIM> > r(v.size());
-      for (unsigned int i=0; i<v.size(); ++i) {
-	r[i] = copy(v[i], false);
-      }
-      if (fence) world.gop.fence();
-      return r;
+    std::vector<Function<T, NDIM>> copy(World& world,
+                                        const std::vector<Function<T, NDIM>>& v,
+                                        bool fence=true) {
+        PROFILE_BLOCK(Vcopy);
+        std::vector<Function<T, NDIM>> r(v.size());
+        for (unsigned int i = 0; i < v.size(); ++i) {
+            r[i] = copy(v[i], false);
+        }
+        if (fence) world.gop.fence();
+        return r;
     }
 
     /// Returns a vector of deep copies of of a function
 
     template <typename T, std::size_t NDIM>
-      std::vector< Function<T,NDIM> >
-      copy(World& world,
-	   const Function<T,NDIM>& v,
-	   const unsigned int n,
-	   bool fence=true) {
-      PROFILE_BLOCK(Vcopy1);
-      std::vector< Function<T,NDIM> > r(n);
-      for (unsigned int i=0; i<n; ++i) {
-	r[i] = copy(v, false);
-      }
-      if (fence) world.gop.fence();
-      return r;
+    std::vector<Function<T, NDIM>> copy(World& world,
+                                        const Function<T,NDIM>& v,
+                                        const unsigned int n,
+                                        bool fence=true) {
+        PROFILE_BLOCK(Vcopy1);
+        std::vector<Function<T, NDIM>> r(n);
+        for (unsigned int i = 0; i < n; ++i) {
+            r[i] = copy(v, false);
+        }
+        if (fence) world.gop.fence();
+        return r;
     }
 
     /// Returns new vector of functions --- q[i] = a[i] + b[i]
 
     template <typename T, typename R, std::size_t NDIM>
-      std::vector< Function<TENSOR_RESULT_TYPE(T,R), NDIM> >
-      add(World& world,
-	  const std::vector< Function<T,NDIM> >& a,
-	  const std::vector< Function<R,NDIM> >& b,
-	  bool fence=true,
-	  unsigned int blk=1) {
-      PROFILE_BLOCK(Vadd);
-      MADNESS_ASSERT(a.size() == b.size());
-      compress(world, a, blk);
-      compress(world, b, blk);
+    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>> add(
+            World& world,
+            const std::vector<Function<T, NDIM>>& a,
+            const std::vector<Function<R, NDIM>>& b,
+            bool fence=true,
+            unsigned int blk=1) {
+        PROFILE_BLOCK(Vadd);
+        MADNESS_ASSERT(a.size() == b.size());
+        compress(world, a, blk);
+        compress(world, b, blk);
 
-      std::vector< Function<TENSOR_RESULT_TYPE(T,R),NDIM> > r(a.size());
+        std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>> r(a.size());
 
-      unsigned int vvsize = a.size();
-      for (unsigned int i=0; i<vvsize; i+= blk) {
-	for (unsigned int j=i; j<std::min(vvsize,(i+1)*blk); ++j)
-	  r[j] = add(a[j], b[j], false);
-	if (fence && (blk !=1 )) world.gop.fence();
-      }
-      if (fence) world.gop.fence();
-
-      return r;
+        unsigned int vvsize = a.size();
+        for (unsigned int i = 0; i < vvsize; i += blk) {
+            for (unsigned int j = i; j < std::min(vvsize, (i + 1) * blk); ++j)
+                r[j] = add(a[j], b[j], false);
+            if (fence && (blk !=1 )) world.gop.fence();
+        }
+        if (fence) world.gop.fence();
+        return r;
     }
 
      /// Returns new vector of functions --- q[i] = a + b[i]
 
     template <typename T, typename R, std::size_t NDIM>
-      std::vector< Function<TENSOR_RESULT_TYPE(T,R), NDIM> >
-      add(World& world,
-	  const Function<T,NDIM> & a,
-	  const std::vector< Function<R,NDIM> >& b,
-	   bool fence=true,
-	  unsigned int blk=1) {
+    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>> add(
+            World& world,
+            const Function<T,NDIM> & a,
+            const std::vector<Function<R, NDIM>>& b,
+            bool fence=true,
+            unsigned int blk=1) {
+        PROFILE_BLOCK(Vadd1);
+        a.compress();
+        compress(world, b, blk);
 
-      PROFILE_BLOCK(Vadd1);
-      a.compress();
-      compress(world, b, blk);
+        std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>> r(b.size());
 
-      std::vector< Function<TENSOR_RESULT_TYPE(T,R),NDIM> > r(b.size());
-
-      unsigned int vvsize = b.size();
-      for (unsigned int i=0; i<vvsize; i+= blk) {
-	for (unsigned int j=i; j<std::min(vvsize,(i+1)*blk); ++j)
-	  r[j] = add(a, b[j], false);
-	if (fence && (blk !=1 )) world.gop.fence();
-      }
-      if (fence) world.gop.fence();
-
-      return r;
+        unsigned int vvsize = b.size();
+        for (unsigned int i = 0; i < vvsize; i += blk) {
+            for (unsigned int j = i; j < std::min(vvsize, (i + 1) * blk); ++j)
+                r[j] = add(a, b[j], false);
+            if (fence && (blk !=1 )) world.gop.fence();
+        }
+        if (fence) world.gop.fence();
+        return r;
     }
 
     template <typename T, typename R, std::size_t NDIM>
-      inline std::vector< Function<TENSOR_RESULT_TYPE(T,R), NDIM> >
-      add(World& world,
-	  const std::vector< Function<R,NDIM> >& b,
-	  const Function<T,NDIM> & a,
-	   bool fence=true,
-	  unsigned int blk=1) {
+    inline std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>> add(
+            World& world,
+            const std::vector<Function<R, NDIM>>& b,
+            const Function<T,NDIM> & a,
+            bool fence=true,
+            unsigned int blk=1) {
       return add(world, a, b, fence, blk);
     }
 
     /// Returns new vector of functions --- q[i] = a[i] - b[i]
 
     template <typename T, typename R, std::size_t NDIM>
-      std::vector< Function<TENSOR_RESULT_TYPE(T,R), NDIM> >
-      sub(World& world,
-	   const std::vector< Function<T,NDIM> >& a,
-	   const std::vector< Function<R,NDIM> >& b,
-	   bool fence=true,
-	   unsigned int blk=1) {
-      PROFILE_BLOCK(Vsub);
-      MADNESS_ASSERT(a.size() == b.size());
-      compress(world, a, fence, blk);
-      compress(world, b, fence, blk);
+    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>> sub(
+            World& world,
+            const std::vector<Function<T, NDIM>>& a,
+            const std::vector<Function<R, NDIM>>& b,
+            bool fence=true,
+            unsigned int blk=1) {
+        PROFILE_BLOCK(Vsub);
+        MADNESS_ASSERT(a.size() == b.size());
+        compress(world, a, fence, blk);
+        compress(world, b, fence, blk);
 
-      std::vector< Function<TENSOR_RESULT_TYPE(T,R),NDIM> > r(a.size());
+        std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>> r(a.size());
 
-      unsigned int vvsize = a.size();
-      for (unsigned int i=0; i<vvsize; i+= blk) {
-	for (unsigned int j=i; j<std::min(vvsize,(i+1)*blk); ++j)
-	  r[j] = sub(a[j], b[j], false);
-	if (fence && (blk !=1 )) world.gop.fence();
-      }
-      if (fence) world.gop.fence();
-      return r;
+        unsigned int vvsize = a.size();
+        for (unsigned int i = 0; i < vvsize; i += blk) {
+            for (unsigned int j = i; j < std::min(vvsize, (i + 1) * blk); ++j)
+                r[j] = sub(a[j], b[j], false);
+            if (fence && (blk !=1 )) world.gop.fence();
+        }
+        if (fence) world.gop.fence();
+        return r;
     }
 
 
     /// Generalized A*X+Y for vectors of functions ---- a[i] = alpha*a[i] + beta*b[i]
 
     template <typename T, typename Q, typename R, std::size_t NDIM>
-      void gaxpy(World& world,
-		 Q alpha,
-		 std::vector< Function<T,NDIM> >& a,
-		 Q beta,
-		 const std::vector< Function<R,NDIM> >& b,
-		 unsigned int blk=1,
-		 bool fence=true) {
-      PROFILE_BLOCK(Vgaxpy);
-      MADNESS_ASSERT(a.size() == b.size());
-      compress(world, a, fence, blk);
-      compress(world, b, fence, blk);
+    void gaxpy(World& world,
+               Q alpha,
+               std::vector<Function<T, NDIM>>& a,
+               Q beta,
+               const std::vector<Function<R, NDIM>>& b,
+               unsigned int blk=1,
+               bool fence=true) {
+        PROFILE_BLOCK(Vgaxpy);
+        MADNESS_ASSERT(a.size() == b.size());
+        compress(world, a, fence, blk);
+        compress(world, b, fence, blk);
 
-      unsigned int vvsize = a.size();
+        unsigned int vvsize = a.size();
 
-      for (unsigned int i=0; i<vvsize; i+= blk) {
-	for (unsigned int j=i; j<std::min(vvsize,(i+1)*blk); ++j)
-	  a[j].gaxpy(alpha, b[j], beta, false);
-
-	if (fence && (blk !=1 )) world.gop.fence();
-
-      }
-      //      for (unsigned int i=0; i<a.size(); ++i) {
-      // 	a[i].gaxpy(alpha, b[i], beta, false);
-      // }
-      if (fence) world.gop.fence();
+        for (unsigned int i = 0; i < vvsize; i += blk) {
+            for (unsigned int j = i; j < std::min(vvsize, (i + 1) * blk); ++j)
+                a[j].gaxpy(alpha, b[j], beta, false);
+            if (fence && (blk !=1 )) world.gop.fence();
+        }
+        // for (unsigned int i = 0; i < a.size(); ++i) {
+        //     a[i].gaxpy(alpha, b[i], beta, false);
+        // }
+        if (fence) world.gop.fence();
     }
 
 
     /// Applies a vector of operators to a vector of functions --- q[i] = apply(op[i],f[i])
 
     template <typename opT, typename R, std::size_t NDIM>
-      std::vector< Function<TENSOR_RESULT_TYPE(typename opT::opT,R), NDIM> >
-      apply(World& world,
-	    const std::vector< std::shared_ptr<opT> >& op,
-	    const std::vector< Function<R,NDIM> > f,
-	    const unsigned int blk=1){
+    std::vector<Function<TENSOR_RESULT_TYPE(typename opT::opT, R), NDIM>>
+    apply(World& world,
+          const std::vector<std::shared_ptr<opT>>& op,
+          const std::vector<Function<R, NDIM>> f,
+          const unsigned int blk=1){
+        PROFILE_BLOCK(Vapplyv);
+        MADNESS_ASSERT(f.size() == op.size());
 
-      PROFILE_BLOCK(Vapplyv);
-      MADNESS_ASSERT(f.size()==op.size());
+        std::vector<Function<R, NDIM>>& ncf = *const_cast<std::vector<Function<R, NDIM>>*>(&f);
 
-      std::vector< Function<R,NDIM> >& ncf = *const_cast< std::vector< Function<R,NDIM> >* >(&f);
+        reconstruct(world, f, blk);
+        nonstandard(world, ncf, blk);
 
-      reconstruct(world, f, blk);
-      nonstandard(world, ncf, blk);
+        std::vector<Function<TENSOR_RESULT_TYPE(typename opT::opT, R), NDIM>> result(f.size());
+        unsigned int ff = f.size();
 
-      std::vector< Function<TENSOR_RESULT_TYPE(typename opT::opT,R), NDIM> > result(f.size());
-      unsigned int ff = f.size();
+        for (unsigned int i = 0; i < ff; ++blk) {
+            for (unsigned int j = i; j < std::min(ff,(i+1)*blk); ++j)
+                result[j] = apply_only(*op[j], f[j], false);
+            if (blk !=1)
+            world.gop.fence();
+        }
 
-      for (unsigned int i=0; i<ff; ++blk) {
-	for (unsigned int j=i; j<std::min(ff,(i+1)*blk); ++j)
-	  result[j] = apply_only(*op[j], f[j], false);
-	if (blk !=1)
-	  world.gop.fence();
-      }
+        world.gop.fence();
 
-      world.gop.fence();
+        standard(world, ncf, false);  // restores promise of logical constness
+        world.gop.fence();
+        reconstruct(world, result, blk);
 
-      standard(world, ncf, false);  // restores promise of logical constness
-      world.gop.fence();
-      reconstruct(world, result, blk);
-
-      return result;
+        return result;
     }
 
 
     /// Applies an operator to a vector of functions --- q[i] = apply(op,f[i])
 
     template <typename T, typename R, std::size_t NDIM>
-      std::vector< Function<TENSOR_RESULT_TYPE(T,R), NDIM> >
-      apply(World& world,
-	    const SeparatedConvolution<T,NDIM>& op,
-	    const std::vector< Function<R,NDIM> > f,
-	    const unsigned int blk=1) {
-      PROFILE_BLOCK(Vapply);
+    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>>
+    apply(World& world,
+          const SeparatedConvolution<T, NDIM>& op,
+          const std::vector<Function<R, NDIM>> f,
+          const unsigned int blk=1) {
+        PROFILE_BLOCK(Vapply);
 
-      std::vector< Function<R,NDIM> >& ncf = *const_cast< std::vector< Function<R,NDIM> >* >(&f);
+        std::vector<Function<R, NDIM>>& ncf = *const_cast< std::vector<Function<R, NDIM>>* >(&f);
 
-      reconstruct(world, f, blk);
-      nonstandard(world, ncf, blk);
+        reconstruct(world, f, blk);
+        nonstandard(world, ncf, blk);
 
-      std::vector< Function<TENSOR_RESULT_TYPE(T,R), NDIM> > result(f.size());
+        std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>> result(f.size());
 
-      unsigned int ff = f.size();
-      for (unsigned int i=0; i<ff; ++blk) {
-	for (unsigned int j=i; j<std::min(ff,(i+1)*blk); ++j)
-	  result[j] = apply_only(op, f[j], false);
-	if (blk !=1)
-	  world.gop.fence();
-      }
-      world.gop.fence();
+        unsigned int ff = f.size();
+        for (unsigned int i = 0; i < ff; ++i) {
+            for (unsigned int j = i; j < std::min(ff, (i + 1) * blk); ++j)
+                result[j] = apply_only(op, f[j], false);
+            if (blk !=1) world.gop.fence();
+        }
+        world.gop.fence();
 
-      standard(world, ncf, blk, false);  // restores promise of logical constness
-      world.gop.fence();
-      reconstruct(world, result, blk);
+        standard(world, ncf, blk, false);  // restores promise of logical constness
+        world.gop.fence();
+        reconstruct(world, result, blk);
 
-      return result;
+        return result;
     }
 
     /// Normalizes a vector of functions --- v[i] = v[i].scale(1.0/v[i].norm2())
 
     template <typename T, std::size_t NDIM>
-      void normalize(World& world,
-		     std::vector< Function<T,NDIM> >& v,
-		     bool fence=true){
+    void normalize(World& world,
+		           std::vector<Function<T, NDIM>>& v,
+		           bool fence=true){
+        PROFILE_BLOCK(Vnormalize);
+        std::vector<double> nn = norm2s(world, v);
 
-      PROFILE_BLOCK(Vnormalize);
-      std::vector<double> nn = norm2s(world, v);
+        for (unsigned int i = 0; i < v.size(); ++i)
+            v[i].scale(1.0 / nn[i], false);
 
-      for (unsigned int i=0; i<v.size(); ++i)
-	v[i].scale(1.0/nn[i],false);
-
-      if (fence) world.gop.fence();
+        if (fence) world.gop.fence();
     }
 
-}
+}  // namespace madness
 #endif // MADNESS_MRA_VMRA_H__INCLUDED

--- a/src/madness/mra/vmra1.h
+++ b/src/madness/mra/vmra1.h
@@ -90,7 +90,7 @@
 
 	*) set_thresh: setting a finite thresh-hold for a vector of functions
 	\code
-	void set_thresh(World& world, std::vector<Function<T, NDIM>>& v, double thresh, bool fence=true);
+	void set_thresh(World& world, std::vector< Function<T,NDIM> >& v, double thresh, bool fence=true);
 	\endcode
 
 	Arithmetic Operations on arrays of functions
@@ -129,22 +129,22 @@ namespace madness {
     /// Compress a vector of functions
     template <typename T, std::size_t NDIM>
     void compress(World& world,
-                  const std::vector<Function<T, NDIM>>& v,
-		          unsigned int blk=1,
+                  const std::vector< Function<T,NDIM> >& v,
+		  unsigned int blk=1,
                   bool fence=true){
 
         PROFILE_BLOCK(Vcompress);
         bool must_fence = false;
-        unsigned int vvsize = v.size();
-        for (unsigned int i = 0; i < vvsize; i += blk) {
-            for (unsigned int j = i; j < std::min(vvsize, (i + 1) * blk); ++j) {
-                if (!v[j].is_compressed()) {
-                    v[j].compress(false);
-                    must_fence = true;
-                }
-	        }
-	        if (blk != 1 && must_fence && fence) world.gop.fence();
-	    }
+	unsigned int vvsize = v.size();
+        for (unsigned int i=0; i<vvsize; i+= blk) {
+	  for (unsigned int j=i; j<std::min(vvsize,(i+1)*blk); ++j) {
+            if (!v[j].is_compressed()) {
+	      v[j].compress(false);
+	      must_fence = true;
+            }
+	  }
+	  if ( blk!=1 && must_fence && fence) world.gop.fence();
+	}
 
         if (fence && must_fence) world.gop.fence();
     }
@@ -153,118 +153,121 @@ namespace madness {
     /// Reconstruct a vector of functions
     template <typename T, std::size_t NDIM>
     void reconstruct(World& world,
-                     const std::vector<Function<T, NDIM>>& v,
-		             unsigned int blk=1,
+                     const std::vector< Function<T,NDIM> >& v,
+		     unsigned int blk=1,
                      bool fence=true){ // reconstr
-        PROFILE_BLOCK(Vreconstruct);
-        bool must_fence = false;
-        unsigned int vvsize = v.size();
-        for (unsigned int i = 0; i < vvsize; i += blk) {
-            for (unsigned int j = i; j < std::min(vvsize, (i + 1) * blk); ++j) {
-                if (v[j].is_compressed()) {
-                    v[j].reconstruct(false);
-                    must_fence = true;
-                }
-            }
-            if ( blk != 1 && must_fence && fence) world.gop.fence();
-        }
+	PROFILE_BLOCK(Vreconstruct);
+	bool must_fence = false;
+	unsigned int vvsize = v.size();
+	for (unsigned int i=0; i<vvsize; i+= blk) {
+	  for (unsigned int j=i; j<std::min(vvsize,(i+1)*blk); ++j) {
+	    if (v[j].is_compressed()) {
+	      v[j].reconstruct(false);
+	      must_fence = true;
+	    }
+	  }
+	  if ( blk!=1 && must_fence && fence) world.gop.fence();
+	}
 
-        if (fence && must_fence) world.gop.fence();
+	if (fence && must_fence) world.gop.fence();
     } // reconstr
 
     /// Generates non-standard form of a vector of functions
     template <typename T, std::size_t NDIM>
-    void nonstandard(World& world,
-		             std::vector<Function<T, NDIM>>& v,
-		             unsigned int blk=1,
-		             bool fence=true) { // nonstand
+      void nonstandard(World& world,
+		       std::vector< Function<T,NDIM> >& v,
+		       unsigned int blk=1,
+		       bool fence=true) { // nonstand
         PROFILE_BLOCK(Vnonstandard);
-	    unsigned int vvsize = v.size();
+	unsigned int vvsize = v.size();
         reconstruct(world, v, blk);
-        for (unsigned int i = 0; i < vvsize; i += blk) {
-            for (unsigned int j = i; j < std::min(vvsize, (i + 1) * blk); ++j) {
-                v[j].make_nonstandard(false, false);
-            }
-            if ( blk!=1 && fence) world.gop.fence();
-        }
-        if (fence) world.gop.fence();
+	for (unsigned int i=0; i<vvsize; i+= blk) {
+	  for (unsigned int j=i; j<std::min(vvsize,(i+1)*blk); ++j) {
+          v[j].make_nonstandard(false, false);
+	  }
+	  if ( blk!=1 && fence) world.gop.fence();
+	}
+	if (fence) world.gop.fence();
     } //nonstand
 
 
     /// Generates standard form of a vector of functions
 
     template <typename T, std::size_t NDIM>
-    void standard(World& world,
-		          std::vector<Function<T, NDIM>>& v,
-		          unsigned int blk=1,
-		          bool fence=true){ // standard
-        PROFILE_BLOCK(Vstandard);
-        unsigned int vvsize = v.size();
-        for (unsigned int i = 0; i < vvsize; i += blk) {
-            for (unsigned int j = i; j < std::min(vvsize, (i + 1) * blk); ++j) {
-                v[j].standard(false);
-            }
-            if ( blk!=1 && fence) world.gop.fence();
-        }
-        if (fence) world.gop.fence();
+      void standard(World& world,
+		    std::vector< Function<T,NDIM> >& v,
+		    unsigned int blk=1,
+		    bool fence=true){ // standard
+	PROFILE_BLOCK(Vstandard);
+	unsigned int vvsize = v.size();
+	for (unsigned int i=0; i<vvsize; i+= blk) {
+	  for (unsigned int j=i; j<std::min(vvsize,(i+1)*blk); ++j) {
+	    v[j].standard(false);
+	  }
+	  if ( blk!=1 && fence) world.gop.fence();
+	}
+	if (fence) world.gop.fence();
     } // standard
 
 
     /// Truncates a vector of functions
     template <typename T, std::size_t NDIM>
     void truncate(World& world,
-                  std::vector<Function<T, NDIM>>& v,
+                  std::vector< Function<T,NDIM> >& v,
                   double tol=0.0,
-		          unsigned int blk=1,
+		  unsigned int blk=1,
                   bool fence=true){ // truncate
-        PROFILE_BLOCK(Vtruncate);
+	PROFILE_BLOCK(Vtruncate);
 
-        compress(world, v, blk);
+	compress(world, v, blk);
 
-        unsigned int vvsize = v.size();
-        for (unsigned int i = 0; i < vvsize; i += blk) {
-            for (unsigned int j = i; j < std::min(vvsize, (i + 1) * blk); ++j) {
-                v[j].truncate(tol, false);
-            }
-            if ( blk!=1 && fence) world.gop.fence();
-        }
+	unsigned int vvsize = v.size();
+	for (unsigned int i=0; i<vvsize; i+= blk) {
+	  for (unsigned int j=i; j<std::min(vvsize,(i+1)*blk); ++j) {
+	    v[j].truncate(tol, false);
+	  }
+	  if ( blk!=1 && fence) world.gop.fence();
+	}
         if (fence) world.gop.fence();
     } //truncate
 
     /// Applies a derivative operator to a vector of functions
 
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T, NDIM>>
-    apply(World& world,
-	      const Derivative<T,NDIM>& D,
-	      const std::vector<Function<T, NDIM>>& v,
-	      const unsigned int blk=1,
-	      const bool fence=true) {
-        reconstruct(world, v, blk);
-        std::vector<Function<T, NDIM>> df(v.size());
+      std::vector< Function<T,NDIM> >
+      apply(World& world,
+	     const Derivative<T,NDIM>& D,
+	     const std::vector< Function<T,NDIM> >& v,
+	     const unsigned int blk=1,
+	     const bool fence=true)
+      {
+	reconstruct(world, v, blk);
+	std::vector< Function<T,NDIM> > df(v.size());
 
-        unsigned int vvsize = v.size();
+	unsigned int vvsize = v.size();
 
-        for (unsigned int i = 0; i < vvsize; i += blk) {
-            for (unsigned int j = i; j < std::min(vvsize, (i + 1) * blk); ++j) {
-                df[j] = D(v[j],false);
-            }
-            if (blk!= 1 && fence) world.gop.fence();
-        }
-        if (fence) world.gop.fence();
-        return df;
-    }
+	for (unsigned int i=0; i<vvsize; i+= blk) {
+	  for (unsigned int j=i; j<std::min(vvsize,(i+1)*blk); ++j) {
+	    df[j] = D(v[j],false);
+	  }
+	  if (blk!= 1 && fence) world.gop.fence();
+	}
+	if (fence) world.gop.fence();
+
+	return df;
+      }
 
     /// Generates a vector of zero functions
 
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T, NDIM>> zero_functions(World& world, int n) {
-        PROFILE_BLOCK(Vzero_functions);
-        std::vector<Function<T, NDIM>> r(n);
-        for (int i = 0; i < n; ++i)
-            r[i] = Function<T,NDIM>(FunctionFactory<T,NDIM>(world));
+      std::vector< Function<T,NDIM> >
+      zero_functions(World& world, int n) {
+      PROFILE_BLOCK(Vzero_functions);
+      std::vector< Function<T,NDIM> > r(n);
+      for (int i=0; i<n; ++i)
+	r[i] = Function<T,NDIM>(FunctionFactory<T,NDIM>(world));
 
-        return r;
+      return r;
     }
 
 
@@ -274,205 +277,214 @@ namespace madness {
     /// zero to take advantage of this.
 
     template <typename T, typename R, std::size_t NDIM>
-        std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>>
-        transform(World& world,
-            const std::vector<Function<T, NDIM>>& v,
-            const Tensor<R>& c,
-            unsigned int blki=1,
-            unsigned int blkj=1,
-            const bool fence=true){
+      std::vector< Function<TENSOR_RESULT_TYPE(T,R),NDIM> >
+      transform(World& world,
+		const std::vector< Function<T,NDIM> >& v,
+		const Tensor<R>& c,
+		unsigned int blki=1,
+		unsigned int blkj=1,
+		const bool fence=true){
 
-        PROFILE_BLOCK(Vtransformsp);
+      PROFILE_BLOCK(Vtransformsp);
 
-        typedef TENSOR_RESULT_TYPE(T,R) resultT;
+      typedef TENSOR_RESULT_TYPE(T,R) resultT;
 
-        unsigned int blk = std::min(blki, blkj);
-        unsigned int n = v.size();  // n is the old dimension
-        unsigned int m = c.dim(1);  // m is the new dimension
-        MADNESS_ASSERT(n==c.dim(0));
+      unsigned int blk = min(blki, blkj);
+      unsigned int n = v.size();  // n is the old dimension
+      unsigned int m = c.dim(1);  // m is the new dimension
+      MADNESS_ASSERT(n==c.dim(0));
 
-        std::vector<Function<resultT,NDIM>> vc = zero_functions_compressed<resultT, NDIM>(world, m);
-        compress(world, v, blk);
+      std::vector< Function<resultT,NDIM> > vc = zero_functions_compressed<resultT,NDIM>(world, m);
+      compress(world, v, blk);
 
-        for (unsigned int i = 0; i < m; i += blki) {
-            for (unsigned int ii = i; ii < std::min(m, (i + 1) * blki); ii++) {
-                for (unsigned int j = 0; j < n; j += blkj) {
-                    for (unsigned int jj = j; jj < std::min(n, (j + 1) * blkj); jj++)
-                        if (c(jj, ii) != R(0.0)) vc[ii].gaxpy(1.0, v[jj], c(jj, ii), false);
-                    if (fence && (blkj != 1)) world.gop.fence();
-                }
-            }
-            if (fence && (blki != 1)) world.gop.fence();  // a bit conservative
-        }
+      for (unsigned int i=0; i<m; i+= blki) {
+	for (unsigned int ii=i; ii<std::min(m,(i+1)*blki); ii++) {
+	  for (unsigned int j=0; j<n; j+= blkj) {
+	    for (unsigned int jj=j; jj<std::min(n, (j+1)*blkj); jj++)
+	      if (c(jj,ii) != R(0.0)) vc[ii].gaxpy(1.0,v[jj],c(jj,ii),false);
+	    if (fence && (blkj!=1)) world.gop.fence();
+	  }
+	}
+	if (fence && (blki!=1)) world.gop.fence();  // a bit conservative
+      }
 
-        // for (unsigned int i = 0; i < m; ++i) {
-        //     for (unsigned int j = 0; j < n; ++j) {
-        //         if (c(j,i) != R(0.0)) vc[i].gaxpy(1.0,v[j],c(j,i),false);
-        //     }
-        // }
 
-        if (fence) world.gop.fence();
-        return vc;
+      //      for (unsigned int i=0; i<m; ++i) {
+      // for (unsigned int j=0; j<n; ++j) {
+      // if (c(j,i) != R(0.0)) vc[i].gaxpy(1.0,v[j],c(j,i),false);
+      // }
+      // }
+
+      if (fence) world.gop.fence();
+      return vc;
     }
 
 
     template <typename L, typename R, std::size_t NDIM>
-     std::vector< Function<TENSOR_RESULT_TYPE(L,R),NDIM> >
-     transform(World& world,
-               const std::vector< Function<L,NDIM> >& v,
-               const Tensor<R>& c,
-               const double tol,
-               const unsigned int blki=1,
-               const bool fence=true) {
+      std::vector< Function<TENSOR_RESULT_TYPE(L,R),NDIM> >
+      transform(World& world,
+		const std::vector< Function<L,NDIM> >& v,
+		const Tensor<R>& c,
+		const double tol,
+		const unsigned int blki=1,
+		const bool fence)
+      {
         PROFILE_BLOCK(Vtransform);
         MADNESS_ASSERT(v.size() == (unsigned int)(c.dim(0)));
 
-        std::vector<Function<TENSOR_RESULT_TYPE(L, R),NDIM>> vresult(c.dim(1));
-        unsigned int m = c.dim(1);
+        std::vector< Function<TENSOR_RESULT_TYPE(L,R),NDIM> > vresult(c.dim(1));
+	unsigned int m=c.dim(1);
 
-        for (unsigned int i = 0; i < m; i += blki) {
-            for (unsigned int ii = i; ii < std::min(m, (i + 1) * blki); ii++) {
-                vresult[ii] = Function<TENSOR_RESULT_TYPE(L, R), NDIM>(FunctionFactory<TENSOR_RESULT_TYPE(L, R), NDIM>(world));
-            }
-            if (fence && (blki != 1)) world.gop.fence();  // a bit conservative
-        }
+	for (unsigned int i=0; i<m; i+= blki) {
+	  for (unsigned int ii=i; ii<std::min(m,(i+1)*blki); ii++) {
+	    vresult[ii] = Function<TENSOR_RESULT_TYPE(L,R),NDIM>(FunctionFactory<TENSOR_RESULT_TYPE(L,R),NDIM>(world));
+	  }
+	  if (fence && (blki!=1)) world.gop.fence();  // a bit conservative
+	}
 
-        // for (unsigned int i = 0; i < c.dim(1); ++i) {
-        //        vresult[i] = Function<TENSOR_RESULT_TYPE(L,R),NDIM>(FunctionFactory<TENSOR_RESULT_TYPE(L,R),NDIM>(world));
-        // }
+
+	//        for (unsigned int i=0; i<c.dim(1); ++i) {
+	// vresult[i] = Function<TENSOR_RESULT_TYPE(L,R),NDIM>(FunctionFactory<TENSOR_RESULT_TYPE(L,R),NDIM>(world));
+	// }
         compress(world, v, blki, false);
         compress(world, vresult, blki, false);
         world.gop.fence();
         vresult[0].vtransform(v, c, vresult, tol, fence);
         return vresult;
-    }
+      }
 
     /// Scales inplace a vector of functions by distinct values
 
     template <typename T, typename Q, std::size_t NDIM>
-    void scale(World& world,
-	           std::vector<Function<T, NDIM>>& v,
-	           const std::vector<Q>& factors,
-	           const unsigned int blk=1,
-	           const bool fence=true) {
-        PROFILE_BLOCK(Vscale);
+      void scale(World& world,
+		 std::vector< Function<T,NDIM> >& v,
+		 const std::vector<Q>& factors,
+		 const unsigned int blk=1,
+		 const bool fence=true)
+      {
+	PROFILE_BLOCK(Vscale);
 
-        unsigned int vvsize = v.size();
-        for (unsigned int i = 0; i < vvsize; i += blk) {
-            for (unsigned int j = i; j < std::min(vvsize, (i + 1) * blk); ++j) {
-                v[j].scale(factors[j], false);
-            }
-            if (fence && blk != 1 ) world.gop.fence();
-        }
-        if (fence) world.gop.fence();
-    }
+	unsigned int vvsize = v.size();
+	for (unsigned int i=0; i<vvsize; i+= blk) {
+	  for (unsigned int j=i; j<std::min(vvsize,(i+1)*blk); ++j) {
+	    v[j].scale(factors[j],false);
+	  }
+	  if (fence && blk!=1 ) world.gop.fence();
+	}
+	if (fence) world.gop.fence();
+      }
 
     /// Scales inplace a vector of functions by the same
 
     template <typename T, typename Q, std::size_t NDIM>
-    void scale(World& world,
-		       std::vector<Function<T, NDIM>>& v,
-		       const Q factor,
-		       const unsigned int blk=1,
-		       const bool fence=true){
-        PROFILE_BLOCK(Vscale); // shouldn't need blocking since it is local
+      void scale(World& world,
+		 std::vector< Function<T,NDIM> >& v,
+		  const Q factor,
+		 const unsigned int blk=1,
+		 const bool fence=true){
 
-        unsigned int vvsize = v.size();
-        for (unsigned int i = 0; i < vvsize; i += blk) {
-            for (unsigned int j = i; j < std::min(vvsize, (i + 1) * blk); ++j) {
-                v[j].scale(factor, false);
-            }
-            if (fence && blk != 1 ) world.gop.fence();
-        }
-        if (fence) world.gop.fence();
-    }
+	PROFILE_BLOCK(Vscale); // shouldn't need blocking since it is local
+
+	unsigned int vvsize = v.size();
+	for (unsigned int i=0; i<vvsize; i+= blk) {
+	  for (unsigned int j=i; j<std::min(vvsize,(i+1)*blk); ++j) {
+	    v[j].scale(factor,false);
+	  }
+	  if (fence && blk!=1 ) world.gop.fence();
+	}
+	if (fence) world.gop.fence();
+      }
 
     /// Computes the 2-norms of a vector of functions
     template <typename T, std::size_t NDIM>
-    std::vector<double> norm2s(World& world,
-				               const std::vector<Function<T, NDIM>>& v,
-				               const unsigned int blk=1,
-				               const bool fence=true) {
-        PROFILE_BLOCK(Vnorm2);
-        unsigned int vvsize = v.size();
-        std::vector<double> norms(vvsize);
+      std::vector<double> norm2s(World& world,
+				 const std::vector< Function<T,NDIM> >& v,
+				 const unsigned int blk=1,
+				 const bool fence=true){
 
-        for (unsigned int i = 0; i < vvsize; i += blk) {
-            for (unsigned int j = i; j < std::min(vvsize, (i + 1) * blk); ++j) {
-                norms[j] = v[j].norm2sq_local();
-            }
-            if (fence && (blk!=1)) world.gop.fence();
-        }
-        if (fence ) world.gop.fence();
+      PROFILE_BLOCK(Vnorm2);
+      unsigned int vvsize = v.size();
+      std::vector<double> norms(vvsize);
 
-        world.gop.sum(&norms[0], norms.size());
+      for (unsigned int i=0; i<vvsize; i+= blk) {
+	for (unsigned int j=i; j<std::min(vvsize,(i+1)*blk); ++j) {
+	  norms[j] = v[j].norm2sq_local();
+	}
+	if (fence && (blk!=1)) world.gop.fence();
+      }
+      if (fence ) world.gop.fence();
 
-        for (unsigned int i = 0; i < vvsize; i += blk) {
-            for (unsigned int j = i; j < std::min(vvsize, (i + 1) * blk); ++j)
-                norms[j] = sqrt(norms[j]);
-            if (fence && (blk != 1)) world.gop.fence();
-        }
+      world.gop.sum(&norms[0], norms.size());
 
-        world.gop.fence();
-        return norms;
+      for (unsigned int i=0; i<vvsize; i+= blk) {
+	for (unsigned int j=i; j<std::min(vvsize,(i+1)*blk); ++j)
+	  norms[j] = sqrt(norms[j]);
+	if (fence && (blk!=1)) world.gop.fence();
+      }
+
+      world.gop.fence();
+      return norms;
     }
 
     /// Computes the 2-norm of a vector of functions
     // should be local; norms[0] contains the result
 
     template <typename T, std::size_t NDIM>
-    double norm2(World& world,
-	             const std::vector<Function<T, NDIM>>& v) {
-        PROFILE_BLOCK(Vnorm2);
-        std::vector<double> norms(v.size());
+      double norm2(World& world,
+		   const std::vector< Function<T,NDIM> >& v)
+      {
 
-        for (unsigned int i = 0; i < v.size(); ++i)
-            norms[i] = v[i].norm2sq_local();
+	PROFILE_BLOCK(Vnorm2);
 
-        world.gop.sum(&norms[0], norms.size());
+	std::vector<double> norms(v.size());
 
-        for (unsigned int i = 1; i < v.size(); ++i)
-            norms[0] += norms[i];
+	for (unsigned int i=0; i<v.size(); ++i)
+	  norms[i] = v[i].norm2sq_local();
 
-        world.gop.fence();
-        return sqrt(norms[0]);
-    }
+	world.gop.sum(&norms[0], norms.size());
+
+	for (unsigned int i=1; i<v.size(); ++i)
+	  norms[0] += norms[i];
+
+	world.gop.fence();
+	return sqrt(norms[0]);
+      }
 
     inline double conj(double x) {
-        return x;
+      return x;
     }
 
     inline double conj(float x) {
-        return x;
+      return x;
     }
 
 
     template <typename T, typename R, std::size_t NDIM>
     struct MatrixInnerTask : public TaskInterface {
-        Tensor<TENSOR_RESULT_TYPE(T, R)> result; // Must be a copy
-        const Function<T, NDIM>& f;
-        const std::vector< Function<R, NDIM> >& g;
+        Tensor<TENSOR_RESULT_TYPE(T,R)> result; // Must be a copy
+        const Function<T,NDIM>& f;
+        const std::vector< Function<R,NDIM> >& g;
         long jtop;
 
-        MatrixInnerTask(const Tensor<TENSOR_RESULT_TYPE(T, R)>& result,
-                        const Function<T, NDIM>& f,
-                        const std::vector<Function<R, NDIM>>& g,
-                        long jtop)
-            : result(result), f(f), g(g), jtop(jtop) {}
+        MatrixInnerTask(const Tensor<TENSOR_RESULT_TYPE(T,R)>& result,
+                const Function<T,NDIM>& f,
+                const std::vector< Function<R,NDIM> >& g,
+                long jtop)
+        : result(result), f(f), g(g), jtop(jtop) {}
 
         void run(World& world) {
-            for (long j = 0; j < jtop; ++j) {
+            for (long j=0; j<jtop; ++j) {
                 result(j) = f.inner_local(g[j]);
             }
         }
 
-        private:
-            /// Get the task id
+    private:
+        /// Get the task id
 
-            /// \param id The id to set for this task
-            virtual void get_id(std::pair<void*,unsigned short>& id) const {
-                PoolTaskInterface::make_id(id, *this);
-            }
+        /// \param id The id to set for this task
+        virtual void get_id(std::pair<void*,unsigned short>& id) const {
+            PoolTaskInterface::make_id(id, *this);
+        }
     }; // struct MatrixInnerTask
 
     /// Computes the matrix inner product of two function vectors - q(i,j) = inner(f[i],g[j])
@@ -482,456 +494,467 @@ namespace madness {
     /// The current parallel loop is non-optimal but functional.
 
     template <typename T, typename R, std::size_t NDIM>
-    Tensor<TENSOR_RESULT_TYPE(T, R)> matrix_inner(
-            World& world,
-            const std::vector<Function<T, NDIM>>& f,
-            const std::vector<Function<R, NDIM>>& g,
-            bool sym=false) {
-        PROFILE_BLOCK(Vmatrix_inner);
-        unsigned int n = f.size(), m = g.size();
-        Tensor< TENSOR_RESULT_TYPE(T, R) > r(n, m);
-        if (sym) MADNESS_ASSERT(n == m);
+      Tensor< TENSOR_RESULT_TYPE(T,R) > matrix_inner(World& world,
+						     const std::vector< Function<T,NDIM> >& f,
+						     const std::vector< Function<R,NDIM> >& g,
+						     bool sym=false) {
+      PROFILE_BLOCK(Vmatrix_inner);
+      unsigned int n=f.size(), m=g.size();
+      Tensor< TENSOR_RESULT_TYPE(T,R) > r(n,m);
+      if (sym) MADNESS_ASSERT(n==m);
 
-        world.gop.fence();
-        compress(world, f);
-        if (&f != &g) compress(world, g);
+      world.gop.fence();
+      compress(world, f);
+      if (&f != &g) compress(world, g);
 
-        // for (long i = 0; i < n; ++i) {
-        //     long jtop = m;
-        //     if (sym) jtop = i + 1;
-        //     for (long j = 0; j < jtop; ++j) {
-        //         r(i, j) = f[i].inner_local(g[j]);
-        //         if (sym) r(j, i) = conj(r(i, j));
-        //     }
-        // }
+      //         for (long i=0; i<n; ++i) {
+      //             long jtop = m;
+      //             if (sym) jtop = i+1;
+      //             for (long j=0; j<jtop; ++j) {
+      //                 r(i,j) = f[i].inner_local(g[j]);
+      //                 if (sym) r(j,i) = conj(r(i,j));
+      //             }
+      //         }
 
-        for (unsigned int i = n - 1; i >= 0; --i) {
-            unsigned int jtop = m;
-            if (sym) jtop = i + 1;
-                world.taskq.add(new MatrixInnerTask<T,R,NDIM>(r(i,_), f[i], g, jtop));
-        }
-        world.gop.fence();
-        world.gop.sum(r.ptr(),n*m);
+      for (unsigned int i=n-1; i>=0; --i) {
+	unsigned int jtop = m;
+	if (sym) jtop = i+1;
+	world.taskq.add(new MatrixInnerTask<T,R,NDIM>(r(i,_), f[i], g, jtop));
+      }
+      world.gop.fence();
+      world.gop.sum(r.ptr(),n*m);
 
-        if (sym) {
-            for (unsigned int i = 0; i < n; ++i) {
-                for (unsigned int j = 0; j < i; ++j) {
-                    r(j, i) = conj(r(i, j));
-                }
-            }
-        }
-        return r;
+      if (sym) {
+	for (unsigned int i=0; i<n; ++i) {
+	  for (unsigned int j=0; j<i; ++j) {
+	    r(j,i) = conj(r(i,j));
+	  }
+	}
+      }
+      return r;
     }
 
     /// Computes the element-wise inner product of two function vectors - q(i) = inner(f[i],g[i])
 
     template <typename T, typename R, std::size_t NDIM>
-    Tensor<TENSOR_RESULT_TYPE(T, R)> inner(
-            World& world,
-            const std::vector<Function<T, NDIM>>& f,
-            const std::vector<Function<R, NDIM>>& g) {
-        PROFILE_BLOCK(Vinnervv);
-        long n = f.size(), m = g.size();
-        MADNESS_ASSERT(n == m);
-        Tensor<TENSOR_RESULT_TYPE(T, R)> r(n);
+      Tensor< TENSOR_RESULT_TYPE(T,R) > inner(World& world,
+					      const std::vector< Function<T,NDIM> >& f,
+					      const std::vector< Function<R,NDIM> >& g) {
+      PROFILE_BLOCK(Vinnervv);
+      long n=f.size(), m=g.size();
+      MADNESS_ASSERT(n==m);
+      Tensor< TENSOR_RESULT_TYPE(T,R) > r(n);
 
-        compress(world, f);
-        compress(world, g);
+      compress(world, f);
+      compress(world, g);
 
-        for (long i = 0; i < n; ++i) {
-            r(i) = f[i].inner_local(g[i]);
-        }
+      for (long i=0; i<n; ++i) {
+	r(i) = f[i].inner_local(g[i]);
+      }
 
-        world.taskq.fence();
-        world.gop.sum(r.ptr(), n);
-        world.gop.fence();
-        return r;
+      world.taskq.fence();
+      world.gop.sum(r.ptr(),n);
+      world.gop.fence();
+      return r;
     }
 
 
     /// Computes the inner product of a function with a function vector - q(i) = inner(f,g[i])
 
     template <typename T, typename R, std::size_t NDIM>
-    Tensor<TENSOR_RESULT_TYPE(T, R)> inner(
-            World& world,
-            const Function<T,NDIM>& f,
-            const std::vector<Function<R, NDIM>>& g) {
-        PROFILE_BLOCK(Vinner);
-        long n = g.size();
-        Tensor<TENSOR_RESULT_TYPE(T, R)> r(n);
+      Tensor< TENSOR_RESULT_TYPE(T,R) > inner(World& world,
+					      const Function<T,NDIM>& f,
+					      const std::vector< Function<R,NDIM> >& g) {
+      PROFILE_BLOCK(Vinner);
+      long n=g.size();
+      Tensor< TENSOR_RESULT_TYPE(T,R) > r(n);
 
-        f.compress();
-        compress(world, g);
+      f.compress();
+      compress(world, g);
 
-        for (long i = 0; i < n; ++i) {
-            r(i) = f.inner_local(g[i]);
-        }
+      for (long i=0; i<n; ++i) {
+	r(i) = f.inner_local(g[i]);
+      }
 
-        world.taskq.fence();
-        world.gop.sum(r.ptr(),n);
-        world.gop.fence();
-        return r;
+      world.taskq.fence();
+      world.gop.sum(r.ptr(),n);
+      world.gop.fence();
+      return r;
     }
 
 
     /// Multiplies a function against a vector of functions --- q[i] = a * v[i]
 
     template <typename T, typename R, std::size_t NDIM>
-    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>> mul(
-            World& world,
-            const Function<T,NDIM>& a,
-            const std::vector<Function<R, NDIM>>& v,
-            const unsigned int blk=1,
-            const bool fence=true) {
-        PROFILE_BLOCK(Vmul);
-        a.reconstruct(false);
-        reconstruct(world, v, blk, false);
-        world.gop.fence();
-        return vmulXX(a, v, 0.0, fence);
+      std::vector< Function<TENSOR_RESULT_TYPE(T,R), NDIM> >
+      mul(World& world,
+	  const Function<T,NDIM>& a,
+	  const std::vector< Function<R,NDIM> >& v,
+	  const unsigned int blk=1,
+	  const bool fence=true) {
+
+      PROFILE_BLOCK(Vmul);
+      a.reconstruct(false);
+      reconstruct(world, v, blk, false);
+      world.gop.fence();
+      return vmulXX(a, v, 0.0, fence);
     }
 
     /// Multiplies a function against a vector of functions using sparsity of a and v[i] --- q[i] = a * v[i]
     template <typename T, typename R, std::size_t NDIM>
-    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>> mul_sparse(
-            World& world,
-            const Function<T, NDIM>& a,
-            const std::vector<Function<R, NDIM>>& v,
-            const double tol,
-            const bool fence=true,
-            const unsigned int blk=1) {
-        PROFILE_BLOCK(Vmulsp);
-        a.reconstruct(false);
-        reconstruct(world, v, blk, false);
-        world.gop.fence();
+      std::vector< Function<TENSOR_RESULT_TYPE(T,R), NDIM> >
+      mul_sparse(World& world,
+		 const Function<T,NDIM>& a,
+		 const std::vector< Function<R,NDIM> >& v,
+		 const double tol,
+		 const bool fence=true,
+		 const unsigned int blk=1)
+ {
+      PROFILE_BLOCK(Vmulsp);
+      a.reconstruct(false);
+      reconstruct(world, v, blk, false);
+      world.gop.fence();
 
-        unsigned int vvsize = v.size();
-        for (unsigned int i = 0; i < vvsize; i += blk) {
-            for (unsigned int j = i; j < std::min(vvsize,(i+1)*blk); ++j)
-                v[j].norm_tree(false);
-            if ( fence && (blk == 1)) world.gop.fence();
-        }
-        a.norm_tree();
-        return vmulXX(a, v, tol, fence);
+      unsigned int vvsize = v.size();
+      for (unsigned int i=0; i<vvsize; i+= blk) {
+	for (unsigned int j=i; j<std::min(vvsize,(i+1)*blk); ++j)
+	  v[j].norm_tree(false);
+	if ( fence && (blk == 1)) world.gop.fence();
+      }
+      a.norm_tree();
+      return vmulXX(a, v, tol, fence);
     }
 
     /// Makes the norm tree for all functions in a vector
     template <typename T, std::size_t NDIM>
-    void norm_tree(World& world,
-            const std::vector<Function<T, NDIM>>& v,
-            bool fence=true,
-            unsigned int blk=1){
+      void norm_tree(World& world,
+		     const std::vector< Function<T,NDIM> >& v,
+		     bool fence=true,
+		     unsigned int blk=1){
         PROFILE_BLOCK(Vnorm_tree);
 
-        unsigned int vvsize = v.size();
-        for (unsigned int i = 0; i < vvsize; i += blk) {
-            for (unsigned int j = i; j < std::min(vvsize,(i+1)*blk); ++j)
-                v[j].norm_tree(false);
-            if (fence && blk!=1 ) world.gop.fence();
-        }
-        if (fence) world.gop.fence();
+      unsigned int vvsize = v.size();
+      for (unsigned int i=0; i<vvsize; i+= blk) {
+	for (unsigned int j=i; j<std::min(vvsize,(i+1)*blk); ++j)
+	  v[j].norm_tree(false);
+        if (fence && blk!=1 ) world.gop.fence();
+      }
+      if (fence) world.gop.fence();
     }
 
     /// Multiplies two vectors of functions q[i] = a[i] * b[i]
 
     template <typename T, typename R, std::size_t NDIM>
-    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>> mul(
-            World& world,
-            const std::vector<Function<T, NDIM>>& a,
-            const std::vector<Function<R, NDIM>>& b,
-            bool fence=true,
-            unsigned int blk=1) {
-        PROFILE_BLOCK(Vmulvv);
-        reconstruct(world, a, blk, false);
-        if (&a != &b) reconstruct(world, b, blk, false);
-        world.gop.fence();
+      std::vector< Function<TENSOR_RESULT_TYPE(T,R), NDIM> >
+      mul(World& world,
+	  const std::vector< Function<T,NDIM> >& a,
+	  const std::vector< Function<R,NDIM> >& b,
+	  bool fence=true,
+	  unsigned int blk=1){
+      PROFILE_BLOCK(Vmulvv);
+      reconstruct(world, a, blk, false);
+      if (&a != &b) reconstruct(world, b, blk, false);
+      world.gop.fence();
 
-        std::vector<Function<TENSOR_RESULT_TYPE(T, R),NDIM>> q(a.size());
+      std::vector< Function<TENSOR_RESULT_TYPE(T,R),NDIM> > q(a.size());
 
-        unsigned int vvsize = a.size();
-        for (unsigned int i = 0; i < vvsize; i += blk) {
-            for (unsigned int j = i; j < std::min(vvsize, (i + 1) * blk); ++j)
-                q[j] = mul(a[j], b[j], false);
-            if (fence && (blk != 1)) world.gop.fence();
-        }
-        if (fence) world.gop.fence();
-        return q;
+      unsigned int vvsize = a.size();
+      for (unsigned int i=0; i<vvsize; i+= blk) {
+	for (unsigned int j=i; j<std::min(vvsize,(i+1)*blk); ++j)
+	  q[j] = mul(a[j], b[j], false);
+	if (fence && (blk !=1 )) world.gop.fence();
+      }
+      if (fence) world.gop.fence();
+      return q;
     }
 
 
     /// Computes the square of a vector of functions --- q[i] = v[i]**2
 
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T, NDIM>> square(World& world,
-                                          const std::vector<Function<T, NDIM>>& v,
-                                          bool fence=true) {
-        return mul<T,T,NDIM>(world, v, v, fence);
-        // std::vector<Function<T, NDIM>> vsq(v.size());
-        // for (unsigned int i = 0; i < v.size(); ++i) {
-        //     vsq[i] = square(v[i], false);
-        // }
-        // if (fence) world.gop.fence();
-        // return vsq;
+      std::vector< Function<T,NDIM> >
+      square(World& world,
+	     const std::vector< Function<T,NDIM> >& v,
+	     bool fence=true) {
+      return mul<T,T,NDIM>(world, v, v, fence);
+      //         std::vector< Function<T,NDIM> > vsq(v.size());
+      //         for (unsigned int i=0; i<v.size(); ++i) {
+      //             vsq[i] = square(v[i], false);
+      //         }
+      //         if (fence) world.gop.fence();
+      //         return vsq;
     }
 
     /// Sets the threshold in a vector of functions
 
     template <typename T, std::size_t NDIM>
-    void set_thresh(World& world,
-                    std::vector<Function<T, NDIM>>& v,
-                    double thresh,
-                    bool fence=true) {
-        for (unsigned int j = 0; j < v.size(); ++j) {
-            v[j].set_thresh(thresh,false);
-        }
-        if (fence) world.gop.fence();
+      void set_thresh(World& world,
+		      std::vector< Function<T,NDIM> >& v,
+		      double thresh,
+		      bool fence=true) {
+      for (unsigned int j=0; j<v.size(); ++j) {
+	v[j].set_thresh(thresh,false);
+      }
+      if (fence) world.gop.fence();
     }
 
     /// Returns the complex conjugate of the vector of functions
 
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T, NDIM>> conj(World& world,
-                                        const std::vector<Function<T, NDIM>>& v,
-                                        bool fence=true) {
-        PROFILE_BLOCK(Vconj);
-        std::vector<Function<T, NDIM>> r = copy(world, v); // Currently don't have oop conj
-        for (unsigned int i = 0; i < v.size(); ++i) {
-            r[i].conj(false);
-        }
-        if (fence) world.gop.fence();
-        return r;
+      std::vector< Function<T,NDIM> >
+      conj(World& world,
+	   const std::vector< Function<T,NDIM> >& v,
+	   bool fence=true){
+      PROFILE_BLOCK(Vconj);
+      std::vector< Function<T,NDIM> > r = copy(world, v); // Currently don't have oop conj
+      for (unsigned int i=0; i<v.size(); ++i) {
+	r[i].conj(false);
+      }
+      if (fence) world.gop.fence();
+      return r;
     }
 
 
     /// Returns a deep copy of a vector of functions
 
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T, NDIM>> copy(World& world,
-                                        const std::vector<Function<T, NDIM>>& v,
-                                        bool fence=true) {
-        PROFILE_BLOCK(Vcopy);
-        std::vector<Function<T, NDIM>> r(v.size());
-        for (unsigned int i = 0; i < v.size(); ++i) {
-            r[i] = copy(v[i], false);
-        }
-        if (fence) world.gop.fence();
-        return r;
+      std::vector< Function<T,NDIM> >
+      copy(World& world,
+	   const std::vector< Function<T,NDIM> >& v,
+	   bool fence=true) {
+      PROFILE_BLOCK(Vcopy);
+      std::vector< Function<T,NDIM> > r(v.size());
+      for (unsigned int i=0; i<v.size(); ++i) {
+	r[i] = copy(v[i], false);
+      }
+      if (fence) world.gop.fence();
+      return r;
     }
 
     /// Returns a vector of deep copies of of a function
 
     template <typename T, std::size_t NDIM>
-    std::vector<Function<T, NDIM>> copy(World& world,
-                                        const Function<T,NDIM>& v,
-                                        const unsigned int n,
-                                        bool fence=true) {
-        PROFILE_BLOCK(Vcopy1);
-        std::vector<Function<T, NDIM>> r(n);
-        for (unsigned int i = 0; i < n; ++i) {
-            r[i] = copy(v, false);
-        }
-        if (fence) world.gop.fence();
-        return r;
+      std::vector< Function<T,NDIM> >
+      copy(World& world,
+	   const Function<T,NDIM>& v,
+	   const unsigned int n,
+	   bool fence=true) {
+      PROFILE_BLOCK(Vcopy1);
+      std::vector< Function<T,NDIM> > r(n);
+      for (unsigned int i=0; i<n; ++i) {
+	r[i] = copy(v, false);
+      }
+      if (fence) world.gop.fence();
+      return r;
     }
 
     /// Returns new vector of functions --- q[i] = a[i] + b[i]
 
     template <typename T, typename R, std::size_t NDIM>
-    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>> add(
-            World& world,
-            const std::vector<Function<T, NDIM>>& a,
-            const std::vector<Function<R, NDIM>>& b,
-            bool fence=true,
-            unsigned int blk=1) {
-        PROFILE_BLOCK(Vadd);
-        MADNESS_ASSERT(a.size() == b.size());
-        compress(world, a, blk);
-        compress(world, b, blk);
+      std::vector< Function<TENSOR_RESULT_TYPE(T,R), NDIM> >
+      add(World& world,
+	  const std::vector< Function<T,NDIM> >& a,
+	  const std::vector< Function<R,NDIM> >& b,
+	  bool fence=true,
+	  unsigned int blk=1) {
+      PROFILE_BLOCK(Vadd);
+      MADNESS_ASSERT(a.size() == b.size());
+      compress(world, a, blk);
+      compress(world, b, blk);
 
-        std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>> r(a.size());
+      std::vector< Function<TENSOR_RESULT_TYPE(T,R),NDIM> > r(a.size());
 
-        unsigned int vvsize = a.size();
-        for (unsigned int i = 0; i < vvsize; i += blk) {
-            for (unsigned int j = i; j < std::min(vvsize, (i + 1) * blk); ++j)
-                r[j] = add(a[j], b[j], false);
-            if (fence && (blk !=1 )) world.gop.fence();
-        }
-        if (fence) world.gop.fence();
-        return r;
+      unsigned int vvsize = a.size();
+      for (unsigned int i=0; i<vvsize; i+= blk) {
+	for (unsigned int j=i; j<std::min(vvsize,(i+1)*blk); ++j)
+	  r[j] = add(a[j], b[j], false);
+	if (fence && (blk !=1 )) world.gop.fence();
+      }
+      if (fence) world.gop.fence();
+
+      return r;
     }
 
      /// Returns new vector of functions --- q[i] = a + b[i]
 
     template <typename T, typename R, std::size_t NDIM>
-    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>> add(
-            World& world,
-            const Function<T,NDIM> & a,
-            const std::vector<Function<R, NDIM>>& b,
-            bool fence=true,
-            unsigned int blk=1) {
-        PROFILE_BLOCK(Vadd1);
-        a.compress();
-        compress(world, b, blk);
+      std::vector< Function<TENSOR_RESULT_TYPE(T,R), NDIM> >
+      add(World& world,
+	  const Function<T,NDIM> & a,
+	  const std::vector< Function<R,NDIM> >& b,
+	   bool fence=true,
+	  unsigned int blk=1) {
 
-        std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>> r(b.size());
+      PROFILE_BLOCK(Vadd1);
+      a.compress();
+      compress(world, b, blk);
 
-        unsigned int vvsize = b.size();
-        for (unsigned int i = 0; i < vvsize; i += blk) {
-            for (unsigned int j = i; j < std::min(vvsize, (i + 1) * blk); ++j)
-                r[j] = add(a, b[j], false);
-            if (fence && (blk !=1 )) world.gop.fence();
-        }
-        if (fence) world.gop.fence();
-        return r;
+      std::vector< Function<TENSOR_RESULT_TYPE(T,R),NDIM> > r(b.size());
+
+      unsigned int vvsize = b.size();
+      for (unsigned int i=0; i<vvsize; i+= blk) {
+	for (unsigned int j=i; j<std::min(vvsize,(i+1)*blk); ++j)
+	  r[j] = add(a, b[j], false);
+	if (fence && (blk !=1 )) world.gop.fence();
+      }
+      if (fence) world.gop.fence();
+
+      return r;
     }
 
     template <typename T, typename R, std::size_t NDIM>
-    inline std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>> add(
-            World& world,
-            const std::vector<Function<R, NDIM>>& b,
-            const Function<T,NDIM> & a,
-            bool fence=true,
-            unsigned int blk=1) {
+      inline std::vector< Function<TENSOR_RESULT_TYPE(T,R), NDIM> >
+      add(World& world,
+	  const std::vector< Function<R,NDIM> >& b,
+	  const Function<T,NDIM> & a,
+	   bool fence=true,
+	  unsigned int blk=1) {
       return add(world, a, b, fence, blk);
     }
 
     /// Returns new vector of functions --- q[i] = a[i] - b[i]
 
     template <typename T, typename R, std::size_t NDIM>
-    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>> sub(
-            World& world,
-            const std::vector<Function<T, NDIM>>& a,
-            const std::vector<Function<R, NDIM>>& b,
-            bool fence=true,
-            unsigned int blk=1) {
-        PROFILE_BLOCK(Vsub);
-        MADNESS_ASSERT(a.size() == b.size());
-        compress(world, a, fence, blk);
-        compress(world, b, fence, blk);
+      std::vector< Function<TENSOR_RESULT_TYPE(T,R), NDIM> >
+      sub(World& world,
+	   const std::vector< Function<T,NDIM> >& a,
+	   const std::vector< Function<R,NDIM> >& b,
+	   bool fence=true,
+	   unsigned int blk=1) {
+      PROFILE_BLOCK(Vsub);
+      MADNESS_ASSERT(a.size() == b.size());
+      compress(world, a, fence, blk);
+      compress(world, b, fence, blk);
 
-        std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>> r(a.size());
+      std::vector< Function<TENSOR_RESULT_TYPE(T,R),NDIM> > r(a.size());
 
-        unsigned int vvsize = a.size();
-        for (unsigned int i = 0; i < vvsize; i += blk) {
-            for (unsigned int j = i; j < std::min(vvsize, (i + 1) * blk); ++j)
-                r[j] = sub(a[j], b[j], false);
-            if (fence && (blk !=1 )) world.gop.fence();
-        }
-        if (fence) world.gop.fence();
-        return r;
+      unsigned int vvsize = a.size();
+      for (unsigned int i=0; i<vvsize; i+= blk) {
+	for (unsigned int j=i; j<std::min(vvsize,(i+1)*blk); ++j)
+	  r[j] = sub(a[j], b[j], false);
+	if (fence && (blk !=1 )) world.gop.fence();
+      }
+      if (fence) world.gop.fence();
+      return r;
     }
 
 
     /// Generalized A*X+Y for vectors of functions ---- a[i] = alpha*a[i] + beta*b[i]
 
     template <typename T, typename Q, typename R, std::size_t NDIM>
-    void gaxpy(World& world,
-               Q alpha,
-               std::vector<Function<T, NDIM>>& a,
-               Q beta,
-               const std::vector<Function<R, NDIM>>& b,
-               unsigned int blk=1,
-               bool fence=true) {
-        PROFILE_BLOCK(Vgaxpy);
-        MADNESS_ASSERT(a.size() == b.size());
-        compress(world, a, fence, blk);
-        compress(world, b, fence, blk);
+      void gaxpy(World& world,
+		 Q alpha,
+		 std::vector< Function<T,NDIM> >& a,
+		 Q beta,
+		 const std::vector< Function<R,NDIM> >& b,
+		 unsigned int blk=1,
+		 bool fence=true) {
+      PROFILE_BLOCK(Vgaxpy);
+      MADNESS_ASSERT(a.size() == b.size());
+      compress(world, a, fence, blk);
+      compress(world, b, fence, blk);
 
-        unsigned int vvsize = a.size();
+      unsigned int vvsize = a.size();
 
-        for (unsigned int i = 0; i < vvsize; i += blk) {
-            for (unsigned int j = i; j < std::min(vvsize, (i + 1) * blk); ++j)
-                a[j].gaxpy(alpha, b[j], beta, false);
-            if (fence && (blk !=1 )) world.gop.fence();
-        }
-        // for (unsigned int i = 0; i < a.size(); ++i) {
-        //     a[i].gaxpy(alpha, b[i], beta, false);
-        // }
-        if (fence) world.gop.fence();
+      for (unsigned int i=0; i<vvsize; i+= blk) {
+	for (unsigned int j=i; j<std::min(vvsize,(i+1)*blk); ++j)
+	  a[j].gaxpy(alpha, b[j], beta, false);
+
+	if (fence && (blk !=1 )) world.gop.fence();
+
+      }
+      //      for (unsigned int i=0; i<a.size(); ++i) {
+      // 	a[i].gaxpy(alpha, b[i], beta, false);
+      // }
+      if (fence) world.gop.fence();
     }
 
 
     /// Applies a vector of operators to a vector of functions --- q[i] = apply(op[i],f[i])
 
     template <typename opT, typename R, std::size_t NDIM>
-    std::vector<Function<TENSOR_RESULT_TYPE(typename opT::opT, R), NDIM>>
-    apply(World& world,
-          const std::vector<std::shared_ptr<opT>>& op,
-          const std::vector<Function<R, NDIM>> f,
-          const unsigned int blk=1){
-        PROFILE_BLOCK(Vapplyv);
-        MADNESS_ASSERT(f.size() == op.size());
+      std::vector< Function<TENSOR_RESULT_TYPE(typename opT::opT,R), NDIM> >
+      apply(World& world,
+	    const std::vector< std::shared_ptr<opT> >& op,
+	    const std::vector< Function<R,NDIM> > f,
+	    const unsigned int blk=1){
 
-        std::vector<Function<R, NDIM>>& ncf = *const_cast<std::vector<Function<R, NDIM>>*>(&f);
+      PROFILE_BLOCK(Vapplyv);
+      MADNESS_ASSERT(f.size()==op.size());
 
-        reconstruct(world, f, blk);
-        nonstandard(world, ncf, blk);
+      std::vector< Function<R,NDIM> >& ncf = *const_cast< std::vector< Function<R,NDIM> >* >(&f);
 
-        std::vector<Function<TENSOR_RESULT_TYPE(typename opT::opT, R), NDIM>> result(f.size());
-        unsigned int ff = f.size();
+      reconstruct(world, f, blk);
+      nonstandard(world, ncf, blk);
 
-        for (unsigned int i = 0; i < ff; ++blk) {
-            for (unsigned int j = i; j < std::min(ff,(i+1)*blk); ++j)
-                result[j] = apply_only(*op[j], f[j], false);
-            if (blk !=1)
-            world.gop.fence();
-        }
+      std::vector< Function<TENSOR_RESULT_TYPE(typename opT::opT,R), NDIM> > result(f.size());
+      unsigned int ff = f.size();
 
-        world.gop.fence();
+      for (unsigned int i=0; i<ff; ++blk) {
+	for (unsigned int j=i; j<std::min(ff,(i+1)*blk); ++j)
+	  result[j] = apply_only(*op[j], f[j], false);
+	if (blk !=1)
+	  world.gop.fence();
+      }
 
-        standard(world, ncf, false);  // restores promise of logical constness
-        world.gop.fence();
-        reconstruct(world, result, blk);
+      world.gop.fence();
 
-        return result;
+      standard(world, ncf, false);  // restores promise of logical constness
+      world.gop.fence();
+      reconstruct(world, result, blk);
+
+      return result;
     }
 
 
     /// Applies an operator to a vector of functions --- q[i] = apply(op,f[i])
 
     template <typename T, typename R, std::size_t NDIM>
-    std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>>
-    apply(World& world,
-          const SeparatedConvolution<T, NDIM>& op,
-          const std::vector<Function<R, NDIM>> f,
-          const unsigned int blk=1) {
-        PROFILE_BLOCK(Vapply);
+      std::vector< Function<TENSOR_RESULT_TYPE(T,R), NDIM> >
+      apply(World& world,
+	    const SeparatedConvolution<T,NDIM>& op,
+	    const std::vector< Function<R,NDIM> > f,
+	    const unsigned int blk=1) {
+      PROFILE_BLOCK(Vapply);
 
-        std::vector<Function<R, NDIM>>& ncf = *const_cast< std::vector<Function<R, NDIM>>* >(&f);
+      std::vector< Function<R,NDIM> >& ncf = *const_cast< std::vector< Function<R,NDIM> >* >(&f);
 
-        reconstruct(world, f, blk);
-        nonstandard(world, ncf, blk);
+      reconstruct(world, f, blk);
+      nonstandard(world, ncf, blk);
 
-        std::vector<Function<TENSOR_RESULT_TYPE(T, R), NDIM>> result(f.size());
+      std::vector< Function<TENSOR_RESULT_TYPE(T,R), NDIM> > result(f.size());
 
-        unsigned int ff = f.size();
-        for (unsigned int i = 0; i < ff; ++i) {
-            for (unsigned int j = i; j < std::min(ff, (i + 1) * blk); ++j)
-                result[j] = apply_only(op, f[j], false);
-            if (blk !=1) world.gop.fence();
-        }
-        world.gop.fence();
+      unsigned int ff = f.size();
+      for (unsigned int i=0; i<ff; ++blk) {
+	for (unsigned int j=i; j<std::min(ff,(i+1)*blk); ++j)
+	  result[j] = apply_only(op, f[j], false);
+	if (blk !=1)
+	  world.gop.fence();
+      }
+      world.gop.fence();
 
-        standard(world, ncf, blk, false);  // restores promise of logical constness
-        world.gop.fence();
-        reconstruct(world, result, blk);
+      standard(world, ncf, blk, false);  // restores promise of logical constness
+      world.gop.fence();
+      reconstruct(world, result, blk);
 
-        return result;
+      return result;
     }
 
     /// Normalizes a vector of functions --- v[i] = v[i].scale(1.0/v[i].norm2())
 
     template <typename T, std::size_t NDIM>
-    void normalize(World& world,
-		           std::vector<Function<T, NDIM>>& v,
-		           bool fence=true){
-        PROFILE_BLOCK(Vnormalize);
-        std::vector<double> nn = norm2s(world, v);
+      void normalize(World& world,
+		     std::vector< Function<T,NDIM> >& v,
+		     bool fence=true){
 
-        for (unsigned int i = 0; i < v.size(); ++i)
-            v[i].scale(1.0 / nn[i], false);
+      PROFILE_BLOCK(Vnormalize);
+      std::vector<double> nn = norm2s(world, v);
 
-        if (fence) world.gop.fence();
+      for (unsigned int i=0; i<v.size(); ++i)
+	v[i].scale(1.0/nn[i],false);
+
+      if (fence) world.gop.fence();
     }
 
-}  // namespace madness
+}
 #endif // MADNESS_MRA_VMRA_H__INCLUDED


### PR DESCRIPTION
### Description
Adds `matrix_dot` to perform an inner product without conjugation in the bra.

### Details
- [X] Introduces `matrix_dot` functions in vmra.h
- [X] Copies `inner_local` in funcimpl.h to `dot_local` removing complex conjugation in `dot_local_X`
- [X] Adds checks using `MADNESS_CHECK` to testvmra.cc so that test fails if error threshold is not met
- [X] Update some structs to be explicitly defaulted