### PR TITLE
Remove Early Exit for Surface Displacements

### DIFF
--- a/src/madness/mra/displacements.h
+++ b/src/madness/mra/displacements.h
@@ -827,7 +827,8 @@ namespace madness {
 
               if (disp_d_eff_abs > bmax_standard) {
                 among_standard_displacements = false;
-                break;
+                // Do not break - this loop needs not only to determine among_standard_displacements but to shift the displacement if domain_is_periodic_
+                // Therefore, looping over all dim is strictly necessary.
               }
             }
             if (among_standard_displacements) {


### PR DESCRIPTION
There is a bug in the displacement logic causing some displacements to be illegitimately dropped when lattice summation is performed.

The `BoxSurfaceDisplacementFilter` is misleadingly named. The filter isn't *just* a filter. For lattice summed kernels, it also [shifts the displacement ](https://github.com/m-a-d-n-e-s-s/madness/blob/master/src/madness/mra/displacements.h#L804-L826)so that it connects two boxes in the simulation cell. The [early-exit condition](https://github.com/m-a-d-n-e-s-s/madness/commit/9b780c54fe8796125c354396066bc8742e25d045) - which makes perfect sense for a pure filter - was so early that it prevented the full displacement-correction. Uncorrected displacements did not connect two boxes in the simulation cell and so would be rejected as [invalid](https://github.com/m-a-d-n-e-s-s/madness/blob/master/src/madness/mra/funcimpl.h#L5000-L5001). At least for the case I tried, the offending displacements were so small that the entire boundary was screened out, which was why this wasn't observed earlier.

The easiest fix is to just remove early-exit...