### PR TITLE
WorldGopInterface::is_in_do_cleanup() — let deferred destructors skip cross-rank handshakes

### DIFF
--- a/src/madness/world/worldgop.cc
+++ b/src/madness/world/worldgop.cc
@@ -149,7 +149,22 @@ namespace madness {
         MADNESS_ASSERT(pause_during_epilogue == false);
         epilogue();
         world_.am.free_managed_buffers(); // free up communication buffers
-        deferred_->do_cleanup();
+        // Run deferred cleanup with the in_do_cleanup_ flag set so that any
+        // destructor invoked here can detect that it runs from inside the
+        // fence's synchronization boundary and skip cross-rank handshakes
+        // (e.g. TA's DistArray::lazy_deleter checks this and bypasses
+        // lazy_sync, which would otherwise schedule lazy_sync_children tasks
+        // that the fence cannot drain and that survive into the global
+        // ThreadPool past this world's lifetime). The flag is reset on every
+        // exit path, including exceptions.
+        {
+          struct InDoCleanupScope {
+            bool& flag;
+            ~InDoCleanupScope() { flag = false; }
+          } scope{in_do_cleanup_};
+          in_do_cleanup_ = true;
+          deferred_->do_cleanup();
+        }
 #ifdef MADNESS_HAS_GOOGLE_PERF_TCMALLOC
         MallocExtension::instance()->ReleaseFreeMemory();
 //        print("clearing memory");

--- a/src/madness/world/worldgop.h
+++ b/src/madness/world/worldgop.h
@@ -151,6 +151,7 @@ namespace madness {
         bool debug_; ///< Debug mode
         bool forbid_fence_=false; ///< forbid calling fence() in case of several active worlds
         int max_reducebcast_msg_size_ = std::numeric_limits<int>::max();  ///< maximum size of messages (in bytes) sent by reduce and broadcast
+        bool in_do_cleanup_ = false; ///< set while this gop's deferred_->do_cleanup() is running inside fence_impl, so that destructors invoked during cleanup can skip cross-rank handshakes safely (see is_in_do_cleanup)
 
         friend class detail::DeferredCleanup;
 
@@ -696,6 +697,23 @@ namespace madness {
         /// \return the maximum size of messages (in bytes) sent by reduce and broadcast
         int max_reducebcast_msg_size() const {
           return max_reducebcast_msg_size_;
+        }
+
+        /// Reports whether this gop is currently inside its deferred-cleanup
+        /// phase (invoked from fence_impl after the global-termination loop).
+
+        /// \return true iff `deferred_->do_cleanup()` is being run from within
+        /// this gop's `fence_impl`.
+        /// \note Intended for destructors of objects stored in the deferred
+        /// list to specialize their teardown when they can rely on the fence
+        /// having already established global quiescence -- in particular, to
+        /// skip cross-rank handshakes (e.g. \c lazy_sync) that would otherwise
+        /// schedule \c lazy_sync_children tasks the fence cannot drain.
+        /// Symmetric, collective use of the deferred list is assumed: every
+        /// rank must add the same set of objects to its deferred list, so
+        /// every rank performs the matching cleanup in lockstep.
+        bool is_in_do_cleanup() const {
+          return in_do_cleanup_;
         }
 
         /// Synchronizes all processes in communicator ... does NOT fence pending AM or tasks


### PR DESCRIPTION
## Summary

Add a per-`WorldGopInterface` bool flag, set via an RAII scope in `fence_impl` around `deferred_->do_cleanup()`, and a public accessor `is_in_do_cleanup()`. Destructors invoked from within the deferred-cleanup phase can query the flag and skip cross-rank collective synchronization that the fence has already established.

## Why

`fence_impl` runs the global-termination protocol (drain loop + Dykstra-style nsent/nrecv tree handshake), so by the time `do_cleanup` runs, all ranks are at the same point with no AM in flight. `defer_deleter_to_next_fence` is, by contract, used collectively, so every rank's deferred list holds the same set of objects at this point and the matching cleanup actions on each rank are issued in lockstep.

Under those two invariants, a destructor running here may delete its object directly rather than route through a collective handshake like `lazy_sync` — the handshake's purpose (avoiding deletion while a peer may still send AM addressed to the object) is already satisfied by the fence.

Downstream consumer ([ValeevGroup/tiledarray#550](https://github.com/ValeevGroup/tiledarray/pull/550)) uses this to make `DistArray::lazy_deleter` bypass `lazy_sync` in the deferred-cleanup path. That eliminates a class of bugs where `lazy_sync_children` tasks survive the fence (they're scheduled after the drain loop) and are later run against freed state when the world is destroyed before peers reach a matching fence — most visibly when TA-`einsum` per-Hadamard sub-Worlds are torn down at function exit or during exception unwind, tripping `~WorldObject`'s `World::exists(&world)` assertion.

## What

- `worldgop.h`: private `bool in_do_cleanup_ = false`, public `is_in_do_cleanup()`.
- `worldgop.cc`: tiny RAII scope in `fence_impl` that flips the flag around `deferred_->do_cleanup()`, exception-safe.

## Test plan

- [x] Local downstream MPQC repro (bimal.json CSV-CCk traced expression with arena-ToT operands): previously aborted in `~WorldObject` during einsum stack unwind; runs end-to-end with exit 0 after this + TA#550.
- [ ] CI green (single-rank and multi-rank).

## Note on a previous attempt

An earlier version of this PR added a `world_.taskq.fence()` after `do_cleanup()` inside `fence_impl`. That deadlocked on multi-rank because `lazy_sync` is a collective requiring matching `lazy_sync(id, ...)` on every peer for the same id — but per-rank `shared_ptr<...>` refcounts are independent and peers' deferred lists need not agree at a given fence boundary (broke TA's `expressions_complex_suite/assign_subblock_block_contract` test). The current approach removes the offending synchronization entirely rather than trying to drain it locally.