### PR TITLE
More explicit virtual function declarations in derived classes

### DIFF
--- a/src/madness/world/taskfn.h
+++ b/src/madness/world/taskfn.h
@@ -854,6 +854,7 @@ namespace madness {
         const futureT& result() const { return result_; }
 
       protected:
+        using TaskInterface::run;
         virtual void run(World&, const TaskThreadEnv&) /*override*/{
             detail::run_function(result_, func_, arg1_, arg2_, arg3_, arg4_,
                     arg5_, arg6_, arg7_, arg8_, arg9_);

--- a/src/madness/world/world_task_queue.h
+++ b/src/madness/world/world_task_queue.h
@@ -1428,6 +1428,8 @@ namespace madness {
             /// \return A const reference to the result future.
             const Future<bool>& result() const { return completion_status_; }
 
+            using TaskInterface::run;
+
             /// Task run work.
 
             /// Sets the result future based on the status of all iterations.
@@ -1496,6 +1498,8 @@ namespace madness {
 
             /// Virtual destructor.
             virtual ~ForEachTask() = default;
+
+            using TaskInterface::run;
 
             /// Run the task.
 
@@ -1583,6 +1587,8 @@ namespace madness {
                 status_ += status;
                 DependencyInterface::notify();
             }
+
+            using TaskInterface::run;
 
             /// Task run work.
 


### PR DESCRIPTION
NVCC is picky and complains about incomplete overrides.