### PR TITLE
Update DFdriver

### DIFF
--- a/src/apps/dirac/DF.cc
+++ b/src/apps/dirac/DF.cc
@@ -465,7 +465,7 @@ DF::DF(World & world,std::shared_ptr<std::istream> input) {
 
 //returns a new Fcwf that is the result of applying the Dirac free-particle hamiltonian on psi
 Fcwf apply_T(World& world, Fcwf& psi){
-     double myc = 137.0359895; //speed of light in atomic units
+     double myc = 137.03599917697017; //speed of light in atomic units from CODATA 2022
      std::complex<double> myi(0,1);
      complex_derivative_3d Dx(world,0);
      complex_derivative_3d Dy(world,1);
@@ -520,7 +520,7 @@ void DF::exchange(World& world, real_convolution_3d& op, std::vector<Fcwf>& Kpsi
 
      //Calculate and accumulate exchange contributions
      unsigned int n = Init_params.num_occupied;
-     double myc = 137.0359895; //speed of light in atomic units
+     double myc = 137.03599917697017; //speed of light in atomic units from CODATA 2022
 
      //Calculates exchange contributions from the orbitals that we have stored
      //Loop through orbitals phi_i, computing K(phi_i), and while we're at it, use symmetry to start calculating contributions to later orbitals
@@ -1029,7 +1029,7 @@ void DF::orthogonalize_inplace(World& world){
 void apply_BSH(World& world, Fcwf& Vpsi, double& eps, double& small, double& thresh){
 
      //necessary constants
-     double myc = 137.0359895; //speed of light
+     double myc = 137.03599917697017; //speed of light in a.u. from CODATA 2022
      double c2 = myc*myc; //speed of light squared
      std::complex<double> myi(0,1); //imaginary number i
      std::complex<double> ic = myi*myc; //i*c
@@ -1099,7 +1099,7 @@ void apply_BSH(World& world, Fcwf& Vpsi, double& eps, double& small, double& thr
 void apply_BSH_new(World& world, Fcwf& Vpsi, double& eps, double& small, double& thresh){
 
      //necessary constants
-     double myc = 137.0359895; //speed of light
+     double myc = 137.03599917697017; //speed of light in a.u. from CODATA 2022
      double c2 = myc*myc; //speed of light squared
      std::complex<double> myi(0,1); //imaginary number i
      //std::complex<double> ic = myi*myc; //i*c
@@ -1612,7 +1612,7 @@ bool DF::iterate(World& world, real_function_3d& V, real_convolution_3d& op, rea
      double exchange_energy = 0.0;
      double nuclear_attraction_energy = 0.0;
      double old_total_energy = total_energy;
-     double myc = 137.0359895; //speed of light
+     double myc = 137.03599917697017; //speed of light in a.u. from CODATA 2022
      Tensor<double> nuclear_attraction_tensor;
      Tensor<double> coulomb_tensor;
      Tensor<double> exchange_tensor;

--- a/src/apps/dirac/DF.cc
+++ b/src/apps/dirac/DF.cc
@@ -1591,11 +1591,12 @@ DF::iterate(World &world, real_function_3d &V, real_convolution_3d &op,
      //If any residual is still larger than the tolerance then we need to iterate again.
      //Can just enforce this on the max residual
      auto drho = (prev_rho - rho).norm2();
+     auto dconv = (DFparams.thresh < 5e-8) ? 10 * DFparams.thresh : DFparams.thresh;
      const auto nelec = rho.trace();
      if(maxresidual <= tolerance) {
           iterate_again = false;
           printf("\nConverge due to residuals");
-     } else if (std::abs((total_energy - prev_energy) / total_energy) <= DFparams.thresh && drho <= 10 * DFparams.thresh * nelec
+     } else if (std::abs((total_energy - prev_energy) / total_energy) <= DFparams.thresh && drho <= dconv * nelec
                 && maxresidual <= 1e2 * tolerance) {
           iterate_again = false;
           printf("\nConverge due to energy, density, and residuals");

--- a/src/apps/dirac/DF.cc
+++ b/src/apps/dirac/DF.cc
@@ -1591,15 +1591,16 @@ DF::iterate(World &world, real_function_3d &V, real_convolution_3d &op,
      //If any residual is still larger than the tolerance then we need to iterate again.
      //Can just enforce this on the max residual
      auto drho = (prev_rho - rho).norm2();
-     auto dconv = (DFparams.thresh < 5e-8) ? 10 * DFparams.thresh : DFparams.thresh;
+     if(world.rank()==0) printf("                density norm: %.10e\n",drho);
+     if(world.rank()==0) printf("                tolerance: %.10e\n",DFparams.dconv);
      const auto nelec = rho.trace();
      if(maxresidual <= tolerance) {
           iterate_again = false;
-          printf("\nConverge due to residuals");
-     } else if (std::abs((total_energy - prev_energy) / total_energy) <= DFparams.thresh && drho <= dconv * nelec
+          if (world.rank() == 0)  printf("\nConverged due to residuals");
+     } else if (std::abs((total_energy - prev_energy) / total_energy) <= DFparams.thresh && drho <= DFparams.dconv * nelec
                 && maxresidual <= 1e2 * tolerance) {
           iterate_again = false;
-          printf("\nConverge due to energy, density, and residuals");
+          if (world.rank() == 0) printf("\nConverged due to energy, density, and residuals");
      }
 
      //Apply the kain solver, if called for

--- a/src/apps/dirac/DF.h
+++ b/src/apps/dirac/DF.h
@@ -110,6 +110,12 @@ class DF {
           //Creates the fermi nuclear potential from the molecule object. Also calculates the nuclear repulsion energy
           void make_fermi_potential(World& world, real_convolution_3d& op, real_function_3d& potential, double& nuclear_repulsion_energy);
 
+          //Creates the point nuclear potential from the molecule object
+          void make_point_potential(World& world, real_function_3d& potential);
+
+          //Creates the point nuclear potential from the molecule object. Also calculates the nuclear repulsion energy
+          void make_point_potential(World& world, real_function_3d& potential, double& nuclear_repulsion_energy);
+
           //Load balancing function
           void DF_load_balance(World& world, real_function_3d& Vnuc);
 

--- a/src/apps/dirac/DF.h
+++ b/src/apps/dirac/DF.h
@@ -5,6 +5,7 @@
 #include <madness/mra/operator.h>
 #include <madness/constants.h>
 #include <madness/mra/nonlinsol.h>  // The kain solver
+#include <tuple>
 #include <vector>
 #include <math.h>
 #include <stdio.h>
@@ -120,8 +121,14 @@ class DF {
           void DF_load_balance(World& world, real_function_3d& Vnuc);
 
           //Does one full SCF iteration
-          bool iterate(World& world, real_function_3d& V, real_convolution_3d& op, real_function_3d& JandV, std::vector<Fcwf>& Kpsis, XNonlinearSolver<std::vector<Fcwf>, std::complex<double>, Fcwf_vector_allocator>& kainsolver, double& tolerance, int& iteration_number, double& nuclear_repulsion_energy);
-                
+          std::tuple<bool, double, real_function_3d>
+          iterate(World &world, real_function_3d &V, real_convolution_3d &op,
+                  real_function_3d &JandV, std::vector<Fcwf> &Kpsis,
+                  XNonlinearSolver<std::vector<Fcwf>, std::complex<double>,
+                                   Fcwf_vector_allocator> &kainsolver,
+                  double &tolerance, int &iteration_number,
+                  double &nuclear_repulsion_energy, double &prev_energy,
+                  real_function_3d &prev_rho);
 
           //Runs the job specified in the input parameters
           void solve(World& world);

--- a/src/apps/dirac/DFParameters.h
+++ b/src/apps/dirac/DFParameters.h
@@ -40,7 +40,8 @@ namespace madness {
           bool nwchem;                 ///< Indicates archive given is actually an nwchem file for starting the job
           bool lineplot;               ///< Whether or not to make lineplots at the end of the job
           bool no_compute;             ///< If true, will skip all computation
-          double bohr_rad;             ///< bohr radius in fm (default: 52917.7211)
+          double bohr_rad;             ///< bohr radius in fm (default: 52917.7210544 CODATA2022) 
+          double speed_of_light;       ///< speed_of_light in au (default: 137.03599917697017 CODATA2022)
           int min_iter;                ///< minimum number of iterations (default: 2)
           bool Krestricted;            ///< Calculation should be performed in Kramers-restricted manner (default: false)
           //!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -74,6 +75,7 @@ namespace madness {
           , lineplot(false)
           , no_compute(false)
           , bohr_rad(52917.7210544)  // bohr radius in fm from CODATA 2022
+          , speed_of_light(137.03599917697017) // speed of light in atomic units from CODATA 2022
           , min_iter(2)
           , Krestricted(false)
           {}
@@ -151,6 +153,9 @@ namespace madness {
                     else if (s == "bohr_rad"){
                          f >> bohr_rad;
                     }
+                    else if (s == "speed_of_light"){
+                         f >> speed_of_light;
+                    }
                     else if (s == "min_iter"){
                          f >> min_iter;
                     }
@@ -173,6 +178,8 @@ namespace madness {
                madness::print("          Refinement Threshold:", thresh);
                madness::print("                             k:", k);
                madness::print("Smallest Resolved Length Scale:", small);
+               madness::print("             Bohr radius in fm:", bohr_rad);
+               madness::print("          Speed of light in au:", speed_of_light);
                madness::print("                Max Iterations:", max_iter);
                madness::print("               Use KAIN Solver:", kain);
                if(kain) madness::print("     KAIN Solver Subspace Size:", maxsub);

--- a/src/apps/dirac/DFParameters.h
+++ b/src/apps/dirac/DFParameters.h
@@ -71,7 +71,7 @@ namespace madness {
           , nwchem(false)
           , lineplot(false)
           , no_compute(false)
-          , bohr_rad(52917.7211)
+          , bohr_rad(52917.7210544)  // bohr radius in fm from CODATA 2022
           , min_iter(2)
           , Krestricted(false)
           {}

--- a/src/apps/dirac/DFParameters.h
+++ b/src/apps/dirac/DFParameters.h
@@ -27,6 +27,7 @@ namespace madness {
           int max_iter;                ///< Maximum number of iterations
           double small;                ///< Minimum length scale to be resolved
           double thresh;               ///< Accuracy criterion when truncating
+          double dconv;                ///< Accuracy criterion for charge density. Defaults to thresh.
           int k;                       ///< Number of legendre polynomials in scaling basis
           bool kain;                   ///< Turns on KAIN nonlinear solver 
           int maxsub;                  ///< Sets maximum subspace size for KAIN
@@ -59,6 +60,7 @@ namespace madness {
           , max_iter(20)
           , small(1e-5)
           , thresh(1e-6)
+          , dconv(1e-6)
           , k(8)
           , kain(false)
           , maxsub(10)
@@ -105,6 +107,10 @@ namespace madness {
                     }
                     else if (s == "thresh"){
                          f >> thresh;
+                         dconv = thresh;
+                    }
+                    else if (s == "dconv"){
+                         f >> dconv;
                     }
                     else if (s == "k"){
                          f >> k;

--- a/src/apps/dirac/DFParameters.h
+++ b/src/apps/dirac/DFParameters.h
@@ -175,6 +175,9 @@ namespace madness {
                if(nucleus == 1){
                     madness::print("                       Nucleus: fermi");
                }
+               else if (nucleus == 2) {
+                    madness::print("                       Nucleus: point");
+               }
                else{
                     madness::print("                       Nucleus: gaussian");
                }

--- a/src/apps/dirac/InitParameters.h
+++ b/src/apps/dirac/InitParameters.h
@@ -129,7 +129,7 @@ namespace madness{
                          real_function_3d yfunc = real_factory_3d(world).f(myyfunc);
                          
                          //Handle Kramers-restricted and unrestricted cases differently
-                         if(Krestricted){
+                         if(Krestricted || closed_shell){
                               //Loop over the occupied orbitals and convert
                               for(unsigned int i = 0; i < num_occupied; i++){
                                    //read in orbital

--- a/src/apps/dirac/InitParameters.h
+++ b/src/apps/dirac/InitParameters.h
@@ -35,7 +35,7 @@ namespace madness{
           InitParameters() {}
 
           // Initializes InitParameters using the contents of file \c filename
-          void read(World& world, const std::string& filename, bool restart, bool Krestricted){ 
+          void read(World& world, const std::string& filename, const double& myc, bool restart, bool Krestricted){ 
                // Save the filename
                inFile = filename;
   
@@ -63,7 +63,7 @@ namespace madness{
 
                     //Now we just have to unpack the orbitals
                     for(unsigned int i=0; i < num_occupied; i++){
-                         Fcwf reader(world);
+                         Fcwf reader(world, myc);
                          for(int j=0; j < 4; j++){
                               input & reader[j];
                          }
@@ -123,8 +123,8 @@ namespace madness{
                          //Initialize some functions for reading in the orbitals
                          real_function_3d reader;
                          complex_function_3d complexreader;
-                         Fcwf spinup(world);
-                         Fcwf spindown(world); //used if !Krestricted
+                         Fcwf spinup(world, myc);
+                         Fcwf spindown(world, myc); //used if !Krestricted
                          real_function_3d xfunc = real_factory_3d(world).f(myxfunc);
                          real_function_3d yfunc = real_factory_3d(world).f(myyfunc);
                          
@@ -196,7 +196,7 @@ namespace madness{
                          // Read in alpha ground state orbitals
                          real_function_3d reader;
                          complex_function_3d complexreader;
-                         Fcwf fcwfreader(world);
+                         Fcwf fcwfreader(world, myc);
                          for(unsigned int i = 0; i < num_occupied; i++){
                               input & reader;
                               complexreader = function_real2complex(reader);
@@ -259,7 +259,7 @@ namespace madness{
                     
                     //reorder orbitals and energies in ascending order, if necessary.
                     double tempdouble;
-                    Fcwf fcwfreader(world);
+                    Fcwf fcwfreader(world, myc);
                     for(unsigned int i = 0; i < num_occupied; i++){
                          for(unsigned int j = i+1; j < num_occupied; j++){
                               if(energies(j) < energies(i)){
@@ -278,7 +278,7 @@ namespace madness{
 
           //This function no longer works
           //TODO: Update this function before using it
-          void readnw(World& world, const std::string& filename, bool Krestricted){
+          void readnw(World& world, const std::string& filename, const double& myc, bool Krestricted){
                //Called to read in initial parameters from an nwchem output file
                
                //For now just use default values for L and order
@@ -413,8 +413,8 @@ namespace madness{
 
                //Convert and store alpha occupied MOs.
                complex_function_3d complexreader(world);
-               Fcwf spinup(world);
-               Fcwf spindown(world);
+               Fcwf spinup(world, myc);
+               Fcwf spindown(world, myc);
                complex_derivative_3d Dx(world,0);
                complex_derivative_3d Dy(world,1);
                complex_derivative_3d Dz(world,2);

--- a/src/apps/dirac/InitParameters.h
+++ b/src/apps/dirac/InitParameters.h
@@ -20,6 +20,7 @@ namespace madness{
           // Ground state parameters that are read in from archive
           std::string inFile;                      ///< Name of input archive to read in
           double Init_total_energy;                ///< Total energy of the nonrelativistic ground state
+          double conv_thresh;                      ///< Convergence threshold for MOs
           bool spinrestricted;                     ///< Indicates if input calc. was spin-restricted
           bool closed_shell;
           unsigned int num_occupied;               ///< Number of orbitals
@@ -82,13 +83,14 @@ namespace madness{
                     std::string localize_method;
 
                     input & version;
-                    input & Init_total_energy;              // double
+                    input & Init_total_energy;   // double
                     input & spinrestricted;      // bool
                     input & L;                   // double            box size
                     input & order;               // int               wavelet order
                     input & molecule;            // Molecule   
                     input & xc;
                     input & localize_method;
+                    input & conv_thresh;         // double
 
                     input & num_occupied;        // int
                     input & temp_energies;       // Tensor<double>    orbital energies
@@ -113,7 +115,7 @@ namespace madness{
                     complex_derivative_3d Dx(world,0);
                     complex_derivative_3d Dy(world,1);
                     complex_derivative_3d Dz(world,2);
-                    //double myc = 137.0359895; //speed of light in atomic units
+                    //double myc = 137.03599917697017; //speed of light in atomic units from CODATA 2022
                     std::complex<double> myi(0,1);
                     if(spinrestricted){ 
                          //If the calculation was spin-restricted in moldft, then we only have "spin-up" orbitals

--- a/src/apps/dirac/README
+++ b/src/apps/dirac/README
@@ -44,7 +44,7 @@ List of interesting input options (from DFParameters.h)
           int lb_iter;                 ///< How many iterations to load balance (after the initial load balancing)
           bool lineplot;               ///< Whether or not to make lineplots at the end of the job
           bool no_compute;             ///< If true, will skip all computation
-          double bohr_rad;             ///< bohr radius in fm (default: 52917.7211)
+          double bohr_rad;             ///< bohr radius in fm (default: 52917.7210544)
           int min_iter;                ///< minimum number of iterations (default: 2)
 
 (Kramers restricted does not seem to be working --- bug in the exchange piece?)

--- a/src/apps/dirac/README
+++ b/src/apps/dirac/README
@@ -38,7 +38,7 @@ List of interesting input options (from DFParameters.h)
           int maxsub;                  ///< Sets maximum subspace size for KAIN
           double maxrotn;              ///< maximum step allowed by kain
           bool restart;                ///< Indicates this is a restarted DF job
-          int nucleus;                 ///< Indicates which nucleus model to use (1 for fermi, anything else for Gaussian)
+          int nucleus;                 ///< Indicates which nucleus model to use (1 for fermi, 2 for point, anything else for Gaussian)
           bool do_save;                ///< Whether or not to save after each iteration. Defaults to true. Turn off with 'no_save'
           std::string savefile;        ///< Gives the file to save the archive each iteration Default: DFrestartdata (in working directory)
           int lb_iter;                 ///< How many iterations to load balance (after the initial load balancing)

--- a/src/apps/dirac/fcwf.cc
+++ b/src/apps/dirac/fcwf.cc
@@ -16,22 +16,25 @@ Fcwf::Fcwf(){
 Fcwf::Fcwf(const complex_function_3d& wf1,
      const complex_function_3d& wf2,
      const complex_function_3d& wf3,
-     const complex_function_3d& wf4){
+     const complex_function_3d& wf4,
+     const double myc){
      MADNESS_ASSERT(m_psi.size() == 0);
      m_psi.push_back(wf1);
      m_psi.push_back(wf2);
      m_psi.push_back(wf3);
      m_psi.push_back(wf4);
      m_initialized = true;
+     speed_of_light = myc;
 }
 
 //This constructor creates a zero Fcwf
-Fcwf::Fcwf(World& world){
+Fcwf::Fcwf(World& world, const double myc){
      MADNESS_ASSERT(m_psi.size() == 0);
      for(int i = 0 ; i < 4 ; i ++){
           m_psi.push_back(complex_factory_3d(world));
      }
      m_initialized = true;
+     speed_of_light = myc;
 }
 
 //give access to the individual components
@@ -48,13 +51,14 @@ const complex_function_3d& Fcwf::operator[](const int i) const {
 }
 
 //Can also initialize from a vector of complex functions
-Fcwf::Fcwf(std::vector<complex_function_3d>& phi){
+Fcwf::Fcwf(std::vector<complex_function_3d>& phi, const double myc){
      MADNESS_ASSERT(m_psi.size() == 0);
      MADNESS_ASSERT(phi.size() == 4);
      for(int i = 0 ; i < 4 ; i++){
           m_psi.push_back(phi[i]);
      }
      m_initialized=true;
+     speed_of_light = myc;
 }
 
 //learn whether an Fcwf is initialized
@@ -64,6 +68,17 @@ bool Fcwf::getinitialize(){
 
 bool Fcwf::getinitialize() const {
      return m_initialized;
+}
+
+// get speed of light
+double Fcwf::get_myc(){
+     MADNESS_ASSERT(m_initialized);
+     return speed_of_light;
+}
+
+double Fcwf::get_myc() const {
+     MADNESS_ASSERT(m_initialized);
+     return speed_of_light;
 }
 
 //Probably don't need this, but get the size of m_psi, which should only be 0 or 4
@@ -79,19 +94,21 @@ unsigned int Fcwf::size() const {
 
 //copy constructor defaults to deep copy
 //if this ever changes, you will need to change the copy() function, as it calls this
-Fcwf::Fcwf(const Fcwf& phi){
+Fcwf::Fcwf(const Fcwf& phi, const double myc){
      MADNESS_ASSERT(m_psi.size() == 0);
      MADNESS_ASSERT(phi.size() == 4);
      for(int i = 0 ; i < 4 ; i++){
           m_psi.push_back(copy(phi[i]));
      }
      m_initialized = true;
+     speed_of_light = myc;
 }
 
 //Assignment operator defaults to shallow copy
 Fcwf Fcwf::operator=(const Fcwf& phi){
      m_psi = phi.m_psi;
      m_initialized = phi.m_initialized;
+     speed_of_light = phi.speed_of_light;
      return *this;
 }
 
@@ -110,7 +127,7 @@ Fcwf Fcwf::operator-(const Fcwf& phi) const {
                temp[i].scale(-1.0);
           }
      }
-     return Fcwf(temp);
+     return Fcwf(temp, phi.speed_of_light);
 }
 
 //add two Fcwfs. The Fcwf being added must be initialized
@@ -127,7 +144,7 @@ Fcwf Fcwf::operator+(const Fcwf& phi){
                temp.push_back(copy(phi[i]));
           }
      }
-     return Fcwf(temp);
+     return Fcwf(temp, phi.speed_of_light);
 }
 
 //multiply an Fcwf by a complex number a
@@ -137,7 +154,7 @@ Fcwf Fcwf::operator*(std::complex<double> a) const {
      for(int i = 0 ; i < 4 ; i++){
           temp[i] = a*m_psi[i];    
      }
-     return Fcwf(temp);
+     return Fcwf(temp, speed_of_light);
 }
 
 //scale an Fcwf in place by a complex number a
@@ -161,6 +178,7 @@ Fcwf Fcwf::operator+=(const Fcwf& phi){
                m_psi.push_back(copy(phi[i]));
           }
           m_initialized = true;
+          speed_of_light = phi.speed_of_light;
      }
      return *this;
 }
@@ -179,6 +197,7 @@ Fcwf Fcwf::operator-=(const Fcwf& phi){
                m_psi[i].scale(-1.0);
           }
           m_initialized = true;
+          speed_of_light = phi.speed_of_light;
      }
      return *this;
 }
@@ -186,7 +205,7 @@ Fcwf Fcwf::operator-=(const Fcwf& phi){
 //Returns the 2-norm of an initialized Fcwf
 double Fcwf::norm2(){
      MADNESS_ASSERT(m_initialized);
-     double c2 = 137.03599917697017 * 137.03599917697017; //speed of light in atomic units from CODATA 2022
+     double c2 = speed_of_light * speed_of_light; //speed of light in atomic units from CODATA 2022
      std::complex<double> temp(0,0);
 
      temp += madness::inner(m_psi[0],m_psi[0]);
@@ -216,7 +235,7 @@ Fcwf Fcwf::operator*(madness::complex_function_3d& phi){
      for(int i = 0 ; i < 4 ; i++){
           temp[i] = phi*m_psi[i];
      }
-     return Fcwf(temp);
+     return Fcwf(temp, speed_of_light);
 }
 
 Fcwf Fcwf::operator*(madness::real_function_3d& phi){
@@ -225,7 +244,7 @@ Fcwf Fcwf::operator*(madness::real_function_3d& phi){
      for(int i = 0 ; i < 4 ; i++){
           temp[i] = phi*m_psi[i];
      }
-     return Fcwf(temp);
+     return Fcwf(temp, speed_of_light);
 }
 
 //truncate
@@ -239,7 +258,7 @@ void Fcwf::truncate(){
 //Returns the inner product of two Fcwfs
 std::complex<double> Fcwf::inner(World& world, const Fcwf& phi) const{
      MADNESS_ASSERT(m_initialized && phi.getinitialize());
-     double c2 = 137.03599917697017 * 137.03599917697017; //speed of light in atomic units from CODATA 2022
+     double c2 = speed_of_light * speed_of_light; //speed of light in atomic units from CODATA 2022
      std::complex<double> temp(0,0);
 
      temp += madness::inner(m_psi[0],phi.m_psi[0]);
@@ -264,11 +283,12 @@ void Fcwf::apply(World& world, complex_derivative_3d& D){
 
 //Return result of time-reversal of the input Fcwf
 Fcwf Fcwf::KramersPair(){
+     MADNESS_ASSERT(m_initialized);
      complex_function_3d phi0 = -1.0*conj(m_psi[1]);
      complex_function_3d phi1 = conj(m_psi[0]);
      complex_function_3d phi2 = -1.0*conj(m_psi[3]);
      complex_function_3d phi3 = conj(m_psi[2]);
-     return Fcwf(phi0,phi1,phi2,phi3);
+     return Fcwf(phi0,phi1,phi2,phi3,speed_of_light);
 }
 
 //function for computing the inner product of two Fcwfs
@@ -294,7 +314,7 @@ Fcwf apply(World& world, complex_derivative_3d& D, const Fcwf& psi){
 //Returns the square modulus of an Fcwf, which is a real function
 real_function_3d squaremod(Fcwf& psi){
      MADNESS_ASSERT(psi.getinitialize());
-     double c2 = 137.03599917697017 * 137.03599917697017; //speed of light in atomic units from CODATA 2022
+     double c2 = psi.get_myc() * psi.get_myc(); //speed of light in atomic units from CODATA 2022
      real_function_3d temp = abssq(psi[0]) + abssq(psi[1]) + abssq(psi[2]).scale(1.0/c2) + abssq(psi[3]).scale(1.0/c2);
      return temp;
 }
@@ -302,7 +322,7 @@ real_function_3d squaremod(Fcwf& psi){
 //Returns the square modulus of the small component of an Fcwf, which is a real function
 real_function_3d squaremod_small(Fcwf& psi){
      MADNESS_ASSERT(psi.getinitialize());
-     double c2 = 137.03599917697017 * 137.03599917697017; //speed of light in atomic units from CODATA 2022
+     double c2 = psi.get_myc() * psi.get_myc(); //speed of light in atomic units from CODATA 2022
      real_function_3d temp = (abssq(psi[2]) + abssq(psi[3])).scale(1.0/c2); //don't forget the factor of c^2
      return temp;
 }
@@ -317,7 +337,7 @@ real_function_3d squaremod_large(Fcwf& psi){
 //compute the function inner product between two Fcwfs. Result is a complex function.
 complex_function_3d inner_func(World& world, Fcwf& psi, Fcwf& phi){
      MADNESS_ASSERT(psi.getinitialize() && phi.getinitialize());
-     double c = 137.03599917697017; //speed of light in atomic units from CODATA 2022
+     double c = psi.get_myc(); //speed of light in atomic units from CODATA 2022
      std::vector<complex_function_3d> a(4);
      std::vector<complex_function_3d> b(4);
      for(unsigned int i = 0; i < 2; i++){
@@ -336,7 +356,8 @@ complex_function_3d inner_func(World& world, Fcwf& psi, Fcwf& phi){
 
 //deep copy of an Fcwf
 Fcwf copy(Fcwf psi){
-     return Fcwf(psi);
+     MADNESS_ASSERT(psi.getinitialize());
+     return Fcwf(psi, psi.get_myc());
 
 }
 
@@ -403,23 +424,24 @@ std::vector<Fcwf> operator-(const std::vector<Fcwf>& phi, const std::vector<Fcwf
 }
 
 //Constructor for allocator for vector of Fcwfs
-Fcwf_vector_allocator::Fcwf_vector_allocator(World& world, unsigned int m_size)
+Fcwf_vector_allocator::Fcwf_vector_allocator(World& world, unsigned int m_size, const double& myc)
 : world(world)
 , m_size(m_size)
+, speed_of_light(myc)
 {}
 
 //Overloading () operator
 std::vector<Fcwf> Fcwf_vector_allocator::operator()(){
      std::vector<Fcwf> result;
      for(int i=0; i < m_size; i++){
-          result.push_back(Fcwf(world));
+          result.push_back(Fcwf(world, speed_of_light));
      }
      return result;
 }
 
 //Copy Constructor for allocator. Necessary for KAIN
 Fcwf_vector_allocator Fcwf_vector_allocator::operator=(const Fcwf_vector_allocator& other){
-     Fcwf_vector_allocator tmp(world, other.m_size);
+     Fcwf_vector_allocator tmp(world, other.m_size, speed_of_light);
      return tmp;
 }
 
@@ -433,7 +455,7 @@ Tensor<std::complex<double>> matrix_inner(World& world, std::vector<Fcwf>& a, st
      unsigned int m = b.size();
      //MADNESS_ASSERT(n==m);
 
-     double c2 = 137.03599917697017 * 137.03599917697017; //speed of light in atomic units from CODATA 2022
+     double c2 = a[0].get_myc() * a[0].get_myc(); //speed of light in atomic units from CODATA 2022
 
      //Reassign the vectors of Fcwfs to vectors of complex functions to facilitate use of vmra functions
      std::vector<complex_function_3d> a_1(n); //all first components of Fcwfs in input a
@@ -500,7 +522,7 @@ std::vector<Fcwf> transform(World& world, std::vector<Fcwf>& a, Tensor<std::comp
 
      //Now put the components back into Fcwf form and push back into a vector
      std::vector<Fcwf> result;
-     Fcwf reader(world); 
+     Fcwf reader(world, a[0].get_myc()); 
      for(unsigned int i = 0; i < k; i++){
           reader[0] = a_1[i];
           reader[1] = a_2[i];

--- a/src/apps/dirac/fcwf.cc
+++ b/src/apps/dirac/fcwf.cc
@@ -186,7 +186,7 @@ Fcwf Fcwf::operator-=(const Fcwf& phi){
 //Returns the 2-norm of an initialized Fcwf
 double Fcwf::norm2(){
      MADNESS_ASSERT(m_initialized);
-     double c2 = 137.0359895*137.0359895; //speed of light in atomic units
+     double c2 = 137.03599917697017 * 137.03599917697017; //speed of light in atomic units from CODATA 2022
      std::complex<double> temp(0,0);
 
      temp += madness::inner(m_psi[0],m_psi[0]);
@@ -239,7 +239,7 @@ void Fcwf::truncate(){
 //Returns the inner product of two Fcwfs
 std::complex<double> Fcwf::inner(World& world, const Fcwf& phi) const{
      MADNESS_ASSERT(m_initialized && phi.getinitialize());
-     double c2 = 137.0359895*137.0359895; //speed of light in atomic units
+     double c2 = 137.03599917697017 * 137.03599917697017; //speed of light in atomic units from CODATA 2022
      std::complex<double> temp(0,0);
 
      temp += madness::inner(m_psi[0],phi.m_psi[0]);
@@ -294,7 +294,7 @@ Fcwf apply(World& world, complex_derivative_3d& D, const Fcwf& psi){
 //Returns the square modulus of an Fcwf, which is a real function
 real_function_3d squaremod(Fcwf& psi){
      MADNESS_ASSERT(psi.getinitialize());
-     double c2 = 137.0359895*137.0359895; //speed of light in atomic units
+     double c2 = 137.03599917697017 * 137.03599917697017; //speed of light in atomic units from CODATA 2022
      real_function_3d temp = abssq(psi[0]) + abssq(psi[1]) + abssq(psi[2]).scale(1.0/c2) + abssq(psi[3]).scale(1.0/c2);
      return temp;
 }
@@ -302,7 +302,7 @@ real_function_3d squaremod(Fcwf& psi){
 //Returns the square modulus of the small component of an Fcwf, which is a real function
 real_function_3d squaremod_small(Fcwf& psi){
      MADNESS_ASSERT(psi.getinitialize());
-     double c2 = 137.0359895*137.0359895; //speed of light in atomic units
+     double c2 = 137.03599917697017 * 137.03599917697017; //speed of light in atomic units from CODATA 2022
      real_function_3d temp = (abssq(psi[2]) + abssq(psi[3])).scale(1.0/c2); //don't forget the factor of c^2
      return temp;
 }
@@ -317,7 +317,7 @@ real_function_3d squaremod_large(Fcwf& psi){
 //compute the function inner product between two Fcwfs. Result is a complex function.
 complex_function_3d inner_func(World& world, Fcwf& psi, Fcwf& phi){
      MADNESS_ASSERT(psi.getinitialize() && phi.getinitialize());
-     double c = 137.0359895; //speed of light in atomic units
+     double c = 137.03599917697017; //speed of light in atomic units from CODATA 2022
      std::vector<complex_function_3d> a(4);
      std::vector<complex_function_3d> b(4);
      for(unsigned int i = 0; i < 2; i++){
@@ -433,7 +433,7 @@ Tensor<std::complex<double>> matrix_inner(World& world, std::vector<Fcwf>& a, st
      unsigned int m = b.size();
      //MADNESS_ASSERT(n==m);
 
-     double c2 = 137.0359895*137.0359895; //speed of light in atomic units
+     double c2 = 137.03599917697017 * 137.03599917697017; //speed of light in atomic units from CODATA 2022
 
      //Reassign the vectors of Fcwfs to vectors of complex functions to facilitate use of vmra functions
      std::vector<complex_function_3d> a_1(n); //all first components of Fcwfs in input a

--- a/src/apps/dirac/fcwf.h
+++ b/src/apps/dirac/fcwf.h
@@ -11,6 +11,7 @@ using namespace madness;
 
 class Fcwf{
      std::vector<complex_function_3d> m_psi;
+     double speed_of_light;
      bool m_initialized;
 
 public:
@@ -20,25 +21,30 @@ public:
      Fcwf(const complex_function_3d& wf1,
           const complex_function_3d& wf2,
           const complex_function_3d& wf3,
-          const complex_function_3d& wf4);
+          const complex_function_3d& wf4,
+          const double myc);
 
-     Fcwf(World& world);
+     Fcwf(World& world, const double myc);
 
      complex_function_3d& operator[](const int i);
 
      const complex_function_3d& operator[](const int i) const ;
      
-     explicit Fcwf(std::vector<complex_function_3d>& phi);
+     explicit Fcwf(std::vector<complex_function_3d>& phi, const double myc);
 
      bool getinitialize();
 
      bool getinitialize() const ;
 
+     double get_myc();
+
+     double get_myc() const ;
+
      unsigned int size();
 
      unsigned int size() const ;
 
-     Fcwf(const Fcwf& phi);
+     Fcwf(const Fcwf& phi, const double myc);
 
      Fcwf operator=(const Fcwf& phi);
 
@@ -112,9 +118,10 @@ std::vector<Fcwf> transform(World& world, std::vector<Fcwf>& a, Tensor<std::comp
 class Fcwf_vector_allocator {
      World& world;
      unsigned int m_size;
+     double speed_of_light;
      public:
           //Constructor
-          Fcwf_vector_allocator(World& world, unsigned int m_size);
+          Fcwf_vector_allocator(World& world, unsigned int m_size, const double& myc);
 
           //Overloading () operator
           std::vector<Fcwf> operator()();

--- a/src/apps/dirac/relops.cc
+++ b/src/apps/dirac/relops.cc
@@ -7,7 +7,7 @@
 #include "../../../../mpfrc++-3/mpreal.h"
 
 static const double m = 1.0;
-static const double c = 137.0359895;
+static const double c = 137.03599917697017; // from CODATA 2022
 static const double mc2 = m*c*c;
 static const double PI = 3.14159265358979323846264338328;
 

--- a/src/apps/dirac/rk.cc
+++ b/src/apps/dirac/rk.cc
@@ -193,7 +193,7 @@ double rk_v(double Z) {
   if (NONREL) return 0.0;
   if (DK1) Z *= 0.5;
 
-    static const double c = 137.0359895;
+    static const double c = 137.03599917697017; // from CODATA 2022
     double v = -2.0*Z/(constants::pi*c);
     while (true) {
         double vnew = -2.0*std::atan(Z/(c*(v+1.0)))/constants::pi;


### PR DESCRIPTION
### Description
Updates the Dirac-Fock code to correctly read in orbitals from moldft to compute a closed-shell system. PR is purposely more minimal to keep implementation independent of MPQC.

Note, I did have working version of DFdriver using small memory exchange algorithm, but it was 10x slower than current algo due to need for better calls to vmra.h and mra.h. Seems better to leave exchange as is to have independent implementation from MPQC, which does use smallmem exchange algorithm for bispinors.

### Details
- [X] Adds point charge nucleus model, option is `nucleus == 2`
- [X] Properly computes closed-shell computation, without Kramers symmetry
- [X] Converge either due to BSH residuals or energy, density, and BSH residuals
- [X] Updates for speed of light and bohr radius in fm to CODATA 2022 values