### PR TITLE
build: enable -Werror on MADNESS translation units (Phase 1)

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -52,6 +52,7 @@ jobs:
         -DMADNESS_BUILD_MADWORLD_ONLY=${{ matrix.task_backend != 'Threads' }}
         -DMADNESS_BUILD_LIBRARIES_ONLY=${{ matrix.build_type == 'Debug' }}
         -DENABLE_GENTENSOR=${{ matrix.gentensor || 'OFF' }}
+        -DMADNESS_WERROR=ON
 
     steps:
     - uses: actions/checkout@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,6 +243,15 @@ from TiledArray and MPQC). Maintain both invariants when editing CMake.
   tests during iteration.
 - **`CMAKE_FIND_NO_INSTALL_PREFIX=ON`** is set as a safety net so
   `find_package` doesn't pick up a stale installed copy during development.
+- **Internal warning policy lives on the `madness_internal_warnings` INTERFACE
+  target** (`cmake/modules/MADNESSWarnings.cmake`), linked PRIVATE-ly to
+  `MAD*-obj` object libraries by `add_mad_library` and to in-tree executables
+  by `add_mad_executable`. The PRIVATE scope is load-bearing: it keeps
+  warning flags out of `INTERFACE_COMPILE_OPTIONS` on the exported MAD*
+  targets so downstream consumers don't inherit them, and the target itself
+  is not installed/exported. Add new warning-related flags here, not to
+  individual targets. `-DMADNESS_WERROR=ON` (default OFF, on in CI) attaches
+  `-Werror` to this target.
 
 ### Commit messages
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,8 @@ if (NOT MADNESS_BUILD_LIBRARIES_ONLY)
   redefaultable_option(MADNESS_BUILD_MADWORLD_ONLY "Build only MADWorld runtime (excluding BLAS/LAPACK interfaces)" OFF)
 endif()
 redefaultable_option(MADNESS_ENABLE_CEREAL "Support use of Cereal archives as backends for MADNESS serialization" OFF)
+redefaultable_option(MADNESS_WERROR "Treat compiler warnings as errors when compiling MADNESS's own translation units (does not propagate to consumers of installed MADNESS targets)" OFF)
+include(MADNESSWarnings)
 
 # Enable optional libraries ====================================================
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -107,6 +107,11 @@ The following CMake cache variables turn features on and off.
 * MADNESS_BUILD_LIBRARIES_ONLY --- whether to build the MADNESS libraries only; if `ON`,
       building of numerical components and applications will be disabled and
       the value of `MADNESS_BUILD_MADWORLD_ONLY` ignored [default=`OFF`]
+* MADNESS_WERROR --- treat compiler warnings as errors when compiling MADNESS's
+      own translation units. The flag is applied PRIVATE-ly to MADNESS sources
+      only and does not propagate to consumers of an installed MADNESS package.
+      Supported with GNU, Clang, AppleClang, and IntelLLVM compilers; ignored
+      with a warning on others. Enabled in CI. [default=`OFF`]
 
 ## External libraries
 

--- a/cmake/modules/AddMADExecutable.cmake
+++ b/cmake/modules/AddMADExecutable.cmake
@@ -2,6 +2,7 @@ macro(add_mad_executable _name _source_files _libs)
 
   add_executable(${_name} ${_source_files})
   target_link_libraries(${_name} PRIVATE "${_libs}")
+  target_link_libraries(${_name} PRIVATE madness_internal_warnings)
   add_dependencies(everything ${_name})
 
 endmacro()

--- a/cmake/modules/AddMADLibrary.cmake
+++ b/cmake/modules/AddMADLibrary.cmake
@@ -21,8 +21,10 @@ macro(add_mad_library _name _source_files _header_files _dep_mad_comp _include_d
       $<TARGET_PROPERTY:MAD${_name},COMPILE_DEFINITIONS>)
   target_include_directories(MAD${_name}-obj PRIVATE 
       $<TARGET_PROPERTY:MAD${_name},INCLUDE_DIRECTORIES>)
-  target_compile_options(MAD${_name}-obj PRIVATE 
+  target_compile_options(MAD${_name}-obj PRIVATE
       $<TARGET_PROPERTY:MAD${_name},COMPILE_OPTIONS>)
+  # PRIVATE: warning flags must not propagate to consumers of the installed MAD${_name}.
+  target_link_libraries(MAD${_name}-obj PRIVATE madness_internal_warnings)
 
   # target-common setup
   add_custom_target(install-madness-${_name}

--- a/cmake/modules/MADNESSWarnings.cmake
+++ b/cmake/modules/MADNESSWarnings.cmake
@@ -1,0 +1,23 @@
+include_guard(GLOBAL)
+
+# MADNESS internal warning-policy target.
+#
+# Owns an INTERFACE library `madness_internal_warnings` that carries the
+# warning flags applied to MADNESS's own translation units. The target is
+# linked PRIVATE-ly to MAD*-obj object libraries (by add_mad_library) and
+# to in-tree executables (by add_mad_executable). PRIVATE scope is load-
+# bearing: it keeps these flags out of INTERFACE_COMPILE_OPTIONS on the
+# installed/exported MAD* targets, so downstream consumers (TiledArray,
+# MPQC, …) do not inherit -Werror through find_package(madness).
+#
+# It is also NOT installed/exported, which keeps it out of the package.
+
+add_library(madness_internal_warnings INTERFACE)
+
+if (MADNESS_WERROR)
+  if (CMAKE_CXX_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang|IntelLLVM)$")
+    target_compile_options(madness_internal_warnings INTERFACE -Werror)
+  else()
+    message(WARNING "MADNESS_WERROR=ON but compiler '${CMAKE_CXX_COMPILER_ID}' is not in the supported set; ignoring.")
+  endif()
+endif()

--- a/src/madness/chem/distpm.cc
+++ b/src/madness/chem/distpm.cc
@@ -120,7 +120,15 @@ public:
         if (snew > sold) {
             nswitched++;
             //print("rotation", i, j, sold, snew);
+            MADNESS_PRAGMA_GCC(diagnostic push)
+            MADNESS_PRAGMA_GCC(diagnostic ignored "-Wvla")
+            MADNESS_PRAGMA_CLANG(diagnostic push)
+            MADNESS_PRAGMA_CLANG(diagnostic ignored "-Wunknown-warning-option")
+            MADNESS_PRAGMA_CLANG(diagnostic ignored "-Wvla-extension")
+            MADNESS_PRAGMA_CLANG(diagnostic ignored "-Wvla-cxx-extension")
             double tmp[m];
+            MADNESS_PRAGMA_CLANG(diagnostic pop)
+            MADNESS_PRAGMA_GCC(diagnostic pop)
             memcpy(tmp, Ui, m*sizeof(double));
             memcpy(Ui, Uj, m*sizeof(double));
             memcpy(Uj, tmp, m*sizeof(double));

--- a/src/madness/mra/test_sepop.cc
+++ b/src/madness/mra/test_sepop.cc
@@ -4121,6 +4121,7 @@ namespace madness {
 MADNESS_PRAGMA_GCC(diagnostic push)
 MADNESS_PRAGMA_GCC(diagnostic ignored "-Wmaybe-uninitialized")
 MADNESS_PRAGMA_CLANG(diagnostic push)
+MADNESS_PRAGMA_CLANG(diagnostic ignored "-Wunknown-warning-option")
 MADNESS_PRAGMA_CLANG(diagnostic ignored "-Wmaybe-uninitialized")
     bool test_rnlij_rangelimited(const bool log_errors) {
       double maxerr = 0.0;

--- a/src/madness/tensor/test_Zmtxmq.cc
+++ b/src/madness/tensor/test_Zmtxmq.cc
@@ -174,10 +174,10 @@ int main(int argc, char * argv[]) {
 
     SafeMPI::Init_thread(argc, argv, MPI_THREAD_SINGLE);
 
-    posix_memalign((void **) &a, 16, nkmax*nimax*sizeof(double_complex));
-    posix_memalign((void **) &b, 16, nkmax*njmax*sizeof(double_complex));
-    posix_memalign((void **) &c, 16, nimax*njmax*sizeof(double_complex));
-    posix_memalign((void **) &d, 16, nimax*njmax*sizeof(double_complex));
+    if (posix_memalign((void **) &a, 16, nkmax*nimax*sizeof(double_complex)) != 0) return 1;
+    if (posix_memalign((void **) &b, 16, nkmax*njmax*sizeof(double_complex)) != 0) return 1;
+    if (posix_memalign((void **) &c, 16, nimax*njmax*sizeof(double_complex)) != 0) return 1;
+    if (posix_memalign((void **) &d, 16, nimax*njmax*sizeof(double_complex)) != 0) return 1;
 
 
     bool smalltest = false;

--- a/src/madness/tensor/test_mtxmq.cc
+++ b/src/madness/tensor/test_mtxmq.cc
@@ -179,10 +179,10 @@ int main(int argc, char * argv[]) {
 
     SafeMPI::Init_thread(argc, argv, MPI_THREAD_SINGLE);
 
-    posix_memalign((void **) &a, 16, nkmax*nimax*sizeof(double));
-    posix_memalign((void **) &b, 16, nkmax*njmax*sizeof(double));
-    posix_memalign((void **) &c, 16, nimax*njmax*sizeof(double));
-    posix_memalign((void **) &d, 16, nimax*njmax*sizeof(double));
+    if (posix_memalign((void **) &a, 16, nkmax*nimax*sizeof(double)) != 0) return 1;
+    if (posix_memalign((void **) &b, 16, nkmax*njmax*sizeof(double)) != 0) return 1;
+    if (posix_memalign((void **) &c, 16, nimax*njmax*sizeof(double)) != 0) return 1;
+    if (posix_memalign((void **) &d, 16, nimax*njmax*sizeof(double)) != 0) return 1;
 
     ran_fill(nkmax*nimax, a);
     ran_fill(nkmax*njmax, b);

--- a/src/madness/tensor/test_systolic.cc
+++ b/src/madness/tensor/test_systolic.cc
@@ -28,7 +28,13 @@ public:
     void start_iteration_hook(const TaskThreadEnv& env) {
         int id = env.id();
         if (id == 0) {
+            MADNESS_PRAGMA_GCC(diagnostic push)
+            MADNESS_PRAGMA_GCC(diagnostic ignored "-Wvolatile")
+            MADNESS_PRAGMA_CLANG(diagnostic push)
+            MADNESS_PRAGMA_CLANG(diagnostic ignored "-Wdeprecated-volatile")
             ++niter;
+            MADNESS_PRAGMA_CLANG(diagnostic pop)
+            MADNESS_PRAGMA_GCC(diagnostic pop)
         }
     }
     

--- a/src/madness/world/future.h
+++ b/src/madness/world/future.h
@@ -611,7 +611,14 @@ namespace madness {
                 // if the task setting f is gone *and* this is the only ref, move out
                 // to prevent a race with another thread that will make a copy of this Future while we are moving the data
                 // atomically swap f with nullptr, then check use count of f's copy
-                auto fcopy = std::atomic_exchange(&f, {});  // N.B. deprecated in C++20! need to convert f to std::atomic<std::shared_ptr<FutureImpl>>
+                MADNESS_PRAGMA_GCC(diagnostic push)
+                MADNESS_PRAGMA_GCC(diagnostic ignored "-Wdeprecated-declarations")
+                MADNESS_PRAGMA_CLANG(diagnostic push)
+                MADNESS_PRAGMA_CLANG(diagnostic ignored "-Wdeprecated-declarations")
+                // FIXME: deprecated in C++20! need to convert f to std::atomic<std::shared_ptr<FutureImpl>>
+                auto fcopy = std::atomic_exchange(&f, {});
+                MADNESS_PRAGMA_CLANG(diagnostic pop)
+                MADNESS_PRAGMA_GCC(diagnostic pop)
                 // f is now null and no new ref to the value can be created
                 if (fcopy.use_count() == 1)
                     return std::move(value_ref);


### PR DESCRIPTION
Phase 1 of the warnings-as-errors plan: clean up the small remaining
warning surface on master and turn on `-Werror` for MADNESS's own
translation units in CI.

## What changes

**CMake — opt-in `MADNESS_WERROR` flag, default OFF.**
- New `cmake/modules/MADNESSWarnings.cmake` owns an `INTERFACE` library
  `madness_internal_warnings`. When `MADNESS_WERROR=ON`, it carries
  `-Werror` (on GNU/Clang/AppleClang/IntelLLVM; warns otherwise).
- `add_mad_library`: links the warnings target `PRIVATE` to each
  `MAD${_name}-obj`. `PRIVATE` scope keeps `-Werror` out of
  `INTERFACE_COMPILE_OPTIONS` on the installed/exported MAD targets, so
  downstream consumers via `find_package(madness)` (TiledArray, MPQC, …)
  do **not** inherit it.
- `add_mad_executable`: links the warnings target `PRIVATE` to each
  in-tree executable, so apps, examples, and tests are also under
  `-Werror`.
- Verified by inspecting the generated `madness-targets.cmake`: zero
  `Werror` occurrences, `madness_internal_warnings` absent from every
  `INTERFACE_LINK_LIBRARIES`.

**Scope of `-Werror` intentionally excludes:**
- Bundled FetchContent code (parsec, nlohmann_json, cereal) — those
  targets are not built via `add_mad_*`.
- `pymadness` — pybind11-generated code, built via `pybind11_add_module`.

**CI — `-DMADNESS_WERROR=ON` for all 12 matrix cells.**

**Source-level warning fixes (the only remaining ones on master HEAD):**
- `distpm.cc`, `test_sepop.cc`, `test_systolic.cc` — original
  `MADNESS_PRAGMA_{GCC,CLANG}` suppressions (`-Wvla*`,
  `-Wunknown-warning-option`, `-Wdeprecated-volatile` / `-Wvolatile`).
- `test_mtxmq.cc`, `test_Zmtxmq.cc` — check the `posix_memalign` return
  values (was `-Wunused-result` on gcc, 8 instances).

## What this is not

- `-Wall` / `-Wextra` are **not** enabled — those would surface dozens
  to hundreds of additional warnings (sign-compare, unused-parameter,
  missing-field-initializers, …). Phases 2/3 of the plan.
- The flag is opt-in, so distro packagers and `FetchContent` consumers
  who don't pass `-DMADNESS_WERROR=ON` are unaffected.

## Verification done locally

- `cmake-build-relwithdebinfo` with `-DMADNESS_WERROR=ON`: full tree
  builds clean (394 targets, 0 compiler warnings).
- `madness-targets.cmake`: `-Werror` does not appear; warnings target
  not linked in any `INTERFACE_LINK_LIBRARIES`.
- `ninja -t commands` confirms `-Werror` is on MAD obj compiles and on
  in-tree test executables.

## Test plan
- [x] CI green across the 12-cell matrix with `MADNESS_WERROR=ON`
- [ ] Spot-check a downstream build (e.g. TiledArray pulling MADNESS via
  `FetchContent`) does **not** inherit `-Werror` from MADNESS targets