### PR TITLE
Update he_xpbe.in

### DIFF
--- a/src/apps/moldft/tests/he_xpbe.in
+++ b/src/apps/moldft/tests/he_xpbe.in
@@ -1,5 +1,5 @@
 dft
-  xc GGA_X_PBE 1.
+  xc "GGA_X_PBE 1."
   restricted 
   maxsub 5
   protocol 1e-6


### PR DESCRIPTION
The current parser couldn't read the previous xc line and raised a warning message. By adding quotes, the parser can understand the line again and actually do PBE rather than Hartree-Fock...