### PR TITLE
Pr exchange p2p

### DIFF
--- a/src/madness/chem/CMakeLists.txt
+++ b/src/madness/chem/CMakeLists.txt
@@ -164,7 +164,8 @@ if(BUILD_TESTING)
   SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
   # The list of unit test source files
   set(CHEM_TEST_SOURCES_SHORT test_pointgroupsymmetry.cc test_masks_and_boxes.cc
-  test_qc.cc test_MolecularOrbitals.cc test_BSHApply.cc test_projector.cc)
+  test_qc.cc test_MolecularOrbitals.cc test_BSHApply.cc test_projector.cc
+  test_exchange_owner_assign.cc)
   set(CHEM_TEST_SOURCES_LONG test_localizer.cc test_ccpairfunction.cc test_low_rank_function.cc)
   if (TARGET Libxc::xc)
     list(APPEND CHEM_TEST_SOURCES_SHORT test_dft.cc )

--- a/src/madness/chem/CMakeLists.txt
+++ b/src/madness/chem/CMakeLists.txt
@@ -165,7 +165,7 @@ if(BUILD_TESTING)
   # The list of unit test source files
   set(CHEM_TEST_SOURCES_SHORT test_pointgroupsymmetry.cc test_masks_and_boxes.cc
   test_qc.cc test_MolecularOrbitals.cc test_BSHApply.cc test_projector.cc
-  test_exchange_owner_assign.cc)
+  test_exchange_owner_assign.cc test_exchange_batch_cache.cc)
   set(CHEM_TEST_SOURCES_LONG test_localizer.cc test_ccpairfunction.cc test_low_rank_function.cc)
   if (TARGET Libxc::xc)
     list(APPEND CHEM_TEST_SOURCES_SHORT test_dft.cc )

--- a/src/madness/chem/CalculationParameters.h
+++ b/src/madness/chem/CalculationParameters.h
@@ -69,6 +69,7 @@ struct CalculationParameters : public QCCalculationParametersBase {
 		initialize<std::string> ("xc","hf","XC input line");
 		initialize<std::string> ("hfexalg","multiworld_row","hf exchange algorithm; multiworld stores the orbitals once as batches and has each task fetch the two it needs from the rank holding them, which bounds memory but needs one subworld per rank",{"multiworld","multiworld_row","fetch_compute","smallmem","largemem"});
 		initialize<long>  ("hfex_batch_granularity",1,"hfexalg=multiworld: batches of orbitals per rank (>=1). 1 is the coarsest and has the lowest peak memory; raising it makes tasks smaller and easier to balance at the cost of more transfers");
+		initialize<bool>  ("hfex_cost_aware_assign",true,"hfexalg=multiworld: place tasks by their measured cost from the previous application instead of by counting them, which matters because screening makes the tiles uneven. Takes effect from the third application on, since it needs a representative reference; set false for the count-based placement");
 		initialize<int>   ("hfex_local_accumulation",2,"hfexalg=multiworld: how tile results are gathered. 1=sum per subworld, then one transfer per subworld into the result; 2=additionally sum the subworlds of a node first, so only one rank per node transfers between nodes (falls back to 1 on a single node)");
 		initialize<std::vector<std::string>>("memory",{"storefunction","nodereplicated","distributed"},"memory algorithm for storing functions (storing,cloud,target)");
 		initialize<double>("smear",0.0,"smearing parameter");
@@ -208,6 +209,7 @@ struct CalculationParameters : public QCCalculationParametersBase {
 	std::string xc() const {return get<std::string>("xc");}
     std::string hfexalg() const {return get<std::string>("hfexalg");}
     long hfex_batch_granularity() const {return get<long>("hfex_batch_granularity");}
+    bool hfex_cost_aware_assign() const {return get<bool>("hfex_cost_aware_assign");}
     int hfex_local_accumulation() const {return get<int>("hfex_local_accumulation");}
 
 	std::vector<std::string> memory() const {return get<std::vector<std::string>>("memory");}

--- a/src/madness/chem/CalculationParameters.h
+++ b/src/madness/chem/CalculationParameters.h
@@ -67,7 +67,9 @@ struct CalculationParameters : public QCCalculationParametersBase {
 		initialize<std::string>("prefix","mad","prefixes your output/restart/json/plot/etc files");
 		initialize<double>("charge",0.0,"total molecular charge");
 		initialize<std::string> ("xc","hf","XC input line");
-		initialize<std::string> ("hfexalg","multiworld_row","hf exchange algorithm",{"multiworld","multiworld_row","fetch_compute","smallmem","largemem"});
+		initialize<std::string> ("hfexalg","multiworld_row","hf exchange algorithm; multiworld stores the orbitals once as batches and has each task fetch the two it needs from the rank holding them, which bounds memory but needs one subworld per rank",{"multiworld","multiworld_row","fetch_compute","smallmem","largemem"});
+		initialize<long>  ("hfex_batch_granularity",1,"hfexalg=multiworld: batches of orbitals per rank (>=1). 1 is the coarsest and has the lowest peak memory; raising it makes tasks smaller and easier to balance at the cost of more transfers");
+		initialize<int>   ("hfex_local_accumulation",2,"hfexalg=multiworld: how tile results are gathered. 1=sum per subworld, then one transfer per subworld into the result; 2=additionally sum the subworlds of a node first, so only one rank per node transfers between nodes (falls back to 1 on a single node)");
 		initialize<std::vector<std::string>>("memory",{"storefunction","nodereplicated","distributed"},"memory algorithm for storing functions (storing,cloud,target)");
 		initialize<double>("smear",0.0,"smearing parameter");
 		initialize<double>("econv",1.e-5,"energy convergence");
@@ -205,6 +207,8 @@ struct CalculationParameters : public QCCalculationParametersBase {
 	std::string ac_data() const {return get<std::string>("ac_data");}
 	std::string xc() const {return get<std::string>("xc");}
     std::string hfexalg() const {return get<std::string>("hfexalg");}
+    long hfex_batch_granularity() const {return get<long>("hfex_batch_granularity");}
+    int hfex_local_accumulation() const {return get<int>("hfex_local_accumulation");}
 
 	std::vector<std::string> memory() const {return get<std::vector<std::string>>("memory");}
 

--- a/src/madness/chem/SCF.cc
+++ b/src/madness/chem/SCF.cc
@@ -1381,6 +1381,8 @@ vecfuncT SCF::apply_potential(World& world, const tensorT& occ,
         K.set_symmetric(true).set_printlevel(param.print_level());
         K.set_macro_task_info(MacroTaskInfo::preset("default"));
         K.set_macro_task_info(param.memory());
+        K.set_batch_granularity(param.hfex_batch_granularity());
+        K.set_accumulation_mode(param.hfex_local_accumulation());
 
         vecfuncT Kamo = K(amo);
         tensorT excv = inner(world, Kamo, amo);

--- a/src/madness/chem/SCF.cc
+++ b/src/madness/chem/SCF.cc
@@ -1383,6 +1383,7 @@ vecfuncT SCF::apply_potential(World& world, const tensorT& occ,
         K.set_macro_task_info(param.memory());
         K.set_batch_granularity(param.hfex_batch_granularity());
         K.set_accumulation_mode(param.hfex_local_accumulation());
+        K.set_cost_aware_assignment(param.hfex_cost_aware_assign());
 
         vecfuncT Kamo = K(amo);
         tensorT excv = inner(world, Kamo, amo);

--- a/src/madness/chem/SCFOperators.cc
+++ b/src/madness/chem/SCFOperators.cc
@@ -746,6 +746,18 @@ Exchange<T,NDIM>& Exchange<T,NDIM>::set_macro_task_info(const MacroTaskInfo& inf
     return *this;
 }
 
+template<typename T, std::size_t NDIM>
+Exchange<T,NDIM>& Exchange<T,NDIM>::set_batch_granularity(const long level) {
+    impl->set_batch_granularity(level);
+    return *this;
+}
+
+template<typename T, std::size_t NDIM>
+Exchange<T,NDIM>& Exchange<T,NDIM>::set_accumulation_mode(const int mode) {
+    impl->set_accumulation_mode(mode);
+    return *this;
+}
+
 template<>
 Fock<double, 3>::Fock(World &world, const Nemo *nemo) : world(world) {
     auto tmp = nemo->make_fock_operator();

--- a/src/madness/chem/SCFOperators.cc
+++ b/src/madness/chem/SCFOperators.cc
@@ -758,6 +758,12 @@ Exchange<T,NDIM>& Exchange<T,NDIM>::set_accumulation_mode(const int mode) {
     return *this;
 }
 
+template<typename T, std::size_t NDIM>
+Exchange<T,NDIM>& Exchange<T,NDIM>::set_cost_aware_assignment(const bool flag) {
+    impl->set_cost_aware_assignment(flag);
+    return *this;
+}
+
 template<>
 Fock<double, 3>::Fock(World &world, const Nemo *nemo) : world(world) {
     auto tmp = nemo->make_fock_operator();

--- a/src/madness/chem/SCFOperators.h
+++ b/src/madness/chem/SCFOperators.h
@@ -188,6 +188,12 @@ public:
 
     Exchange& set_printlevel(const long& level);
 
+    /// batches per rank in the owner-pinned symmetric partition (>= 1)
+    Exchange& set_batch_granularity(const long level);
+
+    /// 1 = gather tile results per subworld, 2 = also gather per node first
+    Exchange& set_accumulation_mode(const int mode);
+
     Exchange& set_taskq(std::shared_ptr<MacroTaskQ> taskq1) {
         this->taskq=taskq1;
         return *this;

--- a/src/madness/chem/SCFOperators.h
+++ b/src/madness/chem/SCFOperators.h
@@ -194,6 +194,9 @@ public:
     /// 1 = gather tile results per subworld, 2 = also gather per node first
     Exchange& set_accumulation_mode(const int mode);
 
+    /// place tasks by their measured cost rather than by counting them
+    Exchange& set_cost_aware_assignment(const bool flag);
+
     Exchange& set_taskq(std::shared_ptr<MacroTaskQ> taskq1) {
         this->taskq=taskq1;
         return *this;

--- a/src/madness/chem/exchangeoperator.cc
+++ b/src/madness/chem/exchangeoperator.cc
@@ -117,7 +117,11 @@ Exchange<T, NDIM>::ExchangeImpl::K_macrotask_efficient(const vecfuncT& vf, const
 
     // the result is a vector of functions living in the universe
     const long nresult = vf.size();
-    MacroTaskExchangeSimple xtask(nresult, lo, mul_tol, is_symmetric());
+    // Owner-pinned placement applies to the symmetric case only: it needs bra == ket so
+    // that one set of batches serves every operand role and both of a task's batches are
+    // owned by some rank. The asymmetric case keeps the size-driven partition.
+    MacroTaskExchangeSimple xtask(nresult, lo, mul_tol, is_symmetric(),
+                                  /*owner_pinned=*/is_symmetric(), batch_granularity_);
     if (taskq) taskq->set_printlevel(printlevel);
 
     // construct MacroTask with or without user-provided taskq -> deferred execution or immediate execution

--- a/src/madness/chem/exchangeoperator.cc
+++ b/src/madness/chem/exchangeoperator.cc
@@ -271,10 +271,13 @@ Exchange<T, NDIM>::ExchangeImpl::compute_K_tile(World& world, const vecfuncT& mo
 
 /// compute a batch of the exchange matrix, with non-identical ranges
 
+/// Streams the tile one bra row at a time, so only one row of intermediates is live at
+/// once where building the tile in one go holds all nrow*ncolumn of them. Row `irow`
+/// builds N_ij = P(bra[irow] vf[j]) over the whole column range and contributes to both
+/// result ranges: ket[irow] N_ij to column j, and the sum over j of ket[j] N_ij to row irow.
 /// \param subworld     the world we're computing in
-/// \param cloud        where to store the results
+/// \param mo_ket       the orbitals to premultiply with, not batched
 /// \param bra_batch    the bra batch of orbitals (including the nuclear correlation factor square)
-/// \param ket_batch    the ket batch of orbitals, also the orbitals to premultiply with
 /// \param vf_batch     the argument of the exchange operator
 template<typename T, std::size_t NDIM>
 std::pair<std::vector<Function<T, NDIM>>, std::vector<Function<T, NDIM>>>
@@ -282,72 +285,52 @@ Exchange<T, NDIM>::ExchangeImpl::MacroTaskExchangeSimple::compute_offdiagonal_ba
                                                                                           const vecfuncT& mo_ket,      // not batched
                                                                                           const vecfuncT& bra_batch,   // batched
                                                                                           const vecfuncT& vf_batch) const { // batched
-    // orbital_product is a vector of vectors
-    double cpu0 = cpu_time();
-    std::vector<vecfuncT> orbital_product = matrix_mul_sparse<T, T, NDIM>(subworld, bra_batch, vf_batch, mul_tol);
-    vecfuncT orbital_product_flat = flatten(orbital_product); // convert into a flattened vector
-    truncate(subworld, orbital_product_flat);
-    double cpu1 = cpu_time();
-    mul1_timer += long((cpu1 - cpu0) * 1000l);
-
-    cpu0 = cpu_time();
-    auto poisson = set_poisson(subworld, lo);
-    vecfuncT Nij = apply(subworld, *poisson.get(), orbital_product_flat);
-    truncate(subworld, Nij);
-    cpu1 = cpu_time();
-    apply_timer += long((cpu1 - cpu0) * 1000l);
-
-    // accumulate columns:      resultrow(i)=\sum_j j N_ij
-    // accumulate rows:      resultcolumn(j)=\sum_i i N_ij
-    cpu0 = cpu_time();
-
-    // some helper functions
-    std::size_t nrow = bra_batch.size();
-    std::size_t ncolumn = vf_batch.size();
-    auto ij = [&ncolumn](const int i, const int j) { return i * ncolumn + j; };
-
-    auto Nslice = [&Nij, &ij, &ncolumn](const long irow, const Slice s) {
-        vecfuncT result;
-        MADNESS_CHECK(s.start == 0 && s.end == -1 && s.step == 1);
-        for (std::size_t i = s.start; i <= s.end + ncolumn; ++i) {
-            result.push_back(Nij[ij(irow, i)]);
-        }
-        return result;
-    };
-    auto Nslice1 = [&Nij, &ij, &nrow](const Slice s, const long jcolumn) {
-        vecfuncT result;
-        MADNESS_CHECK(s.start == 0 && s.end == -1 && s.step == 1);
-        for (std::size_t i = s.start; i <= s.end + nrow; ++i) {
-            result.push_back(Nij[ij(i, jcolumn)]);
-        }
-        return result;
-    };
-
-    // corresponds to bra_batch and ket_batch, but without the ncf R^2
-    // result[i]        =                      sum_{k}                ket[k] \int bra[k] vf[i]
-    // result[rowbatch] = \sum_{columnbatches} sum_{k in columnbatch} ket[k] \int bra[k] vf[rowbatch]
     MADNESS_CHECK(batch.input.size() == 2);
-    auto row_range = batch.input[0];            // corresponds to bra_batch
-    auto column_range = batch.input[1];         // corresponds to f_batch
-    vecfuncT to_dot_with_bra = column_range.copy_batch(mo_ket);
-    vecfuncT to_dot_with_vf = row_range.copy_batch(mo_ket);
+    // input[1] is the bra/row range and input[0] the vf/column range -- the same labelling
+    // ExchangeImpl::operator() uses when it accumulates the two results back into Kf
+    const auto row_range = batch.input[1];
+    const auto column_range = batch.input[0];
+    MADNESS_CHECK_THROW(row_range.size() == long(bra_batch.size()),
+                        "symmetric offdiagonal tile: row range does not match the bra batch");
+    MADNESS_CHECK_THROW(column_range.size() == long(vf_batch.size()),
+                        "symmetric offdiagonal tile: column range does not match the vf batch");
 
-    vecfuncT resultcolumn(nrow);
-    for (std::size_t irow = 0; irow < nrow; ++irow) {
-        resultcolumn[irow] = dot(subworld, to_dot_with_vf,
-                                 Nslice(irow, _));  // sum over columns result=sum_j ket[j] N[j,i]
-    }
-    vecfuncT resultrow(ncolumn);
-    for (std::size_t icolumn = 0; icolumn < ncolumn; ++icolumn) {
-        resultrow[icolumn] = dot(subworld, to_dot_with_bra,
-                                 Nslice1(_, icolumn));  // sum over rows result=sum_i ket[i] N[j,i]
+    // result[i] = sum_k ket[k] \int bra[k] vf[i], so the tile needs the ket over both of
+    // its ranges: over the rows to accumulate into the columns, and vice versa
+    const vecfuncT ket_rows = row_range.copy_batch(mo_ket);
+    const vecfuncT ket_columns = column_range.copy_batch(mo_ket);
+
+    const long nrow = long(bra_batch.size());
+    const long ncolumn = long(vf_batch.size());
+    vecfuncT resultcolumn(nrow);                                                   // maps to the row range
+    vecfuncT resultrow = zero_functions_compressed<T, NDIM>(subworld, ncolumn);    // maps to the column range
+    auto poisson = set_poisson(subworld, lo);
+
+    for (long irow = 0; irow < nrow; ++irow) {
+        double cpu0 = cpu_time();
+        vecfuncT Nij = mul_sparse(subworld, bra_batch[irow], vf_batch, mul_tol);
+        truncate(subworld, Nij);
+        double cpu1 = cpu_time();
+        mul1_timer += long((cpu1 - cpu0) * 1000l);
+
+        cpu0 = cpu_time();
+        Nij = apply(subworld, *poisson.get(), Nij);
+        truncate(subworld, Nij);
+        cpu1 = cpu_time();
+        apply_timer += long((cpu1 - cpu0) * 1000l);
+
+        cpu0 = cpu_time();
+        // every row contributes to every column, so the column result accumulates ...
+        vecfuncT row_update = mul_sparse(subworld, ket_rows[irow], Nij, mul_tol);
+        compress(subworld, row_update);
+        gaxpy(subworld, 1.0, resultrow, 1.0, row_update);
+        // ... while each row's own entry is written exactly once
+        resultcolumn[irow] = dot(subworld, ket_columns, Nij, true, true, mul_tol);
+        cpu1 = cpu_time();
+        mul2_timer += long((cpu1 - cpu0) * 1000l);
     }
 
     // !! NO TRUNCATION AT THIS POINT !!
-    subworld.gop.fence();
-    cpu1 = cpu_time();
-    mul2_timer += long((cpu1 - cpu0) * 1000l);
-
     return std::make_pair(resultcolumn, resultrow);
 }
 

--- a/src/madness/chem/exchangeoperator.cc
+++ b/src/madness/chem/exchangeoperator.cc
@@ -145,6 +145,12 @@ Exchange<T, NDIM>::ExchangeImpl::K_macrotask_efficient(const vecfuncT& vf, const
         auto& costs = MacroTaskExchangeSimple::cost_this_call();
         if (not costs.empty()) {
             world.gop.sum(costs.data(), costs.size());
+            // dump before committing: this is the matrix just measured, which is what the next
+            // application will place against
+            if (world.rank() == 0 and exch_task_profile_enabled())
+                exch_write_cost_matrix(MacroTaskExchangeSimple::exchange_call_index(),
+                                       FunctionDefaults<NDIM>::get_k(),
+                                       MacroTaskExchangeSimple::cost_matrix_dimension(), costs);
             MacroTaskExchangeSimple::commit_cost_reference();
         }
     }
@@ -322,26 +328,42 @@ Exchange<T, NDIM>::ExchangeImpl::MacroTaskExchangeSimple::compute_offdiagonal_ba
     vecfuncT resultrow = zero_functions_compressed<T, NDIM>(subworld, ncolumn);    // maps to the column range
     auto poisson = set_poisson(subworld, lo);
 
+    // per-stage wall, for the profiler only; `tick` is a no-op when it is off
+    const bool prof_on = profile_active();
+    auto tick = [&](double& acc, const double t0) { if (prof_on) acc += wall_time() - t0; };
+
     for (long irow = 0; irow < nrow; ++irow) {
         double cpu0 = cpu_time();
+        double w0 = prof_on ? wall_time() : 0.0;
         vecfuncT Nij = mul_sparse(subworld, bra_batch[irow], vf_batch, mul_tol);
+        tick(prof_.mul1_wall, w0);
+        w0 = prof_on ? wall_time() : 0.0;
         truncate(subworld, Nij);
+        tick(prof_.truncate_wall, w0);
         double cpu1 = cpu_time();
         mul1_timer += long((cpu1 - cpu0) * 1000l);
 
         cpu0 = cpu_time();
+        w0 = prof_on ? wall_time() : 0.0;
         Nij = apply(subworld, *poisson.get(), Nij);
+        tick(prof_.apply_wall, w0);
+        w0 = prof_on ? wall_time() : 0.0;
         truncate(subworld, Nij);
+        tick(prof_.truncate_wall, w0);
         cpu1 = cpu_time();
         apply_timer += long((cpu1 - cpu0) * 1000l);
 
         cpu0 = cpu_time();
         // every row contributes to every column, so the column result accumulates ...
+        w0 = prof_on ? wall_time() : 0.0;
         vecfuncT row_update = mul_sparse(subworld, ket_rows[irow], Nij, mul_tol);
+        tick(prof_.mul2_wall, w0);
         compress(subworld, row_update);
         gaxpy(subworld, 1.0, resultrow, 1.0, row_update);
         // ... while each row's own entry is written exactly once
+        w0 = prof_on ? wall_time() : 0.0;
         resultcolumn[irow] = dot(subworld, ket_columns, Nij, true, true, mul_tol);
+        tick(prof_.mul2_wall, w0);
         cpu1 = cpu_time();
         mul2_timer += long((cpu1 - cpu0) * 1000l);
     }

--- a/src/madness/chem/exchangeoperator.cc
+++ b/src/madness/chem/exchangeoperator.cc
@@ -121,12 +121,18 @@ Exchange<T, NDIM>::ExchangeImpl::K_macrotask_efficient(const vecfuncT& vf, const
     // that one set of batches serves every operand role and both of a task's batches are
     // owned by some rank. The asymmetric case keeps the size-driven partition.
     MacroTaskExchangeSimple xtask(nresult, lo, mul_tol, is_symmetric(),
-                                  /*owner_pinned=*/is_symmetric(), batch_granularity_);
+                                  /*owner_pinned=*/is_symmetric(), batch_granularity_,
+                                  world.rank());
+    // The owner-pinned path stores the orbitals as batches itself and fetches the two it
+    // needs per task, so the cloud must hold pointers rather than copy every operand into
+    // every subworld. The algorithm therefore fixes the storage policy.
+    const MacroTaskInfo policy = is_symmetric() ? MacroTaskInfo::preset("small_memory_owner")
+                                                : macro_task_info;
     if (taskq) taskq->set_printlevel(printlevel);
 
     // construct MacroTask with or without user-provided taskq -> deferred execution or immediate execution
     auto mtask = (taskq) ? MacroTask(world, xtask, taskq)
-                 : MacroTask(world, xtask, MacroTaskQFactory(world).set_printlevel(printlevel).set_policy(macro_task_info));
+                 : MacroTask(world, xtask, MacroTaskQFactory(world).set_printlevel(printlevel).set_policy(policy));
 
     // deferred execution if a taskq is provided by the user
     vecfuncT Kf = mtask(vf, mo_bra, mo_ket);
@@ -280,29 +286,23 @@ Exchange<T, NDIM>::ExchangeImpl::compute_K_tile(World& world, const vecfuncT& mo
 /// builds N_ij = P(bra[irow] vf[j]) over the whole column range and contributes to both
 /// result ranges: ket[irow] N_ij to column j, and the sum over j of ket[j] N_ij to row irow.
 /// \param subworld     the world we're computing in
-/// \param mo_ket       the orbitals to premultiply with, not batched
+/// \param ket_rows     the orbitals to premultiply with, over the bra/row range
+/// \param ket_columns  the orbitals to premultiply with, over the vf/column range
 /// \param bra_batch    the bra batch of orbitals (including the nuclear correlation factor square)
 /// \param vf_batch     the argument of the exchange operator
 template<typename T, std::size_t NDIM>
 std::pair<std::vector<Function<T, NDIM>>, std::vector<Function<T, NDIM>>>
 Exchange<T, NDIM>::ExchangeImpl::MacroTaskExchangeSimple::compute_offdiagonal_batch_in_symmetric_matrix(World& subworld,
-                                                                                          const vecfuncT& mo_ket,      // not batched
+                                                                                          const vecfuncT& ket_rows,
+                                                                                          const vecfuncT& ket_columns,
                                                                                           const vecfuncT& bra_batch,   // batched
                                                                                           const vecfuncT& vf_batch) const { // batched
-    MADNESS_CHECK(batch.input.size() == 2);
-    // input[1] is the bra/row range and input[0] the vf/column range -- the same labelling
-    // ExchangeImpl::operator() uses when it accumulates the two results back into Kf
-    const auto row_range = batch.input[1];
-    const auto column_range = batch.input[0];
-    MADNESS_CHECK_THROW(row_range.size() == long(bra_batch.size()),
-                        "symmetric offdiagonal tile: row range does not match the bra batch");
-    MADNESS_CHECK_THROW(column_range.size() == long(vf_batch.size()),
-                        "symmetric offdiagonal tile: column range does not match the vf batch");
-
-    // result[i] = sum_k ket[k] \int bra[k] vf[i], so the tile needs the ket over both of
-    // its ranges: over the rows to accumulate into the columns, and vice versa
-    const vecfuncT ket_rows = row_range.copy_batch(mo_ket);
-    const vecfuncT ket_columns = column_range.copy_batch(mo_ket);
+    // result[i] = sum_k ket[k] \int bra[k] vf[i], so the tile contributes to both of its
+    // ranges: the ket over the rows accumulates into the columns, and the other way round
+    MADNESS_CHECK_THROW(ket_rows.size() == bra_batch.size(),
+                        "symmetric offdiagonal tile: ket/bra row size mismatch");
+    MADNESS_CHECK_THROW(ket_columns.size() == vf_batch.size(),
+                        "symmetric offdiagonal tile: ket/vf column size mismatch");
 
     const long nrow = long(bra_batch.size());
     const long ncolumn = long(vf_batch.size());

--- a/src/madness/chem/exchangeoperator.cc
+++ b/src/madness/chem/exchangeoperator.cc
@@ -122,7 +122,7 @@ Exchange<T, NDIM>::ExchangeImpl::K_macrotask_efficient(const vecfuncT& vf, const
     // owned by some rank. The asymmetric case keeps the size-driven partition.
     MacroTaskExchangeSimple xtask(nresult, lo, mul_tol, is_symmetric(),
                                   /*owner_pinned=*/is_symmetric(), batch_granularity_,
-                                  world.rank(), accumulation_mode_);
+                                  world.rank(), accumulation_mode_, cost_aware_assign_);
     // The owner-pinned path stores the orbitals as batches itself and fetches the two it
     // needs per task, so the cloud must hold pointers rather than copy every operand into
     // every subworld. The algorithm therefore fixes the storage policy.
@@ -137,6 +137,18 @@ Exchange<T, NDIM>::ExchangeImpl::K_macrotask_efficient(const vecfuncT& vf, const
     // deferred execution if a taskq is provided by the user
     vecfuncT Kf = mtask(vf, mo_bra, mo_ket);
     world.gop.fence();
+
+    // Every tile ran on exactly one rank, so summing the per-rank cost buffers unions them and
+    // leaves every rank holding the same matrix -- which is what lets the next call's placement
+    // be computed independently everywhere and still agree.
+    if (is_symmetric() and cost_aware_assign_) {
+        auto& costs = MacroTaskExchangeSimple::cost_this_call();
+        if (not costs.empty()) {
+            world.gop.sum(costs.data(), costs.size());
+            MacroTaskExchangeSimple::commit_cost_reference();
+        }
+    }
+
     statistics=gather_statistics();
     statistics["cloud"]=mtask.get_taskq()->get_cloud_statistics();
     statistics["macrotaskq"]=mtask.get_taskq()->get_taskq_statistics();

--- a/src/madness/chem/exchangeoperator.cc
+++ b/src/madness/chem/exchangeoperator.cc
@@ -122,7 +122,7 @@ Exchange<T, NDIM>::ExchangeImpl::K_macrotask_efficient(const vecfuncT& vf, const
     // owned by some rank. The asymmetric case keeps the size-driven partition.
     MacroTaskExchangeSimple xtask(nresult, lo, mul_tol, is_symmetric(),
                                   /*owner_pinned=*/is_symmetric(), batch_granularity_,
-                                  world.rank());
+                                  world.rank(), accumulation_mode_);
     // The owner-pinned path stores the orbitals as batches itself and fetches the two it
     // needs per task, so the cloud must hold pointers rather than copy every operand into
     // every subworld. The algorithm therefore fixes the storage policy.

--- a/src/madness/chem/exchangeoperator.h
+++ b/src/madness/chem/exchangeoperator.h
@@ -485,6 +485,9 @@ private:
     double thresh = FunctionDefaults<NDIM>::get_thresh();
     long printlevel = 0;
     double mul_tol = FunctionDefaults<NDIM>::get_thresh()*0.1;
+    /// batches per rank in the owner-pinned symmetric partition; 1 is the coarsest split
+    /// and the one with the lowest peak memory
+    long batch_granularity_ = 1;
 
     mutable nlohmann::json statistics;  ///< statistics of the Cloud (timings, memory)  and of the parameters of this run
 
@@ -494,6 +497,12 @@ private:
         double lo = 1.e-4;
         double mul_tol = 1.e-7;
         bool symmetric = false;
+        /// pin each task to a rank that owns one of its batches, over the owner-pinned split
+        bool owner_pinned = false;
+        long granularity_level = 1;
+        /// (column batch offset, row batch offset) -> owning rank, filled by
+        /// prepare_owner_assignment and read by owner_hint
+        std::map<std::pair<long,long>,long> owner_map_;
 
         /// custom partitioning for the exchange operator in exchangeoperator.h
 
@@ -501,14 +510,37 @@ private:
         /// with f and vbra being batched, result and vket being passed on as a whole
         class MacroTaskPartitionerExchange : public MacroTaskPartitioner {
         public:
-            MacroTaskPartitionerExchange(const bool symmetric) : symmetric(symmetric) {
+            MacroTaskPartitionerExchange(const bool symmetric, const bool owner_pinned = false,
+                                         const long granularity_level = 1)
+                    : symmetric(symmetric), owner_pinned(owner_pinned),
+                      granularity_level(granularity_level) {
                 max_batch_size=30;
             }
 
             bool symmetric = false;
+            /// build the grid from the owner-pinned split instead of the size-driven one,
+            /// so a task's two batches coincide with batches some rank owns
+            bool owner_pinned = false;
+            long granularity_level = 1;
 
             partitionT do_partitioning(const std::size_t& vsize1, const std::size_t& vsize2,
                                        const std::string policy) const override {
+
+                if (owner_pinned) {
+                    // lower-triangular grid over one granularity-aware split, shared with
+                    // the owner assignment: input[0] = batch i (column), input[1] = batch j
+                    // (row), j <= i. Owners are assigned by prepare_owner_assignment.
+                    const std::vector<Batch_1D> batches =
+                            exchange_sym_owner_split(vsize1, long(nsubworld), granularity_level);
+                    partitionT result;
+                    for (long i = 0; i < long(batches.size()); ++i) {
+                        for (long j = 0; j <= i; ++j) {
+                            Batch batch(batches[i], batches[j], _);
+                            result.push_back(std::make_pair(batch, compute_priority(batch)));
+                        }
+                    }
+                    return result;
+                }
 
                 partitionT partition1 = do_1d_partition(vsize1, policy);
                 partitionT partition2 = do_1d_partition(vsize2, policy);
@@ -543,9 +575,60 @@ private:
         };
 
     public:
-        MacroTaskExchangeSimple(const long nresult, const double lo, const double mul_tol, const bool symmetric)
-                : nresult(nresult), lo(lo), mul_tol(mul_tol), symmetric(symmetric) {
-            partitioner.reset(new MacroTaskPartitionerExchange(symmetric));
+        MacroTaskExchangeSimple(const long nresult, const double lo, const double mul_tol,
+                                const bool symmetric, const bool owner_pinned = false,
+                                const long granularity_level = 1)
+                : nresult(nresult), lo(lo), mul_tol(mul_tol), symmetric(symmetric),
+                  owner_pinned(owner_pinned), granularity_level(granularity_level) {
+            partitioner.reset(new MacroTaskPartitionerExchange(symmetric, owner_pinned, granularity_level));
+        }
+
+        /// Assign every task to the rank that will own one of its two batches.
+
+        /// Called by the macrotask queue after partitioning and before it asks for each
+        /// task's owner. The batch boundaries come from the same split the partitioner
+        /// used, so a task's (column, row) batch offsets identify a pair of batch indices,
+        /// and exchange_sym_round_robin_assign turns that pair into an owner. Every rank
+        /// runs this over the same partition and gets the same map without communicating.
+        void prepare_owner_assignment(const MacroTaskPartitioner::partitionT& partition,
+                                      const long nsubworld) {
+            owner_map_.clear();
+            if (not owner_pinned or nsubworld <= 0) return;
+
+            const std::vector<Batch_1D> split =
+                    exchange_sym_owner_split(nresult, nsubworld, granularity_level);
+            const long M = long(split.size());
+            std::map<long,long> begin_to_index;
+            for (long k = 0; k < M; ++k) begin_to_index[split[k].begin] = k;
+
+            const std::map<std::pair<long,long>,long> assignment =
+                    exchange_sym_round_robin_assign(nsubworld, M);
+
+            for (const auto& [task_batch, priority] : partition) {
+                MADNESS_CHECK_THROW(task_batch.input.size() >= 2,
+                                    "owner-pinned exchange expects two-dimensional task batches");
+                const long column_begin = task_batch.input[0].begin;
+                const long row_begin = task_batch.input[1].begin;
+                auto ic = begin_to_index.find(column_begin);
+                auto jr = begin_to_index.find(row_begin);
+                MADNESS_CHECK_THROW(ic != begin_to_index.end() and jr != begin_to_index.end(),
+                                    "owner-pinned exchange: a task batch is not one of the split batches");
+                // the assignment is keyed on the lower triangle, so order the pair
+                const long i = std::max(ic->second, jr->second);
+                const long j = std::min(ic->second, jr->second);
+                auto it = assignment.find({i, j});
+                owner_map_[{column_begin, row_begin}] =
+                        (it != assignment.end()) ? it->second : (i % nsubworld);
+            }
+        }
+
+        /// \return the rank this task is pinned to, or -1 to leave the choice to the queue
+        long owner_hint(const Batch& task_batch, const long nsubworld) const override {
+            if (not owner_pinned or nsubworld <= 0 or owner_map_.empty()) return -1;
+            MADNESS_CHECK_THROW(task_batch.input.size() >= 2,
+                                "owner-pinned exchange expects two-dimensional task batches");
+            auto it = owner_map_.find({task_batch.input[0].begin, task_batch.input[1].begin});
+            return (it != owner_map_.end()) ? it->second : -1;
         }
 
 

--- a/src/madness/chem/exchangeoperator.h
+++ b/src/madness/chem/exchangeoperator.h
@@ -243,6 +243,11 @@ struct ExchTaskProfile {
     double wall_start = 0.0, wall_end = 0.0;
     double wait_for_data_wall = 0.0;        ///< task entry until its operands are in hand
     double compute_wall = 0.0, compute_cpu = 0.0;
+    /// wall inside each stage of the tile loop, accumulated over its rows. Honest without adding
+    /// any fence: every stage below runs with fence=true, so each completes before the next is
+    /// timed. What they do not cover -- building the per-row update vector, the compresses and the
+    /// accumulating gaxpys -- shows up as the emitted `other` residual.
+    double mul1_wall = 0.0, apply_wall = 0.0, mul2_wall = 0.0, truncate_wall = 0.0;
     int operand_source = -1;                ///< worst of its fetches: 0 resident, 1 ahead, 2 cold
     bool waited = false;                    ///< a cold fetch happened, so this task paid latency
     double peak_rss_gb = 0.0;
@@ -286,11 +291,40 @@ inline void exch_write_task_profile(const ExchTaskProfile& p) {
        << ",\"wait_for_data\":" << p.wait_for_data_wall
        << ",\"compute_wall\":" << p.compute_wall
        << ",\"compute_cpu\":" << p.compute_cpu
+       << ",\"compute_components_wall\":{"
+       <<   "\"mul1\":" << p.mul1_wall << ",\"apply\":" << p.apply_wall
+       <<   ",\"mul2\":" << p.mul2_wall << ",\"truncate\":" << p.truncate_wall
+       <<   ",\"other\":" << (p.compute_wall - p.mul1_wall - p.apply_wall
+                               - p.mul2_wall - p.truncate_wall)
+       << "}"
        << ",\"operand_source\":" << p.operand_source
        << ",\"waited\":" << (p.waited ? "true" : "false")
        << ",\"peak_rss_gb\":" << p.peak_rss_gb
        << "}\n";
     os.flush();   // keep it readable mid-run; there is one write per task, not per node
+}
+
+/// Write the measured per-task cost matrix of one application, for offline inspection.
+
+/// Behind the same flag as the rest of the profiler. One file per application per rank 0:
+/// `Ccall<NNN>_k<K>.csv`, holding `i,j,cost` over the lower-triangular batch grid, with the call
+/// index, wavelet order and batch count in a leading comment so a reader needs no other context.
+/// This is the matrix the next application's placement is derived from, so dumping it is how a
+/// straggler can be traced back to the cost that put it there.
+inline void exch_write_cost_matrix(const long call_index, const long k, const long M,
+                                   const std::vector<double>& cost) {
+    if (M <= 0 or cost.empty()) return;
+    char name[64];
+    std::snprintf(name, sizeof(name), "Ccall%03ld_k%ld.csv", call_index, k);
+    std::ofstream os(name);
+    if (not os.is_open()) return;
+    os << "# call=" << call_index << " k=" << k << " M=" << M << "\n";
+    os << "i,j,cost\n";
+    for (long i = 0; i < M; ++i)
+        for (long j = 0; j <= i; ++j) {
+            const long t = i * (i + 1) / 2 + j;
+            if (t < long(cost.size())) os << i << "," << j << "," << cost[t] << "\n";
+        }
 }
 
 /// which of the three exchange operand vectors a stored batch belongs to
@@ -967,6 +1001,9 @@ private:
         /// per-task profiling on for this task?
         bool profile_active() const { return owner_pinned and exch_task_profile_enabled(); }
         static std::vector<double>& cost_this_call() { return cost_this_call_; }
+        static long exchange_call_index() { return exchange_call_index_; }
+        /// number of batches this application split into, which squares to the cost matrix
+        static long cost_matrix_dimension() { return long(batch_begin_to_index_.size()); }
         /// make this call's measured costs the reference for the next one
         static void commit_cost_reference() { cost_reference_ = cost_this_call_; }
         static void reset_batch_cache_counters() {
@@ -1428,17 +1465,29 @@ private:
             vecfuncT resultcolumn = zero_functions_compressed<T, NDIM>(subworld, n);
             auto poisson = Exchange<double, 3>::ExchangeImpl::set_poisson(subworld, lo);
 
+            // per-stage wall, for the profiler only; `tick` is a no-op when it is off
+            const bool prof_on = profile_active();
+            auto tick = [&](double& acc, const double t0) { if (prof_on) acc += wall_time() - t0; };
+
             for (long i = 0; i < n; ++i) {
                 double cpu0 = cpu_time();
+                double w0 = prof_on ? wall_time() : 0.0;
                 const vecfuncT vf_subset(vf_batch.begin(), vf_batch.begin() + i + 1);
                 vecfuncT psif = mul_sparse(subworld, bra_batch[i], vf_subset, mul_tol);
+                tick(prof_.mul1_wall, w0);
+                w0 = prof_on ? wall_time() : 0.0;
                 truncate(subworld, psif);
+                tick(prof_.truncate_wall, w0);
                 double cpu1 = cpu_time();
                 mul1_timer += long((cpu1 - cpu0) * 1000l);
 
                 cpu0 = cpu_time();
+                w0 = prof_on ? wall_time() : 0.0;
                 psif = apply(subworld, *poisson.get(), psif);
+                tick(prof_.apply_wall, w0);
+                w0 = prof_on ? wall_time() : 0.0;
                 truncate(subworld, psif);
+                tick(prof_.truncate_wall, w0);
                 cpu1 = cpu_time();
                 apply_timer += long((cpu1 - cpu0) * 1000l);
 
@@ -1446,11 +1495,15 @@ private:
                 // assembled on its own and accumulated
                 cpu0 = cpu_time();
                 vecfuncT update = zero_functions_compressed<T, NDIM>(subworld, n);
+                double w1 = prof_on ? wall_time() : 0.0;
                 vecfuncT row_contrib = mul_sparse(subworld, ket_batch[i], psif, mul_tol);
+                tick(prof_.mul2_wall, w1);
                 compress(subworld, row_contrib);
                 for (long j = 0; j <= i; ++j) update[j] += row_contrib[j];
                 for (long j = 0; j < i; ++j) {
+                    w1 = prof_on ? wall_time() : 0.0;
                     vecfuncT mirrored = mul_sparse(subworld, ket_batch[j], vecfuncT(1, psif[j]), mul_tol);
+                    tick(prof_.mul2_wall, w1);
                     compress(subworld, mirrored);
                     update[i] += mirrored[0];
                 }

--- a/src/madness/chem/exchangeoperator.h
+++ b/src/madness/chem/exchangeoperator.h
@@ -707,8 +707,18 @@ private:
         static inline vecfuncT Kf_node_;
         static inline bool Kf_node_initialized_ = false;
         static inline long Kf_node_world_id_ = -1;
+        /// Receiving endpoints for the two drains, one per world they transfer within.
+
+        /// These are WorldObjects, so they are bound to a world exactly as a Function is, and the
+        /// same lifetime rule applies: **release them while that world is still alive.** The node
+        /// world is built per application (the queue owns it and a fresh queue is built per call),
+        /// so a cached node reducer that survives the application is registered in a world that no
+        /// longer exists. The world id is kept beside the pointer rather than read back out of it,
+        /// because comparing `reducer->get_world().id()` is itself a read of the dead world.
         static inline std::shared_ptr<FinalizeReducer<T, NDIM>> universe_reducer_;
+        static inline long universe_reducer_world_id_ = -1;
         static inline std::shared_ptr<FinalizeReducer<T, NDIM>> node_reducer_;
+        static inline long node_reducer_world_id_ = -1;
         /// each drain happens once per rank, not once per task object
         static inline bool finalize_stage1_done_ = false;
         static inline bool finalize_universe_done_ = false;
@@ -730,14 +740,18 @@ private:
         /// One reducer per transport world, rebuilt when that world changes. Collective:
         /// constructing a WorldObject is, so every rank of `world` reaches this together.
         static FinalizeReducer<T, NDIM>& get_universe_reducer(World& world) {
-            if (not universe_reducer_ or universe_reducer_->get_world().id() != world.id())
+            if (not universe_reducer_ or universe_reducer_world_id_ != long(world.id())) {
                 universe_reducer_ = std::make_shared<FinalizeReducer<T, NDIM>>(world);
+                universe_reducer_world_id_ = long(world.id());
+            }
             return *universe_reducer_;
         }
 
         static FinalizeReducer<T, NDIM>& get_node_reducer(World& world) {
-            if (not node_reducer_ or node_reducer_->get_world().id() != world.id())
+            if (not node_reducer_ or node_reducer_world_id_ != long(world.id())) {
                 node_reducer_ = std::make_shared<FinalizeReducer<T, NDIM>>(world);
+                node_reducer_world_id_ = long(world.id());
+            }
             return *node_reducer_;
         }
 
@@ -1063,6 +1077,14 @@ private:
             Kf_node_world_id_ = -1;
             finalize_stage1_done_ = false;
             finalize_universe_done_ = false;
+            // Both reducers go too, for the reason given at their declaration. Rebuilding one per
+            // application costs a WorldObject construction, which is nothing beside an
+            // application, and it also removes the shutdown hazard of a static outliving its
+            // world.
+            universe_reducer_.reset();
+            universe_reducer_world_id_ = -1;
+            node_reducer_.reset();
+            node_reducer_world_id_ = -1;
             // cost_reference_ deliberately survives: it is what the next call places against.
             // cost_this_call_ survives too, until the caller has summed and committed it.
         }

--- a/src/madness/chem/exchangeoperator.h
+++ b/src/madness/chem/exchangeoperator.h
@@ -332,6 +332,7 @@ class Exchange<T,NDIM>::ExchangeImpl {
         mul2_timer = 0l;
         apply_timer = 0l;
         elapsed_time = 0.0;
+        MacroTaskExchangeSimple::reset_batch_cache_counters();
     }
 
 public:
@@ -339,14 +340,23 @@ public:
         double t1 = double(mul1_timer) * 0.001;
         double t2 = double(apply_timer) * 0.001;
         double t3 = double(mul2_timer) * 0.001;
+        // the operand batches a task found resident vs had to fetch from their owner. Summed
+        // here rather than read off the local counters, so this reports the whole run like
+        // every other number in this object
+        double resident = double(MacroTaskExchangeSimple::batch_cache_hits());
+        double fetched = double(MacroTaskExchangeSimple::batch_cache_misses());
         world.gop.sum(t1);
         world.gop.sum(t2);
         world.gop.sum(t3);
+        world.gop.sum(resident);
+        world.gop.sum(fetched);
         nlohmann::json j;
         j["multiply1"] = t1;
         j["apply"] = t2;
         j["multiply2"] = t3;
         j["total"] = elapsed_time;
+        j["batch_cache_hits"] = long(resident);
+        j["batch_cache_misses"] = long(fetched);
         return j;
     }
 
@@ -359,8 +369,8 @@ public:
             printf(" total wall time               %8.2fs\n", timings["total"].template get<double>());
             // only the owner-pinned path fetches operand batches, so this stays quiet for
             // every other algorithm; zero fetches would mean that path never ran
-            const long resident = MacroTaskExchangeSimple::batch_cache_hits();
-            const long fetched = MacroTaskExchangeSimple::batch_cache_misses();
+            const long resident = timings["batch_cache_hits"].template get<long>();
+            const long fetched = timings["batch_cache_misses"].template get<long>();
             if (resident + fetched > 0)
                 printf(" operand batches resident/fetched %6ld /%6ld\n", resident, fetched);
         }
@@ -454,10 +464,6 @@ public:
         j["printlevel"] = printlevel;
         j["algorithm"] = to_string(algorithm_);
         j["macro_task_info"] = macro_task_info.to_json();
-        // how often a task found its operand batch already resident instead of fetching it
-        // from its owner; zero fetches at all means the owner-pinned path did not run
-        j["batch_cache_hits"] = MacroTaskExchangeSimple::batch_cache_hits();
-        j["batch_cache_misses"] = MacroTaskExchangeSimple::batch_cache_misses();
         auto timings = gather_timings(world);
         j.update(timings);
         return j;
@@ -634,12 +640,14 @@ private:
                   owner_pinned(owner_pinned), granularity_level(granularity_level),
                   universe_rank_(universe_rank) {
             partitioner.reset(new MacroTaskPartitionerExchange(symmetric, owner_pinned, granularity_level));
+            name="MacroTaskExchangeSimple";
         }
 
         /// how often a task's operand batch was already resident, and how often it had to be
         /// fetched from the rank owning it. No fetches at all means the path never ran.
         static long batch_cache_hits() { return batch_cache_hits_; }
         static long batch_cache_misses() { return batch_cache_misses_; }
+        static void reset_batch_cache_counters() { batch_cache_hits_ = 0l; batch_cache_misses_ = 0l; }
 
         /// Assign every task to the rank that will own one of its two batches.
 

--- a/src/madness/chem/exchangeoperator.h
+++ b/src/madness/chem/exchangeoperator.h
@@ -427,7 +427,11 @@ public:
 
     void accumulate_chunk(const std::vector<recT>& recs) {
         for (const auto& r : recs) {
-            MADNESS_ASSERT(r.f < dests_.size() and dests_[r.f] != nullptr);
+            // always on: this guards a raw pointer dereference, so it must not be a check that
+            // release builds compile out. ASSERTION_TYPE=disable is a supported configuration
+            MADNESS_CHECK_THROW(r.f < dests_.size() and dests_[r.f] != nullptr,
+                                "exchange finalize: a chunk names a destination this rank has not "
+                                "been given, so its reducer targets were never set");
             typename implT::dcT::accessor acc;
             dests_[r.f]->get_coeffs().insert(acc, r.key);   // get-or-create, locks the key
             acc->second.template gaxpy_inplace<T, T>(T(1.0), r.node, beta_);

--- a/src/madness/chem/exchangeoperator.h
+++ b/src/madness/chem/exchangeoperator.h
@@ -7,6 +7,7 @@
 #include<madness/chem/SCFOperators.h>
 
 #include <algorithm>
+#include <list>
 #include <map>
 #include <utility>
 #include <vector>
@@ -219,6 +220,101 @@ exchange_sym_cost_aware_assign(const long n, const long M, const std::vector<dou
     }
     return owner;
 }
+
+/// which of the three exchange operand vectors a stored batch belongs to
+enum ExchangeBatchDim { EXCHANGE_BATCH_VF = 0, EXCHANGE_BATCH_BRA = 1, EXCHANGE_BATCH_KET = 2 };
+
+/// Per-invocation salt for the exchange batch record keys, from the ket identities.
+
+/// Taken from the ket vector because that one is available in full on both sides — where
+/// the batches are stored and where a task fetches them — so both derive the same record
+/// keys without anyone communicating a manifest. Function implementation ids are handed out
+/// in collective creation order, so the salt is identical on every rank and changes when
+/// the operator is applied to freshly built functions.
+///
+/// \warning It keys on identity, not on content: two applications over the same function
+///          objects produce the same salt, so a cache keyed by it must not outlive an
+///          in-place mutation of those functions.
+template<typename T, std::size_t NDIM>
+inline long exchange_batch_salt(const std::vector<Function<T, NDIM>>& ket) {
+    std::size_t k = 0x5a17ull;
+    for (const auto& f : ket) hash_combine(k, hash_value(f.get_impl()->id()));
+    return long(k);
+}
+
+/// Deterministic cloud record key for one stored batch: (salt, dimension, range).
+
+/// Range-keyed, so the storing side and the fetching side agree on the key by construction.
+inline long exchange_batch_record_key(const long salt, const int dim, const Batch_1D& r) {
+    std::size_t k = std::size_t(salt);
+    hash_combine(k, std::size_t(dim));
+    hash_combine(k, std::size_t(r.begin));
+    hash_combine(k, std::size_t(r.end));
+    return long(k);
+}
+
+/// Bounded cache of fetched exchange batches, keyed by cloud record key.
+
+/// A rank reuses the batches it owns across all of its tasks, so those are **pinned** and
+/// never evicted; only the batches fetched from elsewhere are transient and bounded. An
+/// earlier single bound over both let the churning transients evict the reusable owned
+/// batches, which re-fetched them at every owned-batch switch. Pinning the owned ones costs
+/// a fixed share of the data (orbitals per rank) and is independent of batch granularity.
+///
+/// Entries are held in a list, so a reference returned by find() or insert() stays valid
+/// until that entry is evicted — promotion and insertion of other entries do not move it.
+template<typename keyT, typename dataT>
+class ExchangeBatchLRU {
+public:
+    /// how many non-owned entries may be resident; at least one is always allowed
+    void set_transient_capacity(const std::size_t c) { transient_capacity_ = std::max<std::size_t>(1, c); }
+    std::size_t transient_capacity() const { return transient_capacity_; }
+
+    bool contains(const keyT& key) const {
+        for (const auto& s : slots_) if (s.key == key) return true;
+        return false;
+    }
+
+    /// \return the cached batch, promoted to most-recently-used, or nullptr if absent
+    const dataT* find(const keyT& key) {
+        for (auto it = slots_.begin(); it != slots_.end(); ++it) {
+            if (it->key == key) {
+                slots_.splice(slots_.begin(), slots_, it);
+                return &slots_.front().data;
+            }
+        }
+        return nullptr;
+    }
+
+    /// Insert as most-recently-used. `pinned` marks a batch this rank owns.
+    const dataT& insert(const keyT& key, dataT&& data, const bool pinned) {
+        slots_.push_front(Slot{key, std::move(data), pinned});
+        while (n_transient() > transient_capacity_) {
+            // drop the least-recently-used transient entry; pinned ones are skipped
+            for (auto it = slots_.end(); it != slots_.begin(); ) {
+                --it;
+                if (not it->pinned) { slots_.erase(it); break; }
+            }
+        }
+        return slots_.front().data;
+    }
+
+    /// drop every entry; the capacity setting survives
+    void clear() { slots_.clear(); }
+
+    std::size_t size() const { return slots_.size(); }
+
+    std::size_t n_transient() const {
+        std::size_t c = 0;
+        for (const auto& s : slots_) if (not s.pinned) ++c;
+        return c;
+    }
+
+private:
+    struct Slot { keyT key; dataT data; bool pinned; };
+    std::list<Slot> slots_;                  // front = most recently used
+    std::size_t transient_capacity_ = 2;
+};
 
 
 template<typename T, std::size_t NDIM>

--- a/src/madness/chem/exchangeoperator.h
+++ b/src/madness/chem/exchangeoperator.h
@@ -548,6 +548,12 @@ public:
         return *this;
     }
 
+    ExchangeImpl& set_batch_granularity(const long level) {
+        MADNESS_CHECK_THROW(level >= 1, "exchange batch granularity must be at least 1");
+        batch_granularity_ = level;
+        return *this;
+    }
+
     ExchangeImpl& set_accumulation_mode(const int mode) {
         MADNESS_CHECK_THROW(mode == 1 or mode == 2, "exchange accumulation mode must be 1 or 2");
         accumulation_mode_ = mode;

--- a/src/madness/chem/exchangeoperator.h
+++ b/src/madness/chem/exchangeoperator.h
@@ -357,6 +357,12 @@ public:
             printf(" cpu time spent in apply       %8.2fs\n", timings["apply"].template get<double>());
             printf(" cpu time spent in multiply2   %8.2fs\n", timings["multiply2"].template get<double>());
             printf(" total wall time               %8.2fs\n", timings["total"].template get<double>());
+            // only the owner-pinned path fetches operand batches, so this stays quiet for
+            // every other algorithm; zero fetches would mean that path never ran
+            const long resident = MacroTaskExchangeSimple::batch_cache_hits();
+            const long fetched = MacroTaskExchangeSimple::batch_cache_misses();
+            if (resident + fetched > 0)
+                printf(" operand batches resident/fetched %6ld /%6ld\n", resident, fetched);
         }
     }
 
@@ -448,6 +454,10 @@ public:
         j["printlevel"] = printlevel;
         j["algorithm"] = to_string(algorithm_);
         j["macro_task_info"] = macro_task_info.to_json();
+        // how often a task found its operand batch already resident instead of fetching it
+        // from its owner; zero fetches at all means the owner-pinned path did not run
+        j["batch_cache_hits"] = MacroTaskExchangeSimple::batch_cache_hits();
+        j["batch_cache_misses"] = MacroTaskExchangeSimple::batch_cache_misses();
         auto timings = gather_timings(world);
         j.update(timings);
         return j;
@@ -503,6 +513,48 @@ private:
         /// (column batch offset, row batch offset) -> owning rank, filled by
         /// prepare_owner_assignment and read by owner_hint
         std::map<std::pair<long,long>,long> owner_map_;
+        /// this process's rank in the universe, to recognise the batches it owns
+        long universe_rank_ = 0;
+
+        /// Batches fetched from the cloud, reused across the tasks that run in one subworld.
+
+        /// Static because the tasks of a subworld are separate objects: the cache has to
+        /// outlive any one of them to be reused at all. It is therefore scoped by hand to
+        /// the subworld that filled it -- see ensure_cache_world, which drops it when the
+        /// subworld changes so a batch from one subworld is never read in another.
+        static inline ExchangeBatchLRU<long, vecfuncT> batch_cache_;
+        static inline long cache_world_id_ = -1;
+        static inline std::atomic<long> batch_cache_hits_;
+        static inline std::atomic<long> batch_cache_misses_;
+
+        static void clear_local_caches() { batch_cache_.clear(); }
+
+        /// drop cached batches when the subworld changes; they belong to the old one
+        void ensure_cache_world(World& world) const {
+            if (cache_world_id_ != long(world.id())) {
+                clear_local_caches();
+                cache_world_id_ = long(world.id());
+            }
+        }
+
+        /// Fetch one owner-pinned batch, from the local cache if it is resident.
+
+        /// A miss goes straight to the owning rank over the cloud's point-to-point batch
+        /// path. Batches this rank owns are pinned, since every one of its tasks needs
+        /// them; the others are transient and bounded.
+        ///
+        /// \return a reference into the cache, valid until that entry is evicted
+        const vecfuncT& fetch_batch(World& world, Cloud& cloud, const long record) const {
+            ensure_cache_world(world);
+            if (const vecfuncT* resident = batch_cache_.find(record)) {
+                ++batch_cache_hits_;
+                return *resident;
+            }
+            ++batch_cache_misses_;
+            const bool owned = (cloud.batch_owner(record) == universe_rank_);
+            vecfuncT data = cloud.template fetch_batch_p2p<T, NDIM>(world, record, /*cache_result=*/false);
+            return batch_cache_.insert(record, std::move(data), owned);
+        }
 
         /// custom partitioning for the exchange operator in exchangeoperator.h
 
@@ -577,11 +629,17 @@ private:
     public:
         MacroTaskExchangeSimple(const long nresult, const double lo, const double mul_tol,
                                 const bool symmetric, const bool owner_pinned = false,
-                                const long granularity_level = 1)
+                                const long granularity_level = 1, const long universe_rank = 0)
                 : nresult(nresult), lo(lo), mul_tol(mul_tol), symmetric(symmetric),
-                  owner_pinned(owner_pinned), granularity_level(granularity_level) {
+                  owner_pinned(owner_pinned), granularity_level(granularity_level),
+                  universe_rank_(universe_rank) {
             partitioner.reset(new MacroTaskPartitionerExchange(symmetric, owner_pinned, granularity_level));
         }
+
+        /// how often a task's operand batch was already resident, and how often it had to be
+        /// fetched from the rank owning it. No fetches at all means the path never ran.
+        static long batch_cache_hits() { return batch_cache_hits_; }
+        static long batch_cache_misses() { return batch_cache_misses_; }
 
         /// Assign every task to the rank that will own one of its two batches.
 
@@ -647,12 +705,89 @@ private:
             return result;
         }
 
+        /// Store the orbitals as owner-pinned batches, one record per batch.
+
+        /// Called by the macrotask queue on the universe right after the argument tuple is
+        /// stored. The batch boundaries and the record keys are derived exactly as the task
+        /// side derives them, so no manifest has to be communicated.
+        ///
+        /// Every rank registers the routing for all records, which is local and needs no
+        /// communication, and then each owner **pulls** the batches it owns into its own
+        /// size-1 subworld and serializes them there. That is what spreads the ingest across
+        /// the owners: serializing centrally instead funnels the whole orbital set through
+        /// one rank's network interface.
+        ///
+        /// The symmetric case stores one set: bra == ket == vf, so the same batch serves as
+        /// column, row and ket operand.
+        void store_batches(World& world, World& subworld, Cloud& cloud, const argtupleT& argtuple,
+                           const long nsubworld) {
+            if (not owner_pinned) return;
+            // Batch k is owned by rank (k mod nsubworld), so a batch index has to name a
+            // universe rank, and that only holds with one subworld per rank. Anything else
+            // would register the routing to the wrong ranks and read the wrong coefficients,
+            // so say so rather than compute something wrong.
+            MADNESS_CHECK_THROW(nsubworld == world.size(),
+                                "owner-pinned exchange needs one subworld per rank");
+            const vecfuncT& mo_ket = std::get<2>(argtuple);
+            // one fence up front, so store_batch does not need one per function
+            world.gop.fence();
+            const long salt = exchange_batch_salt(mo_ket);
+            const std::vector<Batch_1D> split =
+                    exchange_sym_owner_split(mo_ket.size(), nsubworld, granularity_level);
+
+            // A cross-world copy picks its process map from the target world, but anything
+            // on that path reading the process-wide default would route to universe ranks
+            // that do not exist in a size-1 subworld. Point the default at the subworld for
+            // the duration and restore it afterwards.
+            auto saved_pmap = FunctionDefaults<NDIM>::get_pmap();
+            FunctionDefaults<NDIM>::set_default_pmap(subworld);
+
+            std::vector<std::pair<long, vecfuncT>> owned;
+            for (long k = 0; k < long(split.size()); ++k) {
+                const Batch_1D& r = split[k];
+                const long record = exchange_batch_record_key(salt, EXCHANGE_BATCH_VF, r);
+                cloud.register_batch_owner(record, ProcessID(k % nsubworld));
+                if (k % nsubworld == world.rank()) {
+                    vecfuncT local(r.size());
+                    for (long i = r.begin; i < r.end; ++i)
+                        local[i - r.begin] = copy(subworld, mo_ket[i], /*fence=*/false);
+                    owned.emplace_back(record, std::move(local));
+                }
+            }
+            // the source ranks' comm threads serve the pulls, so a fence on the size-1
+            // subworld drains this owner's copies
+            subworld.gop.fence();
+            for (auto& [record, batch] : owned)
+                cloud.store_batch(subworld, batch, world.rank(), record, /*fence=*/false);
+            subworld.gop.fence();
+
+            FunctionDefaults<NDIM>::set_pmap(saved_pmap);
+            world.gop.fence();
+        }
+
+        /// the owner-pinned path fetches its operand batches from the cloud itself
+        bool handles_own_data_movement() const override { return owner_pinned; }
+
+        /// Drop the cached batches while the subworld holding them is still alive.
+
+        /// Leaving it to ensure_cache_world to notice a new subworld is too late: by then the
+        /// cached functions refer to a destroyed world, and merely releasing them walks into
+        /// it.
+        void cleanup() override {
+            clear_local_caches();
+            cache_world_id_ = -1;
+        }
+
+
         std::vector<Function<T, NDIM>>
         operator()(const std::vector<Function<T, NDIM>>& vf_batch,     // will be batched (column)
                    const std::vector<Function<T, NDIM>>& bra_batch,    // will be batched (row)
                    const std::vector<Function<T, NDIM>>& vket) {       // will not be batched
 
-            World& world = vf_batch.front().world();
+            // the operands are not necessarily this world's: on the owner-pinned path the
+            // queue leaves them in the universe and the task fetches what it needs
+            MADNESS_CHECK_THROW(subworld_ptr != nullptr, "MacroTaskExchangeSimple: subworld_ptr is null");
+            World& world = *subworld_ptr;
             resultT Kf = zero_functions_compressed<T, NDIM>(world, nresult);
 
             bool diagonal_block = batch.input[0] == batch.input[1];
@@ -665,17 +800,42 @@ private:
             MADNESS_CHECK(vf_range.end <= nresult);
             if (symmetric) MADNESS_CHECK(bra_range.end <= nresult);
 
+            // Owner-pinned: fetch the two batches this task needs from the cloud. Because
+            // bra == ket == vf there, one batch per range serves every operand role, so the
+            // ket over a range is just that range's batch.
+            vecfuncT bra_owned, vf_owned;
+            const vecfuncT* bra_work = &bra_batch;
+            const vecfuncT* vf_work = &vf_batch;
+            if (owner_pinned) {
+                MADNESS_CHECK_THROW(cloud_ptr != nullptr, "owner-pinned exchange: cloud_ptr is null");
+                Cloud& cloud = *cloud_ptr;
+                const long salt = exchange_batch_salt(vket);
+                // copy the handles out of the cache: the reference is only good until the
+                // entry is evicted, and the second fetch may evict the first
+                bra_owned = fetch_batch(world, cloud,
+                                        exchange_batch_record_key(salt, EXCHANGE_BATCH_VF, bra_range));
+                vf_owned = diagonal_block
+                        ? bra_owned                     // one range, so one batch
+                        : fetch_batch(world, cloud,
+                                      exchange_batch_record_key(salt, EXCHANGE_BATCH_VF, vf_range));
+                bra_work = &bra_owned;
+                vf_work = &vf_owned;
+            }
+
             if (symmetric and diagonal_block) {
-                auto ket_batch = bra_range.copy_batch(vket);
-                vecfuncT resultcolumn = compute_diagonal_batch_in_symmetric_matrix(world, ket_batch, bra_batch,
-                                                                                   vf_batch);
+                const vecfuncT ket_batch = owner_pinned ? *bra_work : bra_range.copy_batch(vket);
+                vecfuncT resultcolumn = compute_diagonal_batch_in_symmetric_matrix(world, ket_batch, *bra_work,
+                                                                                   *vf_work);
 
                 for (int i = vf_range.begin; i < vf_range.end; ++i){
                     Kf[i] += resultcolumn[i - vf_range.begin];}
 
             } else if (symmetric and not diagonal_block) {
-                auto[resultcolumn, resultrow]=compute_offdiagonal_batch_in_symmetric_matrix(world, vket, bra_batch,
-                                                                                            vf_batch);
+                const vecfuncT ket_rows = owner_pinned ? *bra_work : bra_range.copy_batch(vket);
+                const vecfuncT ket_columns = owner_pinned ? *vf_work : vf_range.copy_batch(vket);
+                auto[resultcolumn, resultrow]=compute_offdiagonal_batch_in_symmetric_matrix(world, ket_rows,
+                                                                                            ket_columns,
+                                                                                            *bra_work, *vf_work);
 
                 for (int i = bra_range.begin; i < bra_range.end; ++i){
                     Kf[i] += resultcolumn[i - bra_range.begin];}
@@ -768,14 +928,13 @@ private:
 
         /// compute a batch of the exchange matrix, with non-identical ranges
 
-        /// \param subworld     the world we're computing in
-        /// \param cloud        where to store the results
-        /// \param bra_batch    the bra batch of orbitals (including the nuclear correlation factor square)
-        /// \param ket_batch    the ket batch of orbitals, i.e. the orbitals to premultiply with
-        /// \param vf_batch     the argument of the exchange operator
+        /// The caller supplies the ket over each of the tile's two ranges: it is the one
+        /// that knows the ranges, and where those orbitals come from depends on how the
+        /// operands were supplied, which is not the kernel's concern.
         std::pair<vecfuncT, vecfuncT> compute_offdiagonal_batch_in_symmetric_matrix(World& subworld,
-                                                                                    const vecfuncT& ket, // not batched
-                                                                                    const vecfuncT& bra_batch, // batched
+                                                                                    const vecfuncT& ket_rows,    // ket over the bra/row range
+                                                                                    const vecfuncT& ket_columns, // ket over the vf/column range
+                                                                                    const vecfuncT& bra_batch,   // batched
                                                                                     const vecfuncT& vf_batch) const; // batched
 
     };

--- a/src/madness/chem/exchangeoperator.h
+++ b/src/madness/chem/exchangeoperator.h
@@ -559,6 +559,11 @@ public:
         return *this;
     }
 
+    ExchangeImpl& set_cost_aware_assignment(const bool flag) {
+        cost_aware_assign_ = flag;
+        return *this;
+    }
+
     ExchangeImpl& set_accumulation_mode(const int mode) {
         MADNESS_CHECK_THROW(mode == 1 or mode == 2, "exchange accumulation mode must be 1 or 2");
         accumulation_mode_ = mode;
@@ -624,6 +629,8 @@ private:
     /// how the tile results are gathered: 1 = subworld buffer then universe, 2 = also reduce
     /// within a node first (default; degrades to 1 on a single node)
     int accumulation_mode_ = 2;
+    /// place tasks by measured cost instead of by counting them
+    bool cost_aware_assign_ = true;
 
     mutable nlohmann::json statistics;  ///< statistics of the Cloud (timings, memory)  and of the parameters of this run
 
@@ -640,6 +647,8 @@ private:
         /// 2 = additionally reduce within a node first, so only one rank per node scatters
         ///     across nodes. Degrades to 1 automatically when there is a single node.
         int accumulation_mode_ = 2;
+        /// place tasks by their measured cost rather than by counting them
+        bool cost_aware_ = true;
         /// (column batch offset, row batch offset) -> owning rank, filled by
         /// prepare_owner_assignment and read by owner_hint
         std::map<std::pair<long,long>,long> owner_map_;
@@ -673,6 +682,19 @@ private:
         };
         static inline PrefetchSlot prefetch_current_;   ///< promoted from the previous task
         static inline PrefetchSlot prefetch_next_;      ///< requested during this task
+
+        /// What each task cost last time, to place them better this time.
+
+        /// Screening makes the tiles strongly uneven for large molecules, and a placement that
+        /// balances task *counts* cannot see that. The measured wall time of each tile is
+        /// recorded here, summed across ranks after the call -- each tile ran on exactly one
+        /// rank, so summing unions the contributions -- and used as the reference for the next
+        /// call. Kept across calls and across protocol changes on purpose: only the relative
+        /// cost matters, and its structure barely moves between them.
+        static inline std::vector<double> cost_reference_;   ///< from the previous call
+        static inline std::vector<double> cost_this_call_;    ///< rank-local, summed after the call
+        static inline std::map<long,long> batch_begin_to_index_;   ///< batch offset -> index
+        static inline long exchange_call_index_ = 0;
 
         /// Where this subworld's tile results are summed before they leave it, and where a
         /// node's subworlds are summed before that leaves the node. Static for the same reason
@@ -830,10 +852,11 @@ private:
         MacroTaskExchangeSimple(const long nresult, const double lo, const double mul_tol,
                                 const bool symmetric, const bool owner_pinned = false,
                                 const long granularity_level = 1, const long universe_rank = 0,
-                                const int accumulation_mode = 2)
+                                const int accumulation_mode = 2, const bool cost_aware = true)
                 : nresult(nresult), lo(lo), mul_tol(mul_tol), symmetric(symmetric),
                   owner_pinned(owner_pinned), granularity_level(granularity_level),
-                  accumulation_mode_(accumulation_mode), universe_rank_(universe_rank) {
+                  accumulation_mode_(accumulation_mode), cost_aware_(cost_aware),
+                  universe_rank_(universe_rank) {
             partitioner.reset(new MacroTaskPartitionerExchange(symmetric, owner_pinned, granularity_level));
             name="MacroTaskExchangeSimple";
         }
@@ -843,6 +866,9 @@ private:
         static long batch_cache_hits() { return batch_cache_hits_; }
         static long batch_cache_misses() { return batch_cache_misses_; }
         static long batch_prefetch_hits() { return batch_prefetch_hits_; }
+        static std::vector<double>& cost_this_call() { return cost_this_call_; }
+        /// make this call's measured costs the reference for the next one
+        static void commit_cost_reference() { cost_reference_ = cost_this_call_; }
         static void reset_batch_cache_counters() {
             batch_cache_hits_ = 0l; batch_cache_misses_ = 0l; batch_prefetch_hits_ = 0l;
         }
@@ -865,8 +891,19 @@ private:
             std::map<long,long> begin_to_index;
             for (long k = 0; k < M; ++k) begin_to_index[split[k].begin] = k;
 
+            // Cost-aware placement needs a reference from a previous call, and the first call
+            // is not representative of the ones that follow it -- cold caches and an initial
+            // guess -- so it takes effect from the third call on, with the second call's
+            // measurements as its reference.
+            ++exchange_call_index_;
+            batch_begin_to_index_ = begin_to_index;
+            const std::size_t ntask = std::size_t(M) * std::size_t(M + 1) / 2;
+            cost_this_call_.assign(ntask, 0.0);
+            const bool use_cost = cost_aware_ and exchange_call_index_ >= 3
+                    and cost_reference_.size() == ntask;
             const std::map<std::pair<long,long>,long> assignment =
-                    exchange_sym_round_robin_assign(nsubworld, M);
+                    use_cost ? exchange_sym_cost_aware_assign(nsubworld, M, cost_reference_)
+                             : exchange_sym_round_robin_assign(nsubworld, M);
 
             for (const auto& [task_batch, priority] : partition) {
                 MADNESS_CHECK_THROW(task_batch.input.size() >= 2,
@@ -1026,6 +1063,8 @@ private:
             Kf_node_world_id_ = -1;
             finalize_stage1_done_ = false;
             finalize_universe_done_ = false;
+            // cost_reference_ deliberately survives: it is what the next call places against.
+            // cost_this_call_ survives too, until the caller has summed and committed it.
         }
 
         /// true if the task sums its own tile results and drains them in the finalize, rather
@@ -1164,6 +1203,8 @@ private:
             MADNESS_CHECK(vf_range.end <= nresult);
             if (symmetric) MADNESS_CHECK(bra_range.end <= nresult);
 
+            const double tile_wall_start = wall_time();
+
             // Owner-pinned: fetch the two batches this task needs from the cloud. Because
             // bra == ket == vf there, one batch per range serves every operand role, so the
             // ket over a range is just that range's batch.
@@ -1210,6 +1251,19 @@ private:
                 vecfuncT resultcolumn = compute_batch_in_asymmetric_matrix(world, ket_batch, bra_batch, vf_batch);
                 for (int i = vf_range.begin; i < vf_range.end; ++i)
                     Kf[i] += resultcolumn[i - vf_range.begin];
+            }
+
+            // this tile's cost, for the next call's placement. Keyed by its batch pair, so the
+            // reference survives a different partition only if the pair count matches -- which
+            // prepare_owner_assignment checks before using it.
+            if (owner_pinned and not cost_this_call_.empty()) {
+                const auto ic = batch_begin_to_index_.find(vf_range.begin);
+                const auto jr = batch_begin_to_index_.find(bra_range.begin);
+                if (ic != batch_begin_to_index_.end() and jr != batch_begin_to_index_.end()) {
+                    const long t = exchange_sym_tri(ic->second, jr->second);
+                    if (t < long(cost_this_call_.size()))
+                        cost_this_call_[t] += wall_time() - tile_wall_start;
+                }
             }
             return Kf;
         }

--- a/src/madness/chem/exchangeoperator.h
+++ b/src/madness/chem/exchangeoperator.h
@@ -614,15 +614,56 @@ private:
         /// \param bra_batch    the bra batch of orbitals (including the nuclear correlation factor square)
         /// \param ket_batch    the ket batch of orbitals, i.e. the orbitals to premultiply with
         /// \param vf_batch     the argument of the exchange operator
+        /// Streams the tile one row at a time, so only the intermediates of a single row
+        /// are live at once where computing the tile in one go holds the whole triangle.
+        /// Row i builds N_ij = P(bra[i] vf[j]) for j <= i, adds ket[i] N_ij to column j,
+        /// and adds the mirrored ket[j] N_ij to column i.
         vecfuncT compute_diagonal_batch_in_symmetric_matrix(World& subworld,
                                                             const vecfuncT& ket_batch,      // is batched
                                                             const vecfuncT& bra_batch,      // is batched
                                                             const vecfuncT& vf_batch        // is batched
         ) const {
-            double symmetric = true;
+            MADNESS_CHECK_THROW(ket_batch.size() == bra_batch.size(),
+                                "symmetric diagonal tile: ket/bra batch size mismatch");
+            MADNESS_CHECK_THROW(vf_batch.size() == bra_batch.size(),
+                                "symmetric diagonal tile: vf/bra batch size mismatch");
+
+            const long n = long(vf_batch.size());
+            vecfuncT resultcolumn = zero_functions_compressed<T, NDIM>(subworld, n);
             auto poisson = Exchange<double, 3>::ExchangeImpl::set_poisson(subworld, lo);
-            return Exchange<T, NDIM>::ExchangeImpl::compute_K_tile(subworld, bra_batch, ket_batch, vf_batch, poisson, symmetric,
-                                                     mul_tol);
+
+            for (long i = 0; i < n; ++i) {
+                double cpu0 = cpu_time();
+                const vecfuncT vf_subset(vf_batch.begin(), vf_batch.begin() + i + 1);
+                vecfuncT psif = mul_sparse(subworld, bra_batch[i], vf_subset, mul_tol);
+                truncate(subworld, psif);
+                double cpu1 = cpu_time();
+                mul1_timer += long((cpu1 - cpu0) * 1000l);
+
+                cpu0 = cpu_time();
+                psif = apply(subworld, *poisson.get(), psif);
+                truncate(subworld, psif);
+                cpu1 = cpu_time();
+                apply_timer += long((cpu1 - cpu0) * 1000l);
+
+                // rows overlap in the columns they touch, so this row's contribution is
+                // assembled on its own and accumulated
+                cpu0 = cpu_time();
+                vecfuncT update = zero_functions_compressed<T, NDIM>(subworld, n);
+                vecfuncT row_contrib = mul_sparse(subworld, ket_batch[i], psif, mul_tol);
+                compress(subworld, row_contrib);
+                for (long j = 0; j <= i; ++j) update[j] += row_contrib[j];
+                for (long j = 0; j < i; ++j) {
+                    vecfuncT mirrored = mul_sparse(subworld, ket_batch[j], vecfuncT(1, psif[j]), mul_tol);
+                    compress(subworld, mirrored);
+                    update[i] += mirrored[0];
+                }
+                gaxpy(subworld, 1.0, resultcolumn, 1.0, update);
+                cpu1 = cpu_time();
+                mul2_timer += long((cpu1 - cpu0) * 1000l);
+            }
+            // !! NO TRUNCATION AT THIS POINT !!
+            return resultcolumn;
         }
 
         /// compute a batch of the exchange matrix, with non-identical ranges

--- a/src/madness/chem/exchangeoperator.h
+++ b/src/madness/chem/exchangeoperator.h
@@ -92,24 +92,32 @@ exchange_sym_round_robin_assign(const long n, const long M) {
         return ((i % n) == t) or ((j % n) == t);
     };
     // all tasks, ascending by (i,j)
-    std::vector<std::pair<long,long>> remaining;
-    remaining.reserve(std::size_t(M) * std::size_t(M + 1) / 2);
+    const std::size_t ntask = std::size_t(M) * std::size_t(M + 1) / 2;
+    std::vector<std::pair<long,long>> tasks;
+    tasks.reserve(ntask);
     for (long i = 0; i < M; ++i)
         for (long j = 0; j <= i; ++j)
-            remaining.emplace_back(i, j);
+            tasks.emplace_back(i, j);
 
     std::vector<std::vector<std::pair<long,long>>> T(n);
 
-    // Phase 1 — round-robin placement
+    // Phase 1 — round-robin placement. Each worker takes the first task, in ascending
+    // (i,j), that is still free and eligible for it. `cursor[t]` remembers how far worker
+    // t has scanned: everything before it is either taken or permanently ineligible for t,
+    // and neither condition is ever undone, so the cursor only moves forward. That makes
+    // the phase linear in the task count per worker rather than quadratic overall.
+    std::vector<char> taken(ntask, 0);
+    std::vector<std::size_t> cursor(n, 0);
+    std::size_t placed = 0;
     long t = 0, misses = 0;
-    while (not remaining.empty() and misses < n) {
-        long picked = -1;
-        for (long idx = 0; idx < long(remaining.size()); ++idx) {
-            if (eligible(remaining[idx].first, remaining[idx].second, t)) { picked = idx; break; }
-        }
-        if (picked >= 0) {
-            T[t].push_back(remaining[picked]);
-            remaining.erase(remaining.begin() + picked);
+    while (placed < ntask and misses < n) {
+        std::size_t& c = cursor[t];
+        while (c < ntask and (taken[c] or not eligible(tasks[c].first, tasks[c].second, t))) ++c;
+        if (c < ntask) {
+            taken[c] = 1;
+            T[t].push_back(tasks[c]);
+            ++placed;
+            ++c;
             misses = 0;
         } else {
             ++misses;
@@ -117,7 +125,8 @@ exchange_sym_round_robin_assign(const long n, const long M) {
         t = (t + 1) % n;
     }
     // any leftovers; every task is eligible for someone, so this should not trigger
-    for (const auto& task : remaining) T[task.first % n].push_back(task);
+    for (std::size_t idx = 0; idx < ntask; ++idx)
+        if (not taken[idx]) T[tasks[idx].first % n].push_back(tasks[idx]);
 
     // Phase 2 — rebalance until the spread is <= 1 (the iteration cap is a backstop)
     for (long iter = 0; iter < 10000; ++iter) {

--- a/src/madness/chem/exchangeoperator.h
+++ b/src/madness/chem/exchangeoperator.h
@@ -445,11 +445,13 @@ public:
         // every other number in this object
         double resident = double(MacroTaskExchangeSimple::batch_cache_hits());
         double fetched = double(MacroTaskExchangeSimple::batch_cache_misses());
+        double ahead = double(MacroTaskExchangeSimple::batch_prefetch_hits());
         world.gop.sum(t1);
         world.gop.sum(t2);
         world.gop.sum(t3);
         world.gop.sum(resident);
         world.gop.sum(fetched);
+        world.gop.sum(ahead);
         nlohmann::json j;
         j["multiply1"] = t1;
         j["apply"] = t2;
@@ -457,6 +459,7 @@ public:
         j["total"] = elapsed_time;
         j["batch_cache_hits"] = long(resident);
         j["batch_cache_misses"] = long(fetched);
+        j["batch_prefetch_hits"] = long(ahead);
         return j;
     }
 
@@ -471,8 +474,10 @@ public:
             // every other algorithm; zero fetches would mean that path never ran
             const long resident = timings["batch_cache_hits"].template get<long>();
             const long fetched = timings["batch_cache_misses"].template get<long>();
-            if (resident + fetched > 0)
-                printf(" operand batches resident/fetched %6ld /%6ld\n", resident, fetched);
+            const long ahead = timings["batch_prefetch_hits"].template get<long>();
+            if (resident + fetched + ahead > 0)
+                printf(" operand batches resident/ahead/fetched %6ld /%6ld /%6ld\n",
+                       resident, ahead, fetched);
         }
     }
 
@@ -651,6 +656,23 @@ private:
         static inline long cache_world_id_ = -1;
         static inline std::atomic<long> batch_cache_hits_;
         static inline std::atomic<long> batch_cache_misses_;
+        static inline std::atomic<long> batch_prefetch_hits_;
+
+        /// One batch requested ahead of the task that will read it.
+
+        /// A strict double buffer: `next` is requested while this task computes, and every
+        /// task promotes it to `current` before computing, so **at most two requests are ever
+        /// in flight per rank**. That bound is load-bearing, not a tuning choice: an earlier
+        /// design that allowed several concurrent requests corrupted the transport on large
+        /// replies, because the outstanding replies could outnumber what the receive path was
+        /// prepared for.
+        struct PrefetchSlot {
+            bool valid = false;
+            long key = 0;
+            Future<batch_bytesT> fut;
+        };
+        static inline PrefetchSlot prefetch_current_;   ///< promoted from the previous task
+        static inline PrefetchSlot prefetch_next_;      ///< requested during this task
 
         /// Where this subworld's tile results are summed before they leave it, and where a
         /// node's subworlds are summed before that leaves the node. Static for the same reason
@@ -669,7 +691,12 @@ private:
         static inline bool finalize_stage1_done_ = false;
         static inline bool finalize_universe_done_ = false;
 
-        static void clear_local_caches() { batch_cache_.clear(); }
+        static void clear_local_caches() {
+            batch_cache_.clear();
+            // drop requests issued in a subworld that is no longer the one we are in
+            prefetch_current_ = PrefetchSlot();
+            prefetch_next_ = PrefetchSlot();
+        }
 
         /// entries per chunk in coalesced_gaxpy, sized so one message stays modest at any k
         static std::size_t finalize_chunk_entries() {
@@ -713,8 +740,18 @@ private:
                 ++batch_cache_hits_;
                 return *resident;
             }
-            ++batch_cache_misses_;
             const bool owned = (cloud.batch_owner(record) == universe_rank_);
+            // requested one task ahead, so the transfer overlapped that task's compute
+            for (PrefetchSlot* slot : {&prefetch_current_, &prefetch_next_}) {
+                if (slot->valid and slot->key == record) {
+                    vecfuncT data = cloud.template deserialize_batch_p2p<T, NDIM>(
+                            world, slot->fut, record, /*cache_result=*/false);
+                    *slot = PrefetchSlot();
+                    ++batch_prefetch_hits_;
+                    return batch_cache_.insert(record, std::move(data), owned);
+                }
+            }
+            ++batch_cache_misses_;
             vecfuncT data = cloud.template fetch_batch_p2p<T, NDIM>(world, record, /*cache_result=*/false);
             return batch_cache_.insert(record, std::move(data), owned);
         }
@@ -805,7 +842,10 @@ private:
         /// fetched from the rank owning it. No fetches at all means the path never ran.
         static long batch_cache_hits() { return batch_cache_hits_; }
         static long batch_cache_misses() { return batch_cache_misses_; }
-        static void reset_batch_cache_counters() { batch_cache_hits_ = 0l; batch_cache_misses_ = 0l; }
+        static long batch_prefetch_hits() { return batch_prefetch_hits_; }
+        static void reset_batch_cache_counters() {
+            batch_cache_hits_ = 0l; batch_cache_misses_ = 0l; batch_prefetch_hits_ = 0l;
+        }
 
         /// Assign every task to the rank that will own one of its two batches.
 
@@ -929,6 +969,41 @@ private:
 
             FunctionDefaults<NDIM>::set_pmap(saved_pmap);
             world.gop.fence();
+        }
+
+        /// Request the batch the next task will have to fetch, before computing this one.
+
+        /// Called by the queue once per task, before the task body, with the batches of the
+        /// next task this rank will run. Of that task's two batches one is normally owned here
+        /// and reads locally, so at most one is worth requesting -- and requesting exactly one
+        /// keeps the in-flight count within the bound PrefetchSlot documents.
+        ///
+        /// This is what makes the owner-pinned transport worth its machinery: without it every
+        /// task pays the full latency of its remote batch with nothing to overlap it against.
+        void sym_pipeline_advance(World& subworld, const vecfuncT& mo_ket,
+                                  const Batch_1D& next_col, const Batch_1D& next_row,
+                                  const bool has_next) const {
+            if (not owner_pinned) return;
+            ensure_cache_world(subworld);
+            // hand the previous task's request to this task, which is the one that reads it.
+            // Retiring an unconsumed request is safe rather than merely tolerated: the reply
+            // still lands, fills a result nobody reads, and the transport drops its pending
+            // entry, so the cost is one wasted transfer and nothing is left dangling.
+            prefetch_current_ = prefetch_next_;
+            prefetch_next_ = PrefetchSlot();
+            if (not has_next or cloud_ptr == nullptr) return;
+            Cloud& cloud = *cloud_ptr;
+            const long salt = exchange_batch_salt(mo_ket);
+            for (const Batch_1D& r : {next_col, next_row}) {
+                const long record = exchange_batch_record_key(salt, EXCHANGE_BATCH_VF, r);
+                if (cloud.batch_owner(record) == universe_rank_) continue;   // reads locally
+                if (batch_cache_.contains(record)) continue;                 // already resident
+                if (prefetch_current_.valid and prefetch_current_.key == record) continue;
+                prefetch_next_.key = record;
+                prefetch_next_.fut = cloud.request_batch_bytes_async(record);
+                prefetch_next_.valid = true;
+                break;                                                      // one per task
+            }
         }
 
         /// the owner-pinned path fetches its operand batches from the cloud itself

--- a/src/madness/chem/exchangeoperator.h
+++ b/src/madness/chem/exchangeoperator.h
@@ -7,6 +7,7 @@
 #include<madness/chem/SCFOperators.h>
 
 #include <algorithm>
+#include <fstream>
 #include <list>
 #include <map>
 #include <utility>
@@ -219,6 +220,77 @@ exchange_sym_cost_aware_assign(const long n, const long M, const std::vector<dou
         if (not improved) break;
     }
     return owner;
+}
+
+/// One task's record for the exchange profiler.
+
+/// Written only when MAD_EXCH_TASK_PROFILE is set. What it adds over the aggregate counters is
+/// **attribution**: the counters say how many batches arrived from where, this says which task
+/// waited and for how long, so a straggler can be identified rather than inferred.
+///
+/// It deliberately does not carry a per-stage breakdown of the compute (multiply / apply /
+/// multiply). That would mean timing calls inside the numerical kernels, and the aggregate split
+/// already exists in the operator's own timers.
+struct ExchTaskProfile {
+    long task_id = -1;
+    long universe_rank = 0;                 ///< keys the output file: one per process
+    unsigned long subworld_id = 0;
+    int subworld_nrank = 0;
+    double thresh = 0.0;                    ///< which protocol tier this task ran in
+    long k = 0;
+    bool diagonal = false;
+    long row_begin = 0, row_end = 0, col_begin = 0, col_end = 0;
+    double wall_start = 0.0, wall_end = 0.0;
+    double wait_for_data_wall = 0.0;        ///< task entry until its operands are in hand
+    double compute_wall = 0.0, compute_cpu = 0.0;
+    int operand_source = -1;                ///< worst of its fetches: 0 resident, 1 ahead, 2 cold
+    bool waited = false;                    ///< a cold fetch happened, so this task paid latency
+    double peak_rss_gb = 0.0;
+
+    void reset() { *this = ExchTaskProfile(); }
+    /// keep the worst source, since that is the one that set the task's wait
+    void observe_fetch_tier(const int tier) {
+        if (tier > operand_source) operand_source = tier;
+        if (tier == 2) waited = true;
+    }
+};
+
+/// Is per-task exchange profiling on? Read once per process.
+inline bool exch_task_profile_enabled() {
+    static const bool on = (std::getenv("MAD_EXCH_TASK_PROFILE") != nullptr);
+    return on;
+}
+
+/// Append one record to exch_taskprof.r<rank>.jsonl.
+
+/// The stream stays open for the life of the process: one file per rank appended across every
+/// application, which bounds the file count at the rank count however many iterations run, and
+/// avoids a per-task open/close -- expensive metadata traffic on a parallel filesystem.
+inline void exch_write_task_profile(const ExchTaskProfile& p) {
+    static std::ofstream os;
+    if (not os.is_open()) {
+        os.open("exch_taskprof.r" + std::to_string(p.universe_rank) + ".jsonl", std::ios::app);
+        if (not os.is_open()) return;
+    }
+    os << "{\"task\":" << p.task_id
+       << ",\"rank\":" << p.universe_rank
+       << ",\"subworld\":" << p.subworld_id
+       << ",\"subworld_nrank\":" << p.subworld_nrank
+       << ",\"thresh\":" << p.thresh
+       << ",\"k\":" << p.k
+       << ",\"diagonal\":" << (p.diagonal ? "true" : "false")
+       << ",\"row\":[" << p.row_begin << "," << p.row_end << "]"
+       << ",\"col\":[" << p.col_begin << "," << p.col_end << "]"
+       << ",\"wall_start\":" << p.wall_start
+       << ",\"wall\":" << (p.wall_end - p.wall_start)
+       << ",\"wait_for_data\":" << p.wait_for_data_wall
+       << ",\"compute_wall\":" << p.compute_wall
+       << ",\"compute_cpu\":" << p.compute_cpu
+       << ",\"operand_source\":" << p.operand_source
+       << ",\"waited\":" << (p.waited ? "true" : "false")
+       << ",\"peak_rss_gb\":" << p.peak_rss_gb
+       << "}\n";
+    os.flush();   // keep it readable mid-run; there is one write per task, not per node
 }
 
 /// which of the three exchange operand vectors a stored batch belongs to
@@ -696,6 +768,11 @@ private:
         static inline std::map<long,long> batch_begin_to_index_;   ///< batch offset -> index
         static inline long exchange_call_index_ = 0;
 
+        /// This task's profile record. NOT static: it belongs to the single operator() call on
+        /// this object, and the fetch writes into it through `this` during that call.
+        mutable ExchTaskProfile prof_;
+        static inline long prof_task_seq_ = 0;   ///< per-process task counter, for identity only
+
         /// Where this subworld's tile results are summed before they leave it, and where a
         /// node's subworlds are summed before that leaves the node. Static for the same reason
         /// the batch cache is -- each task batch is a separate object -- and so subject to the
@@ -774,6 +851,7 @@ private:
             ensure_cache_world(world);
             if (const vecfuncT* resident = batch_cache_.find(record)) {
                 ++batch_cache_hits_;
+                if (profile_active()) prof_.observe_fetch_tier(0);
                 return *resident;
             }
             const bool owned = (cloud.batch_owner(record) == universe_rank_);
@@ -784,10 +862,12 @@ private:
                             world, slot->fut, record, /*cache_result=*/false);
                     *slot = PrefetchSlot();
                     ++batch_prefetch_hits_;
+                    if (profile_active()) prof_.observe_fetch_tier(1);
                     return batch_cache_.insert(record, std::move(data), owned);
                 }
             }
             ++batch_cache_misses_;
+            if (profile_active()) prof_.observe_fetch_tier(2);
             vecfuncT data = cloud.template fetch_batch_p2p<T, NDIM>(world, record, /*cache_result=*/false);
             return batch_cache_.insert(record, std::move(data), owned);
         }
@@ -880,6 +960,8 @@ private:
         static long batch_cache_hits() { return batch_cache_hits_; }
         static long batch_cache_misses() { return batch_cache_misses_; }
         static long batch_prefetch_hits() { return batch_prefetch_hits_; }
+        /// per-task profiling on for this task?
+        bool profile_active() const { return owner_pinned and exch_task_profile_enabled(); }
         static std::vector<double>& cost_this_call() { return cost_this_call_; }
         /// make this call's measured costs the reference for the next one
         static void commit_cost_reference() { cost_reference_ = cost_this_call_; }
@@ -1226,6 +1308,20 @@ private:
             if (symmetric) MADNESS_CHECK(bra_range.end <= nresult);
 
             const double tile_wall_start = wall_time();
+            const bool profiling = profile_active();
+            if (profiling) {
+                prof_.reset();
+                prof_.task_id = prof_task_seq_++;
+                prof_.universe_rank = universe_rank_;
+                prof_.subworld_id = static_cast<unsigned long>(world.id());
+                prof_.subworld_nrank = world.size();
+                prof_.thresh = FunctionDefaults<NDIM>::get_thresh();
+                prof_.k = FunctionDefaults<NDIM>::get_k();
+                prof_.diagonal = diagonal_block;
+                prof_.row_begin = bra_range.begin; prof_.row_end = bra_range.end;
+                prof_.col_begin = vf_range.begin;  prof_.col_end = vf_range.end;
+                prof_.wall_start = tile_wall_start;
+            }
 
             // Owner-pinned: fetch the two batches this task needs from the cloud. Because
             // bra == ket == vf there, one batch per range serves every operand role, so the
@@ -1248,6 +1344,10 @@ private:
                 bra_work = &bra_owned;
                 vf_work = &vf_owned;
             }
+            // everything up to here was getting the operands in hand; everything after is compute
+            const double compute_wall_start = wall_time();
+            const double compute_cpu_start = process_cpu_time();
+            if (profiling) prof_.wait_for_data_wall = compute_wall_start - tile_wall_start;
 
             if (symmetric and diagonal_block) {
                 const vecfuncT ket_batch = owner_pinned ? *bra_work : bra_range.copy_batch(vket);
@@ -1278,6 +1378,15 @@ private:
             // this tile's cost, for the next call's placement. Keyed by its batch pair, so the
             // reference survives a different partition only if the pair count matches -- which
             // prepare_owner_assignment checks before using it.
+            if (profiling) {
+                prof_.compute_wall = wall_time() - compute_wall_start;
+                prof_.compute_cpu = process_cpu_time() - compute_cpu_start;
+                prof_.wall_end = wall_time();
+                prof_.peak_rss_gb = get_rss_usage_in_GB();
+                // one record per task, from the rank that ran it
+                if (world.rank() == 0) exch_write_task_profile(prof_);
+            }
+
             if (owner_pinned and not cost_this_call_.empty()) {
                 const auto ic = batch_begin_to_index_.find(vf_range.begin);
                 const auto jr = batch_begin_to_index_.find(bra_range.begin);

--- a/src/madness/chem/exchangeoperator.h
+++ b/src/madness/chem/exchangeoperator.h
@@ -317,6 +317,106 @@ private:
 };
 
 
+/// One coefficient node in transit during the exchange finalize.
+
+/// Carries the destination function index, the tree-node key and the whole node, which is
+/// the same content the per-node active message would have sent -- just batched.
+template <typename T, std::size_t NDIM>
+struct FinalizeNodeRec {
+    std::size_t f = 0;                  ///< index into the destination function vector
+    Key<NDIM> key;                      ///< tree-node key
+    FunctionNode<T, NDIM> node;         ///< the source node
+    template <typename Archive>
+    void serialize(Archive& ar) { ar & f & key & node; }
+};
+
+/// Receiving end of the exchange finalize, living in the world the transfer rides on.
+
+/// Sources push bulk chunks here with task(), so deserializing and accumulating happens on a
+/// worker and never on the communication thread. The arithmetic is the same as
+/// FunctionNode::gaxpy_inplace; the accessor write lock is what serializes two senders that
+/// reach the same key at once.
+template <typename T, std::size_t NDIM>
+class FinalizeReducer : public WorldObject<FinalizeReducer<T, NDIM>> {
+public:
+    typedef FunctionImpl<T, NDIM> implT;
+    typedef FinalizeNodeRec<T, NDIM> recT;
+
+    explicit FinalizeReducer(World& world)
+        : WorldObject<FinalizeReducer<T, NDIM>>(world) {
+        this->process_pending();
+    }
+
+    /// point at the destinations for the next drain; local, called by every rank
+    void set_targets(std::vector<implT*> dests, T beta) {
+        dests_ = std::move(dests);
+        beta_ = beta;
+    }
+
+    void accumulate_chunk(const std::vector<recT>& recs) {
+        for (const auto& r : recs) {
+            MADNESS_ASSERT(r.f < dests_.size() and dests_[r.f] != nullptr);
+            typename implT::dcT::accessor acc;
+            dests_[r.f]->get_coeffs().insert(acc, r.key);   // get-or-create, locks the key
+            acc->second.template gaxpy_inplace<T, T>(T(1.0), r.node, beta_);
+        }
+    }
+
+private:
+    std::vector<implT*> dests_;
+    T beta_ = T(1.0);
+};
+
+/// Accumulate `src_vec` into `dest_vec` in bulk, one message per destination rank per chunk.
+
+/// Replaces one active message per source tree node. The two vectors may live in different
+/// worlds -- subworld or node into universe, or subworld into node -- so routing uses the
+/// **destination** process map while the transfer rides `transport_world`, which must be the
+/// destination's world. Completion is the caller's own fence.
+///
+/// \warning Collective on `transport_world`: every rank must call it once per finalize. The
+///          fence below is a readiness barrier, so that no chunk can arrive at a rank that
+///          has not yet repointed its reducer. A rank whose `src_vec` is empty still has to
+///          reach it -- **do not add an early return for having nothing to send.**
+template <typename T, std::size_t NDIM>
+void coalesced_gaxpy(World& transport_world,
+                     FinalizeReducer<T, NDIM>& reducer,
+                     std::vector<Function<T, NDIM>>& dest_vec,
+                     std::vector<Function<T, NDIM>>& src_vec,
+                     const T beta,
+                     const std::size_t chunk_entries) {
+    typedef FunctionImpl<T, NDIM> implT;
+    typedef FinalizeNodeRec<T, NDIM> recT;
+
+    std::vector<implT*> dests(dest_vec.size(), nullptr);
+    for (std::size_t f = 0; f < dest_vec.size(); ++f)
+        dests[f] = dest_vec[f].get_impl().get();
+    reducer.set_targets(dests, beta);
+    transport_world.gop.fence();          // the readiness barrier -- see the warning above
+
+    std::map<ProcessID, std::vector<recT>> buckets;
+    const std::size_t nf = std::min(src_vec.size(), dest_vec.size());
+    for (std::size_t f = 0; f < nf; ++f) {
+        auto simpl = src_vec[f].get_impl();
+        auto dimpl = dest_vec[f].get_impl();
+        if (not simpl or not dimpl) continue;
+        const implT& dref = *dimpl;
+        for (auto it = simpl->get_coeffs().begin(); it != simpl->get_coeffs().end(); ++it) {
+            const ProcessID owner = dref.get_coeffs().owner(it->first);
+            std::vector<recT>& b = buckets[owner];
+            b.push_back(recT{f, it->first, it->second});
+            if (b.size() >= chunk_entries) {
+                reducer.task(owner, &FinalizeReducer<T, NDIM>::accumulate_chunk, b);
+                b.clear();
+            }
+        }
+    }
+    for (auto& kv : buckets)
+        if (not kv.second.empty())
+            reducer.task(kv.first, &FinalizeReducer<T, NDIM>::accumulate_chunk, kv.second);
+}
+
+
 template<typename T, std::size_t NDIM>
 class Exchange<T,NDIM>::ExchangeImpl {
     typedef Function<T, NDIM> functionT;
@@ -448,6 +548,12 @@ public:
         return *this;
     }
 
+    ExchangeImpl& set_accumulation_mode(const int mode) {
+        MADNESS_CHECK_THROW(mode == 1 or mode == 2, "exchange accumulation mode must be 1 or 2");
+        accumulation_mode_ = mode;
+        return *this;
+    }
+
     std::shared_ptr<MacroTaskQ> get_taskq() const {return taskq;}
 
     World& get_world() const {return world;}
@@ -504,6 +610,9 @@ private:
     /// batches per rank in the owner-pinned symmetric partition; 1 is the coarsest split
     /// and the one with the lowest peak memory
     long batch_granularity_ = 1;
+    /// how the tile results are gathered: 1 = subworld buffer then universe, 2 = also reduce
+    /// within a node first (default; degrades to 1 on a single node)
+    int accumulation_mode_ = 2;
 
     mutable nlohmann::json statistics;  ///< statistics of the Cloud (timings, memory)  and of the parameters of this run
 
@@ -516,6 +625,10 @@ private:
         /// pin each task to a rank that owns one of its batches, over the owner-pinned split
         bool owner_pinned = false;
         long granularity_level = 1;
+        /// 1 = sum into a subworld buffer and drain that into the universe;
+        /// 2 = additionally reduce within a node first, so only one rank per node scatters
+        ///     across nodes. Degrades to 1 automatically when there is a single node.
+        int accumulation_mode_ = 2;
         /// (column batch offset, row batch offset) -> owning rank, filled by
         /// prepare_owner_assignment and read by owner_hint
         std::map<std::pair<long,long>,long> owner_map_;
@@ -533,7 +646,45 @@ private:
         static inline std::atomic<long> batch_cache_hits_;
         static inline std::atomic<long> batch_cache_misses_;
 
+        /// Where this subworld's tile results are summed before they leave it, and where a
+        /// node's subworlds are summed before that leaves the node. Static for the same reason
+        /// the batch cache is -- each task batch is a separate object -- and so subject to the
+        /// same two lifetime rules: the world-id guards below stop a stale read, and cleanup()
+        /// releases them while their world is still alive. Neither alone is enough.
+        static inline vecfuncT Kf_local_;
+        static inline bool Kf_local_initialized_ = false;
+        static inline long Kf_local_world_id_ = -1;
+        static inline vecfuncT Kf_node_;
+        static inline bool Kf_node_initialized_ = false;
+        static inline long Kf_node_world_id_ = -1;
+        static inline std::shared_ptr<FinalizeReducer<T, NDIM>> universe_reducer_;
+        static inline std::shared_ptr<FinalizeReducer<T, NDIM>> node_reducer_;
+        /// each drain happens once per rank, not once per task object
+        static inline bool finalize_stage1_done_ = false;
+        static inline bool finalize_universe_done_ = false;
+
         static void clear_local_caches() { batch_cache_.clear(); }
+
+        /// entries per chunk in coalesced_gaxpy, sized so one message stays modest at any k
+        static std::size_t finalize_chunk_entries() {
+            const std::size_t k = FunctionDefaults<NDIM>::get_k();
+            const std::size_t per_node = std::size_t(1) << (2 * NDIM);   // (2k)^NDIM / k^NDIM bound
+            return std::max<std::size_t>(1, (1u << 20) / (per_node * k * k * k * sizeof(T) + 1));
+        }
+
+        /// One reducer per transport world, rebuilt when that world changes. Collective:
+        /// constructing a WorldObject is, so every rank of `world` reaches this together.
+        static FinalizeReducer<T, NDIM>& get_universe_reducer(World& world) {
+            if (not universe_reducer_ or universe_reducer_->get_world().id() != world.id())
+                universe_reducer_ = std::make_shared<FinalizeReducer<T, NDIM>>(world);
+            return *universe_reducer_;
+        }
+
+        static FinalizeReducer<T, NDIM>& get_node_reducer(World& world) {
+            if (not node_reducer_ or node_reducer_->get_world().id() != world.id())
+                node_reducer_ = std::make_shared<FinalizeReducer<T, NDIM>>(world);
+            return *node_reducer_;
+        }
 
         /// drop cached batches when the subworld changes; they belong to the old one
         void ensure_cache_world(World& world) const {
@@ -635,10 +786,11 @@ private:
     public:
         MacroTaskExchangeSimple(const long nresult, const double lo, const double mul_tol,
                                 const bool symmetric, const bool owner_pinned = false,
-                                const long granularity_level = 1, const long universe_rank = 0)
+                                const long granularity_level = 1, const long universe_rank = 0,
+                                const int accumulation_mode = 2)
                 : nresult(nresult), lo(lo), mul_tol(mul_tol), symmetric(symmetric),
                   owner_pinned(owner_pinned), granularity_level(granularity_level),
-                  universe_rank_(universe_rank) {
+                  accumulation_mode_(accumulation_mode), universe_rank_(universe_rank) {
             partitioner.reset(new MacroTaskPartitionerExchange(symmetric, owner_pinned, granularity_level));
             name="MacroTaskExchangeSimple";
         }
@@ -784,6 +936,129 @@ private:
         void cleanup() override {
             clear_local_caches();
             cache_world_id_ = -1;
+            // released here, while the subworld and node world still exist
+            Kf_local_.clear();
+            Kf_local_initialized_ = false;
+            Kf_local_world_id_ = -1;
+            Kf_node_.clear();
+            Kf_node_initialized_ = false;
+            Kf_node_world_id_ = -1;
+            finalize_stage1_done_ = false;
+            finalize_universe_done_ = false;
+        }
+
+        /// true if the task sums its own tile results and drains them in the finalize, rather
+        /// than the queue moving every tile result into the universe result by itself
+        bool accumulates_own_output() const override { return owner_pinned; }
+
+        /// true if the drain goes subworld -> node -> universe rather than straight to the
+        /// universe, so only one rank per node scatters across nodes
+        /// not an override: the queue reaches this through its optional-hook detection, since
+        /// the virtual it feeds lives on the internal task rather than on this base
+        bool wants_node_local_reduction() const {
+            return owner_pinned and accumulation_mode_ == 2;
+        }
+
+        /// The result entries this tile actually wrote.
+
+        /// operator() scatters into the bra range and the vf range of a full-width Kf and
+        /// leaves everything else zero, so summing all `nresult` entries would gaxpy mostly
+        /// zeros -- a per-tile cost proportional to the whole result vector. The union of the
+        /// two input ranges is a correct superset of every entry the tile touched; a full-size
+        /// or absent range falls back to all of them.
+        std::vector<long> touched_result_indices() const {
+            std::vector<long> idx;
+            auto add_range = [&](const Batch_1D& b) {
+                const long s = b.is_full_size() ? 0 : b.begin;
+                const long e = b.is_full_size() ? long(nresult) : b.end;
+                for (long i = s; i < e and i < long(nresult); ++i) idx.push_back(i);
+            };
+            if (batch.input.empty()) {
+                for (long i = 0; i < long(nresult); ++i) idx.push_back(i);
+                return idx;
+            }
+            add_range(batch.input[0]);
+            if (batch.input.size() > 1 and not (batch.input[1] == batch.input[0])) add_range(batch.input[1]);
+            return idx;
+        }
+
+        /// sum one tile's result into this subworld's accumulator
+        void accumulate_locally(World& subworld, const vecfuncT& result_subworld) const {
+            const long wid = long(subworld.id());
+            if (not Kf_local_initialized_ or Kf_local_world_id_ != wid) {
+                Kf_local_ = zero_functions_compressed<T, NDIM>(subworld, nresult);
+                Kf_local_initialized_ = true;
+                Kf_local_world_id_ = wid;
+            }
+            // shallow handles for just the entries this tile wrote; the rest are structurally
+            // zero, so skipping them is not an approximation
+            const std::vector<long> touched = touched_result_indices();
+            vecfuncT rs_sub, kf_sub;
+            rs_sub.reserve(touched.size());
+            kf_sub.reserve(touched.size());
+            for (long i : touched) { rs_sub.push_back(result_subworld[i]); kf_sub.push_back(Kf_local_[i]); }
+            if (rs_sub.empty()) return;
+            const TreeState op_state =
+                    rs_sub[0].get_impl()->get_tensor_type() == TT_FULL ? compressed : reconstructed;
+            change_tree_state(rs_sub, op_state);
+            gaxpy(1.0, kf_sub, 1.0, rs_sub, false);   // mutates kf_sub[k] == Kf_local_[touched[k]]
+        }
+
+        /// Collectively (re)build the node-shared accumulator in the node world.
+
+        /// Must be reached by every rank of `nodeworld`, since constructing a Function is
+        /// collective; the queue drives this uniformly across the replicated task list, so the
+        /// initialized flag flips in lockstep. The process map is passed explicitly because the
+        /// process-wide default is the subworld's during the finalize -- inheriting it would map
+        /// keys to subworld rank indices for functions that live in the node world.
+        void ensure_node_accumulator(World& nodeworld) const {
+            const long wid = long(nodeworld.id());
+            if (Kf_node_initialized_ and Kf_node_world_id_ == wid) return;
+            auto node_pmap = FunctionDefaults<NDIM>::make_default_pmap(nodeworld);
+            Kf_node_.resize(nresult);
+            for (long i = 0; i < nresult; ++i)
+                Kf_node_[i] = functionT(FunctionFactory<T, NDIM>(nodeworld)
+                                                .pmap(node_pmap)
+                                                .compressed(true)
+                                                .fence(false));
+            nodeworld.gop.fence();
+            Kf_node_initialized_ = true;
+            Kf_node_world_id_ = wid;
+        }
+
+        /// reduce this subworld's accumulator into the node-shared one
+        void finalize_stage1(World& subworld, World* nodeworld) {
+            if (not nodeworld) return;                 // one node: stage 2 drains directly
+            if (finalize_stage1_done_) return;
+            finalize_stage1_done_ = true;
+            ensure_node_accumulator(*nodeworld);       // collective on the node
+            if (Kf_local_initialized_) change_tree_state(Kf_local_, compressed);
+            vecfuncT empty;
+            vecfuncT& src = Kf_local_initialized_ ? Kf_local_ : empty;
+            coalesced_gaxpy<T, NDIM>(*nodeworld, get_node_reducer(*nodeworld),
+                                     Kf_node_, src, T(1.0), finalize_chunk_entries());
+        }
+
+        /// drain into the universe result, from the node accumulator if there is one
+        void finalize_stage2(World& subworld, World* nodeworld, vecfuncT& universe_result) {
+            if (finalize_universe_done_) return;
+            finalize_universe_done_ = true;
+            if (universe_result.empty()) return;
+            World& universe = universe_result.front().world();
+            vecfuncT empty;
+            vecfuncT* src = &empty;
+            if (nodeworld) {
+                if (Kf_node_initialized_) src = &Kf_node_;
+            } else {
+                if (Kf_local_initialized_) {
+                    change_tree_state(Kf_local_, compressed);
+                    src = &Kf_local_;
+                }
+            }
+            // every rank reaches this, including ones with nothing to send -- coalesced_gaxpy
+            // is collective on the universe
+            coalesced_gaxpy<T, NDIM>(universe, get_universe_reducer(universe),
+                                     universe_result, *src, T(1.0), finalize_chunk_entries());
         }
 
 

--- a/src/madness/chem/exchangeoperator.h
+++ b/src/madness/chem/exchangeoperator.h
@@ -6,11 +6,210 @@
 #include<madness/mra/macrotaskq.h>
 #include<madness/chem/SCFOperators.h>
 
+#include <algorithm>
+#include <map>
+#include <utility>
+#include <vector>
+
 namespace madness {
 
 // forward declaration
 class SCF;
 class Nemo;
+
+/// Number of batches M for the owner-pinned symmetric exchange algorithm.
+
+/// M = granularity_level * nsubworld, so the level is directly the number of batches per
+/// rank and every level is selectable regardless of nsubworld parity. Clamped to [1, n]:
+/// there cannot be more batches than orbitals, and a caller that hits the clamp is in the
+/// small-problem regime where batches stop being one-per-rank.
+///
+/// Batch k is owned by rank (k mod nsubworld), so away from the clamp every rank owns
+/// exactly `granularity_level` batches.
+inline long exchange_sym_owner_nbatch(const std::size_t n, const long nsubworld,
+                                      const long granularity_level) {
+    if (n == 0) return 0;
+    const long nsw = std::max<long>(1, nsubworld);
+    const long level = std::max<long>(1, granularity_level);
+    return std::min<long>(level * nsw, long(n));
+}
+
+/// Split a vector of length n into M = exchange_sym_owner_nbatch(...) contiguous batches.
+
+/// Sizes differ by at most 1; the first (n mod M) batches get the extra element, which
+/// avoids a runt batch of 1. Single source of truth for the symmetric owner-pinned batch
+/// boundaries — the task grid, the cloud batch storage and the owner assignment all derive
+/// from it, so they align by construction. Depends only on (n, nsubworld, granularity_level).
+inline std::vector<Batch_1D> exchange_sym_owner_split(const std::size_t n, const long nsubworld,
+                                                      const long granularity_level) {
+    std::vector<Batch_1D> out;
+    if (n == 0) return out;
+    const long nbatch = std::max<long>(1, exchange_sym_owner_nbatch(n, nsubworld, granularity_level));
+    const long bs_floor = long(n) / nbatch;
+    const long rem = long(n) - bs_floor * nbatch;
+    long begin = 0;
+    for (long b = 0; b < nbatch; ++b) {
+        const long sz = bs_floor + (b < rem ? 1 : 0);
+        out.emplace_back(begin, begin + sz);
+        begin += sz;
+    }
+    return out;
+}
+
+/// Triangular index of a batch pair, collapsing (i,j) and (j,i): a*(a+1)/2 + b.
+
+/// The indexing convention of the per-task cost vector, shared by whoever records a
+/// measured cost and by exchange_sym_cost_aware_assign, which consumes it.
+inline long exchange_sym_tri(const long i, const long j) {
+    const long a = std::max(i, j), b = std::min(i, j);
+    return a * (a + 1) / 2 + b;
+}
+
+/// Round-robin owner assignment for the symmetric algorithm's triangular task matrix.
+
+/// Pure function of (n, M): n workers (= nsubworld), M batches, batch k owned by (k mod n).
+/// Task (i,j) with 0 <= j <= i < M is eligible for worker t iff
+///   i==j: (i mod n)==t                    -- a diagonal task has a single owner
+///   i!=j: (i mod n)==t or (j mod n)==t    -- the worker owns at least one operand
+/// Eligibility is what makes the assignment fetch-free: a task always lands on a worker
+/// that already stores one of its two batches. Phase 1 round-robins eligible tasks across
+/// workers; phase 2 then rebalances off-diagonal tasks (diagonals never move) toward a
+/// task-count spread of 1.
+///
+/// Phase 2 is best effort, not a guarantee: it can only move a task to a worker the task
+/// is eligible for, so it stops early when the hottest worker holds nothing the coldest
+/// ones may take. The residual spread is 2 rather than 1 for some (n, M) — measured over
+/// n <= 128 and 1 to 3 batches per rank, never worse than 2.
+///
+/// \return map (i,j) -> owner. Deterministic, so every rank computes the same assignment
+///         without communicating.
+inline std::map<std::pair<long,long>,long>
+exchange_sym_round_robin_assign(const long n, const long M) {
+    std::map<std::pair<long,long>,long> owner;
+    if (n <= 0 or M <= 0) return owner;
+    auto eligible = [n](long i, long j, long t) -> bool {
+        if (i == j) return (i % n) == t;
+        return ((i % n) == t) or ((j % n) == t);
+    };
+    // all tasks, ascending by (i,j)
+    std::vector<std::pair<long,long>> remaining;
+    remaining.reserve(std::size_t(M) * std::size_t(M + 1) / 2);
+    for (long i = 0; i < M; ++i)
+        for (long j = 0; j <= i; ++j)
+            remaining.emplace_back(i, j);
+
+    std::vector<std::vector<std::pair<long,long>>> T(n);
+
+    // Phase 1 — round-robin placement
+    long t = 0, misses = 0;
+    while (not remaining.empty() and misses < n) {
+        long picked = -1;
+        for (long idx = 0; idx < long(remaining.size()); ++idx) {
+            if (eligible(remaining[idx].first, remaining[idx].second, t)) { picked = idx; break; }
+        }
+        if (picked >= 0) {
+            T[t].push_back(remaining[picked]);
+            remaining.erase(remaining.begin() + picked);
+            misses = 0;
+        } else {
+            ++misses;
+        }
+        t = (t + 1) % n;
+    }
+    // any leftovers; every task is eligible for someone, so this should not trigger
+    for (const auto& task : remaining) T[task.first % n].push_back(task);
+
+    // Phase 2 — rebalance until the spread is <= 1 (the iteration cap is a backstop)
+    for (long iter = 0; iter < 10000; ++iter) {
+        long big = 0, small = 0;
+        for (long p = 1; p < n; ++p) {
+            if (long(T[p].size()) > long(T[big].size())) big = p;
+            if (long(T[p].size()) < long(T[small].size())) small = p;
+        }
+        if (long(T[big].size()) - long(T[small].size()) <= 1) break;
+        bool moved = false;
+        std::vector<long> order(n);
+        for (long p = 0; p < n; ++p) order[p] = p;
+        std::sort(order.begin(), order.end(),
+                  [&T](long a, long b){ return T[a].size() > T[b].size(); });
+        for (long bi = 0; bi < n and not moved; ++bi) {
+            for (long si = n - 1; si > bi and not moved; --si) {
+                const long bt = order[bi], st = order[si];
+                if (long(T[bt].size()) - long(T[st].size()) <= 1) continue;
+                for (long idx = 0; idx < long(T[bt].size()); ++idx) {
+                    const auto& tk = T[bt][idx];
+                    if (tk.first == tk.second) continue;           // never move diagonals
+                    if (not eligible(tk.first, tk.second, st)) continue;
+                    T[st].push_back(tk);
+                    T[bt].erase(T[bt].begin() + idx);
+                    moved = true;
+                    break;
+                }
+            }
+        }
+        if (not moved) break;   // accept the residual imbalance
+    }
+
+    for (long p = 0; p < n; ++p)
+        for (const auto& tk : T[p])
+            owner[tk] = p;
+    return owner;
+}
+
+/// Cost-aware owner assignment for the symmetric algorithm's triangular task matrix.
+
+/// Same ownership and eligibility as exchange_sym_round_robin_assign, so the fetch-free
+/// invariant is preserved, but it balances per-worker total COST instead of task COUNT.
+/// Screening makes the tasks strongly inhomogeneous for large molecules, and that is what
+/// a count-based assignment cannot see. `cost` is indexed by exchange_sym_tri and holds a
+/// relative per-task cost, in practice the previous call's measured wall time; entries
+/// past its end count as zero, so an empty or short vector degrades to cost-blind.
+/// Greedy largest-cost-first onto the less loaded eligible worker, then a bounded local
+/// search that relieves the hottest worker.
+///
+/// \return map (i,j) -> owner. Deterministic given the same `cost`.
+inline std::map<std::pair<long,long>,long>
+exchange_sym_cost_aware_assign(const long n, const long M, const std::vector<double>& cost) {
+    std::map<std::pair<long,long>,long> owner;
+    if (n <= 0 or M <= 0) return owner;
+    auto C = [&](long i, long j) -> double {
+        const long t = exchange_sym_tri(i, j); return (t < long(cost.size())) ? cost[t] : 0.0;
+    };
+    std::vector<double> load(n, 0.0);
+    // diagonals first: they have no choice of owner
+    for (long i = 0; i < M; ++i) { const long r = i % n; load[r] += C(i,i); owner[{i,i}] = r; }
+    // off-diagonals, largest cost first, ties broken by (i,j) to stay deterministic
+    std::vector<std::pair<long,long>> off;
+    off.reserve(std::size_t(M) * std::size_t(M > 0 ? M - 1 : 0) / 2);
+    for (long i = 0; i < M; ++i) for (long j = 0; j < i; ++j) off.emplace_back(i, j);
+    std::sort(off.begin(), off.end(), [&](const std::pair<long,long>& A, const std::pair<long,long>& B){
+        const double ca = C(A.first,A.second), cb = C(B.first,B.second);
+        return (ca != cb) ? (ca > cb) : (A < B);
+    });
+    for (const auto& [i,j] : off) {
+        const long ri = i % n, rj = j % n;
+        const long r = (ri == rj) ? ri : (load[ri] <= load[rj] ? ri : rj);
+        owner[{i,j}] = r; load[r] += C(i,j);
+    }
+    // relieve the hottest worker by flipping its off-diagonals to their other eligible owner
+    for (long pass = 0; pass < 50; ++pass) {
+        long hot = 0; for (long p = 1; p < n; ++p) if (load[p] > load[hot]) hot = p;
+        bool improved = false;
+        for (const auto& [i,j] : off) {
+            auto it = owner.find({i,j});
+            if (it->second != hot) continue;
+            const long ri = i % n, rj = j % n;
+            if (ri == rj) continue;                          // no choice
+            const long other = (hot == ri) ? rj : ri;
+            const double c = C(i,j);
+            if (load[other] + c < load[hot]) {               // strictly lowers the hot worker
+                load[hot] -= c; load[other] += c; it->second = other; improved = true;
+            }
+        }
+        if (not improved) break;
+    }
+    return owner;
+}
 
 
 template<typename T, std::size_t NDIM>

--- a/src/madness/chem/test_exchange_batch_cache.cc
+++ b/src/madness/chem/test_exchange_batch_cache.cc
@@ -1,0 +1,122 @@
+/// \file test_exchange_batch_cache.cc
+/// \brief tests the exchange operator's batch record keys and its bounded batch cache
+
+#include <madness/chem/exchangeoperator.h>
+#include <madness/world/test_utilities.h>
+
+#include <set>
+#include <string>
+#include <vector>
+
+using namespace madness;
+
+using cacheT = ExchangeBatchLRU<long, std::string>;
+
+int test_record_keys() {
+    test_output t1("testing exchange batch record keys");
+
+    const long salt = 0x1234;
+    const Batch_1D r0(0, 5), r1(5, 10);
+
+    t1.checkpoint(exchange_batch_record_key(salt, EXCHANGE_BATCH_VF, r0)
+                          == exchange_batch_record_key(salt, EXCHANGE_BATCH_VF, r0),
+                  "the same batch derives the same key, so store and fetch agree");
+
+    // the three operand vectors and every batch range must map to distinct records --
+    // a collision would silently serve one operand's coefficients as another's
+    std::set<long> keys;
+    long ncase = 0;
+    for (int dim : {EXCHANGE_BATCH_VF, EXCHANGE_BATCH_BRA, EXCHANGE_BATCH_KET}) {
+        for (long begin = 0; begin < 40; ++begin) {
+            for (long len = 1; len <= 4; ++len) {
+                keys.insert(exchange_batch_record_key(salt, dim, Batch_1D(begin, begin + len)));
+                ++ncase;
+            }
+        }
+    }
+    t1.checkpoint(long(keys.size()) == ncase, "distinct dimension/range pairs give distinct keys");
+
+    t1.checkpoint(exchange_batch_record_key(salt, EXCHANGE_BATCH_VF, r0)
+                          != exchange_batch_record_key(salt + 1, EXCHANGE_BATCH_VF, r0),
+                  "a different salt gives a different key, so records of one application "
+                  "cannot be served to another");
+    t1.checkpoint(exchange_batch_record_key(salt, EXCHANGE_BATCH_VF, r0)
+                          != exchange_batch_record_key(salt, EXCHANGE_BATCH_VF, r1),
+                  "adjacent ranges of the same operand give different keys");
+
+    return t1.end();
+}
+
+int test_batch_cache() {
+    test_output t1("testing the exchange batch cache");
+
+    cacheT cache;
+    cache.set_transient_capacity(2);
+
+    t1.checkpoint(cache.find(1) == nullptr, "a miss on an empty cache returns nothing");
+
+    cache.insert(1, "one", false);
+    const std::string* hit = cache.find(1);
+    t1.checkpoint(hit != nullptr and *hit == "one", "an inserted batch is found again");
+
+    // transient entries are bounded: inserting a third evicts the least recently used
+    cache.insert(2, "two", false);
+    cache.insert(3, "three", false);
+    t1.checkpoint(cache.n_transient() == 2 and not cache.contains(1) and
+                  cache.contains(2) and cache.contains(3),
+                  "transient entries are held to the capacity, evicting least-recently-used");
+
+    // ... and a hit renews an entry, so it is no longer the eviction candidate
+    cache.find(2);
+    cache.insert(4, "four", false);
+    t1.checkpoint(cache.contains(2) and cache.contains(4) and not cache.contains(3),
+                  "a hit renews an entry, so the untouched one is evicted instead");
+
+    // owned batches are pinned: they survive any amount of transient churn, which is the
+    // point -- a rank reuses its own batch across all of its tasks
+    cacheT pinned;
+    pinned.set_transient_capacity(1);
+    pinned.insert(100, "owned-a", true);
+    pinned.insert(101, "owned-b", true);
+    for (long k = 0; k < 20; ++k) pinned.insert(k, "transient", false);
+    t1.checkpoint(pinned.contains(100) and pinned.contains(101),
+                  "pinned batches are never evicted, however many transients churn through");
+    t1.checkpoint(pinned.n_transient() == 1 and pinned.size() == 3,
+                  "pinning does not enlarge the transient budget");
+    const std::string* owned = pinned.find(100);
+    t1.checkpoint(owned != nullptr and *owned == "owned-a", "a pinned batch is still readable");
+
+    // capacity 0 would mean no transient could ever be held, so it is raised to one
+    cacheT tiny;
+    tiny.set_transient_capacity(0);
+    tiny.insert(7, "seven", false);
+    t1.checkpoint(tiny.transient_capacity() == 1 and tiny.contains(7),
+                  "a zero capacity is raised to one rather than evicting on insert");
+
+    // references must survive promotion and insertion of other entries, since a caller
+    // holds the fetched batch while the next fetch happens
+    cacheT stable;
+    stable.set_transient_capacity(4);
+    const std::string& ref = stable.insert(1, "first", true);
+    stable.insert(2, "second", false);
+    stable.find(2);
+    stable.insert(3, "third", false);
+    t1.checkpoint(ref == "first", "a returned reference stays valid as other entries come and go");
+
+    cache.clear();
+    t1.checkpoint(cache.size() == 0 and cache.transient_capacity() == 2,
+                  "clear drops the entries but keeps the configured capacity");
+
+    return t1.end();
+}
+
+int main(int argc, char** argv) {
+    madness::initialize(argc, argv);
+    int result = 0;
+    result += test_record_keys();
+    result += test_batch_cache();
+    if (result == 0) print("\n --> all tests \033[32m passed \033[0m \n");
+    else print("\n --> all tests \033[31m failed \033[0m \n");
+    madness::finalize();
+    return result;
+}

--- a/src/madness/chem/test_exchange_owner_assign.cc
+++ b/src/madness/chem/test_exchange_owner_assign.cc
@@ -1,0 +1,157 @@
+/// \file test_exchange_owner_assign.cc
+/// \brief tests the pure batch-splitting and owner-assignment helpers of the exchange operator
+
+#include <madness/chem/exchangeoperator.h>
+#include <madness/world/test_utilities.h>
+
+#include <cmath>
+#include <map>
+#include <set>
+#include <vector>
+
+using namespace madness;
+
+namespace {
+
+/// the property that makes owner-pinning fetch-free: a task's owner stores one of its batches
+bool owner_is_eligible(const long i, const long j, const long owner, const long n) {
+    if (i == j) return owner == (i % n);
+    return owner == (i % n) or owner == (j % n);
+}
+
+/// every triangular task assigned exactly once, and always to an eligible worker
+bool assignment_is_valid(const std::map<std::pair<long,long>,long>& owner,
+                         const long n, const long M) {
+    if (owner.size() != std::size_t(M) * std::size_t(M + 1) / 2) return false;
+    for (long i = 0; i < M; ++i) {
+        for (long j = 0; j <= i; ++j) {
+            auto it = owner.find({i, j});
+            if (it == owner.end()) return false;
+            if (it->second < 0 or it->second >= n) return false;
+            if (not owner_is_eligible(i, j, it->second, n)) return false;
+        }
+    }
+    return true;
+}
+
+std::vector<long> task_counts(const std::map<std::pair<long,long>,long>& owner, const long n) {
+    std::vector<long> c(n, 0);
+    for (const auto& [task, r] : owner) ++c[r];
+    return c;
+}
+
+double max_load(const std::map<std::pair<long,long>,long>& owner, const long n,
+                const std::vector<double>& cost) {
+    std::vector<double> load(n, 0.0);
+    for (const auto& [task, r] : owner) load[r] += cost[exchange_sym_tri(task.first, task.second)];
+    return *std::max_element(load.begin(), load.end());
+}
+
+/// a cost model with the inhomogeneity screening actually produces: a few expensive
+/// batches (compact core orbitals) among cheap ones, so a pair's cost is set by its operands
+std::vector<double> hot_batch_cost(const long M, const std::set<long>& hot) {
+    std::vector<double> cost(std::size_t(M) * std::size_t(M + 1) / 2, 0.0);
+    auto weight = [&hot](long k) { return hot.count(k) ? 10.0 : 1.0; };
+    for (long i = 0; i < M; ++i)
+        for (long j = 0; j <= i; ++j)
+            cost[exchange_sym_tri(i, j)] = weight(i) * weight(j);
+    return cost;
+}
+
+}   // namespace
+
+int test_batch_split() {
+    test_output t1("testing exchange_sym_owner_split");
+
+    t1.checkpoint(exchange_sym_owner_nbatch(0, 8, 1) == 0, "no batches for an empty vector");
+    t1.checkpoint(exchange_sym_owner_split(0, 8, 1).empty(), "empty split for an empty vector");
+    t1.checkpoint(exchange_sym_owner_nbatch(40, 8, 1) == 8, "level 1 gives one batch per rank");
+    t1.checkpoint(exchange_sym_owner_nbatch(40, 8, 3) == 24, "level 3 gives three batches per rank");
+    t1.checkpoint(exchange_sym_owner_nbatch(5, 8, 2) == 5, "clamped: never more batches than orbitals");
+    t1.checkpoint(exchange_sym_owner_nbatch(40, 0, 0) == 1, "degenerate rank/level counts clamp to 1");
+
+    bool ok = true;
+    for (long n = 1; n <= 64; ++n) {
+        for (long nsw : {1L, 2L, 3L, 8L, 40L}) {
+            for (long level : {1L, 2L, 5L}) {
+                const auto split = exchange_sym_owner_split(n, nsw, level);
+                const long M = exchange_sym_owner_nbatch(n, nsw, level);
+                if (long(split.size()) != M) ok = false;
+                long covered = 0, mn = n, mx = 0, expect_begin = 0;
+                for (const auto& b : split) {
+                    if (b.begin != expect_begin) ok = false;      // contiguous, no gap or overlap
+                    if (b.size() <= 0) ok = false;                // no empty batch
+                    mn = std::min(mn, b.size());
+                    mx = std::max(mx, b.size());
+                    covered += b.size();
+                    expect_begin = b.end;
+                }
+                if (covered != n) ok = false;                     // covers [0,n)
+                if (mx - mn > 1) ok = false;                      // sizes differ by at most one
+            }
+        }
+    }
+    t1.checkpoint(ok, "splits are contiguous, cover [0,n), and are balanced to within one");
+    return t1.end();
+}
+
+int test_owner_assignment() {
+    test_output t1("testing exchange owner assignment");
+
+    bool rr_valid = true, ca_valid = true, spread_ok = true;
+    for (long n : {1L, 2L, 3L, 8L, 13L}) {
+        for (long level : {1L, 2L, 3L}) {
+            const long M = n * level;
+            const auto rr = exchange_sym_round_robin_assign(n, M);
+            if (not assignment_is_valid(rr, n, M)) rr_valid = false;
+            const auto counts = task_counts(rr, n);
+            const long spread = *std::max_element(counts.begin(), counts.end())
+                              - *std::min_element(counts.begin(), counts.end());
+            if (spread > 2) spread_ok = false;
+
+            const auto cost = hot_batch_cost(M, {0, 1});
+            if (not assignment_is_valid(exchange_sym_cost_aware_assign(n, M, cost), n, M)) ca_valid = false;
+        }
+    }
+    t1.checkpoint(rr_valid, "round-robin assigns every task once to an eligible owner");
+    t1.checkpoint(ca_valid, "cost-aware assigns every task once to an eligible owner");
+    // phase 2 aims for a spread of 1 but may only move a task to a worker it is eligible
+    // for, so it stops early on some (n, M); 2 is the bound observed over the sweep
+    t1.checkpoint(spread_ok, "round-robin balances the task count to within two");
+
+    t1.checkpoint(exchange_sym_round_robin_assign(0, 8).empty() and
+                  exchange_sym_round_robin_assign(8, 0).empty(),
+                  "degenerate worker or batch counts give an empty assignment");
+
+    // an empty cost vector must still produce a usable assignment -- the first two exchange
+    // calls have no measured cost yet
+    t1.checkpoint(assignment_is_valid(exchange_sym_cost_aware_assign(8, 16, {}), 8, 16),
+                  "cost-aware degrades gracefully with no cost information");
+
+    t1.checkpoint(exchange_sym_round_robin_assign(8, 16) == exchange_sym_round_robin_assign(8, 16) and
+                  exchange_sym_cost_aware_assign(8, 16, hot_batch_cost(16, {0, 1}))
+                          == exchange_sym_cost_aware_assign(8, 16, hot_batch_cost(16, {0, 1})),
+                  "both are deterministic, so every rank agrees without communicating");
+
+    // the reason the cost-aware strategy exists: with inhomogeneous tasks, balancing the
+    // count leaves the worker holding the expensive batches as the straggler
+    const long n = 8, M = 16;
+    const auto cost = hot_batch_cost(M, {0, 8});      // both hot batches round-robin onto worker 0
+    const double rr_max = max_load(exchange_sym_round_robin_assign(n, M), n, cost);
+    const double ca_max = max_load(exchange_sym_cost_aware_assign(n, M, cost), n, cost);
+    print("max per-worker cost: round-robin", rr_max, " cost-aware", ca_max);
+    t1.checkpoint(ca_max < rr_max, "cost-aware lowers the peak load on an inhomogeneous cost model");
+
+    return t1.end();
+}
+
+int main(int argc, char** argv) {
+    madness::initialize(argc, argv);
+    int result = 0;
+    result += test_batch_split();
+    result += test_owner_assignment();
+    if (result == 0) print("\n --> all tests \033[32m passed \033[0m \n");
+    else print("\n --> all tests \033[31m failed \033[0m \n");
+    madness::finalize();
+    return result;
+}

--- a/src/madness/mra/macrotaskq.h
+++ b/src/madness/mra/macrotaskq.h
@@ -324,6 +324,13 @@ struct MacroTaskInfo {
 			info.storage_policy=MacroTaskInfo::StoreFunctionViaPointer;
 			info.cloud_distribution_policy=DistributionType::RankReplicated;
 			info.ptr_target_distribution_policy=DistributionType::Distributed;
+		} else if (name=="small_memory_owner") {
+			// for tasks that fetch their own operands: the cloud holds pointers and the
+			// queue does not copy coefficients into the subworld, see
+			// handles_own_data_movement
+			info.storage_policy=MacroTaskInfo::StorePointerToFunction;
+			info.cloud_distribution_policy=DistributionType::RankReplicated;
+			info.ptr_target_distribution_policy=DistributionType::Distributed;
 		} else if (name=="large_memory") {
 			info.storage_policy=MacroTaskInfo::StoreFunction;
 			info.cloud_distribution_policy=DistributionType::RankReplicated;
@@ -336,7 +343,7 @@ struct MacroTaskInfo {
 	}
 
 	static std::vector<std::string> get_all_preset_names() {
-		return {"default","node_replicated_target","small_memory","large_memory"};
+		return {"default","node_replicated_target","small_memory","small_memory_owner","large_memory"};
 	}
 
 	/// helper function to return all presets
@@ -1377,6 +1384,8 @@ private:
             argtupleT batched_argtuple = task.batch.copy_input_batch(argtuple);
 
             task.subworld_ptr=&subworld;
+            // before the prefetch hook, which fetches through it
+            task.cloud_ptr=&cloud;
             // pre-compute: let the task prefetch what the next task it owns will need, so the
             // transfer overlaps this task's compute
             {
@@ -1390,7 +1399,14 @@ private:
 
     		std::string msg="";
 			// maybe move this block to the cloud?
-    		if (policy.storage_policy==MacroTaskInfo::StoreFunctionViaPointer) {
+			// A task that fetches its own operands must not have them copied in as well --
+			// that would pay for the coefficients twice, once per task instead of once per
+			// owned batch, which is the cost the owner-pinned path exists to avoid.
+			const bool need_auto_copy =
+				(policy.storage_policy==MacroTaskInfo::StoreFunctionViaPointer) or
+				(policy.storage_policy==MacroTaskInfo::StorePointerToFunction
+					and not task.handles_own_data_movement());
+    		if (need_auto_copy) {
     			double cpu0=wall_time();
     			Cloud::cloudtimer timer(subworld,cloud.copy_time);
     			// the functions loaded from the cloud are pointers to the universe functions,
@@ -1474,6 +1490,7 @@ private:
 
     	// this is called after all tasks have been executed and the taskq has ended
     	void cleanup() override {
+    		task.cleanup();
     	}
 
     	template<typename T, std::size_t NDIM>
@@ -1576,6 +1593,9 @@ class MacroTaskOperationBase {
 public:
     Batch batch;
 	World* subworld_ptr=0;
+	/// set by MacroTaskInternal::run before the task body runs, so a task that moves its
+	/// own operands (see handles_own_data_movement) can fetch them from the cloud itself
+	Cloud* cloud_ptr=0;
 	std::string name="unknown_task";
     std::shared_ptr<MacroTaskPartitioner> partitioner=0;
     MacroTaskOperationBase() : batch(Batch(_, _, _)), partitioner(new MacroTaskPartitioner) {}
@@ -1593,6 +1613,15 @@ public:
 
     /// true if the task moves its operand coefficients into the subworld itself
     virtual bool handles_own_data_movement() const { return false; }
+
+    /// release whatever the task kept across its batches, called once the queue has run
+
+    /// A task class that caches operands between its batches has to keep them in static
+    /// state, since each batch is a separate task object. This is where that state must be
+    /// dropped: it still refers to the subworld the batches were built in, and that
+    /// subworld is destroyed after the queue finishes. Clearing it later means destroying
+    /// function implementations whose world is already gone.
+    virtual void cleanup() {}
 };
 
 

--- a/src/madness/mra/macrotaskq.h
+++ b/src/madness/mra/macrotaskq.h
@@ -1357,22 +1357,14 @@ private:
         }
 
     	/// called by the MacroTaskQ when the task is scheduled
-        void run(World &subworld, Cloud &cloud, MacroTaskBase::taskqT &taskq, const long element, const bool debug,
-        	const MacroTaskInfo policy) override {
-        	// per-task files are a debugging aid and become thousands at fine granularity; a
-        	// failing task still reports on the terminal regardless, see the catch below
-        	const auto io_mode = debug ? io_redirect::Mode::File : io_redirect::Mode::Discard;
-        	io_redirect io(io_mode, element, get_name()+"_output", get_name()+"_task", debug);
-        	// The try covers the whole body, not just the compute: a throw while loading the
-        	// inputs or issuing a prefetch would otherwise escape uninstrumented and be
-        	// reported by the task backend with no task id and no what().
-        	try {
-            const argtupleT argtuple = cloud.load<argtupleT>(subworld, inputrecords);
-            argtupleT batched_argtuple = task.batch.copy_input_batch(argtuple);
 
-            task.subworld_ptr=&subworld;
-            // before the prefetch hook, which fetches through it
-            task.cloud_ptr=&cloud;
+    	/// Let this task start the transfer its successor will need.
+
+    	/// Called before the task body so the request overlaps this task's compute. The successor is
+    	/// the next task in the queue this rank owns; a task that declares no prefetch hook does
+    	/// nothing here.
+    	void prefetch_for_next_task(World& subworld, const argtupleT& argtuple,
+    	                            MacroTaskBase::taskqT& taskq, const long element) {
             // pre-compute: let the task prefetch what the next task it owns will need, so the
             // transfer overlaps this task's compute
             {
@@ -1388,8 +1380,11 @@ private:
                                                   next_col, next_row, has_next);
                 }
             }
+    	}
 
-    		std::string msg="";
+    	/// Bring the operand coefficients into the subworld, unless the task does that itself.
+    	void copy_operands_into_subworld(World& subworld, Cloud& cloud, argtupleT& batched_argtuple,
+    	                                 const MacroTaskInfo& policy, const bool debug) {
 			// maybe move this block to the cloud?
 			// A task that fetches its own operands must not have them copied in as well --
 			// that would pay for the coefficients twice, once per task instead of once per
@@ -1423,6 +1418,27 @@ private:
     				print("copied coefficients for task",get_name(),"in",cpu1-cpu0,"seconds");
     			}
     		}
+    	}
+
+        void run(World &subworld, Cloud &cloud, MacroTaskBase::taskqT &taskq, const long element, const bool debug,
+        	const MacroTaskInfo policy) override {
+        	// per-task files are a debugging aid and become thousands at fine granularity; a
+        	// failing task still reports on the terminal regardless, see the catch below
+        	const auto io_mode = debug ? io_redirect::Mode::File : io_redirect::Mode::Discard;
+        	io_redirect io(io_mode, element, get_name()+"_output", get_name()+"_task", debug);
+        	// The try covers the whole body, not just the compute: a throw while loading the
+        	// inputs or issuing a prefetch would otherwise escape uninstrumented and be
+        	// reported by the task backend with no task id and no what().
+        	try {
+            const argtupleT argtuple = cloud.load<argtupleT>(subworld, inputrecords);
+            argtupleT batched_argtuple = task.batch.copy_input_batch(argtuple);
+
+            task.subworld_ptr=&subworld;
+            // before the prefetch hook, which fetches through it
+            task.cloud_ptr=&cloud;
+			prefetch_for_next_task(subworld, argtuple, taskq, element);
+
+			copy_operands_into_subworld(subworld, cloud, batched_argtuple, policy, debug);
 
 			    print("starting task no",element, ", '",get_name(),"', in subworld",subworld.id(),"at time",wall_time());
         	    double cpu0=cpu_time();

--- a/src/madness/mra/macrotaskq.h
+++ b/src/madness/mra/macrotaskq.h
@@ -690,18 +690,12 @@ public:
 	}
 
 	/// run all tasks
-	void run_all() {
 
-		if (printdebug()) print_taskq();
-		if (printtimings_detail()) {
-			if (universe.rank()==0) {
-				print("number of tasks in taskq",taskq.size());
-				print("redirecting output to files task.#####");
-			}
-		}
-		taskq_statistics["number_tasks"]=taskq.size();
-
-		// replicate the cloud (not necessarily the target if pointers are stored)
+	/// Put the cloud where the tasks will read it from.
+	
+	/// Rank- or node-replication of the cloud, and of the targets that stored pointers refer to.
+	/// Both are no-ops under a distributed policy.
+	void replicate_inputs() {
 		auto replication_policy = cloud.get_replication_policy();
 		if (replication_policy!=DistributionType::Distributed) {
 			double cpu0=cpu_time();
@@ -731,23 +725,17 @@ public:
 			double cpu1=cpu_time();
 			if (printtimings_detail()) print("target replication wall time to ",policy.ptr_target_distribution_policy,cpu1-cpu0);
 		}
+	}
 
-        if (printdebug()) cloud.print_size(universe);
-		cloud_statistics=cloud.get_statistics(universe);	// get stats before clearing the cloud
-        universe.gop.fence();
-        universe.gop.set_forbid_fence(true); // make sure there are no hidden universe fences
-        pmap1=FunctionDefaults<1>::get_pmap();
-        pmap2=FunctionDefaults<2>::get_pmap();
-        pmap3=FunctionDefaults<3>::get_pmap();
-        pmap4=FunctionDefaults<4>::get_pmap();
-        pmap5=FunctionDefaults<5>::get_pmap();
-        pmap6=FunctionDefaults<6>::get_pmap();
-        set_pmap(get_subworld());
-
-        double cpu00=cpu_time();
-
+	/// Run this rank's share of the queue.
+	
+	/// Two ways in: if every task names an owner and there is one subworld per rank, each rank walks
+	/// the queue and runs what it owns, since the assignment is already decided and the pull
+	/// scheduler's round trip per task would buy nothing. Otherwise task numbers are handed out
+	/// dynamically. Both converge on the same accounting.
+	/// \return the cpu time this rank spent inside task bodies
+	double execute_tasks() {
 		World& subworld=get_subworld();
-//		if (printdebug()) print("I am subworld",subworld.id());
 		double tasktime=0.0;
 
 		// If every task names an owner and there is one subworld per rank, each rank can walk
@@ -805,7 +793,15 @@ public:
 			}
 		}
 		}   // both the owned-walk and the pull loop converge here
-        universe.gop.set_forbid_fence(false);
+		return tasktime;
+	}
+
+	/// Move the results of tasks that accumulated their own output into the universe result.
+	
+	/// The ordering here is load-bearing and the comments inside say why. Two stages, so a node-local
+	/// reduction can sit between them and only one rank per node scatters between nodes.
+	void drain_own_output_buffers() {
+		World& subworld=get_subworld();
 		universe.gop.fence();
 		// A task that accumulates its own output does so without fencing, once per batch, so
 		// its buffer still has operations in flight here. The drains below read that buffer,
@@ -834,6 +830,40 @@ public:
 		if (nodeworld) nodeworld->gop.fence();
 		for (auto& t : taskq) t->finalize_stage2(subworld, nodeworld, cloud);
 		universe.gop.fence();
+	}
+	void run_all() {
+
+		if (printdebug()) print_taskq();
+		if (printtimings_detail()) {
+			if (universe.rank()==0) {
+				print("number of tasks in taskq",taskq.size());
+				print("redirecting output to files task.#####");
+			}
+		}
+		taskq_statistics["number_tasks"]=taskq.size();
+
+		// replicate the cloud (not necessarily the target if pointers are stored)
+		replicate_inputs();
+
+        if (printdebug()) cloud.print_size(universe);
+		cloud_statistics=cloud.get_statistics(universe);	// get stats before clearing the cloud
+        universe.gop.fence();
+        universe.gop.set_forbid_fence(true); // make sure there are no hidden universe fences
+        pmap1=FunctionDefaults<1>::get_pmap();
+        pmap2=FunctionDefaults<2>::get_pmap();
+        pmap3=FunctionDefaults<3>::get_pmap();
+        pmap4=FunctionDefaults<4>::get_pmap();
+        pmap5=FunctionDefaults<5>::get_pmap();
+        pmap6=FunctionDefaults<6>::get_pmap();
+        set_pmap(get_subworld());
+
+        double cpu00=cpu_time();
+
+		World& subworld=get_subworld();
+//		if (printdebug()) print("I am subworld",subworld.id());
+		double tasktime=execute_tasks();   // not const: gop.sum reduces it in place below
+        universe.gop.set_forbid_fence(false);
+		drain_own_output_buffers();
 
 		universe.gop.sum(tasktime);
 		if (printprogress() and universe.rank()==0) std::cout << std::endl;

--- a/src/madness/mra/macrotaskq.h
+++ b/src/madness/mra/macrotaskq.h
@@ -473,6 +473,7 @@ public:
 	virtual ~MacroTaskBase() {};
 
 	double priority=1.0;
+	long owner_slot=-1;   ///< the subworld that should run this task; -1 means any
 	enum Status {Running, Waiting, Complete, Unknown} stat=Unknown;
 
 	void set_complete() {stat=Complete;}
@@ -501,6 +502,10 @@ public:
 
     double get_priority() const {return priority;}
     void set_priority(const double p) {priority=p;}
+    long get_owner_slot() const {return owner_slot;}
+    void set_owner_slot(const long owner) {owner_slot=owner;}
+    /// an unowned task may be run by any subworld, an owned one only by its own
+    bool is_owned_by(const long slot) const {return (owner_slot<0) or (owner_slot==slot);}
 
     friend std::ostream& operator<<(std::ostream& os, const MacroTaskBase::Status s) {
     	if (s==MacroTaskBase::Status::Running) os << "Running";
@@ -714,6 +719,33 @@ public:
 		World& subworld=get_subworld();
 //		if (printdebug()) print("I am subworld",subworld.id());
 		double tasktime=0.0;
+
+		// If every task names an owner and there is one subworld per rank, each rank can walk
+		// the queue and run its own tasks: the assignment is already decided, so the pull
+		// scheduler's round trip per task buys nothing. Falls through to the dynamic loop
+		// whenever any task is unowned, which is the case for every task that does not use
+		// the owner_hint hook.
+		const long requester_slot = universe.rank() % std::max<long>(1, nsubworld);
+		const bool all_tasks_owned = (not taskq.empty()) and std::all_of(taskq.begin(), taskq.end(),
+				[](const std::shared_ptr<MacroTaskBase>& t) { return t->get_owner_slot() >= 0; });
+
+		if (all_tasks_owned and (nsubworld==universe.size())) {
+			for (long element=0; element<long(taskq.size()); ++element) {
+				std::shared_ptr<MacroTaskBase> task=taskq[element];
+				if (not task->is_owned_by(requester_slot)) continue;
+				double cpu0=cpu_time();
+				if (printdebug()) print("starting task no",element, "in subworld",subworld.id(),"at time",wall_time());
+				task->run(subworld,cloud, taskq, element, printdebug(), policy);
+				double cpu1=cpu_time();
+				tasktime+=(cpu1-cpu0);
+				if (printdebug()) printf("completed task %3ld after %6.1fs at time %6.1fs\n",element,cpu1-cpu0,wall_time());
+			}
+			if (printdebug() and subworld.rank()==0) {
+				printf("rank %3d (subworld %3lu) finished its task queue at time %6.1fs (own tasktime %4.1fs)\n",
+				       universe.rank(), static_cast<unsigned long>(subworld.id()), wall_time(), tasktime);
+			}
+		} else {
+
 		if (printprogress() and universe.rank()==0) std::cout << "progress in percent: " << std::flush;
 		while (true) {
 			long element=get_scheduled_task_number(subworld);
@@ -742,6 +774,7 @@ public:
 				std::cout << int(in_percentile(element)*10) << " " << std::flush;
 			}
 		}
+		}   // both the owned-walk and the pull loop converge here
         universe.gop.set_forbid_fence(false);
 		universe.gop.fence();
 		universe.gop.sum(tasktime);
@@ -877,6 +910,143 @@ class MacroTask {
     struct is_vector<std::vector<Q>> : std::true_type {
     };
 
+    // ---- optional task hooks ----
+    //
+    // A task opts into a piece of framework machinery by declaring the corresponding
+    // member; each hook is a constrained overload plus a variadic no-op, so a task that
+    // declares nothing binds the no-op and behaves exactly as before. Detection is by
+    // overload resolution on a trailing int/... parameter, hence the literal 0 at every
+    // call site.
+    //
+    // The hooks that reach into the argument tuple are wrapped in a tuple_size guard:
+    // std::get<2>(argtuple) inside a decltype is a hard error, not a substitution
+    // failure, for a task with fewer arguments.
+
+    /// which rank should run this batch; -1 leaves the choice to the queue
+    template<typename Q>
+    static auto owner_hint_or_default(const Q& task, const Batch& batch, const long nsubworld, int)
+        -> decltype(task.owner_hint(batch, nsubworld)) {
+        return task.owner_hint(batch, nsubworld);
+    }
+
+    template<typename Q>
+    static long owner_hint_or_default(const Q&, const Batch&, const long, ...) {
+        return -1;
+    }
+
+    /// let the task assign batches to owners before the tasks are created
+    template<typename Q>
+    static auto prepare_owner_assignment_or_noop(Q& task,
+            const MacroTaskPartitioner::partitionT& partition, const long nsubworld, int)
+        -> decltype(task.prepare_owner_assignment(partition, nsubworld), void()) {
+        task.prepare_owner_assignment(partition, nsubworld);
+    }
+
+    template<typename Q>
+    static void prepare_owner_assignment_or_noop(Q&, const MacroTaskPartitioner::partitionT&, const long, ...) {}
+
+    /// let the task reorder the partition, e.g. for locality or to de-synchronize fetches
+    template<typename Q>
+    static auto shuffle_partition_or_noop(Q& task,
+            MacroTaskPartitioner::partitionT& partition, const long nsubworld, int)
+        -> decltype(task.shuffle_partition_by_owner(partition, nsubworld), void()) {
+        task.shuffle_partition_by_owner(partition, nsubworld);
+    }
+
+    template<typename Q>
+    static void shuffle_partition_or_noop(Q&, MacroTaskPartitioner::partitionT&, const long, ...) {}
+
+    /// let the task store its inputs as owner-pinned cloud batches
+    template<typename Q, typename ArgTuple>
+    static auto store_batches_or_noop(Q& task, World& world, World& subworld, Cloud& cloud,
+            const ArgTuple& argtuple, const long nsubworld, int)
+        -> decltype(task.store_batches(world, subworld, cloud, argtuple, nsubworld), void()) {
+        task.store_batches(world, subworld, cloud, argtuple, nsubworld);
+    }
+
+    template<typename Q, typename ArgTuple>
+    static void store_batches_or_noop(Q&, World&, World&, Cloud&, const ArgTuple&, const long, ...) {}
+
+    /// pre-compute: promote the previous prefetch and issue the next task's, so its
+    /// transfer overlaps this task's compute
+    template<typename Q, typename ArgTuple>
+    static auto cloud_kbatch_pipeline_advance_dispatch(Q& task, World& subworld, const ArgTuple& argtuple,
+            const Batch_1D& next_hint, const bool has_next, int)
+        -> decltype(task.cloud_kbatch_pipeline_advance(subworld, std::get<1>(argtuple), std::get<2>(argtuple), next_hint, has_next), void()) {
+        task.cloud_kbatch_pipeline_advance(subworld, std::get<1>(argtuple), std::get<2>(argtuple), next_hint, has_next);
+    }
+
+    template<typename Q, typename ArgTuple>
+    static void cloud_kbatch_pipeline_advance_dispatch(Q&, World&, const ArgTuple&, const Batch_1D&, const bool, ...) {}
+
+    template<typename Q, typename ArgTuple>
+    static void cloud_kbatch_pipeline_advance_or_noop(Q& task, World& subworld, const ArgTuple& argtuple,
+            const Batch_1D& next_hint, const bool has_next, int) {
+        if constexpr (std::tuple_size<ArgTuple>::value >= 3) {
+            cloud_kbatch_pipeline_advance_dispatch(task, subworld, argtuple, next_hint, has_next, 0);
+        }
+    }
+
+    /// pre-compute, symmetric case: takes both of the next task's ranges, so the task can
+    /// prefetch only the operand it does not already hold
+    template<typename Q, typename ArgTuple>
+    static auto sym_pipeline_advance_dispatch(Q& task, World& subworld, const ArgTuple& argtuple,
+            const Batch_1D& next_col, const Batch_1D& next_row, const bool has_next, int)
+        -> decltype(task.sym_pipeline_advance(subworld, std::get<2>(argtuple), next_col, next_row, has_next), void()) {
+        task.sym_pipeline_advance(subworld, std::get<2>(argtuple), next_col, next_row, has_next);
+    }
+
+    template<typename Q, typename ArgTuple>
+    static void sym_pipeline_advance_dispatch(Q&, World&, const ArgTuple&, const Batch_1D&, const Batch_1D&, const bool, ...) {}
+
+    template<typename Q, typename ArgTuple>
+    static void sym_pipeline_advance_or_noop(Q& task, World& subworld, const ArgTuple& argtuple,
+            const Batch_1D& next_col, const Batch_1D& next_row, const bool has_next, int) {
+        if constexpr (std::tuple_size<ArgTuple>::value >= 3) {
+            sym_pipeline_advance_dispatch(task, subworld, argtuple, next_col, next_row, has_next, 0);
+        }
+    }
+
+    /// accumulate the batch result into a task-local buffer instead of the universe result
+    template<typename Q, typename ResT>
+    static auto accumulate_locally_or_noop(Q& task, World& subworld, const ResT& result_subworld, int)
+        -> decltype(task.accumulate_locally(subworld, result_subworld), void()) {
+        task.accumulate_locally(subworld, result_subworld);
+    }
+
+    template<typename Q, typename ResT>
+    static void accumulate_locally_or_noop(Q&, World&, const ResT&, ...) {}
+
+    /// whether the task wants its local buffers reduced within a node before the universe
+    template<typename Q>
+    static auto wants_node_local_reduction_or_default(const Q& task, int)
+        -> decltype(task.wants_node_local_reduction()) {
+        return task.wants_node_local_reduction();
+    }
+
+    template<typename Q>
+    static bool wants_node_local_reduction_or_default(const Q&, ...) { return false; }
+
+    /// reduce the task-local buffers within a node
+    template<typename Q>
+    static auto finalize_stage1_or_noop(Q& task, World& subworld, World* nodeworld, int)
+        -> decltype(task.finalize_stage1(subworld, nodeworld), void()) {
+        task.finalize_stage1(subworld, nodeworld);
+    }
+
+    template<typename Q>
+    static void finalize_stage1_or_noop(Q&, World&, World*, ...) {}
+
+    /// reduce across nodes into the universe result
+    template<typename Q, typename ResT>
+    static auto finalize_stage2_or_noop(Q& task, World& subworld, World* nodeworld, ResT& universe_result, int)
+        -> decltype(task.finalize_stage2(subworld, nodeworld, universe_result), void()) {
+        task.finalize_stage2(subworld, nodeworld, universe_result);
+    }
+
+    template<typename Q, typename ResT>
+    static void finalize_stage2_or_noop(Q&, World&, World*, ResT&, ...) {}
+
     typedef typename taskT::resultT resultT;
     typedef typename taskT::argtupleT argtupleT;
     typedef Cloud::recordlistT recordlistT;
@@ -946,17 +1116,25 @@ public:
         partitioner->set_nsubworld(world.size());
         partitionT partition = partitioner->partition_tasks(argtuple);
 
+        // let the task assign batches to owners from the whole partition, then reorder it
+        prepare_owner_assignment_or_noop(task, partition, taskq_ptr->get_nsubworld(), 0);
+        shuffle_partition_or_noop(task, partition, taskq_ptr->get_nsubworld(), 0);
+
     	if (debug and world.rank()==0) print(taskq_ptr->get_policy());
 
         recordlistT inputrecords = taskq_ptr->cloud.store(world, argtuple);
+        // additionally store the inputs as owner-pinned cloud batches, if the task wants them
+        store_batches_or_noop(task, world, taskq_ptr->get_subworld(), taskq_ptr->cloud, argtuple,
+                              taskq_ptr->get_nsubworld(), 0);
         resultT result = task.allocator(world, argtuple);
         auto outputrecords =prepare_output_records(taskq_ptr->cloud, result);
 
         // create tasks and add them to the taskq
         MacroTaskBase::taskqT vtask;
         for (const auto& batch_prio : partition) {
+            const long owner_slot = owner_hint_or_default(task, batch_prio.first, taskq_ptr->get_nsubworld(), 0);
             vtask.push_back(
-                    std::shared_ptr<MacroTaskBase>(new MacroTaskInternal(task, batch_prio, inputrecords, outputrecords)));
+                    std::shared_ptr<MacroTaskBase>(new MacroTaskInternal(task, batch_prio, inputrecords, outputrecords, owner_slot)));
         }
         taskq_ptr->add_tasks(vtask);
         if (immediate_execution) taskq_ptr->run_all();
@@ -1028,7 +1206,8 @@ private:
     	}
 
         MacroTaskInternal(const taskT &task, const std::pair<Batch,double> &batch_prio,
-                          const recordlistT &inputrecords, const recordlistT &outputrecords)
+                          const recordlistT &inputrecords, const recordlistT &outputrecords,
+                          const long owner_slot = -1)
   	  : inputrecords(inputrecords), outputrecords(outputrecords), task(task) {
     		if constexpr (is_tuple<resultT>::value) {
     			static_assert(check_tuple_is_valid_task_result<resultT,0>(),
@@ -1038,6 +1217,7 @@ private:
     		}
             this->task.batch=batch_prio.first;
             this->priority=batch_prio.second;
+            this->set_owner_slot(owner_slot);
         }
 
 

--- a/src/madness/mra/macrotaskq.h
+++ b/src/madness/mra/macrotaskq.h
@@ -970,134 +970,82 @@ class MacroTask {
 
     // ---- optional task hooks ----
     //
-    // A task opts into a piece of framework machinery by declaring the corresponding
-    // member; each hook is a constrained overload plus a variadic no-op, so a task that
-    // declares nothing binds the no-op and behaves exactly as before. Detection is by
-    // overload resolution on a trailing int/... parameter, hence the literal 0 at every
-    // call site.
+    // A task opts into a piece of framework machinery by declaring the corresponding member. Each
+    // hook is a named detection trait plus an `if constexpr`, the same shape madness::archive uses
+    // to ask whether a type can serialize itself (see has_member_serialize_v in type_traits.h): the
+    // trait names the expression that has to compile, and the dispatch reads as an ordinary branch.
+    // A task that declares nothing takes the empty branch and behaves exactly as before.
     //
-    // Only the hooks whose signature depends on the task's own argument tuple or result
-    // type live here; the ones with a fixed signature are plain virtuals on
-    // MacroTaskOperationBase (owner_hint, accumulates_own_output, handles_own_data_movement)
-    // or on MacroTaskBase (wants_node_local_reduction, finalize_stage1, finalize_stage2),
-    // because run_all dispatches those through a base pointer.
-    //
-    // The hooks that reach into the argument tuple are wrapped in a tuple_size guard:
-    // std::get<2>(argtuple) inside a decltype is a hard error, not a substitution
-    // failure, for a task with fewer arguments.
+    // Only the hooks whose signature depends on the task's own argument tuple or result type live
+    // here; the ones with a fixed signature are plain virtuals on MacroTaskOperationBase
+    // (owner_hint, accumulates_own_output, handles_own_data_movement, cleanup) or on MacroTaskBase
+    // (wants_node_local_reduction, finalize_stage1, finalize_stage2), because run_all dispatches
+    // those through a base pointer.
 
-    /// let the task assign batches to owners before the tasks are created
+    /// true if: task.prepare_owner_assignment(partition, nsubworld)
     template<typename Q>
-    static auto prepare_owner_assignment_or_noop(Q& task,
-            const MacroTaskPartitioner::partitionT& partition, const long nsubworld, int)
-        -> decltype(task.prepare_owner_assignment(partition, nsubworld), void()) {
-        task.prepare_owner_assignment(partition, nsubworld);
-    }
-
+    using has_prepare_owner_assignment_t =
+        decltype(std::declval<Q&>().prepare_owner_assignment(
+                     std::declval<const MacroTaskPartitioner::partitionT&>(), 0L));
     template<typename Q>
-    static void prepare_owner_assignment_or_noop(Q&, const MacroTaskPartitioner::partitionT&, const long, ...) {}
+    static constexpr bool has_prepare_owner_assignment_v =
+        madness::meta::is_detected_v<has_prepare_owner_assignment_t, Q>;
 
-    /// let the task reorder the partition, e.g. for locality or to de-synchronize fetches
-    template<typename Q>
-    static auto shuffle_partition_or_noop(Q& task,
-            MacroTaskPartitioner::partitionT& partition, const long nsubworld, int)
-        -> decltype(task.shuffle_partition_by_owner(partition, nsubworld), void()) {
-        task.shuffle_partition_by_owner(partition, nsubworld);
-    }
-
-    template<typename Q>
-    static void shuffle_partition_or_noop(Q&, MacroTaskPartitioner::partitionT&, const long, ...) {}
-
-    /// let the task store its inputs as owner-pinned cloud batches
+    /// true if: task.store_batches(world, subworld, cloud, argtuple, nsubworld)
     template<typename Q, typename ArgTuple>
-    static auto store_batches_or_noop(Q& task, World& world, World& subworld, Cloud& cloud,
-            const ArgTuple& argtuple, const long nsubworld, int)
-        -> decltype(task.store_batches(world, subworld, cloud, argtuple, nsubworld), void()) {
-        task.store_batches(world, subworld, cloud, argtuple, nsubworld);
-    }
-
+    using has_store_batches_t =
+        decltype(std::declval<Q&>().store_batches(
+                     std::declval<World&>(), std::declval<World&>(), std::declval<Cloud&>(),
+                     std::declval<const ArgTuple&>(), 0L));
     template<typename Q, typename ArgTuple>
-    static void store_batches_or_noop(Q&, World&, World&, Cloud&, const ArgTuple&, const long, ...) {}
+    static constexpr bool has_store_batches_v =
+        madness::meta::is_detected_v<has_store_batches_t, Q, ArgTuple>;
 
-    /// pre-compute: promote the previous prefetch and issue the next task's, so its
-    /// transfer overlaps this task's compute
-    template<typename Q, typename ArgTuple>
-    static auto cloud_kbatch_pipeline_advance_dispatch(Q& task, World& subworld, const ArgTuple& argtuple,
-            const Batch_1D& next_hint, const bool has_next, int)
-        -> decltype(task.cloud_kbatch_pipeline_advance(subworld, std::get<1>(argtuple), std::get<2>(argtuple), next_hint, has_next), void()) {
-        task.cloud_kbatch_pipeline_advance(subworld, std::get<1>(argtuple), std::get<2>(argtuple), next_hint, has_next);
-    }
+    /// true if: task.sym_pipeline_advance(subworld, ket, next_col, next_row, has_next)
+    template<typename Q, typename VecT>
+    using has_sym_pipeline_advance_t =
+        decltype(std::declval<Q&>().sym_pipeline_advance(
+                     std::declval<World&>(), std::declval<const VecT&>(),
+                     std::declval<const Batch_1D&>(), std::declval<const Batch_1D&>(), true));
+    template<typename Q, typename VecT>
+    static constexpr bool has_sym_pipeline_advance_v =
+        madness::meta::is_detected_v<has_sym_pipeline_advance_t, Q, VecT>;
 
-    template<typename Q, typename ArgTuple>
-    static void cloud_kbatch_pipeline_advance_dispatch(Q&, World&, const ArgTuple&, const Batch_1D&, const bool, ...) {}
-
-    template<typename Q, typename ArgTuple>
-    static void cloud_kbatch_pipeline_advance_or_noop(Q& task, World& subworld, const ArgTuple& argtuple,
-            const Batch_1D& next_hint, const bool has_next, int) {
-        if constexpr (std::tuple_size<ArgTuple>::value >= 3) {
-            cloud_kbatch_pipeline_advance_dispatch(task, subworld, argtuple, next_hint, has_next, 0);
-        }
-    }
-
-    /// pre-compute, symmetric case: takes both of the next task's ranges, so the task can
-    /// prefetch only the operand it does not already hold
-    template<typename Q, typename ArgTuple>
-    static auto sym_pipeline_advance_dispatch(Q& task, World& subworld, const ArgTuple& argtuple,
-            const Batch_1D& next_col, const Batch_1D& next_row, const bool has_next, int)
-        -> decltype(task.sym_pipeline_advance(subworld, std::get<2>(argtuple), next_col, next_row, has_next), void()) {
-        task.sym_pipeline_advance(subworld, std::get<2>(argtuple), next_col, next_row, has_next);
-    }
-
-    template<typename Q, typename ArgTuple>
-    static void sym_pipeline_advance_dispatch(Q&, World&, const ArgTuple&, const Batch_1D&, const Batch_1D&, const bool, ...) {}
-
-    template<typename Q, typename ArgTuple>
-    static void sym_pipeline_advance_or_noop(Q& task, World& subworld, const ArgTuple& argtuple,
-            const Batch_1D& next_col, const Batch_1D& next_row, const bool has_next, int) {
-        if constexpr (std::tuple_size<ArgTuple>::value >= 3) {
-            sym_pipeline_advance_dispatch(task, subworld, argtuple, next_col, next_row, has_next, 0);
-        }
-    }
-
-    /// accumulate the batch result into a task-local buffer instead of the universe result
+    /// true if: task.accumulate_locally(subworld, result_subworld)
     template<typename Q, typename ResT>
-    static auto accumulate_locally_or_noop(Q& task, World& subworld, const ResT& result_subworld, int)
-        -> decltype(task.accumulate_locally(subworld, result_subworld), void()) {
-        task.accumulate_locally(subworld, result_subworld);
-    }
-
+    using has_accumulate_locally_t =
+        decltype(std::declval<Q&>().accumulate_locally(
+                     std::declval<World&>(), std::declval<const ResT&>()));
     template<typename Q, typename ResT>
-    static void accumulate_locally_or_noop(Q&, World&, const ResT&, ...) {}
+    static constexpr bool has_accumulate_locally_v =
+        madness::meta::is_detected_v<has_accumulate_locally_t, Q, ResT>;
 
-    /// whether the task wants its local buffers reduced within a node before the universe
+    /// true if: task.wants_node_local_reduction()
     template<typename Q>
-    static auto wants_node_local_reduction_or_default(const Q& task, int)
-        -> decltype(task.wants_node_local_reduction()) {
-        return task.wants_node_local_reduction();
-    }
-
+    using has_wants_node_local_reduction_t =
+        decltype(std::declval<const Q&>().wants_node_local_reduction());
     template<typename Q>
-    static bool wants_node_local_reduction_or_default(const Q&, ...) { return false; }
+    static constexpr bool has_wants_node_local_reduction_v =
+        madness::meta::is_detected_v<has_wants_node_local_reduction_t, Q>;
 
-    /// reduce the task-local buffers within a node
+    /// true if: task.finalize_stage1(subworld, nodeworld)
     template<typename Q>
-    static auto finalize_stage1_or_noop(Q& task, World& subworld, World* nodeworld, int)
-        -> decltype(task.finalize_stage1(subworld, nodeworld), void()) {
-        task.finalize_stage1(subworld, nodeworld);
-    }
-
+    using has_finalize_stage1_t =
+        decltype(std::declval<Q&>().finalize_stage1(std::declval<World&>(),
+                                                    std::declval<World*>()));
     template<typename Q>
-    static void finalize_stage1_or_noop(Q&, World&, World*, ...) {}
+    static constexpr bool has_finalize_stage1_v =
+        madness::meta::is_detected_v<has_finalize_stage1_t, Q>;
 
-    /// reduce across nodes into the universe result
+    /// true if: task.finalize_stage2(subworld, nodeworld, universe_result)
     template<typename Q, typename ResT>
-    static auto finalize_stage2_or_noop(Q& task, World& subworld, World* nodeworld, ResT& universe_result, int)
-        -> decltype(task.finalize_stage2(subworld, nodeworld, universe_result), void()) {
-        task.finalize_stage2(subworld, nodeworld, universe_result);
-    }
-
+    using has_finalize_stage2_t =
+        decltype(std::declval<Q&>().finalize_stage2(std::declval<World&>(),
+                                                    std::declval<World*>(),
+                                                    std::declval<ResT&>()));
     template<typename Q, typename ResT>
-    static void finalize_stage2_or_noop(Q&, World&, World*, ResT&, ...) {}
+    static constexpr bool has_finalize_stage2_v =
+        madness::meta::is_detected_v<has_finalize_stage2_t, Q, ResT>;
 
     typedef typename taskT::resultT resultT;
     typedef typename taskT::argtupleT argtupleT;
@@ -1169,15 +1117,16 @@ public:
         partitionT partition = partitioner->partition_tasks(argtuple);
 
         // let the task assign batches to owners from the whole partition, then reorder it
-        prepare_owner_assignment_or_noop(task, partition, taskq_ptr->get_nsubworld(), 0);
-        shuffle_partition_or_noop(task, partition, taskq_ptr->get_nsubworld(), 0);
+        if constexpr (has_prepare_owner_assignment_v<taskT>)
+            task.prepare_owner_assignment(partition, taskq_ptr->get_nsubworld());
 
     	if (debug and world.rank()==0) print(taskq_ptr->get_policy());
 
         recordlistT inputrecords = taskq_ptr->cloud.store(world, argtuple);
         // additionally store the inputs as owner-pinned cloud batches, if the task wants them
-        store_batches_or_noop(task, world, taskq_ptr->get_subworld(), taskq_ptr->cloud, argtuple,
-                              taskq_ptr->get_nsubworld(), 0);
+        if constexpr (has_store_batches_v<taskT, argtupleT>)
+            task.store_batches(world, taskq_ptr->get_subworld(), taskq_ptr->cloud, argtuple,
+                               taskq_ptr->get_nsubworld());
         resultT result = task.allocator(world, argtuple);
         auto outputrecords =prepare_output_records(taskq_ptr->cloud, result);
 
@@ -1344,18 +1293,20 @@ private:
         /// A task that does not accumulate its own output has nothing to finalize, so the
         /// guard keeps every existing task on the queue's own accumulation path.
         bool wants_node_local_reduction() const override {
-            return wants_node_local_reduction_or_default(task, 0);
+            if constexpr (has_wants_node_local_reduction_v<taskT>) return task.wants_node_local_reduction();
+            else return false;
         }
 
         void finalize_stage1(World& subworld, World* nodeworld, Cloud& /*cloud*/) override {
             if (not task.accumulates_own_output()) return;
-            finalize_stage1_or_noop(task, subworld, nodeworld, 0);
+            if constexpr (has_finalize_stage1_v<taskT>) task.finalize_stage1(subworld, nodeworld);
         }
 
         void finalize_stage2(World& subworld, World* nodeworld, Cloud& cloud) override {
             if (not task.accumulates_own_output()) return;
             resultT result_universe = get_output(subworld, cloud);
-            finalize_stage2_or_noop(task, subworld, nodeworld, result_universe, 0);
+            if constexpr (has_finalize_stage2_v<taskT, resultT>)
+                task.finalize_stage2(subworld, nodeworld, result_universe);
         }
 
         /// the next task in taskq that this task's subworld also owns, or {-1, nullptr}
@@ -1399,8 +1350,13 @@ private:
                 const bool has_next = (next_ptr != nullptr) and (next_ptr->task.batch.input.size() > 1);
                 const Batch_1D next_col = has_next ? next_ptr->task.batch.input[0] : Batch_1D();
                 const Batch_1D next_row = has_next ? next_ptr->task.batch.input[1] : Batch_1D();
-                cloud_kbatch_pipeline_advance_or_noop(task, subworld, argtuple, next_row, has_next, 0);
-                sym_pipeline_advance_or_noop(task, subworld, argtuple, next_col, next_row, has_next, 0);
+                // the ket is the third argument; a task with fewer cannot have the hook either
+                if constexpr (std::tuple_size<argtupleT>::value >= 3) {
+                    using ketT = std::decay_t<std::tuple_element_t<2, argtupleT>>;
+                    if constexpr (has_sym_pipeline_advance_v<taskT, ketT>)
+                        task.sym_pipeline_advance(subworld, std::get<2>(argtuple),
+                                                  next_col, next_row, has_next);
+                }
             }
 
     		std::string msg="";
@@ -1467,7 +1423,8 @@ private:
         		// a subworld-local buffer and drains it once in finalize_stage2, instead of one
         		// subworld->universe gaxpy per batch.
         		if (task.accumulates_own_output()) {
-        			accumulate_locally_or_noop(task, subworld, result_subworld, 0);
+        			if constexpr (has_accumulate_locally_v<taskT, resultT>)
+        				task.accumulate_locally(subworld, result_subworld);
         		} else {
         			resultT result_universe=get_output(subworld, cloud);       // lives in the universe
         			accumulate_into_final_result<resultT>(subworld, result_universe, result_subworld, argtuple);

--- a/src/madness/mra/macrotaskq.h
+++ b/src/madness/mra/macrotaskq.h
@@ -807,6 +807,12 @@ public:
 		}   // both the owned-walk and the pull loop converge here
         universe.gop.set_forbid_fence(false);
 		universe.gop.fence();
+		// A task that accumulates its own output does so without fencing, once per batch, so
+		// its buffer still has operations in flight here. The drains below read that buffer,
+		// so the subworld has to be quiesced first -- once, not per batch, which is the whole
+		// point of accumulating locally. Without this the drain reads a partly-written buffer
+		// and the result is wrong in a way that varies from run to run.
+		subworld.gop.fence();
 
 		// Drain the buffers of tasks that accumulated their own output. Two stages: reduce
 		// within a node, then across nodes into the universe result.

--- a/src/madness/mra/macrotaskq.h
+++ b/src/madness/mra/macrotaskq.h
@@ -488,6 +488,15 @@ public:
 		const bool debug, const MacroTaskInfo policy) = 0;
 	virtual void cleanup() = 0;		// clear static data (presumably persistent input data)
 
+	/// Finalize, for tasks that accumulate their own output.
+
+	/// run_all holds only base pointers, so these have to be virtual. Stage 1 reduces the
+	/// per-subworld buffers within a node, stage 2 reduces across nodes into the universe
+	/// result; a nodeworld of nullptr means one node, so stage 1 has nothing to do.
+	virtual bool wants_node_local_reduction() const { return false; }
+	virtual void finalize_stage1(World& /*subworld*/, World* /*nodeworld*/, Cloud& /*cloud*/) {}
+	virtual void finalize_stage2(World& /*subworld*/, World* /*nodeworld*/, Cloud& /*cloud*/) {}
+
     virtual void print_me(std::string s="") const {
         printf("this is task with priority %4.1f\n",priority);
     }
@@ -583,6 +592,8 @@ class MacroTaskQ : public WorldObject< MacroTaskQ> {
 
     World& universe;
     std::shared_ptr<World> subworld_ptr;
+	/// node-scoped World for the two-stage finalize; created on first use, reused after
+	std::shared_ptr<World> nodeworld_ptr;
 	MacroTaskBase::taskqT taskq;
 	std::mutex taskq_mutex;
 	long printlevel=0;
@@ -657,6 +668,18 @@ public:
 
 		universe.gop.fence();
 		return all_worlds;
+	}
+
+	/// a World spanning the ranks that share memory with this one
+
+	/// Collective, and worth creating only once: the two-stage finalize reduces within a
+	/// node first, so it needs a World with node scope.
+	static std::shared_ptr<World> create_node_world(World& universe) {
+		SafeMPI::Intracomm comm = universe.mpi.comm().Split_type(
+			SafeMPI::Intracomm::SHARED_SPLIT_TYPE, universe.rank());
+		std::shared_ptr<World> node_world(new World(comm));
+		universe.gop.fence();
+		return node_world;
 	}
 
 	/// run all tasks
@@ -777,6 +800,28 @@ public:
 		}   // both the owned-walk and the pull loop converge here
         universe.gop.set_forbid_fence(false);
 		universe.gop.fence();
+
+		// Drain the buffers of tasks that accumulated their own output. Two stages: reduce
+		// within a node, then across nodes into the universe result.
+		//
+		// The accumulator buffers MUST outlive the fences below, so a hook must not release
+		// or clear them: a remote gaxpy that arrives after the buffer is gone finds an impl
+		// that was released but is still registered, and throws bad_weak_ptr intermittently.
+		// Release them in cleanup(), after the universe fence. If this ever fences per
+		// subworld instead, re-audit every task that accumulates its own output.
+		const bool want_node_reduction = (not taskq.empty())
+			and taskq.front()->wants_node_local_reduction();
+		if (want_node_reduction and not nodeworld_ptr)
+			nodeworld_ptr = create_node_world(universe);
+		World* nodeworld = want_node_reduction ? nodeworld_ptr.get() : nullptr;
+		// one node means the node World is the universe, so stage 1 would only add a fence
+		if (nodeworld and nodeworld->size() == universe.size()) nodeworld = nullptr;
+
+		for (auto& t : taskq) t->finalize_stage1(subworld, nodeworld, cloud);
+		if (nodeworld) nodeworld->gop.fence();
+		for (auto& t : taskq) t->finalize_stage2(subworld, nodeworld, cloud);
+		universe.gop.fence();
+
 		universe.gop.sum(tasktime);
 		if (printprogress() and universe.rank()==0) std::cout << std::endl;
 		cloud_statistics.update(cloud.gather_timings(universe));	// get stats before clearing the cloud
@@ -918,21 +963,15 @@ class MacroTask {
     // overload resolution on a trailing int/... parameter, hence the literal 0 at every
     // call site.
     //
+    // Only the hooks whose signature depends on the task's own argument tuple or result
+    // type live here; the ones with a fixed signature are plain virtuals on
+    // MacroTaskOperationBase (owner_hint, accumulates_own_output, handles_own_data_movement)
+    // or on MacroTaskBase (wants_node_local_reduction, finalize_stage1, finalize_stage2),
+    // because run_all dispatches those through a base pointer.
+    //
     // The hooks that reach into the argument tuple are wrapped in a tuple_size guard:
     // std::get<2>(argtuple) inside a decltype is a hard error, not a substitution
     // failure, for a task with fewer arguments.
-
-    /// which rank should run this batch; -1 leaves the choice to the queue
-    template<typename Q>
-    static auto owner_hint_or_default(const Q& task, const Batch& batch, const long nsubworld, int)
-        -> decltype(task.owner_hint(batch, nsubworld)) {
-        return task.owner_hint(batch, nsubworld);
-    }
-
-    template<typename Q>
-    static long owner_hint_or_default(const Q&, const Batch&, const long, ...) {
-        return -1;
-    }
 
     /// let the task assign batches to owners before the tasks are created
     template<typename Q>
@@ -1132,7 +1171,7 @@ public:
         // create tasks and add them to the taskq
         MacroTaskBase::taskqT vtask;
         for (const auto& batch_prio : partition) {
-            const long owner_slot = owner_hint_or_default(task, batch_prio.first, taskq_ptr->get_nsubworld(), 0);
+            const long owner_slot = task.owner_hint(batch_prio.first, taskq_ptr->get_nsubworld());
             vtask.push_back(
                     std::shared_ptr<MacroTaskBase>(new MacroTaskInternal(task, batch_prio, inputrecords, outputrecords, owner_slot)));
         }
@@ -1287,12 +1326,64 @@ private:
 
         }
 
+        /// Bridge the framework's virtual finalize to the task's hooks.
+
+        /// A task that does not accumulate its own output has nothing to finalize, so the
+        /// guard keeps every existing task on the queue's own accumulation path.
+        bool wants_node_local_reduction() const override {
+            return wants_node_local_reduction_or_default(task, 0);
+        }
+
+        void finalize_stage1(World& subworld, World* nodeworld, Cloud& /*cloud*/) override {
+            if (not task.accumulates_own_output()) return;
+            finalize_stage1_or_noop(task, subworld, nodeworld, 0);
+        }
+
+        void finalize_stage2(World& subworld, World* nodeworld, Cloud& cloud) override {
+            if (not task.accumulates_own_output()) return;
+            resultT result_universe = get_output(subworld, cloud);
+            finalize_stage2_or_noop(task, subworld, nodeworld, result_universe, 0);
+        }
+
+        /// the next task in taskq that this task's subworld also owns, or {-1, nullptr}
+
+        /// A task that prefetches needs to know which batch it will be asked for next. With
+        /// owner-pinned scheduling that is decidable locally: the queue order is fixed and
+        /// ownership is already assigned, so the next owned entry is just the next match.
+        std::pair<long, MacroTaskInternal*> find_next_owned_task(
+                const MacroTaskBase::taskqT& taskq, const long element) const {
+            const long owner_slot = this->get_owner_slot();
+            if (owner_slot < 0) return {-1, nullptr};
+            for (long next = element + 1; next < long(taskq.size()); ++next) {
+                if (not taskq[next]->is_owned_by(owner_slot)) continue;
+                auto next_task = std::dynamic_pointer_cast<MacroTaskInternal>(taskq[next]);
+                if (next_task) return {next, next_task.get()};
+            }
+            return {-1, nullptr};
+        }
+
     	/// called by the MacroTaskQ when the task is scheduled
         void run(World &subworld, Cloud &cloud, MacroTaskBase::taskqT &taskq, const long element, const bool debug,
         	const MacroTaskInfo policy) override {
         	io_redirect io(element,get_name()+"_task",debug);
+        	// The try covers the whole body, not just the compute: a throw while loading the
+        	// inputs or issuing a prefetch would otherwise escape uninstrumented and be
+        	// reported by the task backend with no task id and no what().
+        	try {
             const argtupleT argtuple = cloud.load<argtupleT>(subworld, inputrecords);
             argtupleT batched_argtuple = task.batch.copy_input_batch(argtuple);
+
+            task.subworld_ptr=&subworld;
+            // pre-compute: let the task prefetch what the next task it owns will need, so the
+            // transfer overlaps this task's compute
+            {
+                auto [next_elem, next_ptr] = find_next_owned_task(taskq, element);
+                const bool has_next = (next_ptr != nullptr) and (next_ptr->task.batch.input.size() > 1);
+                const Batch_1D next_col = has_next ? next_ptr->task.batch.input[0] : Batch_1D();
+                const Batch_1D next_row = has_next ? next_ptr->task.batch.input[1] : Batch_1D();
+                cloud_kbatch_pipeline_advance_or_noop(task, subworld, argtuple, next_row, has_next, 0);
+                sym_pipeline_advance_or_noop(task, subworld, argtuple, next_col, next_row, has_next, 0);
+            }
 
     		std::string msg="";
 			// maybe move this block to the cloud?
@@ -1322,10 +1413,8 @@ private:
     			}
     		}
 
-    		try {
 			    print("starting task no",element, ", '",get_name(),"', in subworld",subworld.id(),"at time",wall_time());
         	    double cpu0=cpu_time();
-    			task.subworld_ptr=&subworld;	// give the task access to the subworld
         		resultT result_batch = std::apply(task, batched_argtuple);		// lives in the subworld, is a batch of the full vector (if applicable)
         	    double cpu1=cpu_time();
 			    constexpr std::size_t bufsize=256;
@@ -1349,16 +1438,32 @@ private:
 					insert_batch(result_subworld,result_batch);
 				}
 
-        		// accumulate the subworld-local results into the final, universe result
-        		resultT result_universe=get_output(subworld, cloud);       // lives in the universe
-
-        		accumulate_into_final_result<resultT>(subworld, result_universe, result_subworld, argtuple);
+        		// Accumulate the batch result. A task that accumulates its own output keeps it in
+        		// a subworld-local buffer and drains it once in finalize_stage2, instead of one
+        		// subworld->universe gaxpy per batch.
+        		if (task.accumulates_own_output()) {
+        			accumulate_locally_or_noop(task, subworld, result_subworld, 0);
+        		} else {
+        			resultT result_universe=get_output(subworld, cloud);       // lives in the universe
+        			accumulate_into_final_result<resultT>(subworld, result_universe, result_subworld, argtuple);
+        		}
 
         	} catch (std::exception& e) {
+        		// RSS at the moment of failure separates a memory fault (near the node ceiling,
+        		// with a bad_alloc what()) from a logic or communication bug (well below it).
+        		const double rss_at_fail = get_rss_usage_in_GB();
         		print("failing task no",element,"in subworld",subworld.id(),"at time",wall_time());
         		print(e.what());
+        		print("RSS at failure (current resident, GB):", rss_at_fail);
         		print_me_as_table();
         		print("\n\n");
+        		{
+        			// this task's stream may be a file or /dev/null, so repeat it on the terminal
+        			io_redirect_cout io2;
+        			print("failing task no",element,"in subworld",subworld.id(),"at time",wall_time());
+        			print(e.what());
+        			print("RSS at failure (current resident, GB):", rss_at_fail);
+        		}
         		MADNESS_EXCEPTION("failing task",1);
         	}
 
@@ -1471,6 +1576,20 @@ public:
 	std::string name="unknown_task";
     std::shared_ptr<MacroTaskPartitioner> partitioner=0;
     MacroTaskOperationBase() : batch(Batch(_, _, _)), partitioner(new MacroTaskPartitioner) {}
+    virtual ~MacroTaskOperationBase() {}
+
+    /// which subworld should run this batch; -1 leaves the choice to the queue
+
+    /// Reads whatever assignment prepare_owner_assignment computed, so the two go together:
+    /// one decides the mapping for the whole partition, this one applies it per batch.
+    virtual long owner_hint(const Batch&, const long /*nsubworld*/) const { return -1; }
+
+    /// true if the task accumulates its own results and drains them in finalize_stage2,
+    /// instead of the queue moving every batch result into the universe result itself
+    virtual bool accumulates_own_output() const { return false; }
+
+    /// true if the task moves its operand coefficients into the subworld itself
+    virtual bool handles_own_data_movement() const { return false; }
 };
 
 

--- a/src/madness/mra/macrotaskq.h
+++ b/src/madness/mra/macrotaskq.h
@@ -1365,7 +1365,10 @@ private:
     	/// called by the MacroTaskQ when the task is scheduled
         void run(World &subworld, Cloud &cloud, MacroTaskBase::taskqT &taskq, const long element, const bool debug,
         	const MacroTaskInfo policy) override {
-        	io_redirect io(element,get_name()+"_task",debug);
+        	// per-task files are a debugging aid and become thousands at fine granularity; a
+        	// failing task still reports on the terminal regardless, see the catch below
+        	const auto io_mode = debug ? io_redirect::Mode::File : io_redirect::Mode::Discard;
+        	io_redirect io(io_mode, element, get_name()+"_output", get_name()+"_task", debug);
         	// The try covers the whole body, not just the compute: a throw while loading the
         	// inputs or issuing a prefetch would otherwise escape uninstrumented and be
         	// reported by the task backend with no task id and no what().

--- a/src/madness/mra/test_cloud.cc
+++ b/src/madness/mra/test_cloud.cc
@@ -345,6 +345,49 @@ int test_batch_store_and_fetch(World& universe) {
     return t1.end();
 }
 
+/// a payload spanning several MPI messages must arrive intact
+
+/// A unit test cannot afford a 2 GiB batch, so it lowers the chunk size instead, and checks the
+/// payload really is larger so it cannot pass vacuously. Needs two ranks to leave the local leg.
+int test_batch_fetch_chunked(World& universe) {
+    universe.gop.fence();
+    test_output t1("testing a batch transfer split into several MPI messages",
+                   universe.rank() == 0);
+
+    const std::size_t nfunc = 3;
+    std::vector<real_function_3d> batch;
+    std::vector<double> norms;
+    for (std::size_t i = 0; i < nfunc; ++i) {
+        batch.push_back(real_factory_3d(universe).functor(gaussian(1.0 + double(i))));
+        norms.push_back(batch.back().norm2());
+    }
+
+    Cloud cloud(universe);
+    const Cloud::keyT record = 4713;
+    cloud.store_batch(universe, batch, universe.size() > 1 ? 1 : 0, record);
+
+    const std::size_t chunk = 4096;
+    const std::size_t payload =
+            cloud.get_statistics(universe)["max_record_size"].get<std::size_t>();
+    t1.checkpoint(payload > chunk, "the payload spans more than one chunk");
+
+    const std::size_t saved = BatchTransport::batch_chunk_bytes();
+    BatchTransport::set_batch_chunk_bytes(chunk);
+    {
+        auto subworld_ptr = MacroTaskQ::create_worlds(universe, universe.size());
+        World& subworld = *subworld_ptr;
+        MacroTaskQ::set_pmap(subworld);
+        auto got = cloud.fetch_batch_p2p<double, 3>(subworld, record);
+        t1.checkpoint(got.size() == nfunc, "a chunked transfer returns the whole batch");
+        for (std::size_t i = 0; i < got.size(); ++i)
+            t1.checkpoint(got[i].norm2(), norms[i], 1.e-10, "chunked batch function norm");
+        subworld.gop.fence();
+    }
+    BatchTransport::set_batch_chunk_bytes(saved);
+    universe.gop.fence();
+    return t1.end();
+}
+
 /// fetching a record nobody stored must fail where the failure can be attributed
 
 /// The owner discovers it holds no such record inside a comm-thread AM handler, where a
@@ -728,6 +771,7 @@ int main(int argc, char** argv) {
     success += test_copy_function_from_other_world(universe);
     success += test_copy_function_from_other_world_through_cloud(universe);
     success += test_batch_store_and_fetch(universe);
+    success += test_batch_fetch_chunked(universe);
     success += test_batch_fetch_of_missing_record(universe);
     success += test_replication_policy(universe);
 

--- a/src/madness/mra/test_cloud.cc
+++ b/src/madness/mra/test_cloud.cc
@@ -280,6 +280,116 @@ int test_copy_function_from_other_world_through_cloud(World& universe) {
 }
 
 
+/// test the owner-pinned batch store and its point-to-point fetch
+
+/// Two ranks are needed to exercise a remote owner; with one rank only the local leg is
+/// reached, which is why the MPI variant of this test carries the coverage.
+int test_batch_store_and_fetch(World& universe) {
+    universe.gop.fence();
+    test_output t1("testing owner-pinned batch store and p2p fetch", universe.rank() == 0);
+
+    const std::size_t nfunc = 3;
+    std::vector<real_function_3d> batch;
+    std::vector<double> norms;
+    for (std::size_t i = 0; i < nfunc; ++i) {
+        batch.push_back(real_factory_3d(universe).functor(gaussian(1.0 + double(i))));
+        norms.push_back(batch.back().norm2());
+    }
+
+    Cloud cloud(universe);
+    const Cloud::keyT rec_first = 4711;
+    const Cloud::keyT rec_second = 4712;
+    cloud.store_batch(universe, batch, 0, rec_first);
+    cloud.store_batch(universe, batch, universe.size() > 1 ? 1 : 0, rec_second);
+
+    // the routing is registered collectively, so all ranks must agree on it
+    ProcessID owner_here = cloud.batch_owner(rec_second);
+    ProcessID owner_min = owner_here, owner_max = owner_here;
+    universe.gop.min(owner_min);
+    universe.gop.max(owner_max);
+    t1.checkpoint(owner_min == owner_max, "every rank agrees on the batch owner");
+    t1.checkpoint(cloud.batch_owner(rec_first) == 0, "the owner is the rank we asked for");
+
+    {
+        auto subworld_ptr = MacroTaskQ::create_worlds(universe, universe.size());
+        World& subworld = *subworld_ptr;
+        MacroTaskQ::set_pmap(subworld);
+        {
+            // the round trip reproduces the batch whether the record is owned here (local
+            // read) or on another rank (point-to-point transfer)
+            for (const auto record : {rec_first, rec_second}) {
+                auto got = cloud.fetch_batch_p2p<double, 3>(subworld, record);
+                t1.checkpoint(got.size() == nfunc, "batch size survives the round trip");
+                for (std::size_t i = 0; i < got.size(); ++i)
+                    t1.checkpoint(got[i].norm2(), norms[i], 1.e-10, "batch function norm");
+            }
+
+            // the two-phase form must agree with the synchronous one; the trigger is already
+            // in flight when request returns
+            auto fut = cloud.request_batch_bytes_async(rec_second);
+            auto got_async = cloud.deserialize_batch_p2p<double, 3>(subworld, fut, rec_second);
+            t1.checkpoint(got_async.size() == nfunc, "async form returns the whole batch");
+            for (std::size_t i = 0; i < got_async.size(); ++i)
+                t1.checkpoint(got_async[i].norm2(), norms[i], 1.e-10, "async batch function norm");
+
+            // opting into the cloud-side cache must not change the result
+            auto got_cached = cloud.fetch_batch_p2p<double, 3>(subworld, rec_first, true);
+            t1.checkpoint(got_cached.size() == nfunc, "cached fetch returns the whole batch");
+            for (std::size_t i = 0; i < got_cached.size(); ++i)
+                t1.checkpoint(got_cached[i].norm2(), norms[i], 1.e-10, "cached batch function norm");
+            cloud.clear_cache(subworld);
+        }
+        subworld.gop.fence();
+    }
+    universe.gop.fence();
+    return t1.end();
+}
+
+/// fetching a record nobody stored must fail where the failure can be attributed
+
+/// The owner discovers it holds no such record inside a comm-thread AM handler, where a
+/// throw would escape every task-level handler and abort with no task id and no what().
+/// It has to surface here instead, in task context, as a named exception. An abort rather
+/// than a caught throw is a real failure of the transport, not a flaky test.
+int test_batch_fetch_of_missing_record(World& universe) {
+    universe.gop.fence();
+    test_output t1("testing that a missing batch record throws where it can be attributed",
+                   universe.rank() == 0);
+
+    Cloud cloud(universe);
+    const Cloud::keyT never_stored = 9999;
+    // register the routing but store no payload: a request aimed at a definite rank that
+    // holds nothing, which is the visibility gap made deterministic
+    cloud.register_batch_owner(never_stored, universe.size() > 1 ? 1 : 0);
+
+    {
+        auto subworld_ptr = MacroTaskQ::create_worlds(universe, universe.size());
+        World& subworld = *subworld_ptr;
+        MacroTaskQ::set_pmap(subworld);
+        {
+            bool threw = false;
+            std::string what;
+            try {
+                auto got = cloud.fetch_batch_p2p<double, 3>(subworld, never_stored);
+                print("fetch of an unstored record returned", got.size(), "functions");
+            } catch (const std::exception& e) {
+                threw = true;
+                what = e.what();
+                print("caught, as intended:", what);
+            }
+            t1.checkpoint(threw, "a missing record throws instead of returning an empty batch");
+            // check which failure it was: any exception would satisfy the test above, and
+            // one from elsewhere would let it pass for the wrong reason
+            t1.checkpoint(what.find("does not hold this batch record") != std::string::npos,
+                          "the throw is the transport's missing-record check");
+        }
+        subworld.gop.fence();
+    }
+    universe.gop.fence();
+    return t1.end();
+}
+
+
 /// test replication of a function and/or cloud over nodes and ranks
 int test_replication_policy(World& universe) {
     test_output t1("testing node replication of function and cloud", universe.rank() == 0);
@@ -617,6 +727,8 @@ int main(int argc, char** argv) {
     success += simple_example(universe);
     success += test_copy_function_from_other_world(universe);
     success += test_copy_function_from_other_world_through_cloud(universe);
+    success += test_batch_store_and_fetch(universe);
+    success += test_batch_fetch_of_missing_record(universe);
     success += test_replication_policy(universe);
 
     if (1) {

--- a/src/madness/mra/test_vectormacrotask.cc
+++ b/src/madness/mra/test_vectormacrotask.cc
@@ -84,6 +84,31 @@ public:
 };
 
 
+/// a task that names an owner for every batch
+
+/// With every task owned and one subworld per rank the queue skips its central scheduler and
+/// each rank walks the queue running only the tasks it owns. Nothing else here declares
+/// owner_hint, so without this task that path is never executed.
+class OwnedTask : public MacroTaskOperationBase {
+public:
+    typedef std::tuple<const std::vector<real_function_3d> &> argtupleT;
+    using resultT = std::vector<real_function_3d>;
+
+    long owner_hint(const Batch& batch, const long nsubworld) const override {
+        if (nsubworld<=0 or batch.input.empty()) return -1;
+        return std::max<long>(0, batch.input[0].begin) % nsubworld;
+    }
+
+    resultT allocator(World& world, const argtupleT& argtuple) const {
+        return zero_functions_auto_tree_state<double,3>(world, std::get<0>(argtuple).size());
+    }
+
+    /// deliberately cheap: this exercises the scheduling path, not the arithmetic
+    resultT operator()(const std::vector<real_function_3d>& v) const {
+        return 2.0*v;
+    }
+};
+
 class MicroTask1 : public MacroTaskOperationBase{
 public:
     // you need to define the result type
@@ -492,6 +517,20 @@ int test_mixed_tuple(World& universe, const std::vector<real_function_3d>& v3) {
     return 0;
 }
 
+/// run a task that owns all its batches, so the queue takes its owned-walk path
+
+/// The result has to match the same task computed directly, and the run has to complete:
+/// the owned walk shares the finalize and the collective fences that follow the scheduling
+/// loop, so an error there shows up as a hang or an aborted fence rather than a wrong number.
+int test_owned_tasks(World& universe, const std::vector<real_function_3d>& v3) {
+    if (universe.rank()==0) print("\nstarting OwnedTask\n");
+    OwnedTask t;
+    std::vector<real_function_3d> ref = t(v3);
+    MacroTask task(universe, t);
+    std::vector<real_function_3d> test = task(v3);
+    return check_vector(universe, ref, test, "owned tasks bypass the scheduler");
+}
+
 int test_2d_partitioning(World& universe, const std::vector<real_function_3d>& v3) {
     if (universe.rank() == 0) print("\nstarting 2d partitioning");
     auto policy=MacroTaskInfo::preset("large_memory");
@@ -574,6 +613,9 @@ int main(int argc, char **argv) {
 
         success+=test_2d_partitioning(universe,v3);
         timer1.tag("2D partitioning");
+
+        success+=test_owned_tasks(universe,v3);
+        timer1.tag("owned tasks");
 
         if (universe.rank() == 0) {
             if (success==0) print("\n --> all tests \033[32m", "passed ", "\033[0m\n");

--- a/src/madness/world/cloud.h
+++ b/src/madness/world/cloud.h
@@ -632,6 +632,14 @@ public:
         print("  min/max of node");
         print("    memory in GBytes:         ",min_memsize,max_memsize);
         print("    max record size in GBytes:",max_record_size*byte2gbyte);
+        // the owner-pinned batches, reported separately because they are a different lifetime and
+        // usually the bulk of it. Zero unless some task stored batches.
+        const double b_size = stats.value("batch_container_size_global", 0.0);
+        if (b_size > 0.0) {
+            print("  owner-pinned batches");
+            print("    number of records:        ", b_size);
+            print("    memory in GBytes:         ", stats.value("batch_memory_global_GB", 0.0));
+        }
     }
 
     void clear_cache(World &subworld) {
@@ -642,6 +650,11 @@ public:
 
     void clear() {
         container.clear();
+        // The owner-pinned batches too. They are not leaked without this -- an SCF run derives the
+        // same record keys each time, so the next application overwrites them -- but they are the
+        // largest thing the cloud holds, and without this they stay resident through everything
+        // that follows the exchange in an iteration, which is where the memory ceiling actually is.
+        batch_container.clear();
     }
 
     void clear_timings() {

--- a/src/madness/world/cloud.h
+++ b/src/madness/world/cloud.h
@@ -16,7 +16,10 @@
 
 #include <madness/world/parallel_dc_archive.h>
 #include<any>
+#include<atomic>
 #include<iomanip>
+#include<list>
+#include<mutex>
 
 
 /*!
@@ -153,6 +156,139 @@ struct Recordlist {
 
 };
 
+/// Process map for the cloud's batch container
+
+/// Routes a record to an explicitly assigned owner, falling back to a hash for any
+/// record that was never registered. `set_owner` is collective, so all ranks agree on
+/// routing without further communication. Unlike the default cloud container this map
+/// is never reset to local, which is what keeps owner pinning stable.
+template <typename keyT, typename hashfunT = Hash<keyT>>
+class CloudOwnerPmap : public WorldDCPmapInterface<keyT> {
+private:
+    const int nproc;
+    hashfunT hashfun;
+    std::shared_ptr<std::map<keyT, ProcessID>> table;
+
+public:
+    CloudOwnerPmap(World& world, const hashfunT& hf = hashfunT())
+        : nproc(world.mpi.nproc()), hashfun(hf), table(new std::map<keyT, ProcessID>()) {}
+
+    /// collective: every rank must register the same (key, owner) pair
+    void set_owner(const keyT& key, const ProcessID owner) { (*table)[key] = owner; }
+
+    ProcessID owner(const keyT& key) const override {
+        auto it = table->find(key);
+        if (it != table->end()) return it->second;
+        if (nproc == 1) return 0;
+        return hashfun(key) % nproc;
+    }
+
+    void print_table(const std::string& tag = "") const {
+        print("CloudOwnerPmap::table", tag, "size=", table->size(), "(nproc=", nproc, ")");
+        for (const auto& kv : *table) {
+            std::ostringstream os;
+            os << "  key=0x" << std::hex << kv.first << std::dec << "  owner=" << kv.second;
+            print(os.str());
+        }
+    }
+};
+
+/// BatchTransport holds a back-reference to its Cloud; its bodies are defined below the class
+class Cloud;
+
+using batch_keyT = madness::archive::ContainerRecordOutputArchive::keyT;
+/// the serialized batch travels by value through a Future, so it must be
+/// archive-serializable: a plain vector is, a shared_ptr is not
+using batch_bytesT = std::vector<unsigned char>;
+
+/// Point-to-point transfer of serialized function batches between universe ranks
+
+/// The bytes stream straight from the owner's local batch store to the requester by
+/// MPI point-to-point; they never ride inside an active-message payload, so there is
+/// no eager-buffer limit and no extra copy on the wire.
+///
+/// Both endpoints are posted from **comm-thread AM handlers** (`WorldObject::send` runs
+/// the member inline on the RMI receiver thread), never from worker tasks. That is what
+/// buys overlap under worker saturation: at a tight protocol every worker sits in the
+/// exchange kernel for a long time, so an endpoint posted as a *task* would queue behind
+/// it and the MPI op would not be posted until compute ended. On the comm thread the RMI
+/// loop's Testsome drives the rendezvous to completion during compute instead, leaving
+/// only the final await for the worker.
+///
+/// Wire protocol:
+///   1. requester (worker): record a pending slot keyed by `tag`, send `on_trigger`
+///   2. owner `on_trigger` (comm thread): Isend the local bytes, reply `on_reply` with the size
+///   3. requester `on_reply` (comm thread): size the buffer, post the Irecv, enqueue `finish_recv`
+///   4. requester `finish_recv` (worker): await the Irecv and set the future
+///
+/// The size travels in the reply of step 2 rather than a separate Isend so that step 3 can
+/// post the payload Irecv *during* compute; posting it at consume time would move the data
+/// transfer to post-compute and lose the overlap.
+class BatchTransport : public WorldObject<BatchTransport> {
+public:
+    /// tags live in the range MADNESS does not manage (safempi.h); 32767 is the
+    /// conservative MPI_TAG_UB floor
+    static constexpr int BATCH_TAG_BASE = 8192;
+    static constexpr int BATCH_TAG_CAP = 32767;
+
+    /// reply size meaning "the owner does not hold this record"; see on_trigger
+    static constexpr std::size_t BATCH_NOT_FOUND = ~std::size_t(0);
+
+    /// @param[in] universe  the world the cloud lives in (collective construction)
+    /// @param[in] cloud     back-reference used to read owner-local batch bytes
+    BatchTransport(World& universe, Cloud* cloud)
+        : WorldObject<BatchTransport>(universe), cloud_(cloud), next_tag_(0) {
+        this->process_pending();
+    }
+
+    /// Future to the serialized bytes of `record`, fetched from its owner
+
+    /// Resolves locally without MPI when this rank owns the record. The trigger is in
+    /// flight on return, so the round trip overlaps work until the future is consumed.
+    Future<batch_bytesT> request(batch_keyT record);
+
+private:
+    Cloud* cloud_;                 ///< back-reference (not owned)
+    std::atomic<int> next_tag_;
+
+    /// requester-side state for one outstanding receive. Held by shared_ptr so the buffer
+    /// address is stable for the Irecv and the entry can leave pending_ while finish_recv
+    /// still owns its reference.
+    struct PendingRecv {
+        ProcessID owner = -1;
+        int tag = -1;
+        bool not_found = false;        ///< owner reported it does not hold the record
+        batch_bytesT buf;              ///< sized in on_reply
+        SafeMPI::Request req;          ///< posted in on_reply
+        Future<batch_bytesT> fut;      ///< set by finish_recv
+    };
+    std::mutex pending_mtx_;
+    std::map<int, std::shared_ptr<PendingRecv>> pending_;
+
+    /// owner-side in-flight Isends, reaped lazily. Their buffers live in the cloud's
+    /// batch container and stay valid for the duration, so an un-reaped Isend is harmless.
+    std::mutex sends_mtx_;
+    std::list<SafeMPI::Request> sends_;
+
+    int alloc_tag() {
+        const int span = BATCH_TAG_CAP - BATCH_TAG_BASE + 1;
+        const int t = next_tag_.fetch_add(1);
+        return BATCH_TAG_BASE + ((t % span) + span) % span;
+    }
+
+    void reap_sends();
+
+    /// owner side, comm thread: Isend the record's bytes, then reply with the count.
+    /// Must not throw: an exception here escapes every task-level handler.
+    void on_trigger(batch_keyT record, ProcessID requester, int tag);
+
+    /// requester side, comm thread: size the buffer, post the Irecv, enqueue finish_recv
+    void on_reply(int tag, std::size_t size);
+
+    /// requester side, worker task: await the background-progressed Irecv and set the future
+    void finish_recv(int tag);
+};
+
 /// cloud class
 
 /// store and load data to/from the cloud into arbitrary worlds
@@ -223,6 +359,12 @@ private:
     DistributionType cloud_replication_policy = Distributed;
 
     mutable madness::WorldContainer<keyT, valueT> container;
+    /// dedicated container for owner-pinned function batches; see store_batch / fetch_batch_p2p.
+    /// Uses CloudOwnerPmap so each batch record lives on an explicitly chosen rank.
+    std::shared_ptr<CloudOwnerPmap<keyT>> batch_pmap;
+    mutable madness::WorldContainer<keyT, valueT> batch_container;
+    /// constructed after batch_container so it is destroyed first, as WorldObject lifetimes require
+    std::unique_ptr<BatchTransport> batch_transport_;
     cacheT cached_objects;
     recordlistT local_list_of_container_keys;   // a world-local list of keys occupied in container
 
@@ -238,7 +380,11 @@ public:
 public:
 
     /// @param[in]	universe	the universe world
-    Cloud(madness::World &universe) : container(universe), reading_time(0l), copy_time(0l), writing_time(0l),
+    Cloud(madness::World &universe) : container(universe),
+        batch_pmap(new CloudOwnerPmap<keyT>(universe)),
+        batch_container(universe, batch_pmap),
+        batch_transport_(new BatchTransport(universe, this)),
+        reading_time(0l), copy_time(0l), writing_time(0l),
         cache_reads(0l), cache_stores(0l) {
     }
 
@@ -254,6 +400,13 @@ public:
 
     void set_debug(bool value) {
         debug = value;
+    }
+
+    /// dump the record->owner table on rank 0; pair with the caller's own task-to-rank
+    /// print to check that task assignment and batch routing agree
+    void print_batch_owner_map(World& universe, const std::string& tag = "") const {
+        if (universe.rank() != 0) return;
+        batch_pmap->print_table(tag);
     }
 
     void set_fence(bool value) {
@@ -347,6 +500,14 @@ public:
             memsize+=item.second.size();
             max_record_size=std::max(max_record_size,item.second.size());
         }
+        // batch records are held separately, and for a caller that stores batches they are
+        // the larger half; leaving them out would understate the cloud's footprint
+        std::size_t batch_memsize=0;
+        for (auto& item : batch_container) {
+            batch_memsize+=item.second.size();
+            max_record_size=std::max(max_record_size,item.second.size());
+        }
+        memsize+=batch_memsize;
         std::size_t global_memsize=memsize;
         std::size_t max_memsize=memsize;
         std::size_t min_memsize=memsize;
@@ -367,8 +528,14 @@ public:
         auto local_size=container.size();
         auto global_size=local_size;
         universe.gop.sum(global_size);
+        auto batch_global_size=batch_container.size();
+        universe.gop.sum(batch_global_size);
+        std::size_t batch_global_memsize=batch_memsize;
+        universe.gop.sum(batch_global_memsize);
         nlohmann::json j;
         j["container_size_global"] = global_size;
+        j["batch_container_size_global"] = batch_global_size;
+        j["batch_memory_global_GB"] = batch_global_memsize*uchar2gbyte;
         j["memory_global_GB"] = global_memsize*uchar2gbyte;
         j["memory_min_GB"] = min_memsize*uchar2gbyte;
         j["memory_max_GB"] = max_memsize*uchar2gbyte;
@@ -569,6 +736,46 @@ public:
         }
     }
 
+    /// Register the owner of a batch record; local map insert, no communication
+
+    /// Collective in the same sense as store_batch: every rank must call it with an
+    /// identical (record, owner) pair or fetches will route inconsistently. Separating
+    /// registration from the payload lets all ranks replicate the routing while each
+    /// owner stores only its own bytes, over a size-1 subworld.
+    void register_batch_owner(const keyT record, const ProcessID owner) {
+        batch_pmap->set_owner(record, owner);
+    }
+
+    /// Store a batch of functions as one owner-pinned record
+
+    /// The whole vector -- its size and each function -- is serialized into a single
+    /// record in the batch container and routed to `owner`, so one batch is one record
+    /// with one owner. Must be called with identical (owner, record) on every rank of
+    /// `world`.
+    ///
+    /// @param[in] fence  false lets a caller storing many batches emit one fence for all
+    ///                   of them; the collective gather inside the archive self-synchronizes
+    template<typename T, std::size_t NDIM>
+    keyT store_batch(madness::World& world, const std::vector<Function<T, NDIM>>& batch,
+                     const ProcessID owner, const keyT record, const bool fence = true) {
+        if (is_replicated) {
+            print("Cloud contents are replicated and read-only!");
+            MADNESS_EXCEPTION("cloud error", 1);
+        }
+        batch_pmap->set_owner(record, owner);
+        cloudtimer t_batch(world, batch_store_time);
+        {
+            madness::archive::ContainerRecordOutputArchive ar(world, batch_container, record);
+            madness::archive::ParallelOutputArchive<madness::archive::ContainerRecordOutputArchive> par(world, ar);
+            par.set_dofence(false);
+            std::size_t fsize = batch.size();
+            par & fsize;
+            for (std::size_t i = 0; i < fsize; ++i) par & batch[i];
+        }
+        if (dofence and fence) world.gop.fence();
+        return record;
+    }
+
     /// @param[in]  world presumably the universe
     template<typename T>
     recordlistT store(madness::World &world, const T &source) {
@@ -696,6 +903,9 @@ public:
 private:
 
     mutable std::atomic<long> reading_time=0l;     // in microseconds
+    mutable std::atomic<long> batch_store_time=0l;       ///< store_batch wall time, microseconds
+    mutable std::atomic<long> batch_find_time=0l;        ///< waiting on the p2p transfer, microseconds
+    mutable std::atomic<long> batch_deserialize_time=0l; ///< deserializing the bytes, microseconds
 public:
     mutable std::atomic<long> copy_time=0l;        // if pointers are stored in cloud, time to copy from universe to subworld
     mutable std::atomic<long> target_replication_time=0l;     // if pointers are stored in cloud, time to replicate targets
@@ -750,6 +960,99 @@ private:
     bool is_cached(const keyT &key) const {
         return (cached_objects.count(key) == 1);
     }
+
+public:
+
+    /// the owner of a batch record; a pmap lookup, no communication
+    ProcessID batch_owner(const keyT record) const {
+        return batch_pmap->owner(record);
+    }
+
+private:
+
+    /// only the transport reads owner-local bytes; callers go through fetch_batch_p2p
+    friend class BatchTransport;
+
+    /// bytes of a batch record held by this rank, empty if it holds none
+
+    /// Never throws: the callers are BatchTransport's comm-thread handlers, where an
+    /// escaping exception bypasses every task-level handler and surfaces as an
+    /// unattributable abort. A miss is reported to the requester instead, and raised
+    /// there in task context.
+    ///
+    /// Emptiness is a sound "not found" marker because a stored batch always begins with
+    /// its serialized element count, so a present record is never zero bytes.
+    valueT try_get_local_batch_bytes(const keyT record) const {
+        typename madness::WorldContainer<keyT, valueT>::const_accessor acc;
+        if (batch_container.find(acc, record)) return acc->second;
+        return valueT();
+    }
+
+    /// stable pointer and size of a local batch record, {nullptr,0} if this rank holds none
+
+    /// Lets the comm thread Isend without copying the payload. The accessor lock is
+    /// released on return, but the address stays valid because batch records are neither
+    /// erased nor mutated between the store and the end of the consuming operation.
+    /// Never throws, for the reason given on try_get_local_batch_bytes.
+    std::pair<const unsigned char*, std::size_t> try_get_local_batch_ptr(const keyT record) const {
+        typename madness::WorldContainer<keyT, valueT>::const_accessor acc;
+        if (batch_container.find(acc, record))
+            return {acc->second.data(), acc->second.size()};
+        return {nullptr, 0};
+    }
+
+public:
+
+    /// start fetching `record` from its owner; the trigger is in flight on return
+    Future<batch_bytesT> request_batch_bytes_async(const keyT record) const {
+        return batch_transport_->request(record);
+    }
+
+    /// turn the bytes of a p2p transfer into the batch of functions
+
+    /// Blocks on `fut` only if the transfer has not landed yet. Runs in a task, which is
+    /// where a missing record is reported so the failure is attributable.
+    /// @param[in] cache_result  default false: the cloud-side cache is not safe to keep
+    ///                          across changes of the calling world, so opting in is the
+    ///                          caller's decision
+    template<typename T, std::size_t NDIM>
+    std::vector<Function<T, NDIM>> deserialize_batch_p2p(madness::World& subworld,
+            Future<batch_bytesT> fut, const keyT record,
+            const bool cache_result = false) const {
+        typedef std::vector<Function<T, NDIM>> vecfuncT;
+        if (is_cached(record)) return load_from_cache<vecfuncT>(subworld, record);
+        cloudtimer t(subworld, reading_time);
+        const double w0 = wall_time();
+        batch_bytesT bytes = fut.get();
+        const double w1 = wall_time();
+        batch_find_time += long((w1 - w0) * 1.e6);
+        MADNESS_CHECK_THROW(not bytes.empty(),
+                            "deserialize_batch_p2p: the owner does not hold this batch record");
+        vecfuncT batch;
+        {
+            madness::archive::VectorInputArchive var(bytes);
+            madness::archive::ParallelInputArchive<madness::archive::VectorInputArchive> par(subworld, var);
+            std::size_t fsize = 0;
+            par & fsize;
+            batch.resize(fsize);
+            for (std::size_t i = 0; i < fsize; ++i) par & batch[i];
+        }
+        batch_deserialize_time += long((wall_time() - w1) * 1.e6);
+        if (use_cache and cache_result) cache(subworld, batch, record);
+        return batch;
+    }
+
+    /// fetch a batch stored by store_batch; resolves without MPI when this rank owns it
+    template<typename T, std::size_t NDIM>
+    std::vector<Function<T, NDIM>> fetch_batch_p2p(madness::World& subworld,
+            const keyT record, const bool cache_result = false) const {
+        typedef std::vector<Function<T, NDIM>> vecfuncT;
+        if (is_cached(record)) return load_from_cache<vecfuncT>(subworld, record);
+        return deserialize_batch_p2p<T, NDIM>(subworld, request_batch_bytes_async(record),
+                                              record, cache_result);
+    }
+
+private:
 
     /// checks if a (universe) container record is used
 
@@ -925,6 +1228,98 @@ public:
         return target;
     }
 };
+
+// ---- BatchTransport bodies; they need the complete Cloud ----
+
+inline Future<batch_bytesT> BatchTransport::request(batch_keyT record) {
+    World& u = this->get_world();
+    const ProcessID owner = cloud_->batch_owner(record);
+    if (owner == u.rank()) {
+        // local: no MPI. An absent record yields empty bytes, which the consumer
+        // reports in task context, exactly as for the remote path.
+        return Future<batch_bytesT>(cloud_->try_get_local_batch_bytes(record));
+    }
+    const int tag = alloc_tag();
+    auto p = std::make_shared<PendingRecv>();
+    p->owner = owner;
+    p->tag = tag;
+    {
+        std::lock_guard<std::mutex> g(pending_mtx_);
+        pending_[tag] = p;
+    }
+    // send, not add: the trigger runs inline on the owner's comm thread, so the owner
+    // posts its Isend without queueing behind its own saturated workers
+    this->send(owner, &BatchTransport::on_trigger, record, u.rank(), tag);
+    return p->fut;
+}
+
+inline void BatchTransport::reap_sends() {
+    std::lock_guard<std::mutex> g(sends_mtx_);
+    for (auto it = sends_.begin(); it != sends_.end(); ) {
+        if (it->Test()) it = sends_.erase(it);
+        else ++it;
+    }
+}
+
+inline void BatchTransport::on_trigger(batch_keyT record, ProcessID requester, int tag) {
+    World& u = this->get_world();
+    reap_sends();
+    auto ptr_size = cloud_->try_get_local_batch_ptr(record);
+    if (ptr_size.first == nullptr) {
+        // Not held here -- reply with the sentinel and post nothing. Throwing instead
+        // would escape this comm-thread handler past every task-level handler and abort
+        // the run with no attribution; the requester raises it in task context.
+        this->send(requester, &BatchTransport::on_reply, tag, BATCH_NOT_FOUND);
+        return;
+    }
+    const std::size_t n = ptr_size.second;
+    SafeMPI::Request rd = u.mpi.Isend(ptr_size.first, int(n), MPI_BYTE, requester, tag);
+    {
+        std::lock_guard<std::mutex> g(sends_mtx_);
+        sends_.push_back(rd);
+    }
+    // the size rides in the reply so the requester can post its Irecv now, during its
+    // own compute, and let the rendezvous finish in the background
+    this->send(requester, &BatchTransport::on_reply, tag, n);
+}
+
+inline void BatchTransport::on_reply(int tag, std::size_t size) {
+    World& u = this->get_world();
+    std::shared_ptr<PendingRecv> p;
+    {
+        std::lock_guard<std::mutex> g(pending_mtx_);
+        auto it = pending_.find(tag);
+        MADNESS_CHECK(it != pending_.end());
+        p = it->second;
+    }
+    if (size == BATCH_NOT_FOUND) {
+        // no Isend was posted, so post no Irecv; empty bytes mark the miss
+        {
+            std::lock_guard<std::mutex> g(pending_mtx_);
+            pending_.erase(tag);
+        }
+        p->not_found = true;
+        p->fut.set(batch_bytesT());
+        return;
+    }
+    p->buf.resize(size);
+    p->req = u.mpi.Irecv(p->buf.data(), int(size), MPI_BYTE, p->owner, tag);
+    u.taskq.add(this, &BatchTransport::finish_recv, tag);
+}
+
+inline void BatchTransport::finish_recv(int tag) {
+    std::shared_ptr<PendingRecv> p;
+    {
+        std::lock_guard<std::mutex> g(pending_mtx_);
+        auto it = pending_.find(tag);
+        MADNESS_CHECK(it != pending_.end());
+        p = it->second;
+        pending_.erase(it);
+    }
+    // the comm thread has been progressing this Irecv all along, so the await is short
+    World::await(p->req, true);
+    p->fut.set(std::move(p->buf));
+}
 
 } /* namespace madness */
 

--- a/src/madness/world/cloud.h
+++ b/src/madness/world/cloud.h
@@ -15,9 +15,11 @@
 
 
 #include <madness/world/parallel_dc_archive.h>
+#include<algorithm>
 #include<any>
 #include<atomic>
 #include<iomanip>
+#include<limits>
 #include<list>
 #include<mutex>
 
@@ -234,6 +236,23 @@ public:
     /// reply size meaning "the owner does not hold this record"; see on_trigger
     static constexpr std::size_t BATCH_NOT_FOUND = ~std::size_t(0);
 
+    /// bytes per MPI message in a batch transfer; a larger payload is split into several
+
+    /// MPI byte counts are `int`, and batches do exceed 2 GiB: a 161-orbital run at k=10
+    /// measured 3.03 GiB, whose count narrowed to a negative int. MPI rejects that and
+    /// SafeMPI throws it on the comm thread, where nothing catches it.
+    static std::size_t batch_chunk_bytes() { return batch_chunk_bytes_; }
+
+    /// Set the chunk size, for tests only.
+
+    /// Collective and not thread-safe: call it on every rank before any transfer. It exists so
+    /// a unit test can reach the multi-chunk path with an affordable payload.
+    static void set_batch_chunk_bytes(const std::size_t n) {
+        MADNESS_CHECK_THROW(n > 0 and n <= std::size_t(std::numeric_limits<int>::max()),
+                            "batch chunk size must be positive and fit an MPI count");
+        batch_chunk_bytes_ = n;
+    }
+
     /// @param[in] universe  the world the cloud lives in (collective construction)
     /// @param[in] cloud     back-reference used to read owner-local batch bytes
     BatchTransport(World& universe, Cloud* cloud)
@@ -257,10 +276,10 @@ private:
     struct PendingRecv {
         ProcessID owner = -1;
         int tag = -1;
-        bool not_found = false;        ///< owner reported it does not hold the record
-        batch_bytesT buf;              ///< sized in on_reply
-        SafeMPI::Request req;          ///< posted in on_reply
-        Future<batch_bytesT> fut;      ///< set by finish_recv
+        bool not_found = false;             ///< owner reported it does not hold the record
+        batch_bytesT buf;                   ///< sized in on_reply
+        std::vector<SafeMPI::Request> reqs; ///< one per chunk, posted in on_reply
+        Future<batch_bytesT> fut;           ///< set by finish_recv
     };
     std::mutex pending_mtx_;
     std::map<int, std::shared_ptr<PendingRecv>> pending_;
@@ -275,6 +294,8 @@ private:
         const int t = next_tag_.fetch_add(1);
         return BATCH_TAG_BASE + ((t % span) + span) % span;
     }
+
+    static inline std::size_t batch_chunk_bytes_ = std::size_t(1) << 30;   ///< 1 GiB
 
     void reap_sends();
 
@@ -1286,10 +1307,15 @@ inline void BatchTransport::on_trigger(batch_keyT record, ProcessID requester, i
         return;
     }
     const std::size_t n = ptr_size.second;
-    SafeMPI::Request rd = u.mpi.Isend(ptr_size.first, int(n), MPI_BYTE, requester, tag);
+    // MPI does not overtake between messages sharing source, tag and communicator, so posting
+    // the chunks in ascending offset order matches the requester's Irecvs pairwise without a
+    // per-chunk tag. That does rely on one transfer per tag, which alloc_tag's span makes true.
     {
         std::lock_guard<std::mutex> g(sends_mtx_);
-        sends_.push_back(rd);
+        for (std::size_t off = 0; off < n; off += batch_chunk_bytes_) {
+            const std::size_t len = std::min(batch_chunk_bytes_, n - off);
+            sends_.push_back(u.mpi.Isend(ptr_size.first + off, int(len), MPI_BYTE, requester, tag));
+        }
     }
     // the size rides in the reply so the requester can post its Irecv now, during its
     // own compute, and let the rendezvous finish in the background
@@ -1316,7 +1342,11 @@ inline void BatchTransport::on_reply(int tag, std::size_t size) {
         return;
     }
     p->buf.resize(size);
-    p->req = u.mpi.Irecv(p->buf.data(), int(size), MPI_BYTE, p->owner, tag);
+    // must match on_trigger's chunking exactly, in the same order; see batch_chunk_bytes
+    for (std::size_t off = 0; off < size; off += batch_chunk_bytes_) {
+        const std::size_t len = std::min(batch_chunk_bytes_, size - off);
+        p->reqs.push_back(u.mpi.Irecv(p->buf.data() + off, int(len), MPI_BYTE, p->owner, tag));
+    }
     u.taskq.add(this, &BatchTransport::finish_recv, tag);
 }
 
@@ -1329,8 +1359,8 @@ inline void BatchTransport::finish_recv(int tag) {
         p = it->second;
         pending_.erase(it);
     }
-    // the comm thread has been progressing this Irecv all along, so the await is short
-    World::await(p->req, true);
+    // the comm thread has been progressing these Irecvs all along, so the awaits are short
+    for (auto& r : p->reqs) World::await(r, true);
     p->fut.set(std::move(p->buf));
 }
 

--- a/src/madness/world/print.h
+++ b/src/madness/world/print.h
@@ -40,6 +40,7 @@
 
 #include <type_traits>
 #include <iostream>
+#include <filesystem>
 #include <fstream>
 #include <complex>
 #include <list>
@@ -247,29 +248,51 @@ operator<<(std::ostream &s, const T (&v)[N]) {
     }
 
 
-    /// RAII class to redirect cout to a file
+    /// RAII class to redirect cout to a file or to /dev/null
     struct io_redirect {
+        /// File writes <directory>/<filename>.<NNNNN>; Discard silences cout via /dev/null
+        enum class Mode { File, Discard };
+
         std::streambuf* stream_buffer_cout;
         static std::streambuf* stream_buffer_cout_default; ///< default stream buffer for cout, used to restore cout
         std::ofstream ofile;
+        Mode mode = Mode::File;
         bool debug = false;
 
-        io_redirect(const long task_number, std::string filename, bool debug = false) : debug(debug) {
+        /// \param directory  created if needed; empty means the current directory
+        io_redirect(Mode mode, const long task_number,
+                    std::string directory, std::string filename, bool debug = false)
+                : mode(mode), debug(debug) {
             stream_buffer_cout_default = std::cout.rdbuf();
-            constexpr std::size_t bufsize = 256;
-            char cfilename[bufsize];
-            std::snprintf(cfilename, bufsize, "%s.%5.5ld", filename.c_str(), task_number);
-            ofile = std::ofstream(cfilename);
-            if (debug) std::cout << "redirecting to file " << cfilename << std::endl;
+            if (mode == Mode::File) {
+                constexpr std::size_t bufsize = 512;
+                char cfilename[bufsize];
+                if (directory.empty()) {
+                    std::snprintf(cfilename, bufsize, "%s.%5.5ld", filename.c_str(), task_number);
+                } else {
+                    std::error_code ec;
+                    std::filesystem::create_directories(directory, ec);  // idempotent; races are benign
+                    std::snprintf(cfilename, bufsize, "%s/%s.%5.5ld",
+                                  directory.c_str(), filename.c_str(), task_number);
+                }
+                ofile = std::ofstream(cfilename);
+                if (debug) std::cout << "redirecting to file " << cfilename << std::endl;
+            } else {
+                ofile = std::ofstream("/dev/null");
+            }
             stream_buffer_cout = std::cout.rdbuf(ofile.rdbuf());
             std::cout.sync_with_stdio(true);
         }
+
+        /// a file in the current directory
+        io_redirect(const long task_number, std::string filename, bool debug = false)
+                : io_redirect(Mode::File, task_number, std::string(), std::move(filename), debug) {}
 
         ~io_redirect() {
             std::cout.rdbuf(stream_buffer_cout);
             ofile.close();
             std::cout.sync_with_stdio(true);
-            if (debug) std::cout << "redirecting back to cout" << std::endl;
+            if (debug and mode == Mode::File) std::cout << "redirecting back to cout" << std::endl;
         }
     };
 

--- a/src/madness/world/timers.h
+++ b/src/madness/world/timers.h
@@ -41,6 +41,7 @@
 #include <chrono>
 #include <cstdint>
 #include <ctime>
+#include <time.h>       // clock_gettime, CLOCK_PROCESS_CPUTIME_ID (POSIX, not in <ctime>)
 #include <sys/time.h>
 #include <unistd.h>
 #include <madness/madness_config.h>
@@ -139,6 +140,23 @@ namespace madness {
       const auto nanoseconds_since_epoch = std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch()).count();
       return nanoseconds_since_epoch / 1e9;
 #endif
+    }
+
+    /// Returns the CPU time consumed by this process, in seconds.
+
+    /// Aggregated over all threads of the process, so a task's compute time can be
+    /// separated from its idle time. This is *not* what cpu_time() returns: that
+    /// reads a cycle counter on x86 and therefore measures elapsed time. An
+    /// instrumentation helper, not part of the documented timing API.
+    /// \return The process CPU time (in seconds).
+    static inline double process_cpu_time() {
+#if defined(CLOCK_PROCESS_CPUTIME_ID)
+        struct timespec ts;
+        if (clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &ts) == 0) {
+            return static_cast<double>(ts.tv_sec) + 1.0e-9 * static_cast<double>(ts.tv_nsec);
+        }
+#endif
+        return static_cast<double>(std::clock()) / static_cast<double>(CLOCKS_PER_SEC);
     }
 
 


### PR DESCRIPTION
## What this does

Reworks the symmetric HF exchange so that the orbitals are stored once as batches owned by
particular ranks, each task runs where its data already is, and the batch it will need next is
requested while it computes. Adds the runtime and macrotask-framework machinery this needs, and a
consumer that uses it.

Reachable as `hfexalg multiworld`. **moldft's default is `multiworld_row`, which is untouched**, so
no existing calculation changes behaviour unless it asks for the new path.

**1. `world/cloud.h` — owner-pinned batches and a point-to-point transport.**

- a second container holds batches pinned to an owning rank; a requester asks the owner directly
  and gets the bytes back, resolving locally when it is the owner
- both endpoints are posted from comm-thread handlers, so neither queues behind saturated workers
- a transfer is split into 1 GiB messages, because an MPI byte count is an `int` and batches are
  measured above 2 GiB
- batch records are released with the rest of the cloud, and their size is reported alongside it

**2. `mra/macrotaskq.h` — optional task hooks and owner-pinned scheduling.**

- the hooks are stated as detection traits in the shape `madness::archive` uses
  (`has_store_batches_v` and friends): a task opts in by declaring a member, and one that declares
  nothing is unaffected
- tasks may name an owner (`owner_hint`), move their own operands (`handles_own_data_movement`),
  accumulate their own results (`accumulates_own_output`), and release what they cached (`cleanup`)
- when every task names an owner and there is one subworld per rank, each rank walks the queue and
  runs what it owns instead of asking a scheduler for work
- a task that accumulates its own output does so without fencing, so the subworld is quiesced once
  before its buffer is drained

**3. `chem/exchangeoperator.*` — the symmetric path.**

- the orbitals are split once; the task grid is the lower triangle over that split, and every task
  is placed on a rank that already holds one of its two batches, so placement costs no transfer
- tiles are computed one row at a time, so a tile holds one row of intermediates rather than all of
  them
- a task requests its successor's batch before computing its own
- results are summed per subworld, and per node before they reach the universe, so only one rank per
  node scatters between nodes
- tasks are placed by their measured cost from the previous application, because screening leaves
  the tiles uneven and counting them cannot see that

## Commits

| commit | what |
|---|---|
| `f583abaa9` | give `io_redirect` a discard mode and a target directory |
| `380b7895e` | owner-pinned batch storage and p2p fetch in the cloud |
| `ffb4a0ffd` | test the cloud's batch store and p2p fetch |
| `439309835` | optional task hooks and owner-pinned scheduling in the macrotask queue |
| `63523eafd` | let a task prefetch its next batch and accumulate its own output |
| `f7d2a678f` | write per-task output only at high print level |
| `334ebb81a` | exercise the macrotask queue's owned-task scheduling path |
| `7a602ef93` | a process CPU-time reader in `timers.h` |
| `5e572f290` | owner assignment for the symmetric exchange task matrix |
| `56444d6ff` | make the round-robin assignment linear in the task count |
| `c1c631e04` | batch record keys and a bounded batch cache |
| `a4ac84028` | stream the symmetric exchange tile kernels |
| `d755d0920` | pin tasks to the ranks owning their batches |
| `75228867b` | fetch operands from the rank that owns them |
| `cde72883e` | report batch fetches at the scope they are read at |
| `dfe9b77a0` | sum tile results per subworld, and per node before the universe |
| `a288fb3d2` | expose the batching and accumulation settings |
| `584d7a6e4` | request the next batch while the current task computes |
| `9ad8cc514` | place tasks by their measured cost |
| `6c7ba86b7` | release the finalize reducers while their world still exists |
| `fae1c1208` | release and report the cloud's owner-pinned batches |
| `54403ab0e` | per-task profiles behind `MAD_EXCH_TASK_PROFILE` |
| `93386add9` | make the finalize's destination check always on |
| `b35bde62b` | state the optional task hooks as detection traits |
| `4bf8a9993` | split `run_all` into the phases it runs |
| `b1d2b75ed` | split `run` into the phases it runs |
| `326adfd6e` | give the profiler the stage timings and the cost matrix |
| `89af8dcd1` | split batch transfers into 1 GiB MPI messages |

28 commits, +2687/−140 over 15 files.

## Interface changes

Three parameters are added, all for `hfexalg multiworld`:

- `hfex_batch_granularity` (default 1) — batches of orbitals per rank
- `hfex_local_accumulation` (default 2) — 1 gathers per subworld, 2 also gathers per node first and
  degrades to 1 on a single node
- `hfex_cost_aware_assign` (default true) — place tasks by measured cost rather than by counting them

The existing `memory` keyword is untouched, and no checkpoint format changes.

## Tests

`madness/test/chem/test_exchange_owner_assign` and `test_exchange_batch_cache` are new and cover the
placement and the batch cache as pure functions: that every task lands on a rank holding one of its
batches, that the placement is deterministic so ranks agree without communicating, that cost-aware
placement lowers the peak load on an uneven cost model, and that batches a rank owns are never
evicted while fetched ones are bounded. `mra/test_cloud` gains cases for the batch store, the
point-to-point fetch, a fetch of a record no rank holds, and a transfer split across several MPI
messages. `mra/test_vectormacrotask` gains a task that names owners, so the owned-walk scheduling
path is exercised.

## PR checklist

| item | answer |
|---|---|
| raw MPI calls | none. The batch transport's `Isend`/`Irecv` go through `World::mpi` (`SafeMPI`) |
| blocking MPI collectives | none added |
| implicit default World | none added. `store_batches` does point `FunctionDefaults`' pmap at the subworld for the duration of a cross-world copy and restores it, because a copy picks its pmap from the target world |
| non-collective container construction | none. The batch container, its pmap and `BatchTransport` are constructed with the cloud, in the universe |
| threaded-BLAS assumptions | none. Parallelism is macrotasks over the task queue |
| `Function` mutation from user threads | no. Kernels run in tasks; the comm-thread handlers touch only serialized bytes and MPI requests, never a `Function` |
| tree-state preconditions | unchanged; the streamed kernels take the same states as master's |
| checkpoint-format break | none |
| GENTENSOR coverage | builds and tests clean under `-DENABLE_GENTENSOR=ON` |