### PR TITLE
Store the world in WorldObjectBase

### DIFF
--- a/src/madness/world/world.cc
+++ b/src/madness/world/world.cc
@@ -82,6 +82,7 @@ namespace madness {
                  bool fence)
             : obj_id(1)          ///< start from 1 so that 0 is an invalid id
             , user_state(0)
+            , alive(std::make_shared<std::atomic<bool>>(true))
             , mpi(*(new WorldMpiInterface(comm)))
             , am(* (new WorldAmInterface(*this)))
             , taskq(*(new WorldTaskQueue(*this)))
@@ -126,6 +127,9 @@ namespace madness {
         delete &am;
         delete &mpi;
         if (this->_id != 0) worlds.remove(this);
+        // last: any WorldObject destroyed above must still see this world as alive,
+        // just like it must still be findable via world_from_id
+        alive->store(false, std::memory_order_relaxed);
     }
 
     void World::initialize_world_id_range(int global_rank) {

--- a/src/madness/world/world.h
+++ b/src/madness/world/world.h
@@ -55,10 +55,12 @@
 // #endif
 
 // Standard C++ header files needed by MADworld.h
+#include <atomic>   // std::atomic
 #include <cstddef>
 #include <cstdint>  // std::uint64_t
 #include <iostream>
 #include <list>     // std::list
+#include <memory>   // std::shared_ptr
 #include <optional> // std::optional
 #include <utility>  // std::pair
 
@@ -188,6 +190,13 @@ namespace madness {
         unsigned long obj_id; ///< Counter for generating unique IDs within this world.
         void* user_state; ///< Holds a user-defined and managed local state.
 
+        /// Tracks the liveness of this \c World; cleared at the end of \c ~World.
+
+        /// Shared with the objects that memoize a reference to this \c World
+        /// (see \c WorldObjectBase) so that they can detect that it is gone.
+        /// \sa World::liveness
+        std::shared_ptr<std::atomic<bool>> alive;
+
         // Default copy constructor and assignment won't compile
         // (which is good) due to reference members.
 
@@ -313,6 +322,21 @@ namespace madness {
         ///
         /// \return The system-wide unique integer ID of this \c World.
         unsigned long id() const { return _id; }
+
+        /// The type of the handle returned by \c liveness().
+        using liveness_handleT = std::shared_ptr<const std::atomic<bool>>;
+
+        /// Returns a handle reporting whether this \c World is still alive.
+
+        /// Unlike a \c World reference, the handle stays valid --- and
+        /// dereferenceable --- after this \c World has been destroyed, at which
+        /// point it reports \c false. This lets objects that memoize a \c World
+        /// reference (see \c WorldObjectBase) validate it before use, at the
+        /// cost of a relaxed atomic load. The handle becomes \c false at the
+        /// very end of \c ~World, i.e. objects destroyed by \c ~World itself
+        /// still observe their \c World as alive.
+        /// \return The liveness handle of this \c World.
+        liveness_handleT liveness() const { return alive; }
 
         /// Returns the process rank in this \c World (same as MPI_Comm_rank()).
 

--- a/src/madness/world/world_object.h
+++ b/src/madness/world/world_object.h
@@ -336,11 +336,24 @@ namespace madness {
 
     } // namespace detail
 
-    /// Base class for WorldObject, useful for introspection
+    /// Base class for WorldObject
+    /// Provides a protected world reference to the derived class
+    /// and get_world() method to access it.
+    /// Should not be used directly, but rather through WorldObject<Derived>.
     struct WorldObjectBase {
-      virtual ~WorldObjectBase() = default;
+    protected:
+        World& world; ///< The \c World this object belongs to. (Think globally, act locally).
+
+        explicit WorldObjectBase(World& w) : world(w) {}
     public:
-        virtual World& get_world() const = 0;
+
+        virtual ~WorldObjectBase() = default;
+
+        /// Get the world to which this object belongs.
+        /// \return A reference to the world.
+        World& get_world() const {
+            return world;
+        }
     };
 
     /// Implements most parts of a globally addressable object (via unique ID).
@@ -359,7 +372,7 @@ namespace madness {
     /// -# Derived class must have at least one virtual function for serialization
     ///    of derived class pointers to be cast to the appropriate type.
     ///
-    /// Note that \c world is exposed for convenience as a public data member.
+    /// Note that the world is exposed through \c WorldObjectBase::get_world().
     /// \tparam Derived The derived class. \c WorldObject is a curiously
     ///     recurring template pattern.
     template <class Derived>
@@ -369,7 +382,7 @@ namespace madness {
         typedef WorldObject<Derived> objT;
 
         // copy ctor must be enabled to permit RVO; in C++17 will not need this
-        WorldObject(const WorldObject& other) : world(other.world) { abort(); }
+        WorldObject(const WorldObject& other) : WorldObjectBase(other.world) { abort(); }
         // no copy
         WorldObject& operator=(const WorldObject&) = delete;
 
@@ -379,8 +392,6 @@ namespace madness {
 
         /// \todo Description needed.
         typedef detail::voidT voidT;
-
-        World& world; ///< The \c World this object belongs to. (Think globally, act locally).
 
         // The order here matters in a multi-threaded world
         volatile bool ready; ///< True if ready to rock 'n roll.
@@ -703,7 +714,7 @@ namespace madness {
         /// -# to enable processing of future messages.
         /// \param[in,out] world The \c World encapsulating the \"global\" domain.
         WorldObject(World& world)
-                : world(world)
+                : WorldObjectBase(world)
                 , ready(false)
                 , me(world.rank())
                 , objid(world.register_ptr(static_cast<Derived*>(this))) {};
@@ -713,13 +724,6 @@ namespace madness {
         const uniqueidT& id() const {
             return objid;
         }
-
-
-        /// Returns a reference to the \c world.
-        World& get_world() const {
-            return const_cast<WorldObject<Derived>*>(this)->world;
-        }
-
 
         /// \todo Brief description needed.
 
@@ -1555,7 +1559,7 @@ namespace madness {
 #endif  // MADNESS_WORLDOBJECT_FUTURE_TRACE
 
     namespace archive {
-        
+
         /// Specialization of \c ArchiveLoadImpl for globally-addressable objects.
 
         /// \tparam Derived The derived class of \c WorldObject in a curiously

--- a/src/madness/world/world_object.h
+++ b/src/madness/world/world_object.h
@@ -410,6 +410,19 @@ namespace madness {
             MADNESS_ASSERT(world_is_alive());
             return world;
         }
+
+        /// Get the world to which this object belongs, without risking a throw.
+
+        /// Same as \c get_world(), except the memoized reference is validated
+        /// with \c MADNESS_ASSERT_NOEXCEPT, which aborts rather than throws.
+        /// Use this from destructors and other \c noexcept contexts, where a
+        /// throwing \c MADNESS_ASSERT would call \c std::terminate and thereby
+        /// discard the diagnostic.
+        /// \return A reference to the world.
+        World& get_world_noexcept() const noexcept {
+            MADNESS_ASSERT_NOEXCEPT(world_is_alive());
+            return world;
+        }
     };
 
     /// Implements most parts of a globally addressable object (via unique ID).
@@ -1451,7 +1464,9 @@ namespace madness {
 
         virtual ~WorldObject() {
             if(initialized()) {
-              World& world = this->get_world(); // checks whether world exists
+              // noexcept variant: a throwing assertion in a destructor would
+              // call std::terminate and discard the diagnostic
+              World& world = this->get_world_noexcept(); // checks whether world exists
               MADNESS_ASSERT_NOEXCEPT(world.ptr_from_id<Derived>(id()));
               MADNESS_ASSERT_NOEXCEPT(*world.ptr_from_id<Derived>(id()) == this);
             }

--- a/src/madness/world/world_object.h
+++ b/src/madness/world/world_object.h
@@ -337,12 +337,14 @@ namespace madness {
     } // namespace detail
 
     /// Base class for WorldObject
-    /// Provides a protected world reference to the derived class
-    /// and get_world() method to access it.
-    /// Should not be used directly, but rather through WorldObject<Derived>.
+
+    /// Holds the parts of a \c WorldObject that do not depend on the derived
+    /// class: the unique object ID and the \c World the object belongs to,
+    /// the latter accessible to the derived class via \c get_world().
+    /// Should not be used directly, but rather through \c WorldObject<Derived>.
     struct WorldObjectBase {
     private:
-        uniqueidT objid; ///< Unique object ID.
+        uniqueidT objid; ///< Unique object ID; null until \c register_self() has been called.
         World& world; ///< Memoized reference to the world to which this object belongs.
         World::liveness_handleT world_liveness; ///< Reports whether \c world is still alive.
 
@@ -384,6 +386,16 @@ namespace madness {
         void register_self(DerivedT* this_ptr) {
             MADNESS_ASSERT(!objid); // registering twice would leak the first ID
             objid = world.register_ptr(this_ptr);
+        }
+
+        /// Unchecked access to the memoized world reference.
+
+        /// \warning Does not validate that the world is still alive; only use
+        ///          where that has already been established (e.g. right after a
+        ///          \c world_is_alive() check).
+        /// \return A reference to the world.
+        World& get_world_unchecked() const noexcept {
+            return world;
         }
 
     public:
@@ -460,7 +472,13 @@ namespace madness {
     /// -# Derived class must have at least one virtual function for serialization
     ///    of derived class pointers to be cast to the appropriate type.
     ///
-    /// Note that the world is exposed through \c WorldObjectBase::get_world().
+    /// The \c World is accessed through \c WorldObjectBase::get_world(), which
+    /// validates that it is still alive; derived classes that have already
+    /// established that can use \c WorldObjectBase::get_world_unchecked().
+    /// \note This class used to expose the \c World as a public data member
+    ///       named \c world. That member is gone; replace \c obj.world with
+    ///       \c obj.get_world() and, within a derived class, \c world with
+    ///       \c this->get_world().
     /// \tparam Derived The derived class. \c WorldObject is a curiously
     ///     recurring template pattern.
     template <class Derived>

--- a/src/madness/world/world_object.h
+++ b/src/madness/world/world_object.h
@@ -358,7 +358,11 @@ namespace madness {
 
         virtual ~WorldObjectBase() {
             if(initialized()) {
-              this->get_world().unregister_ptr(objid);
+                auto* world_ptr = World::world_from_id(objid.get_world_id());
+                MADNESS_ASSERT_NOEXCEPT(world_ptr != nullptr &&  "WorldObjectBase::~WorldObjectBase() failed to find world");
+                MADNESS_ASSERT_NOEXCEPT(world_ptr == &world &&
+                    "WorldObjectBase::~WorldObjectBase() cached world differs from world in object ID");
+                world.unregister_ptr(objid);
             }
         }
 
@@ -370,11 +374,7 @@ namespace madness {
         /// Get the world to which this object belongs.
         /// \return A reference to the world.
         World& get_world() const {
-            auto* world = World::world_from_id(objid.get_world_id());
-            if (!world) {
-                MADNESS_EXCEPTION("WorldObjectBase::get_world() failed to find world", objid.get_world_id());
-            }
-            return *world;
+            return world;
         }
     };
 

--- a/src/madness/world/world_object.h
+++ b/src/madness/world/world_object.h
@@ -349,12 +349,29 @@ namespace madness {
     protected:
 
         /// Construct a new WorldObjectBase.
-        /// Protected, should only be called from WorldObject constructor.
+
+        /// Protected, should only be called from the \c WorldObject constructor.
+        /// \note This does \em not register the object with \p w; the derived
+        ///       \c WorldObject must call \c register_self() to do that, once
+        ///       its own members have been initialized.
         /// \param[in] w The world to which this object belongs.
-        template <typename DerivedT>
-        explicit WorldObjectBase(World& w, DerivedT* this_ptr)
-        : objid(w.register_ptr(this_ptr)), world(w), world_liveness(w.liveness())
+        explicit WorldObjectBase(World& w)
+        : objid(), world(w), world_liveness(w.liveness())
         { }
+
+        /// Registers this object with its world, making it globally addressable.
+
+        /// \attention Must be called by the \c WorldObject constructor \em after
+        /// all of its members have been initialized: registration publishes this
+        /// object to the active-message handlers running on the runtime threads,
+        /// which read those members (see \c WorldObject::is_ready()).
+        /// \tparam DerivedT The derived class being registered.
+        /// \param[in] this_ptr Pointer to the derived object being registered.
+        template <typename DerivedT>
+        void register_self(DerivedT* this_ptr) {
+            MADNESS_ASSERT(!objid); // registering twice would leak the first ID
+            objid = world.register_ptr(this_ptr);
+        }
 
     public:
 
@@ -755,9 +772,18 @@ namespace madness {
         /// -# to enable processing of future messages.
         /// \param[in,out] world The \c World encapsulating the \"global\" domain.
         WorldObject(World& world)
-                : WorldObjectBase(world, static_cast<Derived*>(this))
+                : WorldObjectBase(world)
                 , ready(false)
-                , me(world.rank()) {};
+                , me(world.rank())
+        {
+            // Registration must come last, hence is not part of the member
+            // initialization above: it publishes this object to the AM handlers
+            // running on the runtime threads, which read `ready` to decide
+            // whether an incoming message must be queued (see is_ready()).
+            // Since construction is collective, such a message can already be
+            // in flight while we are still in here.
+            this->register_self(static_cast<Derived*>(this));
+        };
 
 
         /// \todo Brief description needed.

--- a/src/madness/world/world_object.h
+++ b/src/madness/world/world_object.h
@@ -343,7 +343,9 @@ namespace madness {
     struct WorldObjectBase {
     private:
         uniqueidT objid; ///< Unique object ID.
-        World& world; ///< Reference to the world to which this object belongs.
+        World& world; ///< Memoized reference to the world to which this object belongs.
+        World::liveness_handleT world_liveness; ///< Reports whether \c world is still alive.
+
     protected:
 
         /// Construct a new WorldObjectBase.
@@ -351,13 +353,15 @@ namespace madness {
         /// \param[in] w The world to which this object belongs.
         template <typename DerivedT>
         explicit WorldObjectBase(World& w, DerivedT* this_ptr)
-        : world(w), objid(w.register_ptr(this_ptr))
+        : objid(w.register_ptr(this_ptr)), world(w), world_liveness(w.liveness())
         { }
 
     public:
 
         virtual ~WorldObjectBase() {
             if(initialized()) {
+                MADNESS_ASSERT_NOEXCEPT(world_is_alive() &&
+                    "WorldObjectBase::~WorldObjectBase() the world of this object has already been destroyed");
                 auto* world_ptr = World::world_from_id(objid.get_world_id());
                 MADNESS_ASSERT_NOEXCEPT(world_ptr != nullptr &&  "WorldObjectBase::~WorldObjectBase() failed to find world");
                 MADNESS_ASSERT_NOEXCEPT(world_ptr == &world &&
@@ -371,9 +375,22 @@ namespace madness {
             return objid;
         }
 
+        /// Reports whether the world to which this object belongs still exists.
+
+        /// A \c WorldObject must not outlive its \c World, but it happens; this
+        /// makes the (otherwise silent) use-after-free detectable.
+        /// \return True if the world of this object has not been destroyed yet.
+        bool world_is_alive() const noexcept {
+            return world_liveness && world_liveness->load(std::memory_order_relaxed);
+        }
+
         /// Get the world to which this object belongs.
         /// \return A reference to the world.
+        /// \note The reference is memoized, hence only valid while that world is
+        ///       alive; this is asserted here rather than paying for a lookup of
+        ///       the world by its ID, since \c get_world() is called in hot loops.
         World& get_world() const {
+            MADNESS_ASSERT(world_is_alive());
             return world;
         }
     };

--- a/src/madness/world/world_object.h
+++ b/src/madness/world/world_object.h
@@ -343,7 +343,7 @@ namespace madness {
     struct WorldObjectBase {
     private:
         uniqueidT objid; ///< Unique object ID.
-
+        World& world; ///< Reference to the world to which this object belongs.
     protected:
 
         /// Construct a new WorldObjectBase.
@@ -351,7 +351,7 @@ namespace madness {
         /// \param[in] w The world to which this object belongs.
         template <typename DerivedT>
         explicit WorldObjectBase(World& w, DerivedT* this_ptr)
-        : objid(w.register_ptr(this_ptr))
+        : world(w), objid(w.register_ptr(this_ptr))
         { }
 
     public:

--- a/src/madness/world/world_object.h
+++ b/src/madness/world/world_object.h
@@ -406,11 +406,17 @@ namespace madness {
             if(initialized() && objid) {
                 MADNESS_ASSERT_NOEXCEPT(world_is_alive() &&
                     "WorldObjectBase::~WorldObjectBase() the world of this object has already been destroyed");
-                auto* world_ptr = World::world_from_id(objid.get_world_id());
-                MADNESS_ASSERT_NOEXCEPT(world_ptr != nullptr &&  "WorldObjectBase::~WorldObjectBase() failed to find world");
-                MADNESS_ASSERT_NOEXCEPT(world_ptr == &world &&
-                    "WorldObjectBase::~WorldObjectBase() cached world differs from world in object ID");
-                world.unregister_ptr(objid);
+                // The assertion above is compiled out in release builds, so it
+                // cannot be what keeps us off a dangling reference; world_is_alive()
+                // is a real (relaxed) load and always runs. Nothing is leaked by
+                // skipping: the maps we would unregister from died with the world.
+                if(world_is_alive()) {
+                    auto* world_ptr = World::world_from_id(objid.get_world_id());
+                    MADNESS_ASSERT_NOEXCEPT(world_ptr != nullptr &&  "WorldObjectBase::~WorldObjectBase() failed to find world");
+                    MADNESS_ASSERT_NOEXCEPT(world_ptr == &world &&
+                        "WorldObjectBase::~WorldObjectBase() cached world differs from world in object ID");
+                    world.unregister_ptr(objid);
+                }
             }
         }
 
@@ -1504,10 +1510,14 @@ namespace madness {
         }
 
         virtual ~WorldObject() {
-            if(initialized() && id()) {
+            // this body is pure diagnostics, and every assertion in it is
+            // compiled out in release builds; world_is_alive() is not, so it is
+            // what keeps the dereference below off a dangling reference. The
+            // dead-world diagnostic itself is left to ~WorldObjectBase.
+            if(initialized() && id() && this->world_is_alive()) {
               // noexcept variant: a throwing assertion in a destructor would
               // call std::terminate and discard the diagnostic
-              World& world = this->get_world_noexcept(); // checks whether world exists
+              World& world = this->get_world_noexcept();
               MADNESS_ASSERT_NOEXCEPT(world.ptr_from_id<Derived>(id()));
               MADNESS_ASSERT_NOEXCEPT(*world.ptr_from_id<Derived>(id()) == this);
             }

--- a/src/madness/world/world_object.h
+++ b/src/madness/world/world_object.h
@@ -359,6 +359,19 @@ namespace madness {
         : objid(), world(w), world_liveness(w.liveness())
         { }
 
+        /// Copy constructor; produces an \em unregistered object.
+
+        /// Exists solely so that the derived \c WorldObject remains copy
+        /// constructible (which pre-C++17 is needed to permit RVO), never to
+        /// produce a usable object. The copy aliases the world of \p other but
+        /// deliberately does not copy its ID and is not registered with the
+        /// world: were the copy destroyed it would otherwise unregister
+        /// \p other, evicting a live object from the world's ID maps.
+        /// \param[in] other The object whose world is to be aliased.
+        WorldObjectBase(const WorldObjectBase& other)
+        : objid(), world(other.world), world_liveness(other.world_liveness)
+        { }
+
         /// Registers this object with its world, making it globally addressable.
 
         /// \attention Must be called by the \c WorldObject constructor \em after
@@ -376,7 +389,9 @@ namespace madness {
     public:
 
         virtual ~WorldObjectBase() {
-            if(initialized()) {
+            // objid is null for an unregistered object, i.e. one produced by the
+            // copy ctor above; such an object owns no entry in the world's maps
+            if(initialized() && objid) {
                 MADNESS_ASSERT_NOEXCEPT(world_is_alive() &&
                     "WorldObjectBase::~WorldObjectBase() the world of this object has already been destroyed");
                 auto* world_ptr = World::world_from_id(objid.get_world_id());
@@ -454,8 +469,12 @@ namespace madness {
         /// \todo Description needed.
         typedef WorldObject<Derived> objT;
 
-        // copy ctor must be enabled to permit RVO; in C++17 will not need this
-        WorldObject(const WorldObject& other) : WorldObjectBase(other) { abort(); }
+        // copy ctor must be enabled to permit RVO; in C++17 will not need this.
+        // It never produces a usable object. The safety of that does not rest on
+        // the abort() alone: the base copy ctor deliberately leaves the copy
+        // unregistered, so destroying one would not unregister `other`.
+        WorldObject(const WorldObject& other)
+            : WorldObjectBase(other), ready(false), me(other.me) { abort(); }
         // no copy
         WorldObject& operator=(const WorldObject&) = delete;
 
@@ -1467,7 +1486,7 @@ namespace madness {
         }
 
         virtual ~WorldObject() {
-            if(initialized()) {
+            if(initialized() && id()) {
               // noexcept variant: a throwing assertion in a destructor would
               // call std::terminate and discard the diagnostic
               World& world = this->get_world_noexcept(); // checks whether world exists

--- a/src/madness/world/world_object.h
+++ b/src/madness/world/world_object.h
@@ -406,6 +406,10 @@ namespace madness {
         /// \note The reference is memoized, hence only valid while that world is
         ///       alive; this is asserted here rather than paying for a lookup of
         ///       the world by its ID, since \c get_world() is called in hot loops.
+        /// \todo Promote the assertion to \c MADNESS_CHECK, so that the
+        ///       use-after-free is also caught in release builds (where
+        ///       \c MADNESS_ASSERT compiles away), once the cost of the
+        ///       liveness load in hot loops has been measured.
         World& get_world() const {
             MADNESS_ASSERT(world_is_alive());
             return world;

--- a/src/madness/world/world_object.h
+++ b/src/madness/world/world_object.h
@@ -341,18 +341,40 @@ namespace madness {
     /// and get_world() method to access it.
     /// Should not be used directly, but rather through WorldObject<Derived>.
     struct WorldObjectBase {
-    protected:
-        World& world; ///< The \c World this object belongs to. (Think globally, act locally).
+    private:
+        uniqueidT objid; ///< Unique object ID.
 
-        explicit WorldObjectBase(World& w) : world(w) {}
+    protected:
+
+        /// Construct a new WorldObjectBase.
+        /// Protected, should only be called from WorldObject constructor.
+        /// \param[in] w The world to which this object belongs.
+        template <typename DerivedT>
+        explicit WorldObjectBase(World& w, DerivedT* this_ptr)
+        : objid(w.register_ptr(this_ptr))
+        { }
+
     public:
 
-        virtual ~WorldObjectBase() = default;
+        virtual ~WorldObjectBase() {
+            if(initialized()) {
+              this->get_world().unregister_ptr(objid);
+            }
+        }
+
+        /// Returns the globally unique object ID.
+        const uniqueidT& id() const {
+            return objid;
+        }
 
         /// Get the world to which this object belongs.
         /// \return A reference to the world.
         World& get_world() const {
-            return world;
+            auto* world = World::world_from_id(objid.get_world_id());
+            if (!world) {
+                MADNESS_EXCEPTION("WorldObjectBase::get_world() failed to find world", objid.get_world_id());
+            }
+            return *world;
         }
     };
 
@@ -382,7 +404,7 @@ namespace madness {
         typedef WorldObject<Derived> objT;
 
         // copy ctor must be enabled to permit RVO; in C++17 will not need this
-        WorldObject(const WorldObject& other) : WorldObjectBase(other.world) { abort(); }
+        WorldObject(const WorldObject& other) : WorldObjectBase(other) { abort(); }
         // no copy
         WorldObject& operator=(const WorldObject&) = delete;
 
@@ -396,7 +418,6 @@ namespace madness {
         // The order here matters in a multi-threaded world
         volatile bool ready; ///< True if ready to rock 'n roll.
         ProcessID me; ///< Rank of self.
-        uniqueidT objid; ///< Sense of self.
 
 
         inline static Spinlock pending_mutex; ///< \todo Description needed.
@@ -603,7 +624,8 @@ namespace madness {
                 detail::run_function(result, task_helper::make_task_fn(this, memfn),
                         a1, a2, a3, a4, a5, a6, a7, a8, a9);
             else {
-                detail::info<memfnT> info(objid, me, memfn, result.remote_ref(world));
+                World& world = this->get_world();
+                detail::info<memfnT> info(this->id(), me, memfn, result.remote_ref(world));
                 world.am.send(dest, & objT::template handler<memfnT, a1T, a2T, a3T, a4T, a5T, a6T, a7T, a8T, a9T>,
                         new_am_arg(info, a1, a2, a3, a4, a5, a6, a7, a8, a9));
             }
@@ -649,7 +671,9 @@ namespace madness {
                 const TaskAttributes& attr) const
         {
             typename taskT::futureT result;
-            detail::info<memfnT> info(objid, me, memfn, result.remote_ref(world), attr);
+            World& world = this->get_world();
+            const ProcessID me = world.rank();
+            detail::info<memfnT> info(this->id(), me, memfn, result.remote_ref(world), attr);
             world.am.send(dest, & objT::template spawn_remote_task_handler<taskT>,
                     new_am_arg(info, a1, a2, a3, a4, a5, a6, a7, a8, a9), RMI::ATTR_UNORDERED);
 
@@ -681,7 +705,7 @@ namespace madness {
                 pendingT& nv = const_cast<pendingT&>(pending);
                 for (pendingT::iterator it=nv.begin(); it!=nv.end();) {
                     detail::PendingMsg& p = *it;
-                    if (p.id == objid) {
+                    if (p.id == this->id()) {
                         tmp.push_back(p);
                         it = nv.erase(it);
                     }
@@ -714,16 +738,10 @@ namespace madness {
         /// -# to enable processing of future messages.
         /// \param[in,out] world The \c World encapsulating the \"global\" domain.
         WorldObject(World& world)
-                : WorldObjectBase(world)
+                : WorldObjectBase(world, static_cast<Derived*>(this))
                 , ready(false)
-                , me(world.rank())
-                , objid(world.register_ptr(static_cast<Derived*>(this))) {};
+                , me(world.rank()) {};
 
-
-        /// Returns the globally unique object ID.
-        const uniqueidT& id() const {
-            return objid;
-        }
 
         /// \todo Brief description needed.
 
@@ -1012,7 +1030,7 @@ namespace madness {
             typedef detail::WorldObjectTaskHelper<Derived, memfnT> task_helper;
             typedef TaskFn<typename task_helper::wrapperT> taskT;
             if (dest == me)
-                return world.taskq.add(task_helper::make_task_fn(this, memfn), attr);
+                return this->get_world().taskq.add(task_helper::make_task_fn(this, memfn), attr);
             else
                 return send_task<taskT>(dest, memfn, voidT::value, voidT::value,
                         voidT::value, voidT::value, voidT::value, voidT::value,
@@ -1038,7 +1056,7 @@ namespace madness {
             typedef TaskFn<typename task_helper::wrapperT,
                     typename detail::task_arg<a1T>::type> taskT;
             if (dest == me)
-                return world.taskq.add(task_helper::make_task_fn(this, memfn),
+                return this->get_world().taskq.add(task_helper::make_task_fn(this, memfn),
                         a1, attr);
             else
                 return send_task<taskT>(dest, memfn, am_arg(a1), voidT::value,
@@ -1068,7 +1086,7 @@ namespace madness {
                     typename detail::task_arg<a1T>::type,
                     typename detail::task_arg<a2T>::type> taskT;
             if (dest == me)
-                return world.taskq.add(task_helper::make_task_fn(this, memfn),
+                return this->get_world().taskq.add(task_helper::make_task_fn(this, memfn),
                         a1, a2, attr);
             else
                 return send_task<taskT>(dest, memfn, am_arg(a1), am_arg(a2),
@@ -1101,7 +1119,7 @@ namespace madness {
                     typename detail::task_arg<a2T>::type,
                     typename detail::task_arg<a3T>::type> taskT;
             if (dest == me)
-                return world.taskq.add(task_helper::make_task_fn(this, memfn),
+                return this->get_world().taskq.add(task_helper::make_task_fn(this, memfn),
                         a1, a2, a3, attr);
             else
                 return send_task<taskT>(dest, memfn, am_arg(a1), am_arg(a2),
@@ -1138,7 +1156,7 @@ namespace madness {
                     typename detail::task_arg<a3T>::type,
                     typename detail::task_arg<a4T>::type> taskT;
             if (dest == me)
-                return world.taskq.add(task_helper::make_task_fn(this, memfn),
+                return this->get_world().taskq.add(task_helper::make_task_fn(this, memfn),
                         a1, a2, a3, a4, attr);
             else
                 return send_task<taskT>(dest, memfn, am_arg(a1), am_arg(a2),
@@ -1179,7 +1197,7 @@ namespace madness {
                     typename detail::task_arg<a4T>::type,
                     typename detail::task_arg<a5T>::type> taskT;
             if (dest == me)
-                return world.taskq.add(task_helper::make_task_fn(this, memfn),
+                return this->get_world().taskq.add(task_helper::make_task_fn(this, memfn),
                         a1, a2, a3, a4, a5, attr);
             else
                 return send_task<taskT>(dest, memfn, am_arg(a1), am_arg(a2),
@@ -1223,7 +1241,7 @@ namespace madness {
                     typename detail::task_arg<a5T>::type,
                     typename detail::task_arg<a6T>::type> taskT;
             if (dest == me)
-                return world.taskq.add(task_helper::make_task_fn(this, memfn),
+                return this->get_world().taskq.add(task_helper::make_task_fn(this, memfn),
                         a1, a2, a3, a4, a5, a6, attr);
             else {
                 return send_task<taskT>(dest, memfn, am_arg(a1), am_arg(a2),
@@ -1271,7 +1289,7 @@ namespace madness {
                     typename detail::task_arg<a6T>::type,
                     typename detail::task_arg<a7T>::type> taskT;
             if (dest == me)
-                return world.taskq.add(task_helper::make_task_fn(this, memfn),
+                return this->get_world().taskq.add(task_helper::make_task_fn(this, memfn),
                         a1, a2, a3, a4, a5, a6, a7, attr);
             else
                 return send_task<taskT>(dest, memfn, am_arg(a1), am_arg(a2),
@@ -1322,7 +1340,7 @@ namespace madness {
                     typename detail::task_arg<a7T>::type,
                     typename detail::task_arg<a8T>::type> taskT;
             if (dest == me)
-                return world.taskq.add(task_helper::make_task_fn(this, memfn),
+                return this->get_world().taskq.add(task_helper::make_task_fn(this, memfn),
                         a1, a2, a3, a4, a5, a6, a7, a8, attr);
             else {
                 return send_task<taskT>(dest, memfn, am_arg(a1), am_arg(a2),
@@ -1380,7 +1398,7 @@ namespace madness {
                     typename detail::task_arg<a8T>::type,
                     typename detail::task_arg<a9T>::type> taskT;
             if (dest == me)
-                return world.taskq.add(task_helper::make_task_fn(this, memfn),
+                return this->get_world().taskq.add(task_helper::make_task_fn(this, memfn),
                         a1, a2, a3, a4, a5, a6, a7, a8, a9, attr);
             else
                 return send_task<taskT>(dest, memfn, am_arg(a1), am_arg(a2),
@@ -1390,10 +1408,9 @@ namespace madness {
 
         virtual ~WorldObject() {
             if(initialized()) {
-              MADNESS_ASSERT_NOEXCEPT(World::exists(&world));
+              World& world = this->get_world(); // checks whether world exists
               MADNESS_ASSERT_NOEXCEPT(world.ptr_from_id<Derived>(id()));
               MADNESS_ASSERT_NOEXCEPT(*world.ptr_from_id<Derived>(id()) == this);
-              world.unregister_ptr(this->id());
             }
         }
 


### PR DESCRIPTION
Allows access to the world through type-punned object without having to go through virtual functions.

TTG has its own get_world in a class derived from madness::WorldObject, which collides with the virtual function WorldObjectBase::get_world introduced in f0e5fa295c0158e33c244f6fb1308d9a7fbbfb72. Non-virtual get_world can be hidden by derived classes. Plus, the world is derived type agnostic so it might as well live in the type-agnostic base.