### PR TITLE
vtransform: use node inplace gaxpy to ensure consistent trees

### DIFF
--- a/src/madness/mra/funcdefaults.h
+++ b/src/madness/mra/funcdefaults.h
@@ -58,7 +58,7 @@ namespace madness {
 
     enum TreeState {
     	reconstructed,				///< s coeffs at the leaves only
-		compressed, 				///< d coeffs in internal nodes, s and d coeffs at the root
+		compressed, 				///< d coeffs in internal nodes, s and d coeffs at the root, empty leaves may be present
 		nonstandard, 				///< s and d coeffs in internal nodes
     	nonstandard_with_leaves, 	///< like nonstandard, with s coeffs at the leaves
         nonstandard_after_apply, 	///< s and d coeffs, state after operator application

--- a/src/madness/mra/funcimpl.h
+++ b/src/madness/mra/funcimpl.h
@@ -2776,11 +2776,9 @@ template<size_t NDIM>
                 std::swap(ind[i],ind[j]);
             }
 
-            typename FunctionImpl<R,NDIM>::dcT::const_iterator end = right->coeffs.end();
-            for (typename FunctionImpl<R,NDIM>::dcT::const_iterator it=right->coeffs.begin(); it != end; ++it) {
-                if (it->second.has_coeff()) {
-                    const Key<NDIM>& key = it->first;
-                    const GenTensor<R>& r = it->second.coeff();
+            for (const auto& [key, rnode] : right->coeffs) {
+                if (rnode.has_coeff()) {
+                    const GenTensor<R>& r = rnode.coeff();
                     double norm = r.normf();
                     double keytol = truncate_tol(tol,key);
 
@@ -2789,20 +2787,17 @@ template<size_t NDIM>
                         if (std::abs(norm*c(i)) > keytol) {
                             implT* left = vleft[i].get();
                             typename dcT::accessor acc;
-                            bool newnode = left->coeffs.insert(acc,key);
-                            if (newnode && key.level()>0) {
+                            bool new_node = left->coeffs.insert(acc,key);
+                            if (new_node) {
+                                /* Notify parent nodes that a new child exists. */
                                 Key<NDIM> parent = key.parent();
-				if (left->coeffs.is_local(parent))
-				  left->coeffs.send(parent, &nodeT::set_has_children_recursive, left->coeffs, parent);
-				else
-				  left->coeffs.task(parent, &nodeT::set_has_children_recursive, left->coeffs, parent);
-
+                                if (left->coeffs.is_local(parent))
+                                    left->coeffs.send(parent, &nodeT::set_has_children_recursive, left->coeffs, parent);
+                                else
+                                    left->coeffs.task(parent, &nodeT::set_has_children_recursive, left->coeffs, parent);
                             }
                             nodeT& node = acc->second;
-                            if (!node.has_coeff())
-                                node.set_coeff(coeffT(cdata.v2k,targs));
-                            coeffT& t = node.coeff();
-                            t.gaxpy(1.0, r, c(i));
+                            node.gaxpy_inplace(1.0, rnode, c(i));
                         }
                     }
                 }


### PR DESCRIPTION
The current implementation performs inline truncation, which may lead to missing updates of child information. In particular, the node to which gaxpy is applied itself may not see its `has_children` flag updated if we are screening out all children. This leads to inner nodes being flagged as leaf nodes in the updated tree (i.e., inner nodes with `has_children = false`).

Instead, use `gaxpy_inplace` on the node (not the coefficient tensor) to force an update of `has_children` and the recursion to the parent.

Note: we still do not insert empty leaf nodes in vtransform. A comment on the `compressed` TreeState reflects that leaf nodes are optional.

Fixes #722 