### PR TITLE
Customizable is_trivially_copyable

### DIFF
--- a/src/madness/world/type_traits.h
+++ b/src/madness/world/type_traits.h
@@ -213,6 +213,13 @@ namespace madness {
     template <typename T> struct is_any_function_pointer<T, std::enable_if_t<std::is_member_function_pointer<T>::value || is_function_pointer_v<T>>> : public std::true_type {};
     template <typename T> constexpr bool is_any_function_pointer_v = is_any_function_pointer<T>::value;
 
+    /// trait for trivial (=bitwise) copyability of T, defaults to std::is_trivially_copyable<T> but can be specialized as needed
+    template <typename T>
+    struct is_trivially_copyable : std::is_trivially_copyable<T> {};
+
+    template <typename T>
+    inline constexpr bool is_trivially_copyable_v = is_trivially_copyable<T>::value;
+
     /// This defines stuff that is serializable by bitwise copy.
     /// \warning This reports true for \c T that is an aggregate type
     ///          (struct or array) that includes pointers.

--- a/src/madness/world/worldgop.h
+++ b/src/madness/world/worldgop.h
@@ -730,19 +730,19 @@ namespace madness {
         /// Broadcasts typed contiguous data from process root while still processing AM & tasks
 
         /// Optimizations can be added for long messages
-        template <typename T, typename = std::enable_if_t<std::is_trivially_copyable_v<T>>>
+        template <typename T, typename = std::enable_if_t<madness::is_trivially_copyable_v<T>>>
         inline void broadcast(T* buf, size_t nelem, ProcessID root) {
             broadcast((void *) buf, nelem*sizeof(T), root);
         }
 
         /// Broadcast of a scalar from node 0 to all other nodes
-        template <typename T, typename = std::enable_if_t<std::is_trivially_copyable_v<T>>>
+        template <typename T, typename = std::enable_if_t<madness::is_trivially_copyable_v<T>>>
         void broadcast(T& t) {
             broadcast(&t, 1, 0);
         }
 
         /// Broadcast of a scalar from node root to all other nodes
-        template <typename T, typename = std::enable_if_t<std::is_trivially_copyable_v<T>>>
+        template <typename T, typename = std::enable_if_t<madness::is_trivially_copyable_v<T>>>
         void broadcast(T& t, ProcessID root) {
             broadcast(&t, 1, root);
         }
@@ -781,7 +781,7 @@ namespace madness {
         /// Optimizations can be added for long messages and to reduce the memory footprint
         template <typename T, class opT>
             void reduce(T* buf, std::size_t nelem, opT op) {
-          static_assert(std::is_trivially_copyable_v<T>, "T must be trivially copyable");
+          static_assert(madness::is_trivially_copyable_v<T>, "T must be trivially copyable");
 
           ProcessID parent, child0, child1;
           world_.mpi.binary_tree_info(0, parent, child0, child1);


### PR DESCRIPTION
Allows one to create a specialized `madness::is_trivially_copyable` for custom classes.
Developer needs to ensure that their class is trivial (bitwise), if they create a specialization.
Defaults to `std::is_trivially_copyable`.