### PR TITLE
amended handling of special points at box boundaries

### DIFF
--- a/src/madness/mra/CMakeLists.txt
+++ b/src/madness/mra/CMakeLists.txt
@@ -34,10 +34,11 @@ if(BUILD_TESTING)
   add_library(libtest_sepop EXCLUDE_FROM_ALL test_sepop.cc)
   target_link_libraries(libtest_sepop MADmra)
   
-  set(MRA_TEST_SOURCES testbsh.cc testproj.cc 
-      testpdiff.cc testdiff1Db.cc testgconv.cc testopdir.cc testinnerext.cc 
+  set(MRA_TEST_SOURCES testbsh.cc testproj.cc
+      testpdiff.cc testdiff1Db.cc testgconv.cc testopdir.cc testinnerext.cc
       testgaxpyext.cc testvmra.cc, test_vectormacrotask.cc test_cloud.cc test_tree_state.cc testsolver.cc
-      test_macrotaskpartitioner.cc test_QCCalculationParametersBase.cc test_memory_measurement.cc)
+      test_macrotaskpartitioner.cc test_QCCalculationParametersBase.cc test_memory_measurement.cc
+      test_keybox.cc)
   add_unittests(mra "${MRA_TEST_SOURCES}" "MADmra;MADgtest" "unittests;short")
   set(MRA_SEPOP_TEST_SOURCES testsuite.cc
       testper.cc)

--- a/src/madness/mra/key.h
+++ b/src/madness/mra/key.h
@@ -334,6 +334,49 @@ namespace madness {
         	return (dist <= 1);
         }
 
+        /// True iff this box is a neighbor of a point in simulation coordinates
+
+        /// Geometrically: this box's closure overlaps the closed box of
+        /// half-width 1 (one box-width at this level) centered on `simpt`.
+        /// Equivalently, the Chebyshev distance from this box to `simpt`
+        /// (measured in box-widths) is at most 1.
+        ///
+        /// This is the point-argument analogue of the key-vs-key overload
+        /// `is_neighbor_of(Key, bperiodic)`; both express "within one
+        /// box-width" adjacency. It supersedes the legacy idiom
+        /// `simpt2key(simpt, n).is_neighbor_of(*this, ...)`, which was
+        /// asymmetric for points lying on box boundaries because
+        /// `simpt2key` truncates to a single key. The new test reports
+        /// face-, edge-, and corner-coincident points as contained in
+        /// *every* box that shares the face/edge/corner — and therefore
+        /// every neighbor of those boxes is correctly flagged too.
+        ///
+        /// @param[in] simpt point in simulation coordinates
+        ///                  (in [0,1]^NDIM, modulo 1 in periodic dimensions)
+        /// @param[in] bperiodic per-dimension periodic-boundary flags
+        template <typename T>
+        bool
+        is_neighbor_of(const Vector<T, NDIM>& simpt,
+                       const array_of_bools<NDIM>& bperiodic) const {
+            const double twon = std::ldexp(1.0, n);  // 2^n
+            const double period = twon;              // sim domain has unit length
+            // round-off in d = twon*simpt - l is ~ period * eps; pad by a few
+            // ULPs so points within machine noise of an edge deterministically
+            // count as on it.
+            const double tol = 8.0 * period * std::numeric_limits<double>::epsilon();
+            for (std::size_t i = 0; i < NDIM; ++i) {
+                // signed distance from this box's lower edge, in box-widths
+                double d = twon * static_cast<double>(simpt[i]) - static_cast<double>(l[i]);
+                if (bperiodic[i]) {
+                    // fold to the nearest periodic image: d ∈ [-period/2, period/2)
+                    d -= period * std::floor((d + 0.5 * period) / period);
+                }
+                if (d < -1.0 - tol || d > 2.0 + tol)
+                    return false;
+            }
+            return true;
+        }
+
         /// given a displacement, generate a neighbor key; ignore boundary conditions and disp's level
 
         /// @param[in]  disp    the displacement

--- a/src/madness/mra/leafop.h
+++ b/src/madness/mra/leafop.h
@@ -88,17 +88,8 @@ public:
         for (size_t i = 0; i < special_points.size(); ++i) {
             Vector<double, NDIM> simpt;
             user_to_sim(special_points[i], simpt);
-            Key<NDIM> specialkey = simpt2key(simpt, key.level());
-            // use adaptive scheme: if we are at a low level refine also neighbours
-            int ll = get_half_of_special_level(f->get_special_level());
-            if (ll < f->get_initial_level()) ll = f->get_initial_level();
-            if (key.level() > ll) {
-                if (specialkey == key) return true;
-                else return false;
-            } else {
-                if (specialkey.is_neighbor_of(key, bperiodic)) return true;
-                else return false;
-            }
+            if (key.is_neighbor_of(simpt, bperiodic)) return true;
+            else return false;
         }
         return false;
     }
@@ -253,23 +244,12 @@ public:
         for (size_t i = 0; i < lowdim_sp.size(); ++i) {
             Vector<double, NDIM / 2> simpt;
             user_to_sim(lowdim_sp[i], simpt);
-            Key<NDIM / 2> specialkey = simpt2key(simpt, key1.level());
-            // use adaptive scheme: if we are at a low level refine also neighbours
-            int ll = this->get_half_of_special_level(f->get_special_level());
-            if (ll < f->get_initial_level()) ll = f->get_initial_level();
-            if (key.level() > ll) {
-                if (particle == 1 and specialkey == key1) return true;
-                else if (particle == 2 and specialkey == key2) return true;
-                else if (particle == 0 and (specialkey == key1 or specialkey == key2)) return true;
-                else return false;
-            } else {
-                if (particle == 1 and specialkey.is_neighbor_of(key1, bperiodic)) return true;
-                else if (particle == 2 and specialkey.is_neighbor_of(key2, bperiodic)) return true;
-                else if (particle == 0 and
-                         (specialkey.is_neighbor_of(key1, bperiodic) or specialkey.is_neighbor_of(key2, bperiodic)))
-                    return true;
-                else return false;
-            }
+            const bool hit1 = key1.is_neighbor_of(simpt, bperiodic);
+            const bool hit2 = key2.is_neighbor_of(simpt, bperiodic);
+            if (particle == 1 and hit1) return true;
+            else if (particle == 2 and hit2) return true;
+            else if (particle == 0 and (hit1 or hit2)) return true;
+            else return false;
         }
         return false;
     }

--- a/src/madness/mra/mraimpl.h
+++ b/src/madness/mra/mraimpl.h
@@ -2473,6 +2473,9 @@ namespace madness {
                     if (specialkey.is_neighbor_of(key,bperiodic)) {
                         newspecialpts.push_back(specialpts[i]);
                     }
+                    if (key.is_neighbor_of(simpt, bperiodic)) {
+                        newspecialpts.push_back(specialpts[i]);
+                    }
                 }
             }
 

--- a/src/madness/mra/test_keybox.cc
+++ b/src/madness/mra/test_keybox.cc
@@ -1,0 +1,198 @@
+/// \file test_keybox.cc
+/// \brief Tests for Key::is_neighbor_of(simpt, bperiodic) — the geometric
+///        replacement for the legacy
+///        `simpt2key(simpt, n).is_neighbor_of(*this, bperiodic)` idiom.
+
+#include <madness/mra/mra.h>
+#include <madness/mra/funcdefaults.h>
+#include <madness/mra/key.h>
+#include <madness/world/test_utilities.h>
+
+using namespace madness;
+
+namespace {
+
+template <std::size_t NDIM>
+Key<NDIM> make_key(Level n, std::initializer_list<Translation> ls) {
+    Vector<Translation, NDIM> v;
+    std::size_t i = 0;
+    for (auto x : ls) { v[i++] = x; }
+    return Key<NDIM>(n, v);
+}
+
+// 1D basic adjacency: at level 2 the 4 boxes are
+// l=0:[0,.25] l=1:[.25,.5] l=2:[.5,.75] l=3:[.75,1].
+// is_neighbor_of(simpt) is true on this box and the two boxes adjacent to
+// the box(es) containing simpt.
+int test_1d_basic(World& world) {
+    test_output t("Key<1>::is_neighbor_of(simpt) — 1D");
+
+    array_of_bools<1> nonper{false};
+
+    auto key0 = make_key<1>(2, {0});
+    auto key1 = make_key<1>(2, {1});
+    auto key2 = make_key<1>(2, {2});
+    auto key3 = make_key<1>(2, {3});
+
+    // simpt at sim=0.30 (interior of l=1)
+    Vector<double,1> p_interior{0.30};
+    t.checkpoint( key0.is_neighbor_of(p_interior, nonper),
+                  "interior pt: l=0 is neighbor of containing l=1");
+    t.checkpoint( key1.is_neighbor_of(p_interior, nonper),
+                  "interior pt: l=1 contains pt");
+    t.checkpoint( key2.is_neighbor_of(p_interior, nonper),
+                  "interior pt: l=2 is neighbor of containing l=1");
+    t.checkpoint(!key3.is_neighbor_of(p_interior, nonper),
+                  "interior pt: l=3 is NOT neighbor of containing l=1");
+
+    // simpt at sim=0.5 lies on wall between l=1 and l=2; both adjacent boxes
+    // and their neighbors should be flagged.
+    Vector<double,1> p_wall{0.5};
+    t.checkpoint( key0.is_neighbor_of(p_wall, nonper),
+                  "wall pt: l=0 (neighbor of l=1) flagged");
+    t.checkpoint( key1.is_neighbor_of(p_wall, nonper),
+                  "wall pt: l=1 (contains pt) flagged");
+    t.checkpoint( key2.is_neighbor_of(p_wall, nonper),
+                  "wall pt: l=2 (contains pt) flagged");
+    t.checkpoint( key3.is_neighbor_of(p_wall, nonper),
+                  "wall pt: l=3 (neighbor of l=2) flagged");
+
+    return t.end();
+}
+
+// Symmetry across a wall: the set of flagged boxes should be the same for
+// simpt = 0.5, 0.5 + ε, and 0.5 − ε. The legacy code (simpt2key + is_neighbor_of)
+// flips which box `specialkey` lands in and shifts the 3-box window.
+int test_symmetry_at_boundary(World& world) {
+    test_output t("Key::is_neighbor_of(simpt) — boundary symmetry");
+
+    array_of_bools<1> nonper{false};
+    constexpr double eps = 1e-15;
+    constexpr Level n = 4;
+    const Translation NB = Translation(1) << n;  // 16 boxes
+
+    for (Translation li = 0; li < NB; ++li) {
+        auto key = make_key<1>(n, {li});
+        bool hit_below = key.is_neighbor_of(Vector<double,1>{0.5 - eps}, nonper);
+        bool hit_above = key.is_neighbor_of(Vector<double,1>{0.5 + eps}, nonper);
+        bool hit_exact = key.is_neighbor_of(Vector<double,1>{0.5}, nonper);
+        // wall sits between l=7 and l=8; expected neighborhood is {6,7,8,9}
+        bool expected = (li >= 6 && li <= 9);
+        t.checkpoint(hit_exact == expected,
+                     "exact wall point: l=" + std::to_string(li));
+        t.checkpoint(hit_below == expected,
+                     "wall - eps: l=" + std::to_string(li));
+        t.checkpoint(hit_above == expected,
+                     "wall + eps: l=" + std::to_string(li));
+    }
+    return t.end();
+}
+
+// 3D corner-of-cell: point at sim coord (0.5, 0.5, 0.5) touches 8 boxes at
+// every level n>=1. The 1-box-width neighborhood of those 8 contains 4^3=64
+// boxes: {l[i] ∈ {MID-2, MID-1, MID, MID+1}}.
+int test_3d_corner(World& world) {
+    test_output t("Key<3>::is_neighbor_of(simpt) — 3D corner");
+
+    array_of_bools<3> nonper{false, false, false};
+    constexpr Level n = 3;
+    const Translation MID = Translation(1) << (n - 1);  // = 4
+    const Vector<double,3> origin{0.5, 0.5, 0.5};
+
+    int hits = 0;
+    const Translation NB = Translation(1) << n;
+    for (Translation i = 0; i < NB; ++i)
+      for (Translation j = 0; j < NB; ++j)
+        for (Translation k = 0; k < NB; ++k) {
+            auto key = make_key<3>(n, {i, j, k});
+            if (key.is_neighbor_of(origin, nonper)) ++hits;
+        }
+    t.checkpoint(hits == 64,
+                 "64 boxes within one box-width of the corner (4^NDIM)");
+
+    // explicit symmetry across the corner
+    auto key_lo = make_key<3>(n, {MID - 2, MID - 2, MID - 2});
+    auto key_hi = make_key<3>(n, {MID + 1, MID + 1, MID + 1});
+    t.checkpoint(key_lo.is_neighbor_of(origin, nonper) ==
+                 key_hi.is_neighbor_of(origin, nonper),
+                 "neighborhood is symmetric across the corner");
+
+    return t.end();
+}
+
+// Periodic seam: point at sim coord 0.0 (== 1.0 mod 1) — boxes at both ends
+// of the domain should be flagged when bperiodic[i] is true.
+int test_periodic_seam(World& world) {
+    test_output t("Key<1>::is_neighbor_of(simpt) — periodic seam");
+
+    array_of_bools<1> per{true};
+    constexpr Level n = 3;  // 8 boxes
+    auto key_lo = make_key<1>(n, {0});  // [0/8, 1/8]
+    auto key_hi = make_key<1>(n, {7});  // [7/8, 8/8] — wraps to 0/8
+
+    t.checkpoint( key_lo.is_neighbor_of(Vector<double,1>{0.0}, per),
+                  "sim=0 contained in low box (periodic)");
+    t.checkpoint( key_hi.is_neighbor_of(Vector<double,1>{0.0}, per),
+                  "sim=0 wraps into high box (periodic)");
+    t.checkpoint( key_lo.is_neighbor_of(Vector<double,1>{1.0}, per),
+                  "sim=1 wraps into low box (periodic)");
+    t.checkpoint( key_hi.is_neighbor_of(Vector<double,1>{1.0}, per),
+                  "sim=1 contained in high box (periodic)");
+
+    // Non-periodic: no wrap; sim=1 is contained only in (and adjacent to) high boxes
+    array_of_bools<1> nonper{false};
+    auto key_mid = make_key<1>(n, {3});  // [3/8, 4/8] — far from sim=1
+    t.checkpoint(!key_mid.is_neighbor_of(Vector<double,1>{1.0}, nonper),
+                  "sim=1 does NOT reach interior box (non-periodic)");
+    t.checkpoint( key_hi.is_neighbor_of(Vector<double,1>{1.0}, nonper),
+                  "sim=1 hits high box (non-periodic)");
+
+    return t.end();
+}
+
+// Match interior behavior of the legacy code: for points strictly inside a
+// box, key.is_neighbor_of(simpt) and the legacy
+// simpt2key(simpt).is_neighbor_of(key) idiom must agree.
+int test_legacy_interior_equivalence(World& world) {
+    test_output t("Key::is_neighbor_of(simpt) ≡ legacy on interior");
+
+    array_of_bools<2> nonper{false, false};
+    constexpr Level n = 4;
+    std::vector<Vector<double,2>> pts = {
+        {0.123, 0.456},
+        {0.781, 0.219},
+        {0.9999, 0.0001}};
+
+    const Translation NB = Translation(1) << n;
+    for (auto& pt : pts) {
+        Vector<double,2> simpt = pt;
+        Key<2> specialkey = simpt2key(simpt, n);
+        for (Translation i = 0; i < NB; ++i)
+          for (Translation j = 0; j < NB; ++j) {
+              auto key = make_key<2>(n, {i, j});
+              bool legacy = specialkey.is_neighbor_of(key, nonper);
+              bool now = key.is_neighbor_of(simpt, nonper);
+              t.checkpoint(legacy == now,
+                           "legacy ≡ is_neighbor_of(simpt) at interior pt");
+          }
+    }
+    return t.end();
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    World& world = madness::initialize(argc, argv);
+    startup(world, argc, argv);
+
+    int errors = 0;
+    errors += test_1d_basic(world);
+    errors += test_symmetry_at_boundary(world);
+    errors += test_3d_corner(world);
+    errors += test_periodic_seam(world);
+    errors += test_legacy_interior_equivalence(world);
+
+    world.gop.fence();
+    madness::finalize();
+    return errors;
+}


### PR DESCRIPTION
**Summary** special points at faces/edges/vertices are considered "in"/neighbors of the connecting boxes

**Key improvements:**

### Neighbor detection logic

* New `Key::is_neighbor_of(Vector, bperiodic)` method in `key.h` accurately determines if a box is a _neighbor_ of a point in simulation coordinates, handling the cases of face/edge/vertex special points more robustly.
* Refactored usages in `leafop.h` to use the new point-based neighbor detection, replacing the legacy approach that could be asymmetric on box boundaries. This affects both `Specialbox_op` and `NuclearCuspyBox_op`. [[1]](diffhunk://#diff-21a0ae6b1faf5b2fcf4b601d87a4920fff469aa81b64e12c804f6992223eaedcL91-L102) [[2]](diffhunk://#diff-21a0ae6b1faf5b2fcf4b601d87a4920fff469aa81b64e12c804f6992223eaedcL256-L272)
* Updated `mraimpl.h` to also use the new neighbor detection method for consistency and correctness.

### Testing

* Added a new test file `test_keybox.cc` to the `MRA_TEST_SOURCES` in `CMakeLists.txt` to ensure the new neighbor detection logic is properly tested.