### PR TITLE
Add width setting for Displacements in testopdir

### DIFF
--- a/src/madness/mra/testopdir.cc
+++ b/src/madness/mra/testopdir.cc
@@ -153,6 +153,7 @@ int test_opdir(World& world) {
     cell(2,0)=-40; cell(2,1)=40;
     //FunctionDefaults<3>::set_cubic_cell(-20,20);
     FunctionDefaults<3>::set_cell(cell);
+	Displacements<3>::set_width(FunctionDefaults<3>::get_cell_width());
     FunctionDefaults<3>::set_k(8);
     FunctionDefaults<3>::set_thresh(1e-6);
     //FunctionDefaults<3>::set_k(10);
@@ -265,6 +266,7 @@ int testgradG(World& world) {
     const double thresh = 1e-8;
 
     FunctionDefaults<3>::set_cell(cell);
+	Displacements<3>::set_width(FunctionDefaults<3>::get_cell_width());
     FunctionDefaults<3>::set_k(k);
     FunctionDefaults<3>::set_thresh(thresh);
     FunctionDefaults<3>::set_initial_level(3);


### PR DESCRIPTION
This PR closes #676. The new screening algorithm requires (at least for non-cubic cells) that the displacements receive a copy of the cell width.

I understand @fbischoff is changing where the cell width data lives, and it's worth asking if `FunctionDefaults<NDIM>::set_cell` should update the width in `Displacements<NDIM>`. My intuition is to say yes, but I don't know how his changes affect that.