### PR TITLE
Remove assertion for displacements exceeding 1 cell

### DIFF
--- a/src/madness/mra/displacements.h
+++ b/src/madness/mra/displacements.h
@@ -849,8 +849,6 @@ namespace madness {
               // compare Displacements::make_disp vs Displacements::make_disp_periodic
               auto disp_d_eff_abs = std::abs(disp_d);
               if (domain_policies_[d] == ExtraDomainPolicy::Translate) {
-                MADNESS_ASSERT(range_[d].N() <= 2);  // displacements that exceed 1 whole cell need bit more complex logic
-
                 // for "periodic" displacements the effective disp_d is the shortest of {..., disp_d-twon, disp_d, disp_d+twon, ...} ... see make_disp_periodic
                 const std::int64_t disp_d_eff = map_to_range_twon(disp_d);
                 disp_d_eff_abs = std::min(disp_d_eff,std::abs(disp_d_eff-twon));


### PR DESCRIPTION
Removed assertion for range check on displacements. Numerical tests in MPQC show this assertion is no longer needed, and the logical rewrite of #649 has made it much easier to see that the logic _doesn't_ need to change further.