### PR TITLE
`madness::conj(x)` for double x truncated to float

### DIFF
--- a/src/madness/mra/funcimpl.h
+++ b/src/madness/mra/funcimpl.h
@@ -6066,11 +6066,13 @@ template<size_t NDIM>
        }
 #endif
 
-        static double conj(float x) {
+        template <typename Real>
+        static std::enable_if_t<std::is_floating_point_v<Real>, Real> conj(const Real x) {
             return x;
         }
 
-        static std::complex<double> conj(const std::complex<double> x) {
+        template <typename Real>
+        static std::complex<Real> conj(const std::complex<Real>& x) {
             return std::conj(x);
         }
 


### PR DESCRIPTION
this seemingly is not used everywhere where "conj" is performed (there are other "instances" of conj) but most notably `matrix_inner` uses it ... perhaps used elsewhere also?