### PR TITLE
Fix restartdata reading in `molresponse`

### DIFF
--- a/src/apps/molresponse/ground_parameters.h
+++ b/src/apps/molresponse/ground_parameters.h
@@ -25,8 +25,7 @@ using namespace madness;
 class GroundStateCalculation {
     // Ground state parameters that are read in from archive
     std::string inFile{"../moldft.restartdata"};///< Name of input archive to read in ground state
-    bool spinrestricted{true};///< Indicates if ground state calc. was open or closed
-    ///< shell
+    bool spinrestricted{true};///< Indicates if ground state calc. was open or closed shell
     unsigned int num_orbitals{};///< Number of orbitals in ground state
     Tensor<double> energies{};  ///< Energy of ground state orbitals
     Tensor<double> occ{};       ///< Occupancy of ground state orbitals
@@ -35,7 +34,7 @@ class GroundStateCalculation {
     Molecule molecule_in{};     ///< The molecule used in ground state calculation
     std::vector<real_function_3d> g_orbitals{};///< The ground state orbitals
     std::string xc{};                          ///< Name of xc functional used in ground state
-    std::string localize_method{};             ///< Name of xc functional used in ground state
+    std::string localize_method{};             ///< Name of localization method used in ground state
     double converged_for_thresh{}; ///< Convergence threshold used in ground state calculation
 
     // Default constructor

--- a/src/apps/molresponse/ground_parameters.h
+++ b/src/apps/molresponse/ground_parameters.h
@@ -36,6 +36,7 @@ class GroundStateCalculation {
     std::vector<real_function_3d> g_orbitals{};///< The ground state orbitals
     std::string xc{};                          ///< Name of xc functional used in ground state
     std::string localize_method{};             ///< Name of xc functional used in ground state
+    double converged_for_thresh{}; ///< Convergence threshold used in ground state calculation
 
     // Default constructor
 public:
@@ -87,6 +88,7 @@ public:
         input &molecule_in;    // Molecule
         input &xc;             // std:string        xc functional
         input &localize_method;// std:string        localize  method
+        input &converged_for_thresh; // double      convergence threshold used for ground state
         input &num_orbitals;   // int
         input &energies;       // Tensor<double>    orbital energies
         input &occ;            // Tensor<double>    orbital occupations

--- a/src/madness/chem/SCF.cc
+++ b/src/madness/chem/SCF.cc
@@ -331,7 +331,7 @@ void SCF::save_mos(World& world) {
     ar & version;
     ar & current_energy & param.spin_restricted();
     ar & param.L() & FunctionDefaults<3>::get_k() & molecule & param.xc() & param.localize_method() & converged_for_thresh;
-    // Re order so it doesn't effect orbital data
+    // Reorder so it doesn't affect orbital data
 
     ar & (unsigned int) (amo.size());
     ar & aeps & aocc & aset;
@@ -377,7 +377,8 @@ void SCF::load_mos(World& world) {
       int k;
       Molecule molecule;
       std::string xc;
-    std::string localize;
+      std::string localize;
+      double converged_for_thresh
       unsigned int nmo_alpha;
       Tensor<double> aeps;
       Tensor<double> aocc;


### PR DESCRIPTION
3f361977e32d766bcbfb38a74b9064ce58149c5e Introduced `converged_for_thresh` in `SCF::save_mos`. This PR updates `GroundStateCalculation` to correctly read from the restart file. 