### PR TITLE
Fix to do_dot_localX for GenTensor

### DIFF
--- a/src/madness/mra/funcimpl.h
+++ b/src/madness/mra/funcimpl.h
@@ -50,7 +50,6 @@
 #include <madness/mra/function_factory.h>
 
 #include "leafop.h"
-#include "type_data.h"
 
 namespace madness {
     template <typename T, std::size_t NDIM>

--- a/src/madness/mra/funcimpl.h
+++ b/src/madness/mra/funcimpl.h
@@ -50,6 +50,7 @@
 #include <madness/mra/function_factory.h>
 
 #include "leafop.h"
+#include "type_data.h"
 
 namespace madness {
     template <typename T, std::size_t NDIM>
@@ -5720,6 +5721,7 @@ template<size_t NDIM>
                                   const bool sym,
                                   Tensor<TENSOR_RESULT_TYPE(T, R)>* result_ptr,
                                   Mutex* mutex) {
+            if (TensorTypeData<T>::iscomplex) MADNESS_EXCEPTION("no complex trace in LowRankTensor, sorry", 1);
             Tensor<TENSOR_RESULT_TYPE(T, R)>& result = *result_ptr;
             Tensor<TENSOR_RESULT_TYPE(T, R)> r(result.dim(0), result.dim(1));
             for (typename mapT::iterator lit = lstart; lit != lend; ++lit) {

--- a/src/madness/mra/funcimpl.h
+++ b/src/madness/mra/funcimpl.h
@@ -5631,7 +5631,7 @@ template<size_t NDIM>
             return map;
         }
 
-#if HAVE_GENTENSOR
+#if 0
 // Original
         template <typename R>
         static void do_inner_localX(const typename mapT::iterator lstart,
@@ -5692,8 +5692,8 @@ template<size_t NDIM>
                    Tensor<T> Left(nleft, size);
                    Tensor<R> Right(nright, size);
                    Tensor< TENSOR_RESULT_TYPE(T,R)> r(nleft, nright);
-                   for(unsigned int iv = 0; iv < nleft; ++iv) Left(iv,_) = *(leftv[iv].second);
-                   for(unsigned int jv = 0; jv < nright; ++jv) Right(jv,_) = *(rightv[jv].second);
+                   for(unsigned int iv = 0; iv < nleft; ++iv) Left(iv,_) = (*(leftv[iv].second)).full_tensor();
+                   for(unsigned int jv = 0; jv < nright; ++jv) Right(jv,_) = (*(rightv[jv].second)).full_tensor();
                    // call mxmT from mxm.h in tensor
                    if(TensorTypeData<T>::iscomplex) Left = Left.conj();  // Should handle complex case and leave real case alone
                    mxmT(nleft, nright, size, r.ptr(), Left.ptr(), Right.ptr());
@@ -5711,7 +5711,7 @@ template<size_t NDIM>
        }
 #endif
 
-#if HAVE_GENTENSOR
+#if 0
 // Original
         template <typename R, typename = std::enable_if_t<std::is_floating_point_v<R>>>
         static void do_dot_localX(const typename mapT::iterator lstart,
@@ -5773,8 +5773,8 @@ template<size_t NDIM>
                    Tensor<T> Left(nleft, size);
                    Tensor<R> Right(nright, size);
                    Tensor< TENSOR_RESULT_TYPE(T, R)> r(nleft, nright);
-                   for(unsigned int iv = 0; iv < nleft; ++iv) Left(iv, _) = *(leftv[iv].second);
-                   for(unsigned int jv = 0; jv < nright; ++jv) Right(jv, _) = *(rightv[jv].second);
+                   for(unsigned int iv = 0; iv < nleft; ++iv) Left(iv, _) = (*(leftv[iv].second)).full_tensor();
+                   for(unsigned int jv = 0; jv < nright; ++jv) Right(jv, _) = (*(rightv[jv].second)).full_tensor();
                    // call mxmT from mxm.h in tensor
                    mxmT(nleft, nright, size, r.ptr(), Left.ptr(), Right.ptr());
                    mutex->lock();

--- a/src/madness/mra/funcimpl.h
+++ b/src/madness/mra/funcimpl.h
@@ -5713,7 +5713,7 @@ template<size_t NDIM>
 
 #if HAVE_GENTENSOR
 // Original
-        template <typename R>
+        template <typename R, typename = std::enable_if_t<std::is_floating_point_v<R>>>
         static void do_dot_localX(const typename mapT::iterator lstart,
                                   const typename mapT::iterator lend,
                                   typename FunctionImpl<R, NDIM>::mapT* rmap_ptr,
@@ -5740,7 +5740,7 @@ template<size_t NDIM>
                             const GenTensor<R>* jptr = rightv[jv].second;
 
                             if (!sym || (sym && i <= j))
-                                r(i, j) += iptr->trace(*jptr);
+                                r(i, j) += iptr->trace_conj(*jptr);
                         }
                     }
                 }


### PR DESCRIPTION
### Description
GenTensor does not do [trace of <this|rhs>](https://github.com/m-a-d-n-e-s-s/madness/blob/577c2980cbc83ab49ab9eb99d69a3bbdfd09fa0f/src/madness/tensor/lowranktensor.h#L510) for complex LowRankTensor.

### Details
- [X] Add `std::enable_if_t` to [`do_dot_localX`](https://github.com/m-a-d-n-e-s-s/madness/blob/577c2980cbc83ab49ab9eb99d69a3bbdfd09fa0f/src/madness/mra/funcimpl.h#L5716) for GenTensor implementation.
- [X] Replace `trace` with `trace_conj` in [`do_dot_localX`](https://github.com/m-a-d-n-e-s-s/madness/blob/577c2980cbc83ab49ab9eb99d69a3bbdfd09fa0f/src/madness/mra/funcimpl.h#L5743) for GenTensor implementation. `trace` does not exist for GenTensor.
- [X] Disables HAVE_GENTENSOR implementation, implementation uses GenTensor full_tensor() which will throw if GenTensor does not have Tensor.