### PR TITLE
fix: fence_impl gfence tree-collect awaits use dowork=false

### DIFF
--- a/src/madness/world/worldgop.cc
+++ b/src/madness/world/worldgop.cc
@@ -70,8 +70,14 @@ namespace madness {
             if (child0 != -1) req0 = world_.mpi.Irecv((void*) &sum0, sizeof(sum0), MPI_BYTE, child0, gfence_tag);
             if (child1 != -1) req1 = world_.mpi.Irecv((void*) &sum1, sizeof(sum1), MPI_BYTE, child1, gfence_tag);
             world_.taskq.fence();
-            if (child0 != -1) World::await(req0);
-            if (child1 != -1) World::await(req1);
+            // Use dowork=false: the gfence tree-collect messages are tiny and
+            // arrive quickly.  dowork=true creates a circular dependency when
+            // children have already sent their collect message and entered the
+            // broadcast phase (where they stop draining tasks): the parent
+            // keeps spawning AM traffic toward those children, neither side
+            // makes MPI progress on the gfence recv, and the fence deadlocks.
+            if (child0 != -1) World::await(req0, false);
+            if (child1 != -1) World::await(req1, false);
 
             if (debug && (child0 != -1 || child1 != -1))
               madness::print(world_.rank(), ": WORLD.GOP.FENCE: npass=", npass, " received messages from children={", child0, ",", child1, "} gfence_tag=", gfence_tag);


### PR DESCRIPTION
## Summary

- In `WorldGopInterface::fence_impl` (`worldgop.cc`), the two `World::await` calls that receive the gfence tree-collect messages from children now pass `dowork=false`.
- Fixes a deadlock observed on multi-node runs (≥2 nodes, 2 ppn) during `NemoBase::orthonormalize` → `mul` → `world.gop.fence()`.

## Root cause (brief)

Once children finish their bottom-up collect and enter the broadcast phase, they block in `World::await(..., dowork=true)` for the root's broadcast message and stop draining the task pool.  The parent, also in `World::await(..., dowork=true)` waiting for the children's gfence message, keeps executing pool tasks that generate new AM traffic toward those children.  Neither side makes MPI progress on the gfence recv; the timeout never fires because tasks keep running; the fence deadlocks.

Switching to `dowork=false` for the two gfence-recv awaits breaks the cycle.  The messages are 16 bytes over IB and complete immediately once MPI has an uncontested path.

## Test plan

- [ ] Re-run stalled job (`water`, `k=5`, `thresh=1e-3`, 2 nodes × 2 ppn) and confirm it advances past SCF iteration 3
- [ ] Run full MADNESS test suite (`ctest`) to verify no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)