### PR TITLE
Pr localizer makegw

### DIFF
--- a/src/madness/chem/SCF.cc
+++ b/src/madness/chem/SCF.cc
@@ -2197,12 +2197,21 @@ void SCF::solve(World& world) {
         //     //do_this_iter = false;
         //     param.maxsub = maxsub_save;
         // }
+        // The first localization starts from the atomic guess, where CG can spend hundreds of
+        // iterations chasing 1e-6 while still bouncing above it. Later iterations re-localize
+        // anyway, so loosen that one call.
+        double localize_tolloc_scale = 1.0;
+        if (param.do_localize() && do_this_iter && !initial_localization_done) {
+            localize_tolloc_scale = 100.0;
+            initial_localization_done = true;
+        }
         const bool tile_localize = true;
         if (tile_localize) {
             if (param.do_localize() && do_this_iter) {
                 START_TIMER(world);
                 Localizer localizer(world, aobasis, molecule, ao);
                 localizer.set_method(param.localize_method());
+                localizer.set_tolloc_scale(localize_tolloc_scale);
                 MolecularOrbitals<double, 3> mo(amo, aeps, {}, aocc, aset);
                 tensorT UT = localizer.compute_localization_matrix(world, mo, iter == 0);
                 UT.screen(trantol);
@@ -2242,6 +2251,7 @@ void SCF::solve(World& world) {
                 START_TIMER(world);
                 Localizer localizer(world, aobasis, molecule, ao);
                 localizer.set_method(param.localize_method());
+                localizer.set_tolloc_scale(localize_tolloc_scale);
                 MolecularOrbitals<double, 3> mo(amo, aeps, {}, aocc, aset);
                 tensorT UT = localizer.compute_localization_matrix(world, mo, iter == 0);
                 UT.screen(trantol);

--- a/src/madness/chem/SCF.cc
+++ b/src/madness/chem/SCF.cc
@@ -2205,7 +2205,10 @@ void SCF::solve(World& world) {
             localize_tolloc_scale = 100.0;
             initial_localization_done = true;
         }
-        const bool tile_localize = true;
+        // Tiling the transform bounds the transient memory of the rotated orbitals, which only
+        // threatens at high precision. Below that it costs a fence per orbital and a truncation of
+        // every tile. Take the untiled path except at the tight protocols.
+        const bool tile_localize = FunctionDefaults<3>::get_thresh() < 1.e-7;
         if (tile_localize) {
             if (param.do_localize() && do_this_iter) {
                 START_TIMER(world);

--- a/src/madness/chem/SCF.cc
+++ b/src/madness/chem/SCF.cc
@@ -2206,73 +2206,50 @@ void SCF::solve(World& world) {
             initial_localization_done = true;
         }
         // Tiling the transform bounds the transient memory of the rotated orbitals, which only
-        // threatens at high precision. Below that it costs a fence per orbital and a truncation of
-        // every tile. Take the untiled path except at the tight protocols.
+        // threatens at high precision. Below that it only buys an extra truncation per tile.
+        // Take the untiled path except at the tight protocols.
         const bool tile_localize = FunctionDefaults<3>::get_thresh() < 1.e-7;
-        if (tile_localize) {
-            if (param.do_localize() && do_this_iter) {
-                START_TIMER(world);
-                Localizer localizer(world, aobasis, molecule, ao);
-                localizer.set_method(param.localize_method());
-                localizer.set_tolloc_scale(localize_tolloc_scale);
+
+        // Rotate one spin's orbitals by its localization matrix. When tiled it rotates min_tile
+        // orbitals at a time, bounding the transient to that many functions rather than all of them.
+        auto rotate_orbitals = [&world, tile_localize](vecfuncT& v, const tensorT& UT) {
+            if (tile_localize) {
+                const size_t min_tile = 10;
+                const size_t ntile = std::min(v.size(), min_tile);
+                vecfuncT rotated(v.size());
+                for (size_t ilo = 0; ilo < v.size(); ilo += ntile) {
+                    const size_t iend = std::min(ilo + ntile, v.size());
+                    auto U_slice = copy(transpose(UT)(_, Slice(ilo, iend - 1)));
+                    auto tmp = transform(world, v, U_slice);
+                    truncate(world, tmp);
+                    for (size_t i = ilo; i < iend; ++i) rotated[i] = tmp[i - ilo];
+                }
+                v = rotated;
+            } else {
+                v = transform(world, v, transpose(UT));
+                truncate(world, v);
+            }
+            normalize(world, v);
+        };
+
+        if (param.do_localize() && do_this_iter) {
+            START_TIMER(world);
+            Localizer localizer(world, aobasis, molecule, ao);
+            localizer.set_method(param.localize_method());
+            localizer.set_tolloc_scale(localize_tolloc_scale);
+            {
                 MolecularOrbitals<double, 3> mo(amo, aeps, {}, aocc, aset);
                 tensorT UT = localizer.compute_localization_matrix(world, mo, iter == 0);
                 UT.screen(trantol);
-
-                size_t min_tile = 10;
-                size_t ntile = std::min(amo.size(), min_tile);
-                vecfuncT new_amo = zero_functions<double,3>(world, amo.size());  
-
-                for (size_t ilo=0; ilo<amo.size(); ilo+=ntile){
-                    size_t iend = std::min(ilo+ntile,amo.size());
-                    auto U_slice = copy(transpose(UT)(_,Slice(ilo,iend-1)));
-
-                    auto tmp_amo = transform(world, amo, U_slice);
-
-                    truncate(world, tmp_amo);
-
-                    for (size_t i = ilo; i<iend; ++i){
-                        new_amo[i] += tmp_amo[i-ilo];
-                    }
-                }
-                normalize(world, new_amo);
-                amo = new_amo;
-
-                if (!param.spin_restricted() && param.nbeta() != 0) {
-
-                    MolecularOrbitals<double, 3> mo(bmo, beps, {}, bocc, bset);
-                    tensorT UT = localizer.compute_localization_matrix(world, mo, iter == 0);
-                    UT.screen(trantol);
-                    bmo = transform(world, bmo, transpose(UT));
-                    truncate(world, bmo);
-                    normalize(world, bmo);
-                }
-                END_TIMER(world, "localize");
+                rotate_orbitals(amo, UT);
             }
-        } else {
-            if (param.do_localize() && do_this_iter) {
-                START_TIMER(world);
-                Localizer localizer(world, aobasis, molecule, ao);
-                localizer.set_method(param.localize_method());
-                localizer.set_tolloc_scale(localize_tolloc_scale);
-                MolecularOrbitals<double, 3> mo(amo, aeps, {}, aocc, aset);
+            if (!param.spin_restricted() && param.nbeta() != 0) {
+                MolecularOrbitals<double, 3> mo(bmo, beps, {}, bocc, bset);
                 tensorT UT = localizer.compute_localization_matrix(world, mo, iter == 0);
                 UT.screen(trantol);
-                amo = transform(world, amo, transpose(UT));
-                truncate(world, amo);
-                normalize(world, amo);
-
-                if (!param.spin_restricted() && param.nbeta() != 0) {
-
-                    MolecularOrbitals<double, 3> mo(bmo, beps, {}, bocc, bset);
-                    tensorT UT = localizer.compute_localization_matrix(world, mo, iter == 0);
-                    UT.screen(trantol);
-                    bmo = transform(world, bmo, transpose(UT));
-                    truncate(world, bmo);
-                    normalize(world, bmo);
-                }
-                END_TIMER(world, "localize");
+                rotate_orbitals(bmo, UT);
             }
+            END_TIMER(world, "localize");
         }
 
         START_TIMER(world);

--- a/src/madness/chem/SCF.h
+++ b/src/madness/chem/SCF.h
@@ -228,6 +228,7 @@ public:
     double converged_for_thresh=1.e10;   ///< mos are converged for this threshold
     double converged_for_dconv=1.e10;    ///< mos are converged for this density
     double converged_for_tconv=1.e10;    ///< derivatives of mos are converged for this threshold
+    bool initial_localization_done=false; ///< the first localization of this calculation is loosened
 
     /// forwarding constructor
     SCF(World& world, const commandlineparser& parser)

--- a/src/madness/chem/localizer.cc
+++ b/src/madness/chem/localizer.cc
@@ -79,7 +79,7 @@ Tensor<T> Localizer::compute_localization_matrix(World& world, const MolecularOr
     } else if (method == "boys") {
         dUT = localize_boys(world, psi, mo_in.get_localize_sets(), tolloc, randomize);
     } else if (method == "new") {
-        dUT = localize_new(world, psi, mo_in.get_localize_sets(), tolloc, randomize, false);
+        dUT = localize_new(world, psi, mo_in.get_localize_sets(), tolloc * tolloc_scale, randomize, false);
     } else {
         print("unknown localization method", method);
         MADNESS_EXCEPTION("unknown localization method", 1);

--- a/src/madness/chem/localizer.cc
+++ b/src/madness/chem/localizer.cc
@@ -419,16 +419,25 @@ DistributedMatrix<T> Localizer::localize_new(World& world, const std::vector<Fun
             return qij * (1.0 + breaksym * a); // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! break symmetry
         };
 
-        auto makeGW = [&Q, &nmo, &natom, &QQ](const tensorT& C, double& W, tensorT& g) -> void {
-            W = 0.0;
-            for (int i = 0; i < nmo; ++i) {
-                for (int a = 0; a < natom; ++a) {
-                    Q(i, a) = QQ(C, i, i, a);
-                    W += Q(i, a) * Q(i, a);
-                }
-            }
+        // The fan-out is local, so it must be awaited with Future::get(), never gop.fence(). Rows
+        // are disjoint: row i writes only g(i,j<i) and g(j<i,i). W is summed outside the fan-out to
+        // keep it independent of scheduling order.
+        typedef Range<int> rangeT;
+        auto makeGW = [&world, &Q, &nmo, &natom, &QQ](const tensorT& C, double& W, tensorT& g) -> void {
+            auto q_row = [&Q, &natom, &QQ, &C](const rangeT::iterator& it) -> bool {
+                const int i = it;
+                for (int a = 0; a < natom; ++a) Q(i, a) = QQ(C, i, i, a);
+                return true;
+            };
+            MADNESS_CHECK(world.taskq.for_each(rangeT(0, nmo), q_row).get());
 
-            for (int i = 0; i < nmo; ++i) {
+            W = 0.0;
+            for (int i = 0; i < nmo; ++i)
+                for (int a = 0; a < natom; ++a) W += Q(i, a) * Q(i, a);
+
+            // the gradient is O(nmo^2*natom) and the hot spot of localize_new
+            auto grad_row = [&Q, &natom, &QQ, &C, &g](const rangeT::iterator& it) -> bool {
+                const int i = it;
                 for (int j = 0; j < i; ++j) {
                     double Qiiij = 0.0, Qijjj = 0.0;
                     for (int a = 0; a < natom; ++a) {
@@ -436,10 +445,12 @@ DistributedMatrix<T> Localizer::localize_new(World& world, const std::vector<Fun
                         Qijjj += Qija * Q(j, a);
                         Qiiij += Qija * Q(i, a);
                     }
-                    g(j, i) = Qiiij - Qijjj;
-                    g(i, j) = -g(j, i);
+                    g(i, j) = -(Qiiij - Qijjj);
+                    g(j, i) = -g(i, j);
                 }
-            }
+                return true;
+            };
+            MADNESS_CHECK(world.taskq.for_each(rangeT(0, nmo), grad_row).get());
         };
 
         tensorT xprev; // previous search direction

--- a/src/madness/chem/localizer.h
+++ b/src/madness/chem/localizer.h
@@ -45,6 +45,12 @@ public:
         return *this;
     }
 
+    /// Multiply the "new" method's convergence threshold by this factor (default 1.0).
+    Localizer& set_tolloc_scale(const double scale) {
+        tolloc_scale=scale;
+        return *this;
+    }
+
     AtomicBasisSet get_aobasis() const {
         return aobasis;
     }
@@ -159,6 +165,7 @@ private:
     Function<double,3> metric;       /// =R for computing matrix elements of operators
     double thetamax=0.1;                /// maximum rotation(?)
     const double tolloc = 1e-6; // was std::min(1e-6,0.01*dconv) but now trying to avoid unnecessary change
+    double tolloc_scale = 1.0;  // multiplies tolloc, "new" method only
     double thresh_degenerate;           /// when are orbitals degenerate
     bool enforce_core_valence_separation=false;  /// no rotations between core and valence orbitals (distinguished by 'set')
     std::string method="new";           /// localization method


### PR DESCRIPTION
## What this does

Three changes in the localizer and one in the SCF driver. A 1065-MO system exposed the first two.

**1. Fan out `makeGW` over the task queue.**

- it ran single-threaded on rank 0, and its `O(nmo^2 * natom)` gradient loop is the hot spot of
  `localize_new`
- the fan-out is local, so it is awaited with `Future::get()`, not `gop.fence()`
- rows are disjoint: row `i` writes only `g(i,j<i)` and `g(j<i,i)`
- `W` is summed outside the fan-out to keep it independent of scheduling order
- the values are unchanged; the gradient is rewritten so row `i` writes its own row, and negation
  is exact

**2. Loosen the localization tolerance for the initial-guess iteration.**

- the first localization starts from the atomic guess, where CG can run hundreds of iterations
  chasing `1e-6` while still bouncing above it
- loosened `100x` for that one call, since later iterations re-localize anyway
- applies to the `"new"` method only, where the behaviour was diagnosed
- the decision is held on the `SCF` object rather than a function-local static, so every
  calculation in a process behaves alike

**3. Tile the localization transform only at the tight protocols, for both spins.**

- tiling bounds the transient memory of the rotated orbitals, which only threatens at high
  precision. Below that it only buys an extra truncation per tile
- untiled at `thresh >= 1e-7`, a cutoff between protocol steps
- the tiling covered only alpha. Beta was untiled in both branches, so unrestricted runs had their
  peak set by an untiled transform anyway
- both spins now use one helper, which removes the duplicated `do_localize` block

## Commits

| commit | what |
|---|---|
| `49fcc631c` | fan out `makeGW` over the task queue |
| `b158f2211` | loosen the localization tolerance for the initial-guess iteration |
| `7656eda44` | tile the localization transform only at the tight protocols |
| `05b2c1f34` | rotate both spins with the same tiled transform |

4 commits, +77/−68 over 4 files. `SCF.cc` is a net deletion.

## PR checklist

| item | answer |
|---|---|
| raw MPI calls | none added |
| blocking MPI collectives | none added. The fan-out is local and awaited with `Future::get()` |
| implicit default World | none added; the fan-out uses the `World&` already passed to `localize_new` |
| non-collective container construction | none |
| threaded-BLAS assumptions | none. The parallelised loops are hand-written, not BLAS |
| `Function` mutation from user threads | no. `makeGW` operates on `Tensor`, and the rotation runs on the main thread |
| tree-state preconditions | unchanged |
| checkpoint-format break | none |
| GENTENSOR coverage | `MADchem` and `testsuite` compile clean under `-DENABLE_GENTENSOR=ON` (Debug, C++20) |

## Verification

- `testsuite` green
- the `short|medium` suite, no new failures
- `-DMADNESS_WERROR=ON` build clean
- `-DENABLE_GENTENSOR=ON` Debug C++20 build clean
- `clang-tidy` reports no warnings on the new code. The two `narrowing-conversions` hits it does
  report are on `Slice(ilo, iend - 1)`, which is master's own expression relocated unchanged
- `moldft` on the two-protocol ladder: energies agree within the protocol, and `water3` is
  identical restricted and unrestricted
- the tiled path is only reachable at `thresh < 1e-7`, so it was checked separately by forcing it
  on at the cheap protocols, where it matched the untiled path exactly