### PR TITLE
Provide a wrapper for atomic shared pointers

### DIFF
--- a/src/madness/world/CMakeLists.txt
+++ b/src/madness/world/CMakeLists.txt
@@ -11,7 +11,7 @@ set(MADWORLD_HEADERS
     uniqueid.h worldprofile.h timers.h binary_fstream_archive.h mpi_archive.h 
     text_fstream_archive.h worlddc.h mem_func_wrapper.h taskfn.h group.h 
     dist_cache.h distributed_id.h type_traits.h function_traits.h stubmpi.h 
-    bgq_atomics.h binsorter.h parsec.h meta.h worldinit.h thread_info.h
+    bgq_atomics.h binsorter.h parsec.h meta.h atomic_shared_ptr.h worldinit.h thread_info.h
     cloud.h test_utilities.h timing_utilities.h units.h ranks_and_hosts.h)
 set(MADWORLD_SOURCES
     madness_exception.cc world.cc timers.cc future.cc redirectio.cc

--- a/src/madness/world/atomic_shared_ptr.h
+++ b/src/madness/world/atomic_shared_ptr.h
@@ -23,14 +23,16 @@ namespace madness {
 /// \c use_count, equality comparison) plus a single extension, \c exchange(),
 /// needed for the move-optimisation in \c Future::get()&&.
 ///
-/// \note User-declared copy constructor and copy-assignment operator suppress
-/// the implicit move constructor and move-assignment operator (and
-/// \c std::atomic is itself non-movable in the C++20 backend), so move
-/// operations silently fall back to copy.
+/// \note Move operations are explicitly provided: they atomically take the
+/// value from the source (leaving it empty) via a relaxed-order \c exchange.
+/// This is necessary because (a) user-declared copy operations would otherwise
+/// suppress the implicit move operations, and (b) \c std::atomic is non-movable
+/// in the C++20 backend, so the implicit move would silently fall back to copy.
 ///
-/// \note All loads are \c memory_order_relaxed, relying on the caller to provide necessary
-/// ordering guarantees. The exception is \c exchange(), which defaults to \c memory_order_seq_cst to match the pre-C++20
-/// \c std::atomic_exchange behaviour it replaces.
+/// \note All loads/stores and move operations use \c memory_order_relaxed,
+/// relying on the caller to provide necessary ordering guarantees. The exception
+/// is \c exchange(), which defaults to \c memory_order_seq_cst to match the
+/// pre-C++20 \c std::atomic_exchange behaviour it replaces.
 template<typename T>
 class atomic_shared_ptr {
 #if defined(__cpp_lib_atomic_shared_ptr)
@@ -77,9 +79,22 @@ public:
     /// Copy-constructs by atomically loading the other pointer.
     atomic_shared_ptr(const atomic_shared_ptr& other) noexcept : ptr_(other.do_load()) {}
 
+    /// Move-constructs by atomically taking the value from \p other, which
+    /// is left empty. Uses \c memory_order_relaxed (consistent with
+    /// \c do_load / \c do_store); caller is responsible for any synchronization.
+    atomic_shared_ptr(atomic_shared_ptr&& other) noexcept
+        : ptr_(other.exchange({}, std::memory_order_relaxed)) {}
+
     /// Copy-assigns by atomically loading from \p other and storing.
     atomic_shared_ptr& operator=(const atomic_shared_ptr& other) noexcept {
         if (this != &other) do_store(other.do_load());
+        return *this;
+    }
+
+    /// Move-assigns by atomically taking the value from \p other, which
+    /// is left empty. Self-assignment is a no-op.
+    atomic_shared_ptr& operator=(atomic_shared_ptr&& other) noexcept {
+        if (this != &other) do_store(other.exchange({}, std::memory_order_relaxed));
         return *this;
     }
 

--- a/src/madness/world/atomic_shared_ptr.h
+++ b/src/madness/world/atomic_shared_ptr.h
@@ -1,0 +1,147 @@
+/**
+ \file atomic_shared_ptr.h
+ \brief Defines \c atomic_shared_ptr — a std::shared_ptr-compatible
+        wrapper backed by atomic storage.
+ \ingroup world
+*/
+
+#ifndef MADNESS_WORLD_ATOMIC_SHARED_PTR_H__INCLUDED
+#define MADNESS_WORLD_ATOMIC_SHARED_PTR_H__INCLUDED
+
+#include <atomic>
+#include <memory>
+#include <madness/madness_config.h>
+
+namespace madness {
+
+/// A \c std::shared_ptr-like handle backed by atomic storage.
+///
+/// Uses \c std::atomic<std::shared_ptr<T>> when available (C++20), otherwise
+/// falls back to the pre-C++20 atomic free functions on \c std::shared_ptr.
+/// The public API mirrors \c std::shared_ptr (copy construction/assignment,
+/// \c operator->, \c operator bool, implicit conversion, \c reset,
+/// \c use_count, equality comparison) plus a single extension, \c exchange(),
+/// needed for the move-optimisation in \c Future::get()&&.
+///
+/// \note User-declared copy constructor and copy-assignment operator suppress
+/// the implicit move constructor and move-assignment operator (and
+/// \c std::atomic is itself non-movable in the C++20 backend), so move
+/// operations silently fall back to copy.
+///
+/// \note All loads are \c memory_order_relaxed, relying on the caller to provide necessary
+/// ordering guarantees. The exception is \c exchange(), which defaults to \c memory_order_seq_cst to match the pre-C++20
+/// \c std::atomic_exchange behaviour it replaces.
+template<typename T>
+class atomic_shared_ptr {
+#if defined(__cpp_lib_atomic_shared_ptr)
+    std::atomic<std::shared_ptr<T>> ptr_;
+
+    std::shared_ptr<T> do_load() const noexcept {
+        return ptr_.load(std::memory_order_relaxed);
+    }
+    void do_store(std::shared_ptr<T> p) noexcept {
+        ptr_.store(std::move(p), std::memory_order_relaxed);
+    }
+#else
+    std::shared_ptr<T> ptr_;
+
+    // The atomic_*_explicit free functions on std::shared_ptr are deprecated
+    // in C++20 (superseded by std::atomic<shared_ptr<T>>). We reach this
+    // branch only when the library lacks __cpp_lib_atomic_shared_ptr, which
+    // can happen even on a C++20 compiler (old stdlib), so suppress the
+    // warning specifically for C++20 builds where it would fire.
+#if __cplusplus >= 202002L
+    MADNESS_PRAGMA_CLANG(diagnostic push)
+    MADNESS_PRAGMA_CLANG(diagnostic ignored "-Wdeprecated-declarations")
+    MADNESS_PRAGMA_GCC(diagnostic push)
+    MADNESS_PRAGMA_GCC(diagnostic ignored "-Wdeprecated-declarations")
+#endif
+    // Payload ordering supplied by FutureImpl's Spinlock; relaxed for identity.
+    std::shared_ptr<T> do_load() const noexcept {
+        return std::atomic_load_explicit(&ptr_, std::memory_order_relaxed);
+    }
+    void do_store(std::shared_ptr<T> p) noexcept {
+        std::atomic_store_explicit(&ptr_, std::move(p), std::memory_order_relaxed);
+    }
+#if __cplusplus >= 202002L
+    MADNESS_PRAGMA_CLANG(diagnostic pop)
+    MADNESS_PRAGMA_GCC(diagnostic pop)
+#endif
+#endif
+
+public:
+    constexpr atomic_shared_ptr() noexcept = default;
+
+    atomic_shared_ptr(std::shared_ptr<T> p) noexcept : ptr_(std::move(p)) {}
+
+    /// Copy-constructs by atomically loading the other pointer.
+    atomic_shared_ptr(const atomic_shared_ptr& other) noexcept : ptr_(other.do_load()) {}
+
+    /// Copy-assigns by atomically loading from \p other and storing.
+    atomic_shared_ptr& operator=(const atomic_shared_ptr& other) noexcept {
+        if (this != &other) do_store(other.do_load());
+        return *this;
+    }
+
+    /// Assigns a new shared_ptr value atomically.
+    atomic_shared_ptr& operator=(std::shared_ptr<T> p) noexcept {
+        do_store(std::move(p));
+        return *this;
+    }
+
+    /// Replaces the stored pointer, adopting \p p (may be null).
+    void reset(T* p) { do_store(std::shared_ptr<T>(p)); }
+
+    /// Replaces the stored pointer with an empty shared pointer.
+    void reset() { do_store(std::shared_ptr<T>()); }
+
+    explicit operator bool() const noexcept { return bool(do_load()); }
+
+    /// Dereferences the stored pointer.
+    /// Safe because \c do_load() returns a \c shared_ptr temporary whose
+    /// lifetime extends to the end of the full expression containing the
+    /// \c -> call, keeping the referent alive across the dereference.
+    T* operator->() noexcept { return do_load().get(); }
+
+    /// Dereferences the stored pointer, const overload.
+    /// Safe because \c do_load() returns a \c shared_ptr temporary whose
+    /// lifetime extends to the end of the full expression containing the
+    /// \c -> call, keeping the referent alive across the dereference.
+    const T* operator->() const noexcept { return do_load().get(); }
+
+    /// Implicit conversion to \c shared_ptr, used for lifetime extension and
+    /// APIs that require a \c shared_ptr (e.g. \c RemoteReference).
+    operator std::shared_ptr<T>() const noexcept { return do_load(); }
+
+    long use_count() const noexcept { return do_load().use_count(); }
+
+    bool operator==(const atomic_shared_ptr& r) const noexcept { return do_load() == r.do_load(); }
+    bool operator!=(const atomic_shared_ptr& r) const noexcept { return do_load() != r.do_load(); }
+
+    /// Atomically replaces the stored pointer with \p p and returns the old
+    /// value. This is the only operation that differs from \c std::shared_ptr.
+    /// Defaults to \c memory_order_seq_cst to match the pre-C++20
+    /// \c std::atomic_exchange behaviour this replaces.
+    std::shared_ptr<T> exchange(std::shared_ptr<T> p = {},
+                                std::memory_order order = std::memory_order_seq_cst) noexcept {
+#if defined(__cpp_lib_atomic_shared_ptr)
+        return ptr_.exchange(std::move(p), order);
+#else
+#if __cplusplus >= 202002L
+        MADNESS_PRAGMA_CLANG(diagnostic push)
+        MADNESS_PRAGMA_CLANG(diagnostic ignored "-Wdeprecated-declarations")
+        MADNESS_PRAGMA_GCC(diagnostic push)
+        MADNESS_PRAGMA_GCC(diagnostic ignored "-Wdeprecated-declarations")
+#endif
+        return std::atomic_exchange_explicit(&ptr_, std::move(p), order);
+#if __cplusplus >= 202002L
+        MADNESS_PRAGMA_CLANG(diagnostic pop)
+        MADNESS_PRAGMA_GCC(diagnostic pop)
+#endif
+#endif
+    }
+};
+
+} // namespace madness
+
+#endif // MADNESS_WORLD_ATOMIC_SHARED_PTR_H__INCLUDED

--- a/src/madness/world/future.h
+++ b/src/madness/world/future.h
@@ -11,7 +11,7 @@
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-  GNU General Public License for more details.
+  GNU Genera1l Public License for more details.
 
   You should have received a copy of the GNU General Public License
   along with this program; if not, write to the Free Software
@@ -42,6 +42,7 @@
 #include <vector>
 #include <stack>
 #include <new>
+#include <madness/world/atomic_shared_ptr.h>
 #include <madness/world/nodefaults.h>
 #include <madness/world/dependency_interface.h>
 #include <madness/world/stack.h>
@@ -120,7 +121,7 @@ namespace madness {
   		    T value;
                     input_arch & value;
                     MADNESS_PRAGMA_CLANG(diagnostic pop)
-	
+
 
                     // Copy world and owner from remote_ref since sending remote_ref
                     // will invalidate it.
@@ -373,7 +374,7 @@ namespace madness {
     private:
 
         /// Pointer to the implementation object.
-        std::shared_ptr< FutureImpl<T> > f;
+        atomic_shared_ptr< FutureImpl<T> > f;
         char buffer[sizeof(T)]; ///< Buffer to hold a single \c T object.
         T* const value; ///< Pointer to buffer when it holds a \c T object.
 
@@ -395,7 +396,7 @@ namespace madness {
 
         /// Makes an unassigned future.
         Future() :
-            f(new FutureImpl<T>()), value(nullptr)
+            f(std::make_shared<FutureImpl<T>>()), value(nullptr)
         {
         }
 
@@ -611,14 +612,7 @@ namespace madness {
                 // if the task setting f is gone *and* this is the only ref, move out
                 // to prevent a race with another thread that will make a copy of this Future while we are moving the data
                 // atomically swap f with nullptr, then check use count of f's copy
-                MADNESS_PRAGMA_GCC(diagnostic push)
-                MADNESS_PRAGMA_GCC(diagnostic ignored "-Wdeprecated-declarations")
-                MADNESS_PRAGMA_CLANG(diagnostic push)
-                MADNESS_PRAGMA_CLANG(diagnostic ignored "-Wdeprecated-declarations")
-                // FIXME: deprecated in C++20! need to convert f to std::atomic<std::shared_ptr<FutureImpl>>
-                auto fcopy = std::atomic_exchange(&f, {});
-                MADNESS_PRAGMA_CLANG(diagnostic pop)
-                MADNESS_PRAGMA_GCC(diagnostic pop)
+                auto fcopy = f.exchange({});
                 // f is now null and no new ref to the value can be created
                 if (fcopy.use_count() == 1)
                     return std::move(value_ref);


### PR DESCRIPTION
C++20 has deprecated free-standing atomic operations on `std::shared_ptr` and instead introduced `std::atomic<std::shared_ptr>`. Introduce a wrapper `atomic_shared_ptr` that abstracts away the handling of different versions of C++.

This PR does not change the required C++ version but is needed when MADNESS is pulled into a project that requires new C++.