### PR TITLE
Squash more nvcc compiler warnings/errors

### DIFF
--- a/src/madness/mra/funcplot.h
+++ b/src/madness/mra/funcplot.h
@@ -810,8 +810,8 @@ void plot_plane(World& world, const std::vector<Function<double,NDIM> >& vfuncti
     std::size_t cc1=plane2dim(c1);
     std::size_t cc2=plane2dim(c2);
 
-    MADNESS_ASSERT(cc1>=0 && cc1<NDIM);
-    MADNESS_ASSERT(cc2>=0 && cc2<NDIM);
+    MADNESS_ASSERT(cc1<NDIM);
+    MADNESS_ASSERT(cc2<NDIM);
 
     // output file name for the gnuplot data
     std::string filename="plane_"+c1+c2+"_"+name;
@@ -877,8 +877,8 @@ void plot_plane(World& world, const std::vector<Function<double,NDIM> >& vfuncti
         std::size_t cc1=plane2dim(c1);
         std::size_t cc2=plane2dim(c2);
 
-        MADNESS_ASSERT(cc1>=0 && cc1<NDIM);
-        MADNESS_ASSERT(cc2>=0 && cc2<NDIM);
+        MADNESS_ASSERT(cc1<NDIM);
+        MADNESS_ASSERT(cc2<NDIM);
 
          // output file name for the gnuplot data
          std::string filename="plane_"+c1+c2+"_"+name;

--- a/src/madness/mra/operator.h
+++ b/src/madness/mra/operator.h
@@ -199,8 +199,8 @@ namespace madness {
 
         const double& gamma() const {return info.mu;}
         const double& mu() const {return info.mu;}
-        const int get_rank() const { return rank; }
-        const int get_k() const { return k; }
+        int get_rank() const { return rank; }
+        int get_k() const { return k; }
         const std::vector<ConvolutionND<Q,NDIM>>& get_ops() const { return ops; }
         const std::array<KernelRange, NDIM>& get_range() const { return range; }
         bool range_restricted() const { return std::any_of(range.begin(), range.end(), [](const auto& v) { return v.finite(); }); }

--- a/src/madness/tensor/tensor.h
+++ b/src/madness/tensor/tensor.h
@@ -1838,7 +1838,7 @@ MADNESS_PRAGMA_GCC(diagnostic pop)
 
         /// Returns a pointer to the base class
         const BaseTensor* base() const {
-            return static_cast<BaseTensor*>(this);
+            return static_cast<const BaseTensor*>(this);
         }
 
         /// Return iterator over single tensor


### PR DESCRIPTION
nvcc does not accept returning a non-const cast in a function returning a const pointer. Also, remove const from by-value return type and a superfluous check from assert (unsigned integer are always larger or equal to zero). 