### PR TITLE
Pr scf perf

### DIFF
--- a/src/madness/chem/SCF.cc
+++ b/src/madness/chem/SCF.cc
@@ -1414,7 +1414,10 @@ vecfuncT SCF::apply_potential(World& world, const tensorT& occ,
 
     // compute Vpsi and truncation
     START_TIMER(world);
-    const bool tile_Vpsi = true;
+    // Tiling bounds the products' transient memory, which only threatens at high precision, and
+    // costs nmo/ntile fences plus a truncation of every product. The untiled path was the default
+    // for years; take it below the tight protocols.
+    const bool tile_Vpsi = FunctionDefaults<3>::get_thresh() < 1.e-7;
     size_t min_tile = 10;
     size_t ntile = std::min(amo.size(), min_tile);
     if (!molecule.parameters.pure_ae()) {

--- a/src/madness/chem/SCF.cc
+++ b/src/madness/chem/SCF.cc
@@ -692,6 +692,8 @@ distmatT SCF::kinetic_energy_matrix(World& world, const vecfuncT& v) const {
     START_TIMER(world);
     reconstruct(world, v);
     END_TIMER(world, "KEmat reconstruct");
+    // these operators serve only this matrix, which is the many-tree case the pool submission helps
+    for (int axis = 0; axis < 3; ++axis) gradop[axis]->parallel_submit_ = true;
     START_TIMER(world);
     // Pre-stage the neighbor coefficients the ranks owe each other, so differentiating serves them
     // locally instead of fetching one at a time. The halo is keyed by node, so one covers all axes.

--- a/src/madness/chem/SCF.cc
+++ b/src/madness/chem/SCF.cc
@@ -1425,14 +1425,11 @@ vecfuncT SCF::apply_potential(World& world, const tensorT& occ,
                 size_t iend = std::min(ilo+ntile,amo.size());
                 vecfuncT tmpamo(amo.begin()+ilo,amo.begin()+iend);
                 auto tmpVpsi = mul_sparse(world, vloc, tmpamo, vtol);
-
-                //truncate tmpVpsi
                 truncate(world, tmpVpsi);
 
-                //put the results into their final home
-                for (size_t i = ilo; i<iend; ++i){
-                    Vpsi[i] += tmpVpsi[i-ilo];
-                }
+                // one gaxpy per tile instead of two fences per orbital, as the untiled branch does
+                vecfuncT Vpsi_tile(Vpsi.begin()+ilo, Vpsi.begin()+iend);
+                gaxpy(world, 1.0, Vpsi_tile, 1.0, tmpVpsi);
             }
             END_TIMER(world, "V*psi");
         } else {

--- a/src/madness/chem/SCF.cc
+++ b/src/madness/chem/SCF.cc
@@ -693,11 +693,20 @@ distmatT SCF::kinetic_energy_matrix(World& world, const vecfuncT& v) const {
     reconstruct(world, v);
     END_TIMER(world, "KEmat reconstruct");
     START_TIMER(world);
+    // Pre-stage the neighbor coefficients the ranks owe each other, so differentiating serves them
+    // locally instead of fetching one at a time. The halo is keyed by node, so one covers all axes.
+    for (int i = 0; i < n; ++i) v[i].get_impl()->halo_enable();
+    world.gop.fence();
+    for (int axis = 0; axis < 3; ++axis)
+        for (int i = 0; i < n; ++i) gradop[axis]->stage_halo(v[i].get_impl().get());
+    world.gop.fence();
     vecfuncT dvx = apply(world, *(gradop[0]), v, false);
     vecfuncT dvy = apply(world, *(gradop[1]), v, false);
     vecfuncT dvz = apply(world, *(gradop[2]), v, false);
     world.gop.fence();
     END_TIMER(world, "KEmat differentiate");
+    // all three axes' surfaces are live here, since all three are applied before the fence above
+    for (int i = 0; i < n; ++i) v[i].get_impl()->halo_clear();
     START_TIMER(world);
     compress(world, dvx, false);
     compress(world, dvy, false);

--- a/src/madness/chem/SCF.h
+++ b/src/madness/chem/SCF.h
@@ -89,7 +89,10 @@ struct lbcost {
 
     double operator()(const Key<NDIM>& key, const FunctionNode<T, NDIM>& node) const {
         if (key.level() < 1) {
-            return 100.0 * (leaf_value + parent_value);
+            // Root is a structural catch-all with no work. The old 100x was accumulated once per
+            // function by add_tree, so on balances over many light trees key0 outweighed every real
+            // subtree and the rank holding it was starved of work.
+            return leaf_value + parent_value;
         } else if (node.is_leaf()) {
             return leaf_value;
         } else {

--- a/src/madness/mra/CMakeLists.txt
+++ b/src/madness/mra/CMakeLists.txt
@@ -38,7 +38,7 @@ if(BUILD_TESTING)
       testpdiff.cc testdiff1Db.cc testgconv.cc testopdir.cc testinnerext.cc
       testgaxpyext.cc testvmra.cc test_vectormacrotask.cc test_cloud.cc test_tree_state.cc testsolver.cc
       test_macrotaskpartitioner.cc test_QCCalculationParametersBase.cc test_memory_measurement.cc
-      test_keybox.cc test_eval.cc test_mul_sparse.cc)
+      test_keybox.cc test_eval.cc test_mul_sparse.cc test_halo.cc)
   add_unittests(mra "${MRA_TEST_SOURCES}" "MADmra;MADgtest" "unittests;short")
   set(MRA_SEPOP_TEST_SOURCES testsuite.cc
       testper.cc)
@@ -53,6 +53,8 @@ if(BUILD_TESTING)
   add_mpi_tests(mra test_cloud "2" "MADmra;MADgtest" "unittests;short")
   add_mpi_tests(mra test_vectormacrotask "2" "MADmra;MADgtest" "unittests;short")
   add_mpi_tests(mra test_eval "2" "MADmra;MADgtest" "unittests;short")
+  # the halo only carries data between ranks, so the single-rank run above cannot exercise it
+  add_mpi_tests(mra test_halo "2" "MADmra;MADgtest" "unittests;short")
 
   # Test executables that are not run with unit tests ... consider these executables (unlike unit tests)
   if (NOT MADNESS_BUILD_LIBRARIES_ONLY)

--- a/src/madness/mra/derivative.h
+++ b/src/madness/mra/derivative.h
@@ -237,6 +237,28 @@ namespace madness {
             }
         }
 
+        /// Push f's remote same-level neighbor coefficients to the ranks that will need them.
+
+        /// Node M is the neighbor of M-1 and M+1, so its owner pushes it to the owners of those keys
+        /// without being asked, one batched message per destination. Requires `halo_enable()` and a
+        /// fence first, then a fence before differentiating; `halo_clear()` frees the result.
+        void stage_halo(const implT* f) const {
+            MADNESS_CHECK(f->halo_enabled());
+            const dcT& coeffs = f->get_coeffs();
+            std::map<ProcessID, std::vector<argT> > out;
+            for (const auto& [key, node] : coeffs) {
+                for (int step : {-1, 1}) {
+                    keyT consumer = neighbor(key, step);
+                    if (consumer.is_invalid()) continue;              // domain boundary: no consumer there
+                    ProcessID d = coeffs.owner(consumer);
+                    if (d == world.rank()) continue;                  // local consumer: the pull is cheap
+                    out[d].push_back(argT(key, node.has_coeff() ? node.coeff() : coeffT()));
+                }
+            }
+            for (auto& kv : out)
+                f->task(kv.first, &implT::receive_halo, kv.second, TaskAttributes::hipri());
+        }
+
         Future<argT>
         find_neighbor(const implT* f, const Key<NDIM>& key, int step) const {
             keyT neigh = neighbor(key, step);
@@ -244,6 +266,11 @@ namespace madness {
                 return Future<argT>(argT(neigh,coeffT(vk,f->get_tensor_args()))); // Zero bc
             }
             else {
+                // hit: same-level leaf or interior node. miss: neighbor is coarser, walk up below.
+                if (f->halo_enabled()) {
+                    coeffT c;
+                    if (f->halo_probe(neigh, c)) return Future<argT>(argT(neigh, c));
+                }
                 Future<argT> result;
 		if (f->get_coeffs().is_local(neigh))
 		  f->send(f->get_coeffs().owner(neigh), &implT::sock_it_to_me, neigh, result.remote_ref(world));

--- a/src/madness/mra/derivative.h
+++ b/src/madness/mra/derivative.h
@@ -91,6 +91,11 @@ namespace madness {
         typedef WorldContainer<Key<NDIM> , FunctionNode<T, NDIM> > dcT;
         typedef FunctionNode<T,NDIM> nodeT;
 
+        /// Spawn `diff`'s per-node tasks from the task pool instead of the main thread.
+
+        /// The same tasks are produced, so the result is unchanged. Per instance and off by default,
+        /// since it only pays off when many functions are differentiated at once.
+        bool parallel_submit_ = false;
 
         DerivativeBase(World& world, std::size_t axis, int k, BoundaryConditions<NDIM> bc)
             : WorldObject< DerivativeBase<T, NDIM> >(world)
@@ -280,6 +285,38 @@ namespace madness {
             }
         }
 
+
+        /// Body of `FunctionImpl::diff`'s submission loop, as a functor for `taskq.for_each`.
+        struct submit_op {
+            typedef Range<typename dcT::const_iterator> rangeT;
+            const DerivativeBase<T,NDIM>* D;
+            const implT* f;
+            implT* df;
+            submit_op(const DerivativeBase<T,NDIM>* D=nullptr, const implT* f=nullptr, implT* df=nullptr)
+                : D(D), f(f), df(df) {}
+            bool operator()(typename rangeT::iterator& it) const {
+                const keyT& key = it->first;
+                const nodeT& node = it->second;
+                if (node.has_coeff()) {
+                    Future<argT> left  = D->find_neighbor(f, key, -1);
+                    argT center(key, node.coeff());
+                    Future<argT> right = D->find_neighbor(f, key, 1);
+                    df->world.taskq.add(*df, &implT::do_diff1, D, f, key, left, center, right, TaskAttributes::hipri());
+                }
+                else {
+                    df->get_coeffs().replace(key, nodeT(coeffT(), true)); // empty internal node
+                }
+                return true;
+            }
+            template <typename Archive> void serialize(const Archive& ar) {}
+        };
+
+        /// Parallel form of `FunctionImpl::diff`'s submission loop; the caller owns the fence.
+        void submit_diff_tasks(const implT* f, implT* df) const {
+            typedef Range<typename dcT::const_iterator> rangeT;
+            df->world.taskq.template for_each<rangeT, submit_op>(
+                rangeT(f->get_coeffs().begin(), f->get_coeffs().end()), submit_op(this, f, df));
+        }
 
         template <typename Archive> void serialize(const Archive& ar) const {
             throw "NOT IMPLEMENTED";

--- a/src/madness/mra/funcimpl.h
+++ b/src/madness/mra/funcimpl.h
@@ -1011,10 +1011,52 @@ template<size_t NDIM>
 
         dcT coeffs; ///< The coefficients
 
+        /// Neighbor coefficients pre-staged by a caller of the derivative operator; null unless staged.
+
+        /// Reproduces what `sock_it_to_me` returns for the same key: coefficients for a same-level
+        /// leaf, empty for an interior node, absent when the neighbor is coarser and `find_neighbor`
+        /// must walk up. Allocated lazily, so functions that never stage a halo do not carry the table.
+        mutable std::unique_ptr<ConcurrentHashMap<keyT,coeffT> > neighbor_halo_;
+
         // Disable the default copy constructor
         FunctionImpl(const FunctionImpl<T,NDIM>& p);
 
     public:
+        /// Allocate the neighbor halo.
+
+        /// Every rank must call this and fence before any rank stages: a push arrives as a task and
+        /// cannot allocate the halo itself without racing this call.
+        void halo_enable() const {
+            if (!neighbor_halo_) neighbor_halo_.reset(new ConcurrentHashMap<keyT,coeffT>());
+        }
+
+        /// Is a neighbor halo staged on this function?
+        bool halo_enabled() const { return static_cast<bool>(neighbor_halo_); }
+
+        /// Discard the neighbor halo, freeing the staged coefficients.
+        void halo_clear() const { neighbor_halo_.reset(); }
+
+        /// How many neighbor nodes are staged on this rank; zero if no halo.
+        std::size_t halo_size() const { return neighbor_halo_ ? neighbor_halo_->size() : 0; }
+
+        /// Insert pushed neighbor nodes into the halo; runs as a task, concurrently with other pushes.
+        void receive_halo(const std::vector<std::pair<keyT,coeffT> >& buf) const {
+            MADNESS_CHECK(neighbor_halo_);   // halo_enable() and a fence must precede staging
+            for (const auto& kv : buf) {
+                typename ConcurrentHashMap<keyT,coeffT>::accessor acc;
+                (void) neighbor_halo_->insert(acc, kv.first);
+                acc->second = kv.second;
+            }
+        }
+
+        /// Look up a staged neighbor; on a hit copy its coefficients, which are empty for an interior node.
+        bool halo_probe(const keyT& key, coeffT& out) const {
+            if (!neighbor_halo_) return false;
+            typename ConcurrentHashMap<keyT,coeffT>::const_accessor acc;
+            if (neighbor_halo_->find(acc, key)) { out = acc->second; return true; }
+            return false;
+        }
+
         Timer timer_accumulate;
         Timer timer_change_tensor_type;
         Timer timer_lr_result;

--- a/src/madness/mra/mraimpl.h
+++ b/src/madness/mra/mraimpl.h
@@ -954,6 +954,11 @@ namespace madness {
     template <typename T, std::size_t NDIM>
     void FunctionImpl<T,NDIM>::diff(const DerivativeBase<T,NDIM>* D, const implT* f, bool fence) {
         typedef std::pair<keyT,coeffT> argT;
+        if (D->parallel_submit_) {
+            D->submit_diff_tasks(f, this);   // same tasks, spawned from the pool instead of here
+            if (fence) world.gop.fence();
+            return;
+        }
         for (const auto& [key, node]: f->coeffs) {
             if (node.has_coeff()) {
                 Future<argT> left  = D->find_neighbor(f, key,-1);

--- a/src/madness/mra/test_halo.cc
+++ b/src/madness/mra/test_halo.cc
@@ -1,6 +1,6 @@
-/// Unit tests for the derivative operator's neighbor-halo pre-staging.
+/// Unit tests for the derivative operator's neighbor-halo pre-staging and pool submission.
 ///
-/// Staging may not change results, so the reference is the derivative taken by the plain path and
+/// Neither may change results, so the reference is the derivative taken by the plain path and
 /// agreement with it is required to round-off, not to a tolerance.
 ///
 /// The operands are cusped so the tree is deep and unevenly refined, which is what makes
@@ -57,13 +57,15 @@ static std::vector<Function<double,D>> make_operands(World& world) {
     return v;
 }
 
-/// Differentiate v along every axis, optionally staging the halo first.
+/// Differentiate v along every axis, optionally staging the halo and/or submitting in parallel.
 static std::vector<Function<double,D>>
 differentiate(World& world,
               std::vector<std::shared_ptr<Derivative<double,D>>>& grad,
               const std::vector<Function<double,D>>& v,
-              bool halo,
+              bool halo, bool parallel_submit,
               std::size_t& staged) {
+    for (std::size_t axis = 0; axis < D; ++axis) grad[axis]->parallel_submit_ = parallel_submit;
+
     if (halo) {
         for (const auto& f : v) f.get_impl()->halo_enable();
         world.gop.fence();
@@ -85,26 +87,37 @@ differentiate(World& world,
     return dv;
 }
 
-/// The staged halo against the plain path.
+/// The halo and the parallel submission, separately and together, against the plain path.
 static int test_equivalence(World& world, const std::vector<Function<double,D>>& v) {
-    test_output t("the neighbor halo reproduces the plain derivative");
+    test_output t("neighbor halo and parallel submission reproduce the plain derivative");
     t.set_cout_to_logger();
     std::vector<std::shared_ptr<Derivative<double,D>>> grad = gradient_operator<double,D>(world);
 
     std::size_t staged = 0;
-    std::vector<Function<double,D>> ref = differentiate(world, grad, v, false, staged);
-    std::vector<Function<double,D>> dv  = differentiate(world, grad, v, true,  staged);
+    std::vector<Function<double,D>> ref = differentiate(world, grad, v, false, false, staged);
 
-    double err = 0.0;
-    for (std::size_t i = 0; i < ref.size(); ++i)
-        err = std::max(err, (dv[i] - ref[i]).norm2());
-    if (world.rank() == 0)
-        printf("  halo                     max |d - d_ref| = %.3e   staged nodes %zu\n", err, staged);
-    t.checkpoint(err, EXACT, "halo matches the plain derivative");
+    struct cell { bool halo, submit; const char* name; };
+    const std::vector<cell> cells = {
+        {true,  false, "halo"},
+        {false, true,  "parallel submit"},
+        {true,  true,  "halo + parallel submit"},
+    };
 
-    // a halo that moved nothing would pass the comparison above without exercising anything.
-    // On one rank every consumer is local and nothing is pushed, by design.
-    if (world.size() > 1) t.checkpoint(staged > 0, "halo staged a non-empty halo");
+    for (const cell& c : cells) {
+        staged = 0;
+        std::vector<Function<double,D>> dv = differentiate(world, grad, v, c.halo, c.submit, staged);
+        double err = 0.0;
+        for (std::size_t i = 0; i < ref.size(); ++i)
+            err = std::max(err, (dv[i] - ref[i]).norm2());
+        if (world.rank() == 0)
+            printf("  %-24s max |d - d_ref| = %.3e   staged nodes %zu\n", c.name, err, staged);
+        t.checkpoint(err, EXACT, std::string(c.name) + " matches the plain derivative");
+
+        // a halo that moved nothing would pass the comparison above without exercising anything.
+        // On one rank every consumer is local and nothing is pushed, by design.
+        if (c.halo && world.size() > 1)
+            t.checkpoint(staged > 0, std::string(c.name) + " staged a non-empty halo");
+    }
     return t.end();
 }
 

--- a/src/madness/mra/test_halo.cc
+++ b/src/madness/mra/test_halo.cc
@@ -1,0 +1,181 @@
+/// Unit tests for the derivative operator's neighbor-halo pre-staging.
+///
+/// Staging may not change results, so the reference is the derivative taken by the plain path and
+/// agreement with it is required to round-off, not to a tolerance.
+///
+/// The operands are cusped so the tree is deep and unevenly refined, which is what makes
+/// neighbors resolve by all three routes the halo must reproduce: a same-level leaf, an interior
+/// node to descend into, and a coarser ancestor it does not cover and which falls back to the fetch.
+
+#include <madness/mra/mra.h>
+#include <madness/mra/vmra.h>
+#include <madness/world/test_utilities.h>
+
+#include <cmath>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace madness;
+
+static const std::size_t D = 3;
+
+/// The paths perform identical arithmetic, so any difference is a defect. Round-off rather than
+/// zero only to avoid depending on the order the difference itself is accumulated in.
+static const double EXACT = 1.e-13;
+
+/// c * exp(-a |r-R|), cusped at R
+class Slater : public FunctionFunctorInterface<double, D> {
+    double a, c;
+    Vector<double, D> R;
+public:
+    Slater(double a, double c, const Vector<double, D>& R) : a(a), c(c), R(R) {}
+    double operator()(const Vector<double, D>& r) const override {
+        double r2 = 0.0;
+        for (std::size_t i = 0; i < D; ++i) r2 += (r[i]-R[i]) * (r[i]-R[i]);
+        return c * std::exp(-a * std::sqrt(r2));
+    }
+    std::vector<Vector<double,D>> special_points() const override { return {R}; }
+};
+
+/// Cusps at different places and of different widths, so the ranks own unequal trees.
+static std::vector<Function<double,D>> make_operands(World& world) {
+    std::vector<Vector<double,D>> centres = {
+        {{ 0.0,  0.0,  0.0}},
+        {{ 1.3, -0.7,  0.4}},
+        {{-0.9,  1.1, -1.2}},
+        {{ 2.1,  0.3, -0.6}},
+    };
+    std::vector<double> alpha = {1.0, 1.7, 2.5, 0.8};
+    std::vector<Function<double,D>> v;
+    v.reserve(centres.size());
+    for (std::size_t i = 0; i < centres.size(); ++i)
+        v.emplace_back(FunctionFactory<double,D>(world)
+                       .functor(std::shared_ptr<FunctionFunctorInterface<double,D>>(
+                                    new Slater(alpha[i], 1.0 + 0.1*double(i), centres[i]))));
+    reconstruct(world, v);
+    return v;
+}
+
+/// Differentiate v along every axis, optionally staging the halo first.
+static std::vector<Function<double,D>>
+differentiate(World& world,
+              std::vector<std::shared_ptr<Derivative<double,D>>>& grad,
+              const std::vector<Function<double,D>>& v,
+              bool halo,
+              std::size_t& staged) {
+    if (halo) {
+        for (const auto& f : v) f.get_impl()->halo_enable();
+        world.gop.fence();
+        for (std::size_t axis = 0; axis < D; ++axis)
+            for (const auto& f : v) grad[axis]->stage_halo(f.get_impl().get());
+        world.gop.fence();
+        staged = 0;
+        for (const auto& f : v) staged += f.get_impl()->halo_size();
+    }
+
+    std::vector<Function<double,D>> dv;
+    for (std::size_t axis = 0; axis < D; ++axis) {
+        std::vector<Function<double,D>> d = apply(world, *grad[axis], v, false);
+        dv.insert(dv.end(), d.begin(), d.end());
+    }
+    world.gop.fence();
+
+    if (halo) for (const auto& f : v) f.get_impl()->halo_clear();
+    return dv;
+}
+
+/// The staged halo against the plain path.
+static int test_equivalence(World& world, const std::vector<Function<double,D>>& v) {
+    test_output t("the neighbor halo reproduces the plain derivative");
+    t.set_cout_to_logger();
+    std::vector<std::shared_ptr<Derivative<double,D>>> grad = gradient_operator<double,D>(world);
+
+    std::size_t staged = 0;
+    std::vector<Function<double,D>> ref = differentiate(world, grad, v, false, staged);
+    std::vector<Function<double,D>> dv  = differentiate(world, grad, v, true,  staged);
+
+    double err = 0.0;
+    for (std::size_t i = 0; i < ref.size(); ++i)
+        err = std::max(err, (dv[i] - ref[i]).norm2());
+    if (world.rank() == 0)
+        printf("  halo                     max |d - d_ref| = %.3e   staged nodes %zu\n", err, staged);
+    t.checkpoint(err, EXACT, "halo matches the plain derivative");
+
+    // a halo that moved nothing would pass the comparison above without exercising anything.
+    // On one rank every consumer is local and nothing is pushed, by design.
+    if (world.size() > 1) t.checkpoint(staged > 0, "halo staged a non-empty halo");
+    return t.end();
+}
+
+/// A staged halo must be inert for a lone derivative too, not just for the vector form the
+/// kinetic-energy matrix uses.
+static int test_single_function(World& world, const std::vector<Function<double,D>>& v) {
+    test_output t("a staged halo does not disturb a single-function derivative");
+    t.set_cout_to_logger();
+    std::vector<std::shared_ptr<Derivative<double,D>>> grad = gradient_operator<double,D>(world);
+
+    const Function<double,D>& f = v[0];
+    Function<double,D> ref = (*grad[0])(f, true);
+
+    f.get_impl()->halo_enable();
+    world.gop.fence();
+    grad[0]->stage_halo(f.get_impl().get());
+    world.gop.fence();
+    Function<double,D> df = (*grad[0])(f, true);
+    const std::size_t staged = f.get_impl()->halo_size();
+    f.get_impl()->halo_clear();
+
+    const double err = (df - ref).norm2();
+    if (world.rank() == 0)
+        printf("  single function          max |d - d_ref| = %.3e   staged nodes %zu\n", err, staged);
+    t.checkpoint(err, EXACT, "single-function derivative matches");
+    return t.end();
+}
+
+/// halo_clear must restore the plain path, so that a stale halo cannot leak into a later
+/// derivative of the same function.
+static int test_clear(World& world, const std::vector<Function<double,D>>& v) {
+    test_output t("halo_clear restores the plain path");
+    t.set_cout_to_logger();
+    std::vector<std::shared_ptr<Derivative<double,D>>> grad = gradient_operator<double,D>(world);
+
+    const Function<double,D>& f = v[0];
+    Function<double,D> ref = (*grad[0])(f, true);
+
+    f.get_impl()->halo_enable();
+    world.gop.fence();
+    grad[0]->stage_halo(f.get_impl().get());
+    world.gop.fence();
+    f.get_impl()->halo_clear();
+    t.checkpoint(f.get_impl()->halo_enabled() == false, "halo is disabled after clear");
+
+    Function<double,D> df = (*grad[0])(f, true);
+    const double err = (df - ref).norm2();
+    if (world.rank() == 0) printf("  after clear              max |d - d_ref| = %.3e\n", err);
+    t.checkpoint(err, EXACT, "derivative after clear matches");
+    return t.end();
+}
+
+int main(int argc, char** argv) {
+    World& world = initialize(argc, argv);
+    startup(world, argc, argv, true);
+
+    FunctionDefaults<D>::set_k(6);
+    FunctionDefaults<D>::set_thresh(1.e-6);
+    FunctionDefaults<D>::set_cubic_cell(-8.0, 8.0);
+    FunctionDefaults<D>::set_refine(true);
+    FunctionDefaults<D>::set_initial_level(2);
+
+    int success = 0;
+    {
+        std::vector<Function<double,D>> v = make_operands(world);
+        success += test_equivalence(world, v);
+        success += test_single_function(world, v);
+        success += test_clear(world, v);
+    }
+
+    world.gop.fence();
+    finalize();
+    return success;
+}


### PR DESCRIPTION
## What this does

Three performance changes in the SCF plus a load-balance fix. None alter results. The
kinetic-energy matrix carries most of the code.

**1. Pre-stage neighbor coefficients instead of fetching them.**

Differentiating a function fetches the coefficients of each local node's neighbors along the
axis. These fetches are cross-rank and latency-bound. The kinetic-energy matrix differentiates
`n` orbitals along three axes and issues them in bulk. Profiling put its differentiation at
**65–87% idle**.

The neighbor relation is symmetric and ownership is a pure function of the key. A producer can
therefore compute its own consumers without asking. Node `M` is the neighbor of `M-1` and `M+1`.
Its owner pushes it to the owners of those two keys, one batched message per destination.
`find_neighbor` then serves the node locally.

The cache reproduces what `sock_it_to_me` returns for the same key:

| cache state | meaning | `sock_it_to_me` |
|---|---|---|
| present, has data | same-level leaf | coefficients |
| present, empty | interior node, descend | empty |
| absent | neighbor is coarser | walks up to the coarse ancestor |

The third case is not covered. A coarse ancestor pushes only to the neighbors at its own level.
A miss therefore falls through to the existing fetch. Misses are always correct. `do_diff1`,
`do_diff2` and `matrix_inner` are unmodified.

**2. Spawn the per-node differentiation tasks from the task pool.**

`FunctionImpl::diff` submits one task per local node from a serial loop on the main thread. That
loop becomes the limiting term at high thread counts. It also issues the neighbor fetches
serially, so their latencies do not overlap. `taskq.for_each` over the same nodes produces the
same tasks. Only the spawning is parallel. This is the cost that remains once the fetches are
gone, so it composes with (1).

**3. Tile `V*psi` only at the tight protocols.**

Tiling the local-potential multiplication bounds the transient memory of the products. That peak
only threatens at high precision. The tiling costs `nmo/ntile` fences and a truncation of every
product at every protocol. The untiled path was the default for years. Its fence count does not
grow with `nmo`.

**4. Cost the load-balance root node like an ordinary node.** See below.

## Load-balance root node

`lbcost` charged the level-0 node 100× a normal node. `add_tree` accumulates that once per
function. `key0`'s cost therefore grew as `~100*(leaf+parent)*n_funcs`. On a balance over many
light trees `key0` outweighs every real subtree. The bin-packer gives it to one rank, reads that
rank as the most loaded, and starves it of work. One rank then sits idle. The loss is a flat
`1/nproc`.

This is called out separately because `lbcost` is generic. The kinetic-energy matrix balances
over `n` orbital trees and hits it squarely. Every other `load_balance` caller was paying it to
some degree. Only tree ownership changes. Results are unaffected.

## Commits

| commit | what |
|---|---|
| `5f628fade` | cost the load-balance root node like an ordinary node |
| `8fdf52350` | accumulate the tiled `V*psi` products with `gaxpy` |
| `5883389a5` | tile `V*psi` only at the tight protocols |
| `1b62da8ff` | pre-stage neighbor coefficients for the derivative operator |
| `6d5d37d81` | unit test for the neighbor halo |
| `1a1045316` | submit the derivative's per-node tasks from the task pool |

6 commits, +330/−9 over 7 files. 194 insertions are the new test.

## Interface changes

**1. New optional API on `FunctionImpl`.** `halo_enable`, `halo_clear`, `halo_enabled`,
`halo_size`, `receive_halo`, `halo_probe`. The cache is a `unique_ptr` and is null until a caller
stages one. A function that never stages a halo carries nothing. Consulting it costs one pointer
test. Nothing outside the kinetic-energy matrix stages one.

**2. Staging is collective and fence-ordered.** Every rank must call `halo_enable` and fence
before any rank stages. A push arrives as a task and cannot allocate the cache without racing
that call. A second fence separates staging from differentiating. `receive_halo` asserts that the
cache exists, so a violation fails loudly. `SCF::kinetic_energy_matrix` owns these fences.

**3. `DerivativeBase` gains `parallel_submit_`.** Per instance and off by default. Ordinary
derivative applications keep the serial submission. The kinetic-energy matrix opts in. Its
gradient operators are used nowhere else.

**4. Transient memory.** The staged coefficients are the remote-neighbor surface. All three axes
are staged before the single fence. The union of the three surfaces is live until the derivatives
are taken, then freed. The cost scales with the surface of the trees, not the volume.

No checkpoint-format change. No default behaviour change outside the kinetic-energy matrix.

## Tests

New `src/madness/mra/test_halo.cc` (`short`). Registered at 1 rank, and at 2 via
`add_mpi_tests`. The halo only carries data between ranks, so a single-rank run cannot exercise
it.

Both features must be numerically inert. That is a property of the code rather than of a
calculation, so the test asserts it directly. It compares the derivative taken with a staged halo
against the same derivative taken without one. The two perform identical arithmetic, so agreement
is required to round-off rather than to a tolerance. Three cells: halo alone, pool submission
alone, and both.

The operands are cusped Slater functions at four centres and widths. The tree is then deep and
unevenly refined. Neighbors resolve as same-level leaves, as interior nodes, and as coarser
ancestors the cache does not cover.

Two further assertions. The halo must be non-empty, so a staging path that moved nothing cannot
pass. Clearing the halo must restore the plain path, so a stale cache cannot leak into a later
derivative.

Mutation-tested. Pushing the consumer's key instead of the producer's is a plausible off-by-one
in the symmetry argument. It is caught at `3.8e0` against a `1e-13` bound. The submission-only
cell still reports `0.0`, so the failure localizes.

## PR checklist

| item | answer |
|---|---|
| raw MPI calls | none added; staging goes through `WorldObject::task` |
| blocking MPI collectives | none added; the two new fences are `World::gop.fence()` |
| implicit default World | none added; `stage_halo` uses the operator's `World&` |
| non-collective container construction | none. Staging does add a collective ordering requirement, see interface change 2 |
| threaded-BLAS assumptions | none |
| `Function` mutation from user threads | no. The halo is written from the main thread and from tasks, and read only after a fence |
| tree-state preconditions | unchanged. The caller reconstructs as before, and the halo is keyed by node |
| checkpoint-format break | none |
| GENTENSOR coverage | `coeffT` may be a `GenTensor` and now travels in a new message payload. `MADchem` and `testsuite` compile clean under `-DENABLE_GENTENSOR=ON` (Debug, C++20), and `test_halo` runs the path in every build |
| load-balance ownership | changed for every `load_balance` caller, see above |

## Verification

- the new test at 1, 2, 4 and 8 ranks. Agreement is exactly `0.0` in every cell
- `testsuite` green, serial and under MPI
- the `short|medium` suite, no new failures
- `-DMADNESS_WERROR=ON` build clean
- `-DENABLE_GENTENSOR=ON` Debug C++20 build clean
- `clang-tidy` reports no warnings in the added header code. The new test matches the count of
  the merged `test_mul_sparse.cc`. Two `narrowing-conversions` hits on a changed `SCF.cc` line
  match master's own idiom two lines above
- `moldft` on the three-protocol ladder, HF and LDA. LDA matches the pre-change reference at all
  three protocols. HF matches the two tighter ones and moves by `1e-8` at the loosest, from the
  `V*psi` truncation placement. Every protocol still tightens on the one before