### PR TITLE
cleanup `FunctionDefaults::pmap`

### DIFF
--- a/src/madness/mra/funcdefaults.h
+++ b/src/madness/mra/funcdefaults.h
@@ -122,7 +122,7 @@ namespace madness {
         static double cell_min_width;   ///< Size of smallest dimension
         static TensorType tt;			///< structure of the tensor in FunctionNode
         static std::shared_ptr< WorldDCPmapInterface< Key<NDIM> > > pmap; ///< Default mapping of keys to processes
-    	static int pmap_nproc; ///< Number of processes assumed by pmap, -1 indicates uninitialized pmap
+        static int pmap_nproc; ///< Number of processes assumed by pmap, -1 indicates uninitialized pmap
 
         static Tensor<double> make_default_cell() {
           if (NDIM) {
@@ -400,20 +400,20 @@ namespace madness {
           }
         }
 
-    	/// Returns number of the default processes returned by get_pmap()
-    	static int get_pmap_nproc() {
-        	return pmap_nproc;
-        }
+    /// Returns number of the default processes returned by get_pmap()
+    static int get_pmap_nproc() {
+        return pmap_nproc;
+    }
 
-    	/// Returns the default process map that can be used with the given world
-    	static std::shared_ptr< WorldDCPmapInterface< Key<NDIM> > > get_pmap(World& world) {
-        	if (get_pmap_nproc() == world.nproc()) {
-        		return get_pmap();
-        	}
-        	else {
-        		return make_default_pmap(world);
-        	}
+    /// Returns the default process map that can be used with the given world
+    static std::shared_ptr< WorldDCPmapInterface< Key<NDIM> > > get_pmap(World& world) {
+        if (get_pmap_nproc() == world.nproc()) {
+            return get_pmap();
         }
+        else {
+            return make_default_pmap(world);
+        }
+    }
 
         /// Sets the default process map (does \em not redistribute existing functions)
 
@@ -422,12 +422,12 @@ namespace madness {
         	pmap = value;
         }
 
-    	/// Makes a default process map for the given \p world
-    	static std::shared_ptr< WorldDCPmapInterface< Key<NDIM> > > make_default_pmap(World& world);
+        /// Makes a default process map for the given \p world
+        static std::shared_ptr< WorldDCPmapInterface< Key<NDIM> > > make_default_pmap(World& world);
 
     	/// Sets the default process map for the use with WorldObjects in \p world
     	/// @note sets default pmap to `make_default_pmap(world)`
-    	static void set_default_pmap(World& world);
+        static void set_default_pmap(World& world);
 
         /// Sets the default process map and redistributes all functions using the old map
         static void redistribute(World& world, const std::shared_ptr< WorldDCPmapInterface< Key<NDIM> > >& newpmap) {

--- a/src/madness/mra/funcdefaults.h
+++ b/src/madness/mra/funcdefaults.h
@@ -407,7 +407,7 @@ namespace madness {
 
     	/// Returns the default process map that can be used with the given world
     	static std::shared_ptr< WorldDCPmapInterface< Key<NDIM> > > get_pmap(World& world) {
-        	if (World::get_default().id() == world.id()) {
+        	if (get_pmap_nproc() == world.nproc()) {
         		return get_pmap();
         	}
         	else {

--- a/src/madness/mra/funcdefaults.h
+++ b/src/madness/mra/funcdefaults.h
@@ -122,6 +122,7 @@ namespace madness {
         static double cell_min_width;   ///< Size of smallest dimension
         static TensorType tt;			///< structure of the tensor in FunctionNode
         static std::shared_ptr< WorldDCPmapInterface< Key<NDIM> > > pmap; ///< Default mapping of keys to processes
+    	static int pmap_nproc; ///< Number of processes assumed by pmap, -1 indicates uninitialized pmap
 
         static Tensor<double> make_default_cell() {
           if (NDIM) {
@@ -397,6 +398,11 @@ namespace madness {
             else
               return pmap; // null ptr if uninitialized
           }
+        }
+
+    	/// Returns number of the default processes returned by get_pmap()
+    	static int get_pmap_nproc() {
+        	return pmap_nproc;
         }
 
         /// Sets the default process map (does \em not redistribute existing functions)

--- a/src/madness/mra/funcdefaults.h
+++ b/src/madness/mra/funcdefaults.h
@@ -386,7 +386,7 @@ namespace madness {
         	return cell_volume;
         }
 
-        /// Returns the default process map
+        /// Returns the default process map that was last initialized via set_default_pmap()
         static std::shared_ptr< WorldDCPmapInterface< Key<NDIM> > >& get_pmap() {
           if (pmap)
             return pmap;
@@ -405,6 +405,16 @@ namespace madness {
         	return pmap_nproc;
         }
 
+    	/// Returns the default process map that can be used with the given world
+    	static std::shared_ptr< WorldDCPmapInterface< Key<NDIM> > > get_pmap(World& world) {
+        	if (World::get_default().id() == world.id()) {
+        		return get_pmap();
+        	}
+        	else {
+        		return make_default_pmap(world);
+        	}
+        }
+
         /// Sets the default process map (does \em not redistribute existing functions)
 
         /// Existing functions are probably rendered useless
@@ -412,9 +422,12 @@ namespace madness {
         	pmap = value;
         }
 
-        /// Sets the default process map
-        static void set_default_pmap(World& world);
+    	/// Makes a default process map for the given \p world
+    	static std::shared_ptr< WorldDCPmapInterface< Key<NDIM> > > make_default_pmap(World& world);
 
+    	/// Sets the default process map for the use with WorldObjects in \p world
+    	/// @note sets default pmap to `make_default_pmap(world)`
+    	static void set_default_pmap(World& world);
 
         /// Sets the default process map and redistributes all functions using the old map
         static void redistribute(World& world, const std::shared_ptr< WorldDCPmapInterface< Key<NDIM> > >& newpmap) {

--- a/src/madness/mra/funcplot.h
+++ b/src/madness/mra/funcplot.h
@@ -928,8 +928,6 @@ void plot_plane(World& world, const std::vector<Function<double,NDIM> >& vfuncti
             std::vector<std::string> molecular_info=std::vector<std::string>(), int npoints=100, double zoom=1.0,
             const Vector<double,NDIM> origin=Vector<double,NDIM>(0.0)) {
 
-        if (world.size()>1) return;
-
         // dummy atom in the center
         if (molecular_info.size()==0)
         	molecular_info=std::vector<std::string>(1,"0 0 0.0 0.0 0.0\n");
@@ -1001,9 +999,6 @@ void plot_plane(World& world, const std::vector<Function<double,NDIM> >& vfuncti
      template<typename T, size_t NDIM>
      void
      print_tree_jsonfile(World& world, const Function<T,NDIM>& f, std::string filename) {
-
-         if (world.size() > 1)
-             return;
 
          Tensor<double> cell = copy(FunctionDefaults<NDIM>::get_cell());
          std::ofstream os(filename.c_str());

--- a/src/madness/mra/mra.h
+++ b/src/madness/mra/mra.h
@@ -2120,7 +2120,7 @@ namespace madness {
     Function<T,NDIM> copy(World& world, const Function<T,NDIM>& f, bool fence = true) {
         PROFILE_FUNC;
         typedef FunctionImpl<T,NDIM> implT;
-        auto pmap=FunctionDefaults<NDIM>::get_pmap();
+        auto pmap = FunctionDefaults<NDIM>::get_pmap(world);
 
         // create a new function with pmap distribution, same parameters as f, but no coeffs
         Function<T,NDIM> result;

--- a/src/madness/mra/mraimpl.h
+++ b/src/madness/mra/mraimpl.h
@@ -3552,10 +3552,15 @@ template <typename T, std::size_t NDIM>
     }
 
     template <std::size_t NDIM>
+    std::shared_ptr< WorldDCPmapInterface< Key<NDIM> > > FunctionDefaults<NDIM>::make_default_pmap(World& world) {
+        // return std::make_shared<WorldDCDefaultPmap< Key<NDIM> >>(world);
+        return std::make_shared<LevelPmap< Key<NDIM> >>(world);
+        // return std::make_shared<SimplePmap< Key<NDIM> >>(world);
+    }
+
+    template <std::size_t NDIM>
     void FunctionDefaults<NDIM>::set_default_pmap(World& world) {
-        //pmap = std::shared_ptr< WorldDCPmapInterface< Key<NDIM> > >(new WorldDCDefaultPmap< Key<NDIM> >(world));
-        pmap = std::shared_ptr< WorldDCPmapInterface< Key<NDIM> > >(new madness::LevelPmap< Key<NDIM> >(world));
-        //pmap = std::shared_ptr< WorldDCPmapInterface< Key<NDIM> > >(new SimplePmap< Key<NDIM> >(world));
+        pmap = make_default_pmap(world);
         pmap_nproc = world.nproc();
     }
 

--- a/src/madness/mra/mraimpl.h
+++ b/src/madness/mra/mraimpl.h
@@ -3556,6 +3556,7 @@ template <typename T, std::size_t NDIM>
         //pmap = std::shared_ptr< WorldDCPmapInterface< Key<NDIM> > >(new WorldDCDefaultPmap< Key<NDIM> >(world));
         pmap = std::shared_ptr< WorldDCPmapInterface< Key<NDIM> > >(new madness::LevelPmap< Key<NDIM> >(world));
         //pmap = std::shared_ptr< WorldDCPmapInterface< Key<NDIM> > >(new SimplePmap< Key<NDIM> >(world));
+        pmap_nproc = world.nproc();
     }
 
 
@@ -3604,6 +3605,7 @@ template <typename T, std::size_t NDIM>
     template <std::size_t NDIM> double FunctionDefaults<NDIM>::cell_volume = 1.;
     template <std::size_t NDIM> double FunctionDefaults<NDIM>::cell_min_width = 1.;
     template <std::size_t NDIM> std::shared_ptr< WorldDCPmapInterface< Key<NDIM> > > FunctionDefaults<NDIM>::pmap;
+    template <std::size_t NDIM> int FunctionDefaults<NDIM>::pmap_nproc{-1};
 
     template <std::size_t NDIM> std::vector< Key<NDIM> > Displacements<NDIM>::disp;
     template <std::size_t NDIM> array_of_bools<NDIM> Displacements<NDIM>::periodic_axes{false};

--- a/src/madness/mra/vmra.h
+++ b/src/madness/mra/vmra.h
@@ -1347,7 +1347,7 @@ namespace madness {
     /// Returns a vector of `n` deep copies of a function
     template <typename T, std::size_t NDIM>
     std::vector< Function<T,NDIM> >
-    copy(World& world,
+    copy_n(World& world,
          const Function<T,NDIM>& v,
          const unsigned int n,
          bool fence=true) {

--- a/src/madness/world/worldptr.h
+++ b/src/madness/world/worldptr.h
@@ -465,13 +465,13 @@ namespace madness {
         /// \tparam Archive The archive type.
         /// \tparam T The world pointer type.
         template <typename Archive, typename T>
-        struct ArchiveLoadImpl<Archive, detail::WorldPtr<T> > {
+        struct ArchiveLoadImpl<Archive, madness::detail::WorldPtr<T> > {
 
             /// Load a world pointer from the archive.
 
             /// \param[in] ar The archive.
             /// \param[out] p The world pointer.
-            static inline void load(const Archive& ar, detail::WorldPtr<T>& p) {
+            static inline void load(const Archive& ar, madness::detail::WorldPtr<T>& p) {
                 p.load_internal_(ar);
             }
         };
@@ -481,13 +481,13 @@ namespace madness {
         /// \tparam Archive The archive type.
         /// \tparam T The world pointer type.
         template <typename Archive, typename T>
-        struct ArchiveStoreImpl<Archive, detail::WorldPtr<T> > {
+        struct ArchiveStoreImpl<Archive, madness::detail::WorldPtr<T> > {
 
             /// Store a world pointer from the archive.
 
             /// \param[in] ar The archive.
             /// \param[in] p The world pointer.
-            static inline void store(const Archive& ar, const detail::WorldPtr<T>& p) {
+            static inline void store(const Archive& ar, const madness::detail::WorldPtr<T>& p) {
                 p.store_internal_(ar);
             }
         };

--- a/src/madness/world/worldref.h
+++ b/src/madness/world/worldref.h
@@ -617,15 +617,15 @@ namespace madness {
         // Remote counter serialization
 
         template <typename Archive>
-        struct ArchiveLoadImpl<Archive, detail::RemoteCounter > {
-            static inline void load(const Archive& ar, detail::RemoteCounter& c) {
+        struct ArchiveLoadImpl<Archive, madness::detail::RemoteCounter > {
+            static inline void load(const Archive& ar, madness::detail::RemoteCounter& c) {
                 c.load_(ar);
             }
         };
 
         template <typename Archive>
-        struct ArchiveStoreImpl<Archive, detail::RemoteCounter > {
-            static inline void store(const Archive& ar, const detail::RemoteCounter& c) {
+        struct ArchiveStoreImpl<Archive, madness::detail::RemoteCounter > {
+            static inline void store(const Archive& ar, const madness::detail::RemoteCounter& c) {
                 c.store_(ar);
             }
         };


### PR DESCRIPTION
`FunctionDefaults::set_default_pmap` records how many nprocs it assumes, so that `Function::copy(world,...)` knows whether default pmap is appropriate for this world