### PR TITLE
Jm/fix even lattice sums

### DIFF
--- a/src/madness/mra/CMakeLists.txt
+++ b/src/madness/mra/CMakeLists.txt
@@ -38,7 +38,7 @@ if(BUILD_TESTING)
       testpdiff.cc testdiff1Db.cc testgconv.cc testopdir.cc testinnerext.cc
       testgaxpyext.cc testvmra.cc test_vectormacrotask.cc test_cloud.cc test_tree_state.cc testsolver.cc
       test_macrotaskpartitioner.cc test_QCCalculationParametersBase.cc test_memory_measurement.cc
-      test_keybox.cc test_eval.cc test_mul_sparse.cc test_halo.cc)
+      test_keybox.cc test_eval.cc test_mul_sparse.cc test_halo.cc test_displacements.cc)
   add_unittests(mra "${MRA_TEST_SOURCES}" "MADmra;MADgtest" "unittests;short")
   set(MRA_SEPOP_TEST_SOURCES testsuite.cc
       testper.cc)

--- a/src/madness/mra/displacements.h
+++ b/src/madness/mra/displacements.h
@@ -696,25 +696,121 @@ namespace madness {
           : center_(center), box_radius_(box_radius),
             surface_thickness_(surface_thickness), is_lattice_summed_(is_lattice_summed), validator_(std::move(validator)) {
         // initialize bounds
-        bool has_finite_dimensions = false;
+        std::optional<size_t> backup_face;
+        bool found_probe_face = false;
         const auto n = center_.level();
         Vector<Translation, NDIM> probing_displacement_vec(0);
         for (size_t d=0; d!= NDIM; ++d) {
           if (box_radius_[d]) {
+            if (!backup_face.has_value() || box_radius_[d] < box_radius_[*backup_face]) {
+              backup_face = d;
+            }
             auto r = *box_radius_[d];  // in units of 2^{n-1}
             // n = 0 is special b/c << -1 is undefined
             r = (n == 0) ? (r+1)/2 : (r * Translation(1) << (n-1));
             MADNESS_ASSERT(r > 0);
             box_[d] = {center_[d] - r, center_[d] + r};
-            if (!has_finite_dimensions) // first finite dimension? probing displacement will be nonzero along it, zero along all others
+            if ((!is_lattice_summed_[d] || *box_radius_[d] % 2 == 1 || NDIM == 1 || n == 0) && !found_probe_face) {
+              // Most likely, either there is no lattice summation (this face is mapped onto itself), or
+              // the range is odd (this face is mapped onto a cell face). In the first two cases, the
+              // face is well-separated from the "small magnitude" displacements for large n.
+              // We can displace to the origin of this hyperface.
+              // Whereas if NDIM == 1 or n == 0, the entire boundary has already been mapped to the vicinity of the origin and computed.
+              // We can't screen this out the obvious way, but we can trust the Validator to recognize that these points have already been computed.
               probing_displacement_vec[d] = r;
-            has_finite_dimensions = true;
+              found_probe_face = true;
+            }
           } else {
             box_[d] = {0, (1 << center_.level()) - 1};
           }
         }
-        MADNESS_ASSERT(has_finite_dimensions);
-        probing_displacement_ = Displacement(n, probing_displacement_vec);
+        MADNESS_ASSERT(backup_face.has_value());  // if all dimensions are infinite, then there is no surface!
+        if (found_probe_face) {
+          probing_displacement_ = Displacement(n, probing_displacement_vec);
+        } else {
+          // If we're in this case, then lattice summation *always* maps the periodic face onto a hyperplane
+          // through the cube origin, and the screening test above would screen out the box iff the origin displacement has a small norm.
+          // That screening test isn't viable. We need to choose our probe displacement differently.
+          // Instead, we'll probe on target_face, but not on its origin.
+          // (We know the face has non-orign points because if we're in this clause, NDIM > 1, and there's more than one box.)
+          // Now, the operator norm decays as the displacement magnitude increases.
+          // The challenge is to find a displacement *just big enough* for it to be valid, but no larger.
+          probing_displacement_vec[backup_face.value()] = (*box_radius_[backup_face.value()]) * Translation(1) << (n-1);
+          // We're going to be greedy. Let's try choosing one dimension's displacement to exceed bmax_default.
+          // If we can do that, keep shrinking the distance if possible.
+          // If we wanted the *best* direction for this trick, we'd start with the smallest real-space length.
+          for (size_t d = 0; d != NDIM; ++d) {
+            if (center_[d] - Displacements<NDIM>::bmax_default() - 1 >= box_[d].first) {
+              // If displacing past bmax_default *to the left* keeps us in the box...
+              for (size_t disp = Displacements<NDIM>::bmax_default(); disp == 0; --disp) {
+                probing_displacement_vec[d] = -disp;
+                auto trial_disp = std::make_optional<Key<NDIM>>(center_.level(),  probing_displacement_vec);
+                if (!validator_(n, center_.translation() + probing_displacement_vec, trial_disp)) {
+                  // Let's use the last valid key.
+                  probing_displacement_vec[d] -= 1;
+                  probing_displacement_ = Displacement(n, probing_displacement_vec);
+                  break;
+                }
+              }
+              break;
+            } else if (center_[d] + Displacements<NDIM>::bmax_default() + 1 <= box_[d].second) {
+              // If displacing past bmax_default *to the right* keeps us in the box...
+              for (size_t disp = Displacements<NDIM>::bmax_default(); disp == 0; --disp) {
+                probing_displacement_vec[d] = +disp;
+                auto trial_disp = std::make_optional<Key<NDIM>>(center_.level(),  probing_displacement_vec);
+                if (!validator_(n, center_.translation() + probing_displacement_vec, trial_disp)) {
+                  // Let's use the last valid key.
+                  probing_displacement_vec[d] += 1;
+                  probing_displacement_ = Displacement(n, probing_displacement_vec);
+                  break;
+                }
+              }
+              break;
+            }
+          }
+          // If we can't, set all the distances to the maximum and greedily reduce until we get something invalid.
+          // We could maybe decay some more, but this is fine.
+          Translation max_permissible_abs = 0;
+          for (size_t d = 0; d != NDIM; ++d) {
+            if (d == backup_face.value()) continue;
+            auto plus = box_[d].second - center_[d];
+            auto minus = center_[d] - box_[d].first;
+            max_permissible_abs = std::max({max_permissible_abs, plus, minus});
+            probing_displacement_vec[d] = plus > minus ? plus : -minus;
+          }
+          bool can_shrink = true;
+          max_permissible_abs--;
+          while (true) {
+            for (size_t d = 0; d != NDIM; ++d) {
+              if (d == backup_face.value()) continue;
+              if (probing_displacement_vec[d] > max_permissible_abs) {
+                probing_displacement_vec[d] -= 1;
+                auto trial_disp = std::make_optional<Key<NDIM>>(center_.level(),  probing_displacement_vec);
+                if (!validator_(n, center_.translation() + probing_displacement_vec, trial_disp)) {
+                  // We can't afford to shrink this dimension. Revert!
+                  probing_displacement_vec[d] += 1;
+                  can_shrink = false;
+                }
+              } else if (probing_displacement_vec[d] < -max_permissible_abs) {
+                probing_displacement_vec[d] += 1;
+                auto trial_disp = std::make_optional<Key<NDIM>>(center_.level(),  probing_displacement_vec);
+                if (!validator_(n, center_.translation() + probing_displacement_vec, trial_disp)) {
+                  // We can't afford to shrink this dimension. Revert!
+                  probing_displacement_vec[d] -= 1;
+                  can_shrink = false;
+                }
+              }
+            }
+            if (!can_shrink) {
+              probing_displacement_ = Displacement(n, probing_displacement_vec);
+              break;
+            } else {
+              if (max_permissible_abs == 0) std::cout << probing_displacement_vec << std::endl;
+              MADNESS_ASSERT(max_permissible_abs > 0);
+              max_permissible_abs -= 1;
+            }
+          }
+        }
         for (size_t d=0; d!= NDIM; ++d) {
           // surface thickness should be only given for finite-radius dimensions
           MADNESS_ASSERT(!(box_radius_[d].has_value() ^ surface_thickness_[d].has_value()));

--- a/src/madness/mra/displacements.h
+++ b/src/madness/mra/displacements.h
@@ -569,6 +569,9 @@ namespace madness {
                 if (!filtered_out())
                   break;
               }
+              // This isn't *logically* impossible, (c.f. PR774), but practically,
+              // you should never hit this. If you really do have a practical use case
+              // for this assert failing, remove it.
               MADNESS_ASSERT(have_another_surface_layer);
             }
 

--- a/src/madness/mra/displacements.h
+++ b/src/madness/mra/displacements.h
@@ -798,8 +798,6 @@ namespace madness {
         // If we can do that, keep shrinking the distance if possible.
         // If we wanted the *best* direction for this trick, we'd start with the smallest real-space length.
         for (size_t d = 0; d != NDIM; ++d) {
-          std::cout << "Box bounds " << box_[d].first << " " << box_[d].second << std::endl;
-          std::cout << "Center " << center_[d] << " bmax " << Displacements<NDIM>::bmax_default() - 1 << std::endl;
           if (center_[d] - Displacements<NDIM>::bmax_default() - 1 >= box_[d].first) {
             // If displacing past bmax_default *to the left* keeps us in the box...
             for (size_t disp = Displacements<NDIM>::bmax_default(); disp != 0; --disp) {
@@ -861,7 +859,7 @@ namespace madness {
             return Displacement(n, probing_displacement_vec);
           } else {
             if (max_permissible_abs == 0) {
-	      std::cout << probing_displacement_vec << std::endl;
+	      // Need an actual error message here
 	      throw;
             }
             max_permissible_abs -= 1;

--- a/src/madness/mra/displacements.h
+++ b/src/madness/mra/displacements.h
@@ -696,121 +696,7 @@ namespace madness {
           : center_(center), box_radius_(box_radius),
             surface_thickness_(surface_thickness), is_lattice_summed_(is_lattice_summed), validator_(std::move(validator)) {
         // initialize bounds
-        std::optional<size_t> backup_face;
-        bool found_probe_face = false;
-        const auto n = center_.level();
-        Vector<Translation, NDIM> probing_displacement_vec(0);
-        for (size_t d=0; d!= NDIM; ++d) {
-          if (box_radius_[d]) {
-            if (!backup_face.has_value() || box_radius_[d] < box_radius_[*backup_face]) {
-              backup_face = d;
-            }
-            auto r = *box_radius_[d];  // in units of 2^{n-1}
-            // n = 0 is special b/c << -1 is undefined
-            r = (n == 0) ? (r+1)/2 : (r * Translation(1) << (n-1));
-            MADNESS_ASSERT(r > 0);
-            box_[d] = {center_[d] - r, center_[d] + r};
-            if ((!is_lattice_summed_[d] || *box_radius_[d] % 2 == 1 || NDIM == 1 || n == 0) && !found_probe_face) {
-              // Most likely, either there is no lattice summation (this face is mapped onto itself), or
-              // the range is odd (this face is mapped onto a cell face). In the first two cases, the
-              // face is well-separated from the "small magnitude" displacements for large n.
-              // We can displace to the origin of this hyperface.
-              // Whereas if NDIM == 1 or n == 0, the entire boundary has already been mapped to the vicinity of the origin and computed.
-              // We can't screen this out the obvious way, but we can trust the Validator to recognize that these points have already been computed.
-              probing_displacement_vec[d] = r;
-              found_probe_face = true;
-            }
-          } else {
-            box_[d] = {0, (1 << center_.level()) - 1};
-          }
-        }
-        MADNESS_ASSERT(backup_face.has_value());  // if all dimensions are infinite, then there is no surface!
-        if (found_probe_face) {
-          probing_displacement_ = Displacement(n, probing_displacement_vec);
-        } else {
-          // If we're in this case, then lattice summation *always* maps the periodic face onto a hyperplane
-          // through the cube origin, and the screening test above would screen out the box iff the origin displacement has a small norm.
-          // That screening test isn't viable. We need to choose our probe displacement differently.
-          // Instead, we'll probe on target_face, but not on its origin.
-          // (We know the face has non-orign points because if we're in this clause, NDIM > 1, and there's more than one box.)
-          // Now, the operator norm decays as the displacement magnitude increases.
-          // The challenge is to find a displacement *just big enough* for it to be valid, but no larger.
-          probing_displacement_vec[backup_face.value()] = (*box_radius_[backup_face.value()]) * Translation(1) << (n-1);
-          // We're going to be greedy. Let's try choosing one dimension's displacement to exceed bmax_default.
-          // If we can do that, keep shrinking the distance if possible.
-          // If we wanted the *best* direction for this trick, we'd start with the smallest real-space length.
-          for (size_t d = 0; d != NDIM; ++d) {
-            if (center_[d] - Displacements<NDIM>::bmax_default() - 1 >= box_[d].first) {
-              // If displacing past bmax_default *to the left* keeps us in the box...
-              for (size_t disp = Displacements<NDIM>::bmax_default(); disp != 0; --disp) {
-                probing_displacement_vec[d] = -disp;
-                auto trial_disp = std::make_optional<Key<NDIM>>(center_.level(),  probing_displacement_vec);
-                if (!validator_(n, center_.translation() + probing_displacement_vec, trial_disp)) {
-                  // Let's use the last valid key.
-                  probing_displacement_vec[d] -= 1;
-                  probing_displacement_ = Displacement(n, probing_displacement_vec);
-                  break;
-                }
-              }
-              break;
-            } else if (center_[d] + Displacements<NDIM>::bmax_default() + 1 <= box_[d].second) {
-              // If displacing past bmax_default *to the right* keeps us in the box...
-              for (size_t disp = Displacements<NDIM>::bmax_default(); disp != 0; --disp) {
-                probing_displacement_vec[d] = +disp;
-                auto trial_disp = std::make_optional<Key<NDIM>>(center_.level(),  probing_displacement_vec);
-                if (!validator_(n, center_.translation() + probing_displacement_vec, trial_disp)) {
-                  // Let's use the last valid key.
-                  probing_displacement_vec[d] += 1;
-                  probing_displacement_ = Displacement(n, probing_displacement_vec);
-                  break;
-                }
-              }
-              break;
-            }
-          }
-          // If we can't, set all the distances to the maximum and greedily reduce until we get something invalid.
-          // We could maybe decay some more, but this is fine.
-          Translation max_permissible_abs = 0;
-          for (size_t d = 0; d != NDIM; ++d) {
-            if (d == backup_face.value()) continue;
-            auto plus = box_[d].second - center_[d];
-            auto minus = center_[d] - box_[d].first;
-            max_permissible_abs = std::max({max_permissible_abs, plus, minus});
-            probing_displacement_vec[d] = plus > minus ? plus : -minus;
-          }
-          bool can_shrink = true;
-          max_permissible_abs--;
-          while (true) {
-            for (size_t d = 0; d != NDIM; ++d) {
-              if (d == backup_face.value()) continue;
-              if (probing_displacement_vec[d] > max_permissible_abs) {
-                probing_displacement_vec[d] -= 1;
-                auto trial_disp = std::make_optional<Key<NDIM>>(center_.level(),  probing_displacement_vec);
-                if (!validator_(n, center_.translation() + probing_displacement_vec, trial_disp)) {
-                  // We can't afford to shrink this dimension. Revert!
-                  probing_displacement_vec[d] += 1;
-                  can_shrink = false;
-                }
-              } else if (probing_displacement_vec[d] < -max_permissible_abs) {
-                probing_displacement_vec[d] += 1;
-                auto trial_disp = std::make_optional<Key<NDIM>>(center_.level(),  probing_displacement_vec);
-                if (!validator_(n, center_.translation() + probing_displacement_vec, trial_disp)) {
-                  // We can't afford to shrink this dimension. Revert!
-                  probing_displacement_vec[d] -= 1;
-                  can_shrink = false;
-                }
-              }
-            }
-            if (!can_shrink) {
-              probing_displacement_ = Displacement(n, probing_displacement_vec);
-              break;
-            } else {
-              if (max_permissible_abs == 0) std::cout << probing_displacement_vec << std::endl;
-              MADNESS_ASSERT(max_permissible_abs > 0);
-              max_permissible_abs -= 1;
-            }
-          }
-        }
+	probing_displacement_ = compute_probe();
         for (size_t d=0; d!= NDIM; ++d) {
           // surface thickness should be only given for finite-radius dimensions
           MADNESS_ASSERT(!(box_radius_[d].has_value() ^ surface_thickness_[d].has_value()));
@@ -867,6 +753,122 @@ namespace madness {
       const Displacement& probing_displacement() const {
         return probing_displacement_;
       }
+
+    private:
+      // If all dimensions are lattice-summed and even, then the standard
+      // algorithm to compute the probe displacement fails...
+      Displacement compute_probe() {
+        const auto n = center_.level();
+        std::optional<size_t> backup_face;
+        Vector<Translation, NDIM> probing_displacement_vec(0);
+        for (size_t d=0; d!= NDIM; ++d) {
+          if (box_radius_[d]) {
+            if (!backup_face.has_value() || box_radius_[d] < box_radius_[*backup_face]) {
+              backup_face = d;
+            }
+            auto r = *box_radius_[d];  // in units of 2^{n-1}
+            // n = 0 is special b/c << -1 is undefined
+            r = (n == 0) ? (r+1)/2 : (r * Translation(1) << (n-1));
+            MADNESS_ASSERT(r > 0);
+            box_[d] = {center_[d] - r, center_[d] + r};
+            if ((!is_lattice_summed_[d]) || *box_radius_[d] % 2 == 1 || NDIM == 1 || n == 0) {
+              // Most likely, either there is no lattice summation (this face is mapped onto itself), or
+              // the range is odd (this face is mapped onto a cell face). In the first two cases, the
+              // face is well-separated from the "small magnitude" displacements for large n.
+              // We can displace to the origin of this hyperface.
+              // Whereas if NDIM == 1 or n == 0, the entire boundary has already been mapped to the vicinity of the origin and computed.
+              // We can't screen this out the obvious way, but we can trust the Validator to recognize that these points have already been computed.
+              probing_displacement_vec[d] = r;
+	      return Displacement(n, probing_displacement_vec);
+            }
+          } else {
+            box_[d] = {0, (1 << center_.level()) - 1};
+          }
+        }
+        MADNESS_ASSERT(backup_face.has_value());  // if all dimensions are infinite, then there is no surface!
+        // If we're in this case, then lattice summation *always* maps the periodic face onto a hyperplane
+        // through the cube origin, and the screening test above would screen out the box iff the origin displacement has a small norm.
+        // That screening test isn't viable. We need to choose our probe displacement differently.
+        // Instead, we'll probe on target_face, but not on its origin.
+        // (We know the face has non-orign points because if we're in this clause, NDIM > 1, and there's more than one box.)
+        // Now, the operator norm decays as the displacement magnitude increases.
+        // The challenge is to find a displacement *just big enough* for it to be valid, but no larger.
+        probing_displacement_vec[backup_face.value()] = (*box_radius_[backup_face.value()]) * Translation(1) << (n-1);
+        // We're going to be greedy. Let's try choosing one dimension's displacement to exceed bmax_default.
+        // If we can do that, keep shrinking the distance if possible.
+        // If we wanted the *best* direction for this trick, we'd start with the smallest real-space length.
+        for (size_t d = 0; d != NDIM; ++d) {
+          std::cout << "Box bounds " << box_[d].first << " " << box_[d].second << std::endl;
+          std::cout << "Center " << center_[d] << " bmax " << Displacements<NDIM>::bmax_default() - 1 << std::endl;
+          if (center_[d] - Displacements<NDIM>::bmax_default() - 1 >= box_[d].first) {
+            // If displacing past bmax_default *to the left* keeps us in the box...
+            for (size_t disp = Displacements<NDIM>::bmax_default(); disp != 0; --disp) {
+              probing_displacement_vec[d] = -disp;
+              auto trial_disp = std::make_optional<Key<NDIM>>(center_.level(),  probing_displacement_vec);
+              if (!validator_(n, center_.translation() + probing_displacement_vec, trial_disp)) {
+                // Let's use the last valid key.
+                probing_displacement_vec[d] -= 1;
+                return Displacement(n, probing_displacement_vec);
+              }
+            }
+          } else if (center_[d] + Displacements<NDIM>::bmax_default() + 1 <= box_[d].second) {
+            // If displacing past bmax_default *to the right* keeps us in the box...
+            for (size_t disp = Displacements<NDIM>::bmax_default(); disp != 0; --disp) {
+              probing_displacement_vec[d] = +disp;
+              auto trial_disp = std::make_optional<Key<NDIM>>(center_.level(),  probing_displacement_vec);
+              if (!validator_(n, center_.translation() + probing_displacement_vec, trial_disp)) {
+                // Let's use the last valid key.
+                probing_displacement_vec[d] += 1;
+                return Displacement(n, probing_displacement_vec);
+              }
+            }
+          }
+	}
+        // If we can't, set all the distances to the maximum and greedily reduce until we get something invalid.
+        // We could maybe decay some more, but this is fine.
+        Translation max_permissible_abs = 0;
+        for (size_t d = 0; d != NDIM; ++d) {
+          if (d == backup_face.value()) continue;
+          auto plus = box_[d].second - center_[d];
+          auto minus = center_[d] - box_[d].first;
+          max_permissible_abs = std::max({max_permissible_abs, plus, minus});
+          probing_displacement_vec[d] = plus > minus ? plus : -minus;
+        }
+        bool can_shrink = true;
+        max_permissible_abs--;
+        while (true) {
+          for (size_t d = 0; d != NDIM; ++d) {
+            if (d == backup_face.value()) continue;
+            if (probing_displacement_vec[d] > max_permissible_abs) {
+              probing_displacement_vec[d] -= 1;
+              auto trial_disp = std::make_optional<Key<NDIM>>(center_.level(),  probing_displacement_vec);
+              if (!validator_(n, center_.translation() + probing_displacement_vec, trial_disp)) {
+                // We can't afford to shrink this dimension. Revert!
+                probing_displacement_vec[d] += 1;
+                can_shrink = false;
+              }
+            } else if (probing_displacement_vec[d] < -max_permissible_abs) {
+              probing_displacement_vec[d] += 1;
+              auto trial_disp = std::make_optional<Key<NDIM>>(center_.level(),  probing_displacement_vec);
+              if (!validator_(n, center_.translation() + probing_displacement_vec, trial_disp)) {
+                // We can't afford to shrink this dimension. Revert!
+                probing_displacement_vec[d] -= 1;
+                can_shrink = false;
+              }
+            }
+          }
+          if (!can_shrink) {
+            return Displacement(n, probing_displacement_vec);
+          } else {
+            if (max_permissible_abs == 0) {
+	      std::cout << probing_displacement_vec << std::endl;
+	      throw;
+            }
+            max_permissible_abs -= 1;
+          }
+        }
+      }
+
     };  // BoxSurfaceDisplacementRange
 
 

--- a/src/madness/mra/displacements.h
+++ b/src/madness/mra/displacements.h
@@ -816,7 +816,7 @@ namespace madness {
           if (d == backup_face.value()) continue;
           if (center_[d] - Displacements<NDIM>::bmax_default() - 1 >= box_[d].first) {
             // If displacing past bmax_default *to the left* keeps us in the box...
-            for (size_t disp = Displacements<NDIM>::bmax_default(); disp != 0; --disp) {
+            for (Translation disp = Displacements<NDIM>::bmax_default(); disp != 0; --disp) {
               probing_displacement_vec[d] = -disp;
               auto trial_disp = std::make_optional<Key<NDIM>>(center_.level(),  probing_displacement_vec);
               if (!validator_(n, center_.translation() + probing_displacement_vec, trial_disp)) {
@@ -824,11 +824,12 @@ namespace madness {
                 probing_displacement_vec[d] -= 1;
                 return Displacement(n, probing_displacement_vec);
               }
+              probing_displacement_vec[d] = 0;
             }
             return Displacement(n, probing_displacement_vec);
           } else if (center_[d] + Displacements<NDIM>::bmax_default() + 1 <= box_[d].second) {
             // If displacing past bmax_default *to the right* keeps us in the box...
-            for (size_t disp = Displacements<NDIM>::bmax_default(); disp != 0; --disp) {
+            for (Translation disp = Displacements<NDIM>::bmax_default(); disp != 0; --disp) {
               probing_displacement_vec[d] = +disp;
               auto trial_disp = std::make_optional<Key<NDIM>>(center_.level(),  probing_displacement_vec);
               if (!validator_(n, center_.translation() + probing_displacement_vec, trial_disp)) {
@@ -836,6 +837,7 @@ namespace madness {
                 probing_displacement_vec[d] += 1;
                 return Displacement(n, probing_displacement_vec);
               }
+              probing_displacement_vec[d] = 0;
             }
           return Displacement(n, probing_displacement_vec);
           }
@@ -845,10 +847,11 @@ namespace madness {
         Translation max_permissible_abs = 0;
         for (size_t d = 0; d != NDIM; ++d) {
           if (d == backup_face.value()) continue;
-          auto plus = box_[d].second - center_[d];
-          auto minus = center_[d] - box_[d].first;
-          max_permissible_abs = std::max({max_permissible_abs, plus, minus});
-          probing_displacement_vec[d] = plus > minus ? plus : -minus;
+          // n.b.: If !box_radius_[d]_, we should have returned by now - dimension d isn't lattice-summed.'
+          max_permissible_abs = std::max({max_permissible_abs, *box_radius_[d]});
+          // +/- displacements are equivalent for lattice-summed dimensions.
+          // + is the canonical choice the displacment code makes.
+          probing_displacement_vec[d] = max_permissible_abs;
         }
         bool can_shrink = true;
         max_permissible_abs--;

--- a/src/madness/mra/displacements.h
+++ b/src/madness/mra/displacements.h
@@ -798,8 +798,8 @@ namespace madness {
         // If we're in this case, then lattice summation *always* maps the periodic face onto a hyperplane
         // through the cube origin, and the screening test above would screen out the box iff the origin displacement has a small norm.
         // That screening test isn't viable. We need to choose our probe displacement differently.
-        // Instead, we'll probe on target_face, but not on its origin.
-        // (We know the face has non-orign points because if we're in this clause, NDIM > 1, and there's more than one box.)
+        // Instead, we'll probe on backup_face, but not on its origin.
+        // (We know the face has non-origin points because if we're in this clause, NDIM > 1, and there's more than one box.)
         // Now, the operator norm decays as the displacement magnitude increases.
         // The challenge is to find a displacement *just big enough* for it to be valid, but no larger.
         probing_displacement_vec[backup_face.value()] = (*box_radius_[backup_face.value()]) * Translation(1) << (n-1);
@@ -850,8 +850,8 @@ namespace madness {
           // n.b.: If !box_radius_[d]_, we should have returned by now - dimension d isn't lattice-summed.'
           max_permissible_abs = std::max({max_permissible_abs, *box_radius_[d]});
           // +/- displacements are equivalent for lattice-summed dimensions.
-          // + is the canonical choice the displacment code makes.
-          probing_displacement_vec[d] = max_permissible_abs;
+          // + is the canonical choice the displacement code makes.
+          probing_displacement_vec[d] = box_radius_[d];
         }
         bool can_shrink = true;
         max_permissible_abs--;
@@ -880,9 +880,8 @@ namespace madness {
             return Displacement(n, probing_displacement_vec);
           } else {
             if (max_permissible_abs == 0) {
-              // I want a case where this happens "in the wild," but if we end up here, we probably just need to compute all. The probe doesn't matter.'
+              // I want a case where this happens "in the wild," but if we end up here, we probably just need to compute all. The probe doesn't matter.
 	          MADNESS_EXCEPTION("Attempt to generate a probe displacement failed. Contact developers immediately.", 0)
-	          throw;
             }
             max_permissible_abs -= 1;
           }

--- a/src/madness/mra/displacements.h
+++ b/src/madness/mra/displacements.h
@@ -742,7 +742,7 @@ namespace madness {
           for (size_t d = 0; d != NDIM; ++d) {
             if (center_[d] - Displacements<NDIM>::bmax_default() - 1 >= box_[d].first) {
               // If displacing past bmax_default *to the left* keeps us in the box...
-              for (size_t disp = Displacements<NDIM>::bmax_default(); disp == 0; --disp) {
+              for (size_t disp = Displacements<NDIM>::bmax_default(); disp != 0; --disp) {
                 probing_displacement_vec[d] = -disp;
                 auto trial_disp = std::make_optional<Key<NDIM>>(center_.level(),  probing_displacement_vec);
                 if (!validator_(n, center_.translation() + probing_displacement_vec, trial_disp)) {
@@ -755,7 +755,7 @@ namespace madness {
               break;
             } else if (center_[d] + Displacements<NDIM>::bmax_default() + 1 <= box_[d].second) {
               // If displacing past bmax_default *to the right* keeps us in the box...
-              for (size_t disp = Displacements<NDIM>::bmax_default(); disp == 0; --disp) {
+              for (size_t disp = Displacements<NDIM>::bmax_default(); disp != 0; --disp) {
                 probing_displacement_vec[d] = +disp;
                 auto trial_disp = std::make_optional<Key<NDIM>>(center_.level(),  probing_displacement_vec);
                 if (!validator_(n, center_.translation() + probing_displacement_vec, trial_disp)) {

--- a/src/madness/mra/displacements.h
+++ b/src/madness/mra/displacements.h
@@ -336,7 +336,7 @@ namespace madness {
       using Displacement = Key<NDIM>;
       /// this callable returns whether a given primitive box (or hyperface if only one coordinate is provided) can be filtered out.
       /// if screening a primitive box, the corresponding displacement should be provided both for further screening and for the displacement to be updated, if displacements are translated to connect two cells in the box.
-      /// the validator should normally be a BoxSurfaceDisplacementFilter object. anything else is probably a hack.
+      /// the validator should normally be a BoxSurfaceDisplacementValidator object. anything else is probably a hack.
       using Validator = std::function<bool(Level, const PointPattern&, std::optional<Displacement>&)>;
 
     private:
@@ -696,7 +696,19 @@ namespace madness {
           : center_(center), box_radius_(box_radius),
             surface_thickness_(surface_thickness), is_lattice_summed_(is_lattice_summed), validator_(std::move(validator)) {
         // initialize bounds
-	probing_displacement_ = compute_probe();
+        const auto n = center_.level();
+        for (size_t d=0; d!= NDIM; ++d) {
+          if (box_radius_[d]) {
+            auto r = *box_radius_[d];  // in units of 2^{n-1}
+            // n = 0 is special b/c << -1 is undefined
+            r = (n == 0) ? (r+1)/2 : (r * Translation(1) << (n-1));
+            MADNESS_ASSERT(r > 0);
+            box_[d] = {center_[d] - r, center_[d] + r};
+          } else {
+            box_[d] = {0, (1 << center_.level()) - 1};
+          }
+        }
+        probing_displacement_ = compute_probe();
         for (size_t d=0; d!= NDIM; ++d) {
           // surface thickness should be only given for finite-radius dimensions
           MADNESS_ASSERT(!(box_radius_[d].has_value() ^ surface_thickness_[d].has_value()));
@@ -766,11 +778,6 @@ namespace madness {
             if (!backup_face.has_value() || box_radius_[d] < box_radius_[*backup_face]) {
               backup_face = d;
             }
-            auto r = *box_radius_[d];  // in units of 2^{n-1}
-            // n = 0 is special b/c << -1 is undefined
-            r = (n == 0) ? (r+1)/2 : (r * Translation(1) << (n-1));
-            MADNESS_ASSERT(r > 0);
-            box_[d] = {center_[d] - r, center_[d] + r};
             if ((!is_lattice_summed_[d]) || *box_radius_[d] % 2 == 1 || NDIM == 1 || n == 0) {
               // Most likely, either there is no lattice summation (this face is mapped onto itself), or
               // the range is odd (this face is mapped onto a cell face). In the first two cases, the
@@ -778,11 +785,13 @@ namespace madness {
               // We can displace to the origin of this hyperface.
               // Whereas if NDIM == 1 or n == 0, the entire boundary has already been mapped to the vicinity of the origin and computed.
               // We can't screen this out the obvious way, but we can trust the Validator to recognize that these points have already been computed.
+              auto r = *box_radius_[d];  // in units of 2^{n-1}
+              // n = 0 is special b/c << -1 is undefined
+              r = (n == 0) ? (r+1)/2 : (r * Translation(1) << (n-1));
+              MADNESS_ASSERT(r > 0);
               probing_displacement_vec[d] = r;
-	      return Displacement(n, probing_displacement_vec);
+              return Displacement(n, probing_displacement_vec);
             }
-          } else {
-            box_[d] = {0, (1 << center_.level()) - 1};
           }
         }
         MADNESS_ASSERT(backup_face.has_value());  // if all dimensions are infinite, then there is no surface!
@@ -794,10 +803,17 @@ namespace madness {
         // Now, the operator norm decays as the displacement magnitude increases.
         // The challenge is to find a displacement *just big enough* for it to be valid, but no larger.
         probing_displacement_vec[backup_face.value()] = (*box_radius_[backup_face.value()]) * Translation(1) << (n-1);
+
+        // As a special case, if there is no validator, that means that even the boxes closest to origin could be filtered out.
+        // So then *every* displacement will say to filter this out. Let's choose the easiest one.'
+        if (!validator_) return Displacement(n, probing_displacement_vec);
+        // From here on, we can assume the validator exists.
+
         // We're going to be greedy. Let's try choosing one dimension's displacement to exceed bmax_default.
         // If we can do that, keep shrinking the distance if possible.
         // If we wanted the *best* direction for this trick, we'd start with the smallest real-space length.
         for (size_t d = 0; d != NDIM; ++d) {
+          if (d == backup_face.value()) continue;
           if (center_[d] - Displacements<NDIM>::bmax_default() - 1 >= box_[d].first) {
             // If displacing past bmax_default *to the left* keeps us in the box...
             for (size_t disp = Displacements<NDIM>::bmax_default(); disp != 0; --disp) {
@@ -809,6 +825,7 @@ namespace madness {
                 return Displacement(n, probing_displacement_vec);
               }
             }
+            return Displacement(n, probing_displacement_vec);
           } else if (center_[d] + Displacements<NDIM>::bmax_default() + 1 <= box_[d].second) {
             // If displacing past bmax_default *to the right* keeps us in the box...
             for (size_t disp = Displacements<NDIM>::bmax_default(); disp != 0; --disp) {
@@ -820,6 +837,7 @@ namespace madness {
                 return Displacement(n, probing_displacement_vec);
               }
             }
+          return Displacement(n, probing_displacement_vec);
           }
 	}
         // If we can't, set all the distances to the maximum and greedily reduce until we get something invalid.
@@ -859,8 +877,9 @@ namespace madness {
             return Displacement(n, probing_displacement_vec);
           } else {
             if (max_permissible_abs == 0) {
-	      // Need an actual error message here
-	      throw;
+              // I want a case where this happens "in the wild," but if we end up here, we probably just need to compute all. The probe doesn't matter.'
+	          MADNESS_EXCEPTION("Attempt to generate a probe displacement failed. Contact developers immediately.", 0)
+	          throw;
             }
             max_permissible_abs -= 1;
           }

--- a/src/madness/mra/displacements.h
+++ b/src/madness/mra/displacements.h
@@ -767,7 +767,7 @@ namespace madness {
       }
 
     private:
-      // If all dimensions are lattice-summed and even, then the standard
+      // If all periodic dimensions are lattice-summed and even, then the standard
       // algorithm to compute the probe displacement fails...
       Displacement compute_probe() {
         const auto n = center_.level();
@@ -812,46 +812,49 @@ namespace madness {
         // We're going to be greedy. Let's try choosing one dimension's displacement to exceed bmax_default.
         // If we can do that, keep shrinking the distance if possible.
         // If we wanted the *best* direction for this trick, we'd start with the smallest real-space length.
+        const Translation bmax = Displacements<NDIM>::bmax_default();
         for (size_t d = 0; d != NDIM; ++d) {
           if (d == backup_face.value()) continue;
-          if (center_[d] - Displacements<NDIM>::bmax_default() - 1 >= box_[d].first) {
-            // If displacing past bmax_default *to the left* keeps us in the box...
-            for (Translation disp = Displacements<NDIM>::bmax_default(); disp != 0; --disp) {
-              probing_displacement_vec[d] = -disp;
-              auto trial_disp = std::make_optional<Key<NDIM>>(center_.level(),  probing_displacement_vec);
-              if (!validator_(n, center_.translation() + probing_displacement_vec, trial_disp)) {
-                // Let's use the last valid key.
-                probing_displacement_vec[d] -= 1;
-                return Displacement(n, probing_displacement_vec);
-              }
-              probing_displacement_vec[d] = 0;
+
+          // Can we displace past bmax in any direction?
+	      // For dimensions with a box_radius_, these if-conditions are equivalent, but the equivalence
+	      // does not hold for open dimensions.
+          Translation sign = 0;
+          if (center_[d] - box_[d].first >= bmax + 1)
+            sign = -1;
+          else if (bmax + 1 <= box_[d].second - center_[d])
+            sign = +1;
+          else
+            continue;
+
+          // If we made it here, we're displacing along this direction. We want the least displacement
+          // such that the displacement is both valid and nonzero. Zero displacements is exactly
+          // want to avoid.
+          for (Translation disp = bmax; disp != 0; --disp) {
+            probing_displacement_vec[d] = sign * disp;
+            auto trial_disp = std::make_optional<Key<NDIM>>(center_.level(),  probing_displacement_vec);
+            if (!validator_(n, center_.translation() + probing_displacement_vec, trial_disp)) {
+              // This one is filtered out, so the last valid key was one step longer.
+              probing_displacement_vec[d] = sign * (disp + 1);
+              break;
             }
-            return Displacement(n, probing_displacement_vec);
-          } else if (center_[d] + Displacements<NDIM>::bmax_default() + 1 <= box_[d].second) {
-            // If displacing past bmax_default *to the right* keeps us in the box...
-            for (Translation disp = Displacements<NDIM>::bmax_default(); disp != 0; --disp) {
-              probing_displacement_vec[d] = +disp;
-              auto trial_disp = std::make_optional<Key<NDIM>>(center_.level(),  probing_displacement_vec);
-              if (!validator_(n, center_.translation() + probing_displacement_vec, trial_disp)) {
-                // Let's use the last valid key.
-                probing_displacement_vec[d] += 1;
-                return Displacement(n, probing_displacement_vec);
-              }
-              probing_displacement_vec[d] = 0;
-            }
-          return Displacement(n, probing_displacement_vec);
           }
-	}
+          return Displacement(n, probing_displacement_vec);
+        }
         // If we can't, set all the distances to the maximum and greedily reduce until we get something invalid.
         // We could maybe decay some more, but this is fine.
         Translation max_permissible_abs = 0;
         for (size_t d = 0; d != NDIM; ++d) {
           if (d == backup_face.value()) continue;
-          // n.b.: If !box_radius_[d]_, we should have returned by now - dimension d isn't lattice-summed.'
-          max_permissible_abs = std::max({max_permissible_abs, *box_radius_[d]});
+          // dimensions of unlimited extent have no surface to probe; leave their component at 0
+          if (!box_radius_[d]) continue;
+          // N.B. box_radius_ and r hold the same information, but r is in units of boxes
+          // rather than half-simulation cells.
+          const Translation r = box_[d].second - center_[d];
+          max_permissible_abs = std::max(max_permissible_abs, r);
           // +/- displacements are equivalent for lattice-summed dimensions.
           // + is the canonical choice the displacement code makes.
-          probing_displacement_vec[d] = *box_radius_[d];
+          probing_displacement_vec[d] = r;
         }
         bool can_shrink = true;
         max_permissible_abs--;

--- a/src/madness/mra/displacements.h
+++ b/src/madness/mra/displacements.h
@@ -851,7 +851,7 @@ namespace madness {
           max_permissible_abs = std::max({max_permissible_abs, *box_radius_[d]});
           // +/- displacements are equivalent for lattice-summed dimensions.
           // + is the canonical choice the displacement code makes.
-          probing_displacement_vec[d] = box_radius_[d];
+          probing_displacement_vec[d] = *box_radius_[d];
         }
         bool can_shrink = true;
         max_permissible_abs--;

--- a/src/madness/mra/funcimpl.h
+++ b/src/madness/mra/funcimpl.h
@@ -5190,7 +5190,7 @@ template<size_t NDIM>
               validator = BoxSurfaceDisplacementValidator<opdim>(/* is_infinite_domain= */ op->func_domain_is_periodic(), /* is_lattice_summed= */ op->lattice_summed(), range, default_real_distance_squared, *max_distsq_reached);
 
             // this range iterates over the entire surface layer(s), and provides a probing displacement that can be used to screen out the entire box
-            auto opkey = op->particle() == 1 ? key.template extract_front<opdim>() : key.template extract_front<opdim>();
+            auto opkey = op->particle() == 1 ? key.template extract_front<opdim>() : key.template extract_back<opdim>();
             BoxSurfaceDisplacementRange<opdim>
                 range_boundary_face_displacements(opkey, box_radius,
                                                   surface_thickness,

--- a/src/madness/mra/test_displacements.cc
+++ b/src/madness/mra/test_displacements.cc
@@ -420,7 +420,6 @@ int main(int argc, char** argv) {
   int errors = 0;
   errors += test_surface_extent(world);
   errors += test_no_duplicates(world);
-  errors += test_fully_filtered_faces(world);
   errors += test_probe_hyperface_origin(world);
   errors += test_probe_even_lattice_sum(world);
   errors += test_probe_fallback_is_in_box_units(world);

--- a/src/madness/mra/test_displacements.cc
+++ b/src/madness/mra/test_displacements.cc
@@ -1,0 +1,479 @@
+/// \file test_displacements.cc
+/// \brief Tests for BoxSurfaceDisplacementRange — the surface-of-the-box
+///        displacement enumerator used for range-restricted operators.
+///
+/// This file is very concerned with the case where all periodic dimensions are even.
+/// Why is that special? `box_radius[d] == N` is the kernel range in
+/// half-simulation-cells, so at level `n` the range boundary sits `r = N*2^{n-1}`
+/// boxes from the center while the lattice period is `2^n` boxes. For odd `N`,
+/// `r` is a half-period offset and the boundary hyperface maps onto a cell face.
+/// For even `N`, `r` is an exact multiple of the period, so under lattice
+/// summation the hyperface is equivalent to a hyperplane through the origin —
+/// and the natural probing displacement (the hyperface origin, `r` along one
+/// axis) canonicalizes to the *zero* displacement. This is expected to be large
+/// due to the interaction between the center and itself, so it isn't usable.
+///
+/// The tests below cover both the iteration bounds and each branch of
+/// `compute_probe()`.
+
+#include <madness/mra/mra.h>
+#include <madness/mra/displacements.h>
+#include <madness/world/test_utilities.h>
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+using namespace madness;
+
+namespace {
+
+template <std::size_t NDIM>
+using Radii = std::array<std::optional<std::int64_t>, NDIM>;
+
+/// the range boundary, in boxes, for a kernel range of \p N half-simulation-cells at level \p n
+/// mirrors the conversion in the BoxSurfaceDisplacementRange constructor
+Translation radius_in_boxes(std::int64_t N, Level n) {
+  return (n == 0) ? (N + 1) / 2 : (N * Translation(1) << (n - 1));
+}
+
+/// the center box of the level-\p n grid
+template <std::size_t NDIM>
+Key<NDIM> centered_key(Level n) {
+  return Key<NDIM>(n, Vector<Translation, NDIM>(n == 0 ? 0 : (Translation(1) << (n - 1))));
+}
+
+/// least nonnegative residue of \p x modulo \p m
+Translation mod_positive(Translation x, Translation m) {
+  const auto r = x % m;
+  return (r < 0) ? r + m : r;
+}
+
+/// a validator that rejects everything it is asked about
+/// forces compute_probe()'s shrink loop to stop on its first trial, exposing the
+/// displacement vector exactly as the fallback block initialized it
+template <std::size_t NDIM>
+typename BoxSurfaceDisplacementRange<NDIM>::Validator reject_all() {
+  return [](Level, const typename BoxSurfaceDisplacementRange<NDIM>::PointPattern&,
+            std::optional<Key<NDIM>>&) -> bool { return false; };
+}
+
+/// a validator that accepts everything it is asked about
+/// drives compute_probe()'s greedy stage all the way down to |disp| == 1, so the
+/// shortest still-valid trial is the one that has to come back
+template <std::size_t NDIM>
+typename BoxSurfaceDisplacementRange<NDIM>::Validator accept_all() {
+  return [](Level, const typename BoxSurfaceDisplacementRange<NDIM>::PointPattern&,
+            std::optional<Key<NDIM>>&) -> bool { return true; };
+}
+
+/// keeps only destinations inside the simulation cell
+template <std::size_t NDIM>
+typename BoxSurfaceDisplacementRange<NDIM>::Validator in_domain_only() {
+  return [](const Level level, const typename BoxSurfaceDisplacementRange<NDIM>::PointPattern& dest,
+            std::optional<Key<NDIM>>&) -> bool {
+    const auto twon = (Translation(1) << level);
+    for (std::size_t d = 0; d != NDIM; ++d)
+      if (dest[d].has_value() && (*dest[d] < 0 || *dest[d] >= twon)) return false;
+    return true;
+  };
+}
+
+}  // namespace
+
+/// The surface must span the full extent of *every* dimension.
+///
+/// Regression guard: the per-dimension bounds are computed in one loop in the
+/// constructor. If that loop ever returns early again (it used to, once the
+/// probe computation was folded into it), the trailing dimensions keep
+/// default-constructed bounds and the surface silently collapses along them.
+/// Deliberately uses a different radius per axis so a collapsed axis cannot
+/// hide behind a neighbour's bounds.
+int test_surface_extent(World& world) {
+  test_output t("BoxSurfaceDisplacementRange: surface spans every dimension", world.rank() == 0);
+
+  const auto check_extent = [&](auto ndim_tag, Level n, std::array<std::int64_t, decltype(ndim_tag)::value> N,
+                                std::int64_t thickness, const std::string& what) {
+    constexpr std::size_t NDIM = decltype(ndim_tag)::value;
+    Radii<NDIM> box_radius, surface_thickness;
+    for (std::size_t d = 0; d != NDIM; ++d) {
+      box_radius[d] = N[d];
+      surface_thickness[d] = thickness;
+    }
+    BoxSurfaceDisplacementRange<NDIM> range(centered_key<NDIM>(n), box_radius, surface_thickness,
+                                            array_of_bools<NDIM>{false});
+
+    Vector<Translation, NDIM> lo(std::numeric_limits<Translation>::max());
+    Vector<Translation, NDIM> hi(std::numeric_limits<Translation>::min());
+    std::size_t count = 0;
+    for (auto&& disp : range) {
+      for (std::size_t d = 0; d != NDIM; ++d) {
+        lo[d] = std::min(lo[d], disp.translation()[d]);
+        hi[d] = std::max(hi[d], disp.translation()[d]);
+      }
+      ++count;
+    }
+    t.checkpoint(count > 0, what + ": surface is non-empty");
+    for (std::size_t d = 0; d != NDIM; ++d) {
+      const auto expected = radius_in_boxes(N[d], n) + thickness;
+      t.checkpoint(lo[d] == -expected, what + ": dim " + std::to_string(d) + " reaches -" + std::to_string(expected));
+      t.checkpoint(hi[d] == expected, what + ": dim " + std::to_string(d) + " reaches +" + std::to_string(expected));
+    }
+  };
+
+  check_extent(std::integral_constant<std::size_t, 2>{}, 4, {1, 1}, 1, "2D n=4 N={1,1}");
+  check_extent(std::integral_constant<std::size_t, 2>{}, 4, {1, 2}, 1, "2D n=4 N={1,2}");
+  check_extent(std::integral_constant<std::size_t, 2>{}, 3, {2, 2}, 0, "2D n=3 N={2,2} hard");
+  check_extent(std::integral_constant<std::size_t, 3>{}, 3, {1, 2, 3}, 1, "3D n=3 N={1,2,3}");
+
+  return t.end();
+}
+
+/// No displacement may be enumerated twice.
+/// We test any and cases where the logic splits, including lattice summed or not,
+/// and odd vs even N
+int test_no_duplicates(World& world) {
+  test_output t("BoxSurfaceDisplacementRange: no duplicate displacements", world.rank() == 0);
+
+  const auto check_unique = [&](auto ndim_tag, Level n, std::array<std::int64_t, decltype(ndim_tag)::value> N,
+                                bool lattice_summed, bool filter_to_domain, const std::string& what) {
+    constexpr std::size_t NDIM = decltype(ndim_tag)::value;
+    Radii<NDIM> box_radius, surface_thickness;
+    for (std::size_t d = 0; d != NDIM; ++d) {
+      box_radius[d] = N[d];
+      surface_thickness[d] = 1;
+    }
+    // N.B. the domain filter is only meaningful when the range boundary can land
+    // inside the cell at all.
+    BoxSurfaceDisplacementRange<NDIM> range(
+        centered_key<NDIM>(n), box_radius, surface_thickness, array_of_bools<NDIM>{lattice_summed},
+        filter_to_domain ? in_domain_only<NDIM>() : typename BoxSurfaceDisplacementRange<NDIM>::Validator{});
+    std::vector<Key<NDIM>> disps;
+    for (auto&& disp : range) disps.push_back(disp);
+    std::sort(disps.begin(), disps.end());
+    const auto last = std::unique(disps.begin(), disps.end());
+    t.checkpoint(!disps.empty(), what + ": surface is non-empty");
+    t.checkpoint(last == disps.end(), what + ": all displacements distinct");
+  };
+
+  constexpr auto d2 = std::integral_constant<std::size_t, 2>{};
+  constexpr auto d3 = std::integral_constant<std::size_t, 3>{};
+
+  // odd N and its even counterpart
+  check_unique(d2, 4, {1, 1}, false, true, "2D n=4 N={1,1} plain, in-domain");
+  check_unique(d2, 4, {1, 1}, false, false, "2D n=4 N={1,1} plain");
+  check_unique(d2, 4, {2, 2}, false, false, "2D n=4 N={2,2} plain");
+  // ... and both parities again with lattice summation on
+  check_unique(d2, 4, {1, 1}, true, false, "2D n=4 N={1,1} lattice-summed");
+  check_unique(d2, 4, {2, 2}, true, false, "2D n=4 N={2,2} lattice-summed");
+  check_unique(d2, 4, {2, 3}, true, false, "2D n=4 N={2,3} lattice-summed (mixed parity)");
+  // ... and in 3D, where each face has two free axes rather than one
+  check_unique(d3, 3, {1, 1, 1}, true, false, "3D n=3 N={1,1,1} lattice-summed");
+  check_unique(d3, 3, {2, 2, 2}, true, false, "3D n=3 N={2,2,2} lattice-summed");
+  check_unique(d3, 3, {1, 2, 3}, true, false, "3D n=3 N={1,2,3} lattice-summed (mixed parity)");
+
+  return t.end();
+}
+
+/// A face whose every layer is filtered out makes the range shorter, not fatal.
+int test_fully_filtered_faces(World& world) {
+  test_output t("BoxSurfaceDisplacementRange: an entirely filtered face is not an error", world.rank() == 0);
+
+  // every face out of the domain => empty range
+  {
+    constexpr std::size_t NDIM = 2;
+    const Level n = 4;
+    Radii<NDIM> box_radius, surface_thickness;
+    for (std::size_t d = 0; d != NDIM; ++d) {
+      box_radius[d] = 2;  // r = 2*2^3 = 16 boxes from the center of a 16-box axis
+      surface_thickness[d] = 1;
+    }
+    BoxSurfaceDisplacementRange<NDIM> range(centered_key<NDIM>(n), box_radius, surface_thickness,
+                                            array_of_bools<NDIM>{false}, in_domain_only<NDIM>());
+    std::size_t count = 0;
+    for (auto&& disp : range) {
+      (void)disp;
+      ++count;
+    }
+    t.checkpoint(count == 0, "2D n=4 N={2,2} in-domain: surface is empty, not fatal");
+    t.checkpoint(range.begin() == range.end(), "2D n=4 N={2,2} in-domain: begin() == end()");
+  }
+
+  // one face entirely out of the domain, the other partly inside => the survivors
+  // are still enumerated, and still without duplicates
+  {
+    constexpr std::size_t NDIM = 2;
+    const Level n = 4;
+    Radii<NDIM> box_radius, surface_thickness;
+    box_radius[0] = 2;  surface_thickness[0] = 1;  // boundary a full period away
+    box_radius[1] = 1;  surface_thickness[1] = 1;  // boundary at the cell edge
+    BoxSurfaceDisplacementRange<NDIM> range(centered_key<NDIM>(n), box_radius, surface_thickness,
+                                            array_of_bools<NDIM>{false}, in_domain_only<NDIM>());
+    std::vector<Key<NDIM>> disps;
+    for (auto&& disp : range) disps.push_back(disp);
+    std::sort(disps.begin(), disps.end());
+    t.checkpoint(!disps.empty(), "2D n=4 N={2,1} in-domain: the surviving face is enumerated");
+    t.checkpoint(std::unique(disps.begin(), disps.end()) == disps.end(),
+                 "2D n=4 N={2,1} in-domain: all displacements distinct");
+  }
+
+  return t.end();
+}
+
+/// Whenever the hyperface origin is a usable probe, it is the one chosen.
+///
+/// That covers every case except "lattice-summed with even N on all finite
+/// axes": no lattice summation at all, or an odd N, or NDIM==1, or n==0.
+int test_probe_hyperface_origin(World& world) {
+  test_output t("BoxSurfaceDisplacementRange: probe on the hyperface origin", world.rank() == 0);
+
+  const auto check_probe = [&](Level n, std::array<std::int64_t, 3> N, bool lattice_summed,
+                               const std::string& what) {
+    constexpr std::size_t NDIM = 3;
+    Radii<NDIM> box_radius, surface_thickness;
+    for (std::size_t d = 0; d != NDIM; ++d) {
+      box_radius[d] = N[d];
+      surface_thickness[d] = 1;
+    }
+    BoxSurfaceDisplacementRange<NDIM> range(centered_key<NDIM>(n), box_radius, surface_thickness,
+                                            array_of_bools<NDIM>{lattice_summed}, in_domain_only<NDIM>());
+    const auto probe = range.probing_displacement().translation();
+    t.checkpoint(probe[0] == radius_in_boxes(N[0], n), what + ": probe[0] == range boundary");
+    t.checkpoint(probe[1] == 0 && probe[2] == 0, what + ": probe is axial");
+  };
+
+  check_probe(4, {1, 1, 1}, false, "3D n=4 N={1,1,1} plain");
+  check_probe(4, {2, 2, 2}, false, "3D n=4 N={2,2,2} plain");
+  check_probe(4, {1, 1, 1}, true, "3D n=4 N={1,1,1} lattice-summed (odd)");
+  check_probe(4, {3, 2, 2}, true, "3D n=4 N={3,2,2} lattice-summed (leading odd)");
+  check_probe(0, {2, 2, 2}, true, "3D n=0 N={2,2,2} lattice-summed");
+
+  return t.end();
+}
+
+/// The point of the whole exercise: for an even, lattice-summed range the probe
+/// must not be lattice-equivalent to the zero displacement.
+///
+/// The hyperface origin is `r = N*2^{n-1}` along one axis, an exact multiple of
+/// the period `2^n` when N is even, so it canonicalizes to zero. Screening the
+/// entire range boundary on the norm of a zero displacement is meaningless —
+/// `op->norm(level, probe, source)` would report the on-site norm and the
+/// surface would never be screened correctly.
+int test_probe_even_lattice_sum(World& world) {
+  test_output t("BoxSurfaceDisplacementRange: even lattice-summed probe avoids the origin", world.rank() == 0);
+
+  constexpr std::size_t NDIM = 3;
+  const auto lattice_summed = array_of_bools<NDIM>{true};
+
+  const auto check_probe = [&](Level n, std::array<std::int64_t, NDIM> N, const std::string& what) {
+    Radii<NDIM> box_radius, surface_thickness;
+    std::array<KernelRange, NDIM> kernel_range;
+    for (std::size_t d = 0; d != NDIM; ++d) {
+      box_radius[d] = N[d];
+      surface_thickness[d] = 1;
+      kernel_range[d] = KernelRange(static_cast<unsigned int>(N[d]));
+    }
+    const auto distsq = [&](const Key<NDIM>& disp) -> double {
+      return disp.real_distsq_bc(lattice_summed, FunctionDefaults<NDIM>::get_cell_width());
+    };
+    // a standard-displacement loop that already reached everything nearby, so the
+    // validator rejects any displacement it recognizes as already-computed
+    BoxSurfaceDisplacementValidator<NDIM> validator(/* is_infinite_domain= */ array_of_bools<NDIM>{true},
+                                                    lattice_summed, kernel_range, distsq, 1.e9);
+    BoxSurfaceDisplacementRange<NDIM> range(centered_key<NDIM>(n), box_radius, surface_thickness,
+                                            lattice_summed, validator);
+
+    const auto probe = range.probing_displacement().translation();
+    const auto period = Translation(1) << n;
+
+    bool equivalent_to_origin = true;
+    for (std::size_t d = 0; d != NDIM; ++d)
+      if (mod_positive(probe[d], period) != 0) equivalent_to_origin = false;
+    t.checkpoint(!equivalent_to_origin, what + ": probe is not lattice-equivalent to the origin");
+
+    for (std::size_t d = 0; d != NDIM; ++d) {
+      const auto bound = radius_in_boxes(N[d], n) + 1;  // surface thickness 1
+      t.checkpoint(std::abs(probe[d]) <= bound, what + ": probe[" + std::to_string(d) + "] inside the box");
+    }
+  };
+
+  check_probe(4, {2, 2, 2}, "3D n=4 N={2,2,2}");
+  check_probe(5, {2, 2, 2}, "3D n=5 N={2,2,2}");
+  check_probe(4, {4, 4, 4}, "3D n=4 N={4,4,4}");
+  check_probe(4, {2, 4, 6}, "3D n=4 N={2,4,6}");
+
+  // Same requirement when the validator never rejects anything: the greedy stage
+  // then runs its trial displacement all the way down to |disp| == 1 without ever
+  // being told to stop. That shortest trial is still valid, so it is the answer —
+  // abandoning it and falling back to the bare face displacement would put the
+  // probe right back on the origin.
+  {
+    const Level n = 4;
+    Radii<NDIM> box_radius, surface_thickness;
+    for (std::size_t d = 0; d != NDIM; ++d) {
+      box_radius[d] = 2;
+      surface_thickness[d] = 1;
+    }
+    BoxSurfaceDisplacementRange<NDIM> range(centered_key<NDIM>(n), box_radius, surface_thickness,
+                                            lattice_summed, accept_all<NDIM>());
+    const auto probe = range.probing_displacement().translation();
+    const auto period = Translation(1) << n;
+    bool equivalent_to_origin = true;
+    for (std::size_t d = 0; d != NDIM; ++d)
+      if (mod_positive(probe[d], period) != 0) equivalent_to_origin = false;
+    t.checkpoint(!equivalent_to_origin, "3D n=4 N={2,2,2} accept-all: probe is not lattice-equivalent to the origin");
+  }
+
+  return t.end();
+}
+
+/// The fallback block builds its displacement in *boxes*, not in units of the
+/// kernel range.
+///
+/// `box_radius` is in half-simulation-cells; a displacement is in boxes, and the
+/// two differ by 2^{n-1}. Using the raw radius yields a probe that is 2^{n-1}
+/// times too short — an interior displacement rather than a boundary one, and
+/// inconsistent with the backup-face component, which is scaled.
+///
+/// The configuration below (small level, small even radii) is the one that
+/// reaches the fallback: no axis can be displaced past bmax_default while
+/// staying inside the box, so the greedy stage declines every dimension.
+int test_probe_fallback_is_in_box_units(World& world) {
+  test_output t("BoxSurfaceDisplacementRange: fallback probe is in box units", world.rank() == 0);
+
+  constexpr std::size_t NDIM = 3;
+  const Level n = 2;
+  const std::array<std::int64_t, NDIM> N = {2, 2, 2};
+
+  Radii<NDIM> box_radius, surface_thickness;
+  for (std::size_t d = 0; d != NDIM; ++d) {
+    box_radius[d] = N[d];
+    surface_thickness[d] = 0;
+  }
+  BoxSurfaceDisplacementRange<NDIM> range(centered_key<NDIM>(n), box_radius, surface_thickness,
+                                          array_of_bools<NDIM>{true}, reject_all<NDIM>());
+  const auto probe = range.probing_displacement().translation();
+
+  // r = N * 2^{n-1} = 2*2 = 4 boxes; the raw radius would be 2
+  for (std::size_t d = 0; d != NDIM; ++d) {
+    const auto r = radius_in_boxes(N[d], n);
+    t.checkpoint(probe[d] == r, "probe[" + std::to_string(d) + "] == " + std::to_string(r) + " boxes");
+  }
+
+  return t.end();
+}
+
+/// Every component of the fallback probe must respect *its own* axis' radius.
+///
+/// The running maximum across axes is the loop bound for the shrink stage, not
+/// the value to assign: handing axis d the largest radius seen so far puts the
+/// probe outside the box whenever a later axis is shorter than an earlier one,
+/// and makes the result depend on iteration order.
+///
+/// N={2,4,2} at n=1 keeps r == N, so this isolates the per-axis question from
+/// the units question tested above.
+int test_probe_fallback_respects_each_radius(World& world) {
+  test_output t("BoxSurfaceDisplacementRange: fallback probe respects each axis' radius", world.rank() == 0);
+
+  constexpr std::size_t NDIM = 3;
+  const Level n = 1;
+  const std::array<std::int64_t, NDIM> N = {2, 4, 2};  // shorter axis *after* the longer one
+
+  Radii<NDIM> box_radius, surface_thickness;
+  for (std::size_t d = 0; d != NDIM; ++d) {
+    box_radius[d] = N[d];
+    surface_thickness[d] = 0;
+  }
+  BoxSurfaceDisplacementRange<NDIM> range(centered_key<NDIM>(n), box_radius, surface_thickness,
+                                          array_of_bools<NDIM>{true}, reject_all<NDIM>());
+  const auto probe = range.probing_displacement().translation();
+
+  for (std::size_t d = 0; d != NDIM; ++d) {
+    const auto r = radius_in_boxes(N[d], n);
+    t.checkpoint(std::abs(probe[d]) <= r,
+                 "probe[" + std::to_string(d) + "] = " + std::to_string(probe[d]) + " within its own radius " +
+                     std::to_string(r));
+  }
+
+  return t.end();
+}
+
+/// An axis of unlimited extent has no surface, so it contributes nothing to the
+/// probe — and must not be asked for a radius it does not have.
+int test_probe_partial_range(World& world) {
+  test_output t("BoxSurfaceDisplacementRange: unrestricted axis contributes no probe component",
+                world.rank() == 0);
+
+  constexpr std::size_t NDIM = 3;
+  const Level n = 2;
+
+  Radii<NDIM> box_radius, surface_thickness;
+  box_radius[0] = 2;               surface_thickness[0] = 0;
+  box_radius[1] = std::nullopt;    surface_thickness[1] = std::nullopt;  // unlimited along axis 1
+  box_radius[2] = 2;               surface_thickness[2] = 0;
+
+  BoxSurfaceDisplacementRange<NDIM> range(centered_key<NDIM>(n), box_radius, surface_thickness,
+                                          array_of_bools<NDIM>{true}, reject_all<NDIM>());
+  const auto probe = range.probing_displacement().translation();
+
+  t.checkpoint(probe[1] == 0, "unrestricted axis 1 has a zero probe component");
+  t.checkpoint(probe[0] == radius_in_boxes(2, n), "axis 0 probe is the range boundary");
+  t.checkpoint(probe[2] == radius_in_boxes(2, n), "axis 2 probe is the range boundary");
+
+  return t.end();
+}
+
+/// Constructing without a validator must work.
+///
+/// `Validator` is a std::function and the constructor defaults it to empty;
+/// funcimpl.h leaves it empty whenever the standard-displacement loop screened
+/// everything out. compute_probe() must not call through it.
+int test_probe_without_validator(World& world) {
+  test_output t("BoxSurfaceDisplacementRange: empty validator is not called", world.rank() == 0);
+
+  constexpr std::size_t NDIM = 3;
+  const Level n = 4;
+
+  Radii<NDIM> box_radius, surface_thickness;
+  for (std::size_t d = 0; d != NDIM; ++d) {
+    box_radius[d] = 2;  // even + lattice-summed => the branch that wants a validator
+    surface_thickness[d] = 1;
+  }
+
+  bool threw = false;
+  Translation probe0 = 0;
+  try {
+    BoxSurfaceDisplacementRange<NDIM> range(centered_key<NDIM>(n), box_radius, surface_thickness,
+                                            array_of_bools<NDIM>{true});
+    probe0 = range.probing_displacement().translation()[0];
+  } catch (...) {
+    threw = true;
+  }
+  t.checkpoint(!threw, "construction with a default-constructed validator does not throw");
+  t.checkpoint(probe0 == radius_in_boxes(2, n), "probe falls back to the plain face displacement");
+
+  return t.end();
+}
+
+int main(int argc, char** argv) {
+  World& world = madness::initialize(argc, argv);
+  startup(world, argc, argv, true);
+
+  int errors = 0;
+  errors += test_surface_extent(world);
+  errors += test_no_duplicates(world);
+  errors += test_fully_filtered_faces(world);
+  errors += test_probe_hyperface_origin(world);
+  errors += test_probe_even_lattice_sum(world);
+  errors += test_probe_fallback_is_in_box_units(world);
+  errors += test_probe_fallback_respects_each_radius(world);
+  errors += test_probe_partial_range(world);
+  errors += test_probe_without_validator(world);
+
+  world.gop.fence();
+  madness::finalize();
+  return errors;
+}

--- a/src/madness/mra/test_displacements.cc
+++ b/src/madness/mra/test_displacements.cc
@@ -178,51 +178,6 @@ int test_no_duplicates(World& world) {
   return t.end();
 }
 
-/// A face whose every layer is filtered out makes the range shorter, not fatal.
-int test_fully_filtered_faces(World& world) {
-  test_output t("BoxSurfaceDisplacementRange: an entirely filtered face is not an error", world.rank() == 0);
-
-  // every face out of the domain => empty range
-  {
-    constexpr std::size_t NDIM = 2;
-    const Level n = 4;
-    Radii<NDIM> box_radius, surface_thickness;
-    for (std::size_t d = 0; d != NDIM; ++d) {
-      box_radius[d] = 2;  // r = 2*2^3 = 16 boxes from the center of a 16-box axis
-      surface_thickness[d] = 1;
-    }
-    BoxSurfaceDisplacementRange<NDIM> range(centered_key<NDIM>(n), box_radius, surface_thickness,
-                                            array_of_bools<NDIM>{false}, in_domain_only<NDIM>());
-    std::size_t count = 0;
-    for (auto&& disp : range) {
-      (void)disp;
-      ++count;
-    }
-    t.checkpoint(count == 0, "2D n=4 N={2,2} in-domain: surface is empty, not fatal");
-    t.checkpoint(range.begin() == range.end(), "2D n=4 N={2,2} in-domain: begin() == end()");
-  }
-
-  // one face entirely out of the domain, the other partly inside => the survivors
-  // are still enumerated, and still without duplicates
-  {
-    constexpr std::size_t NDIM = 2;
-    const Level n = 4;
-    Radii<NDIM> box_radius, surface_thickness;
-    box_radius[0] = 2;  surface_thickness[0] = 1;  // boundary a full period away
-    box_radius[1] = 1;  surface_thickness[1] = 1;  // boundary at the cell edge
-    BoxSurfaceDisplacementRange<NDIM> range(centered_key<NDIM>(n), box_radius, surface_thickness,
-                                            array_of_bools<NDIM>{false}, in_domain_only<NDIM>());
-    std::vector<Key<NDIM>> disps;
-    for (auto&& disp : range) disps.push_back(disp);
-    std::sort(disps.begin(), disps.end());
-    t.checkpoint(!disps.empty(), "2D n=4 N={2,1} in-domain: the surviving face is enumerated");
-    t.checkpoint(std::unique(disps.begin(), disps.end()) == disps.end(),
-                 "2D n=4 N={2,1} in-domain: all displacements distinct");
-  }
-
-  return t.end();
-}
-
 /// Whenever the hyperface origin is a usable probe, it is the one chosen.
 ///
 /// That covers every case except "lattice-summed with even N on all finite

--- a/src/madness/mra/testgconv.cc
+++ b/src/madness/mra/testgconv.cc
@@ -367,55 +367,8 @@ int test_gconv(World& world) {
     // test convolution with range restricted Gaussians
     ///////////////////////////////////////////////////
 
-    // validate BoxSurfaceDisplacementRange by making sure
-    // - it does not produce duplicate displacements
-    {
-      constexpr auto ND = 2;
-      const int n = 4;
-      Key<ND> key(n, Vector<Translation, ND>(1<<(n-1)));
-
-      std::size_t disp_count = 0;
-      const auto process_surface_displacements =
-          [&]() {
-            std::array<std::optional<std::int64_t>, ND> box_radius;
-            std::array<std::optional<std::int64_t>, ND> surface_thickness;
-            for (int d = 0; d != ND; ++d) {
-              box_radius[d] = 1;
-              surface_thickness[d] = 1;
-            }
-            BoxSurfaceDisplacementRange<ND> range_boundary_face_displacements(
-                key, box_radius, surface_thickness, array_of_bools<ND>{false},
-                [&](const auto level, const auto &dest, const auto &displacement) -> bool {
-                  // skip displacements not in domain
-                  const auto twon = (1 << level);
-                  for (auto d = 0; d != ND; ++d) {
-                    if (dest[d].has_value()) {
-                      if (dest[d] < 0 ||
-                          dest[d] >= twon)
-                        return false;
-                    }
-                  }
-                  return true;
-                });
-            std::vector<Key<ND>> disps;
-            for (auto &&disp : range_boundary_face_displacements) {
-//              std::cout << "disp = " << disp << " dest = " << key.neighbor(disp)
-//                        << std::endl;
-              disps.push_back(disp);
-              ++disp_count;
-            }
-            std::sort(disps.begin(), disps.end());
-            auto it = std::unique(disps.begin(), disps.end());
-
-            if (it != disps.end()) {
-              std::cout << "Duplicates found!!" << std::endl;
-              success++;
-            }
-          };
-      process_surface_displacements();
-    }
-
-    // now test the convolutions
+    // validation of BoxSurfaceDisplacementRange located in test_displacements.cc
+    // here, test the convolutions
     if constexpr (NDIM == 1) {
 
       int nerrors = 0;


### PR DESCRIPTION
This fixes a technical issue for displacements in Wigner-Seitz sums with lattice summation inside the convolution: the displacement chosen to monitor convergence may be large. This PR modifies the logic to make a more reasonable choice.

My earlier investigations showed that when this logic fixes, computations complete that weren't completing before, but the BSH-based algorithm employing this takes an extra iteration compared to when it wasn't firing. This indicates there's some more investigation to do, but this code is a massive improvement over the old behavior.