### PR TITLE
changing madness-config.cmake 

### DIFF
--- a/cmake/madness-config.cmake.in
+++ b/cmake/madness-config.cmake.in
@@ -148,7 +148,9 @@ if (PaRSEC::parsec IN_LIST madness_MADWORLD_INTERFACE_LINK_LIBRARIES)
    enable_language(C)
    list(APPEND _mpi_languages C)
 endif()
-find_package(MPI REQUIRED COMPONENTS "${_mpi_languages}")
+if (DEFINED _mpi_languages)
+        find_package(MPI REQUIRED COMPONENTS "${_mpi_languages}")
+endif()
 
 ########### PaRSEC ############
 if (PaRSEC::parsec IN_LIST madness_MADWORLD_INTERFACE_LINK_LIBRARIES AND NOT TARGET PaRSEC::parsec)


### PR DESCRIPTION
If madness is build with `-D ENABLE_MPI=OFF` and afterwards installed, then the installed libraries will still look for MPI when `find_packace(MADNESS)` is used somewhere. Tried to change that in the config file. Works locally, but not sure if it has potential for trouble in the future. 

