### PR TITLE
Pr halo api

### DIFF
--- a/src/madness/chem/SCF.cc
+++ b/src/madness/chem/SCF.cc
@@ -696,9 +696,7 @@ distmatT SCF::kinetic_energy_matrix(World& world, const vecfuncT& v) const {
     for (int axis = 0; axis < 3; ++axis) gradop[axis]->parallel_submit_ = true;
     START_TIMER(world);
     // Pre-stage the neighbor coefficients the ranks owe each other, so differentiating serves them
-    // locally instead of fetching one at a time. The halo is keyed by node, so one covers all axes.
-    for (int i = 0; i < n; ++i) v[i].get_impl()->halo_enable();
-    world.gop.fence();
+    // locally instead of fetching one at a time. One table per function holds all three axes.
     for (int axis = 0; axis < 3; ++axis)
         for (int i = 0; i < n; ++i) gradop[axis]->stage_halo(v[i].get_impl().get());
     world.gop.fence();

--- a/src/madness/chem/SCF.cc
+++ b/src/madness/chem/SCF.cc
@@ -695,18 +695,14 @@ distmatT SCF::kinetic_energy_matrix(World& world, const vecfuncT& v) const {
     // these operators serve only this matrix, which is the many-tree case the pool submission helps
     for (int axis = 0; axis < 3; ++axis) gradop[axis]->parallel_submit_ = true;
     START_TIMER(world);
-    // Pre-stage the neighbor coefficients the ranks owe each other, so differentiating serves them
-    // locally instead of fetching one at a time. One table per function holds all three axes.
-    for (int axis = 0; axis < 3; ++axis)
-        for (int i = 0; i < n; ++i) gradop[axis]->stage_halo(v[i].get_impl().get());
-    world.gop.fence();
+    stage_halo(world, gradop, v);
     vecfuncT dvx = apply(world, *(gradop[0]), v, false);
     vecfuncT dvy = apply(world, *(gradop[1]), v, false);
     vecfuncT dvz = apply(world, *(gradop[2]), v, false);
     world.gop.fence();
     END_TIMER(world, "KEmat differentiate");
-    // all three axes' surfaces are live here, since all three are applied before the fence above
-    for (int i = 0; i < n; ++i) v[i].get_impl()->halo_clear();
+    // all three axes' halos are live until here, since all three are applied before the fence above
+    clear_halo(v);
     START_TIMER(world);
     compress(world, dvx, false);
     compress(world, dvy, false);

--- a/src/madness/mra/derivative.h
+++ b/src/madness/mra/derivative.h
@@ -246,9 +246,9 @@ namespace madness {
 
         /// Node M is the neighbor of M-1 and M+1, so its owner pushes it to the owners of those keys
         /// without being asked, one batched message per destination. This is the axis-specific
-        /// staging policy for `FunctionImpl`'s halo table. The pushes arrive as tasks, so a fence
-        /// must separate staging from differentiating; `halo_clear()` frees the result.
-        void stage_halo(const implT* f) const {
+        /// staging policy for `FunctionImpl`'s halo table; `halo_clear()` frees the result. The
+        /// pushes arrive as tasks, so the fence is what separates staging from differentiating.
+        void stage_halo(const implT* f, bool fence = true) const {
             const dcT& coeffs = f->get_coeffs();
             std::map<ProcessID, std::vector<argT> > out;
             for (const auto& [key, node] : coeffs) {
@@ -262,6 +262,7 @@ namespace madness {
             }
             for (auto& kv : out)
                 f->task(kv.first, &implT::receive_halo, kv.second, TaskAttributes::hipri());
+            if (fence) world.gop.fence();
         }
 
         Future<argT>

--- a/src/madness/mra/derivative.h
+++ b/src/madness/mra/derivative.h
@@ -245,10 +245,10 @@ namespace madness {
         /// Push f's remote same-level neighbor coefficients to the ranks that will need them.
 
         /// Node M is the neighbor of M-1 and M+1, so its owner pushes it to the owners of those keys
-        /// without being asked, one batched message per destination. Requires `halo_enable()` and a
-        /// fence first, then a fence before differentiating; `halo_clear()` frees the result.
+        /// without being asked, one batched message per destination. This is the axis-specific
+        /// staging policy for `FunctionImpl`'s halo table. The pushes arrive as tasks, so a fence
+        /// must separate staging from differentiating; `halo_clear()` frees the result.
         void stage_halo(const implT* f) const {
-            MADNESS_CHECK(f->halo_enabled());
             const dcT& coeffs = f->get_coeffs();
             std::map<ProcessID, std::vector<argT> > out;
             for (const auto& [key, node] : coeffs) {
@@ -272,10 +272,8 @@ namespace madness {
             }
             else {
                 // hit: same-level leaf or interior node. miss: neighbor is coarser, walk up below.
-                if (f->halo_enabled()) {
-                    coeffT c;
-                    if (f->halo_probe(neigh, c)) return Future<argT>(argT(neigh, c));
-                }
+                coeffT c;
+                if (f->halo_probe(neigh, c)) return Future<argT>(argT(neigh, c));
                 Future<argT> result;
 		if (f->get_coeffs().is_local(neigh))
 		  f->send(f->get_coeffs().owner(neigh), &implT::sock_it_to_me, neigh, result.remote_ref(world));

--- a/src/madness/mra/funcimpl.h
+++ b/src/madness/mra/funcimpl.h
@@ -1011,49 +1011,65 @@ template<size_t NDIM>
 
         dcT coeffs; ///< The coefficients
 
-        /// Neighbor coefficients pre-staged by a caller of the derivative operator; null unless staged.
+        /// Neighbor coefficients pushed here by whoever owns them; null until something stages.
 
-        /// Reproduces what `sock_it_to_me` returns for the same key: coefficients for a same-level
-        /// leaf, empty for an interior node, absent when the neighbor is coarser and `find_neighbor`
-        /// must walk up. Allocated lazily, so functions that never stage a halo do not carry the table.
-        mutable std::unique_ptr<ConcurrentHashMap<keyT,coeffT> > neighbor_halo_;
+        /// Values mirror what `sock_it_to_me` returns for the same key: coefficients for a same-level
+        /// leaf, empty for an interior node, absent when the neighbor is coarser and the consumer
+        /// must walk up. Which nodes get pushed is the operator's business, not the table's --- see
+        /// `DerivativeBase::stage_halo`.
+        ///
+        /// Allocated on the first push, so functions that never stage one do not carry it: a
+        /// `ConcurrentHashMap` default-constructs 1021 bins, ~32 kB per function.
+        mutable std::atomic<ConcurrentHashMap<keyT,coeffT>*> neighbor_halo_{nullptr};
 
         // Disable the default copy constructor
         FunctionImpl(const FunctionImpl<T,NDIM>& p);
 
     public:
-        /// Allocate the neighbor halo.
-
-        /// Every rank must call this and fence before any rank stages: a push arrives as a task and
-        /// cannot allocate the halo itself without racing this call.
-        void halo_enable() const {
-            if (!neighbor_halo_) neighbor_halo_.reset(new ConcurrentHashMap<keyT,coeffT>());
+        /// Is a neighbor halo staged on this function?
+        bool halo_enabled() const {
+            return neighbor_halo_.load(std::memory_order_acquire) != nullptr;
         }
 
-        /// Is a neighbor halo staged on this function?
-        bool halo_enabled() const { return static_cast<bool>(neighbor_halo_); }
-
         /// Discard the neighbor halo, freeing the staged coefficients.
-        void halo_clear() const { neighbor_halo_.reset(); }
+
+        /// Requires a quiescent window: it frees a table that `halo_probe` may be reading.
+        void halo_clear() const {
+            delete neighbor_halo_.exchange(nullptr, std::memory_order_acq_rel);
+        }
 
         /// How many neighbor nodes are staged on this rank; zero if no halo.
-        std::size_t halo_size() const { return neighbor_halo_ ? neighbor_halo_->size() : 0; }
+        std::size_t halo_size() const {
+            const auto* h = neighbor_halo_.load(std::memory_order_acquire);
+            return h ? h->size() : 0;
+        }
 
         /// Insert pushed neighbor nodes into the halo; runs as a task, concurrently with other pushes.
+
+        /// Allocates the table on the first push, so staging needs no collective set-up.
         void receive_halo(const std::vector<std::pair<keyT,coeffT> >& buf) const {
-            MADNESS_CHECK(neighbor_halo_);   // halo_enable() and a fence must precede staging
+            auto* h = neighbor_halo_.load(std::memory_order_acquire);
+            if (!h) {
+                auto* fresh = new ConcurrentHashMap<keyT,coeffT>();
+                if (neighbor_halo_.compare_exchange_strong(h, fresh, std::memory_order_acq_rel,
+                                                           std::memory_order_acquire))
+                    h = fresh;
+                else
+                    delete fresh;   // lost the race; the failed CAS put the winner's table in h
+            }
             for (const auto& kv : buf) {
                 typename ConcurrentHashMap<keyT,coeffT>::accessor acc;
-                (void) neighbor_halo_->insert(acc, kv.first);
+                (void) h->insert(acc, kv.first);
                 acc->second = kv.second;
             }
         }
 
         /// Look up a staged neighbor; on a hit copy its coefficients, which are empty for an interior node.
         bool halo_probe(const keyT& key, coeffT& out) const {
-            if (!neighbor_halo_) return false;
+            const auto* h = neighbor_halo_.load(std::memory_order_acquire);
+            if (!h) return false;
             typename ConcurrentHashMap<keyT,coeffT>::const_accessor acc;
-            if (neighbor_halo_->find(acc, key)) { out = acc->second; return true; }
+            if (h->find(acc, key)) { out = acc->second; return true; }
             return false;
         }
 
@@ -1178,7 +1194,7 @@ template<size_t NDIM>
             this->process_pending();
         }
 
-        virtual ~FunctionImpl() { }
+        virtual ~FunctionImpl() { halo_clear(); }
 
         const std::shared_ptr< WorldDCPmapInterface< Key<NDIM> > >& get_pmap() const;
 

--- a/src/madness/mra/test_halo.cc
+++ b/src/madness/mra/test_halo.cc
@@ -67,9 +67,7 @@ differentiate(World& world,
     for (std::size_t axis = 0; axis < D; ++axis) grad[axis]->parallel_submit_ = parallel_submit;
 
     if (halo) {
-        for (std::size_t axis = 0; axis < D; ++axis)
-            for (const auto& f : v) grad[axis]->stage_halo(f.get_impl().get());
-        world.gop.fence();
+        stage_halo(world, grad, v);
         staged = 0;
         for (const auto& f : v) staged += f.get_impl()->halo_size();
     }
@@ -81,7 +79,7 @@ differentiate(World& world,
     }
     world.gop.fence();
 
-    if (halo) for (const auto& f : v) f.get_impl()->halo_clear();
+    if (halo) clear_halo(v);
     return dv;
 }
 
@@ -144,8 +142,7 @@ static int test_single_function(World& world, const std::vector<Function<double,
     const Function<double,D>& f = v[0];
     Function<double,D> ref = (*grad[0])(f, true);
 
-    grad[0]->stage_halo(f.get_impl().get());
-    world.gop.fence();
+    grad[0]->stage_halo(f.get_impl().get());   // fences by default
     Function<double,D> df = (*grad[0])(f, true);
     const std::size_t staged = f.get_impl()->halo_size();
     f.get_impl()->halo_clear();
@@ -168,7 +165,6 @@ static int test_clear(World& world, const std::vector<Function<double,D>>& v) {
     Function<double,D> ref = (*grad[0])(f, true);
 
     grad[0]->stage_halo(f.get_impl().get());
-    world.gop.fence();
     f.get_impl()->halo_clear();
     t.checkpoint(f.get_impl()->halo_enabled() == false, "halo is disabled after clear");
 

--- a/src/madness/mra/test_halo.cc
+++ b/src/madness/mra/test_halo.cc
@@ -67,8 +67,6 @@ differentiate(World& world,
     for (std::size_t axis = 0; axis < D; ++axis) grad[axis]->parallel_submit_ = parallel_submit;
 
     if (halo) {
-        for (const auto& f : v) f.get_impl()->halo_enable();
-        world.gop.fence();
         for (std::size_t axis = 0; axis < D; ++axis)
             for (const auto& f : v) grad[axis]->stage_halo(f.get_impl().get());
         world.gop.fence();
@@ -121,6 +119,21 @@ static int test_equivalence(World& world, const std::vector<Function<double,D>>&
     return t.end();
 }
 
+/// The plain path must not allocate the table: a probe on a function with no halo has to answer
+/// without creating one, or every differentiated function would carry ~32 kB it never uses.
+static int test_no_halo_no_allocation(World& world, const std::vector<Function<double,D>>& v) {
+    test_output t("differentiating without staging allocates no halo");
+    t.set_cout_to_logger();
+    std::vector<std::shared_ptr<Derivative<double,D>>> grad = gradient_operator<double,D>(world);
+
+    const Function<double,D>& f = v[0];
+    t.checkpoint(f.get_impl()->halo_enabled() == false, "no halo before differentiating");
+    Function<double,D> df = (*grad[0])(f, true);
+    t.checkpoint(df.norm2() > 0.0, "derivative is non-trivial");
+    t.checkpoint(f.get_impl()->halo_enabled() == false, "no halo after differentiating");
+    return t.end();
+}
+
 /// A staged halo must be inert for a lone derivative too, not just for the vector form the
 /// kinetic-energy matrix uses.
 static int test_single_function(World& world, const std::vector<Function<double,D>>& v) {
@@ -131,8 +144,6 @@ static int test_single_function(World& world, const std::vector<Function<double,
     const Function<double,D>& f = v[0];
     Function<double,D> ref = (*grad[0])(f, true);
 
-    f.get_impl()->halo_enable();
-    world.gop.fence();
     grad[0]->stage_halo(f.get_impl().get());
     world.gop.fence();
     Function<double,D> df = (*grad[0])(f, true);
@@ -156,8 +167,6 @@ static int test_clear(World& world, const std::vector<Function<double,D>>& v) {
     const Function<double,D>& f = v[0];
     Function<double,D> ref = (*grad[0])(f, true);
 
-    f.get_impl()->halo_enable();
-    world.gop.fence();
     grad[0]->stage_halo(f.get_impl().get());
     world.gop.fence();
     f.get_impl()->halo_clear();
@@ -183,6 +192,7 @@ int main(int argc, char** argv) {
     int success = 0;
     {
         std::vector<Function<double,D>> v = make_operands(world);
+        success += test_no_halo_no_allocation(world, v);   // first: needs a function that never staged
         success += test_equivalence(world, v);
         success += test_single_function(world, v);
         success += test_clear(world, v);

--- a/src/madness/mra/vmra.h
+++ b/src/madness/mra/vmra.h
@@ -372,6 +372,32 @@ namespace madness {
     }
 
 
+    /// Pre-stages the neighbor coefficients that differentiating v with each of grad will need
+
+    /// Differentiating then serves those neighbors locally instead of fetching them one at a time.
+    /// One halo per function holds every operator's pushes, so it pays when several functions are
+    /// differentiated together. `clear_halo` frees them afterwards.
+    template <typename T, std::size_t NDIM>
+    void stage_halo(World& world,
+                    const std::vector< std::shared_ptr< Derivative<T,NDIM> > >& grad,
+                    const std::vector< Function<T,NDIM> >& v,
+                    bool fence=true)
+    {
+        for (const auto& f : v) MADNESS_CHECK(f.is_reconstructed());
+        for (const auto& D : grad)
+            for (const auto& f : v) D->stage_halo(f.get_impl().get(), false);
+        if (fence) world.gop.fence();
+    }
+
+    /// Discards the neighbor halos staged on v
+
+    /// Requires a quiescent window: it frees tables the derivative may still be reading.
+    template <typename T, std::size_t NDIM>
+    void clear_halo(const std::vector< Function<T,NDIM> >& v)
+    {
+        for (const auto& f : v) f.get_impl()->halo_clear();
+    }
+
     /// Applies a derivative operator to a vector of functions
     template <typename T, std::size_t NDIM>
     std::vector< Function<T,NDIM> >


### PR DESCRIPTION
## What this does

Follow-up to #729. Staging a neighbor halo required every rank to call `halo_enable()` and fence
before any rank pushed, because `receive_halo` arrives as a task and could not allocate the table
without racing that call.

**1. Allocate the halo on demand.**

- `receive_halo` installs the table with `compare_exchange_strong` on the first push. Readers stay
  lock-free, which matters because `find_neighbor` re-probes at every step of its descent
- `halo_enable()` and the collective fence are gone, leaving `stage -> probe -> clear`.
  `halo_enable()` was added in #729, so no release carries it
- the raw pointer replaces a `unique_ptr`, so `~FunctionImpl` now frees the table
- the header states the split: the table is pattern-agnostic, and the axis-specific part is the push
  policy in `DerivativeBase::stage_halo`

**2. Stage from a vector form.**

- `stage_halo(world, grad, v, fence)` and `clear_halo(v)` in `vmra.h`. The vector form passes
  `fence=false` per call, so the kinetic-energy matrix fences once rather than 3n times
- `stage_halo` checks its operands are reconstructed: staging a compressed tree would push difference
  coefficients into a table that `find_neighbor` reads as scalar coefficients

## Commits

| commit | what |
|---|---|
| `3ef5060a9` | allocate the derivative halo on demand |
| `ed7a0766b` | stage the derivative halo from a vector form |

2 commits, +92/-51 over 5 files. `SCF.cc` and `test_halo.cc` are net deletions.

## PR checklist

| item | answer |
|---|---|
| raw MPI calls | none added |
| blocking MPI collectives | none added; staging fences through `World::gop` |
| implicit default World | none; the `vmra` wrapper takes an explicit `World&` |
| non-collective container construction | none. The table is per-rank and no longer needs collective set-up |
| threaded-BLAS assumptions | none |
| `Function` mutation from user threads | no. Pushes arrive as tasks; staging and clearing run on the main thread |
| tree-state preconditions | now checked -- `stage_halo` requires reconstructed operands |
| checkpoint-format break | none. The halo is not serialized |
| GENTENSOR coverage | left to CI |