### PR TITLE
Pr exchange asym

### DIFF
--- a/src/madness/chem/CMakeLists.txt
+++ b/src/madness/chem/CMakeLists.txt
@@ -164,6 +164,7 @@ if(BUILD_TESTING)
   SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
   # The list of unit test source files
   set(CHEM_TEST_SOURCES_SHORT test_pointgroupsymmetry.cc test_masks_and_boxes.cc
+      test_exchange_asymmetric.cc
   test_qc.cc test_MolecularOrbitals.cc test_BSHApply.cc test_projector.cc
   test_exchange_owner_assign.cc test_exchange_batch_cache.cc)
   set(CHEM_TEST_SOURCES_LONG test_localizer.cc test_ccpairfunction.cc test_low_rank_function.cc)
@@ -176,6 +177,8 @@ if(BUILD_TESTING)
   endif(INTEGRATORXX_FOUND)
 
   add_unittests(chem "${CHEM_TEST_SOURCES_SHORT}" "MADchem;MADgtest" "unittests;short")
+  # the rotating operand only moves between ranks, so the distributed path needs more than one
+  add_mpi_tests(chem test_exchange_asymmetric "2" "MADchem;MADgtest" "unittests;short")
   add_unittests(chem "${CHEM_TEST_SOURCES_LONG}" "MADchem;MADgtest" "unittests;long")
 
   # Create other test executables not included in the unit tests ... consider these executables (unlike unit tests)

--- a/src/madness/chem/CalculationParameters.h
+++ b/src/madness/chem/CalculationParameters.h
@@ -67,10 +67,10 @@ struct CalculationParameters : public QCCalculationParametersBase {
 		initialize<std::string>("prefix","mad","prefixes your output/restart/json/plot/etc files");
 		initialize<double>("charge",0.0,"total molecular charge");
 		initialize<std::string> ("xc","hf","XC input line");
-		initialize<std::string> ("hfexalg","multiworld_row","hf exchange algorithm; multiworld stores the orbitals once as batches and has each task fetch the two it needs from the rank holding them, which bounds memory but needs one subworld per rank",{"multiworld","multiworld_row","fetch_compute","smallmem","largemem"});
-		initialize<long>  ("hfex_batch_granularity",1,"hfexalg=multiworld: batches of orbitals per rank (>=1). 1 is the coarsest and has the lowest peak memory; raising it makes tasks smaller and easier to balance at the cost of more transfers");
-		initialize<bool>  ("hfex_cost_aware_assign",true,"hfexalg=multiworld: place tasks by their measured cost from the previous application instead of by counting them, which matters because screening makes the tiles uneven. Takes effect from the third application on, since it needs a representative reference; set false for the count-based placement");
-		initialize<int>   ("hfex_local_accumulation",2,"hfexalg=multiworld: how tile results are gathered. 1=sum per subworld, then one transfer per subworld into the result; 2=additionally sum the subworlds of a node first, so only one rank per node transfers between nodes (falls back to 1 on a single node)");
+		initialize<std::string> ("hfexalg","multiworld_row","hf exchange algorithm; multiworld bounds memory, needs one subworld per rank",{"multiworld","multiworld_row","fetch_compute","smallmem","largemem"});
+		initialize<long>  ("hfex_batch_granularity",1,"hfexalg=multiworld: orbital batches per rank; >1 balances better");
+		initialize<bool>  ("hfex_cost_aware_assign",true,"hfexalg=multiworld: place tasks by measured cost, not by count");
+		initialize<int>   ("hfex_local_accumulation",2,"hfexalg=multiworld: gather tile results 1=per subworld, 2=per node");
 		initialize<std::vector<std::string>>("memory",{"storefunction","nodereplicated","distributed"},"memory algorithm for storing functions (storing,cloud,target)");
 		initialize<double>("smear",0.0,"smearing parameter");
 		initialize<double>("econv",1.e-5,"energy convergence");

--- a/src/madness/chem/SCF.cc
+++ b/src/madness/chem/SCF.cc
@@ -257,6 +257,7 @@ SCF::SCF(World& world, const CalculationParameters& param1, const Molecule& mole
     FunctionDefaults<3>::set_cubic_cell(-param.L(), param.L());
     //set_protocol < 3 > (world, param.econv());
     FunctionDefaults<3>::set_truncate_mode(1);
+    FunctionDefaults<3>::set_debug(param.print_level() >= 10);
 
 }
 

--- a/src/madness/chem/exchangeoperator.cc
+++ b/src/madness/chem/exchangeoperator.cc
@@ -117,17 +117,24 @@ Exchange<T, NDIM>::ExchangeImpl::K_macrotask_efficient(const vecfuncT& vf, const
 
     // the result is a vector of functions living in the universe
     const long nresult = vf.size();
-    // Whether tasks are pinned to the ranks owning their batches. Today this is exactly the
-    // symmetric case, because bra == ket == vf there lets one set of batches serve every
-    // operand role, so both of a task's batches are owned by someone. It is decided here, once,
-    // rather than spelled as is_symmetric() at each of the three places that need it: pinning,
-    // the storage policy and the cost reduction have to agree, and the asymmetric path will opt
-    // in without changing what symmetric does.
-    const bool owner_pinned = is_symmetric();
+    // Whether the tiles may exploit the i-j symmetry. MAD_EXCH_FORCE_GENERAL takes it away from an
+    // application that is entitled to it, which computes the same numbers down the general path and
+    // so tests that path against a known answer; see exch_force_general_path.
+    const bool symmetric = is_symmetric() and not exch_force_general_path();
+    // printlevel rather than printdebug(), which is >= 10: this has to be visible at the level a
+    // validation run uses, or a forced run reads as a normal one
+    if (symmetric != is_symmetric() and world.rank() == 0 and printlevel >= 4)
+        print("MAD_EXCH_FORCE_GENERAL is set: routing exchange through the general path");
+
+    // Whether tasks are pinned to the ranks owning their batches. That needs one set of batches to
+    // serve every operand role, which is what bra == ket == vf buys, so it follows the symmetry the
+    // tiles actually use rather than the operator's own flag. Decided here, once, because pinning,
+    // the storage policy and the cost reduction have to agree.
+    const bool owner_pinned = symmetric;
 
     // the salt is formed here, once, where the ket is in hand: every rank builds the same task
     // objects collectively, so passing it reaches every rank without a manifest
-    MacroTaskExchangeSimple xtask(nresult, lo, mul_tol, is_symmetric(),
+    MacroTaskExchangeSimple xtask(nresult, lo, mul_tol, symmetric,
                                   owner_pinned, batch_granularity_,
                                   world.rank(), accumulation_mode_, cost_aware_assign_,
                                   exchange_batch_salt(mo_ket));

--- a/src/madness/chem/exchangeoperator.cc
+++ b/src/madness/chem/exchangeoperator.cc
@@ -117,20 +117,25 @@ Exchange<T, NDIM>::ExchangeImpl::K_macrotask_efficient(const vecfuncT& vf, const
 
     // the result is a vector of functions living in the universe
     const long nresult = vf.size();
-    // Owner-pinned placement applies to the symmetric case only: it needs bra == ket so
-    // that one set of batches serves every operand role and both of a task's batches are
-    // owned by some rank. The asymmetric case keeps the size-driven partition.
+    // Whether tasks are pinned to the ranks owning their batches. Today this is exactly the
+    // symmetric case, because bra == ket == vf there lets one set of batches serve every
+    // operand role, so both of a task's batches are owned by someone. It is decided here, once,
+    // rather than spelled as is_symmetric() at each of the three places that need it: pinning,
+    // the storage policy and the cost reduction have to agree, and the asymmetric path will opt
+    // in without changing what symmetric does.
+    const bool owner_pinned = is_symmetric();
+
     // the salt is formed here, once, where the ket is in hand: every rank builds the same task
     // objects collectively, so passing it reaches every rank without a manifest
     MacroTaskExchangeSimple xtask(nresult, lo, mul_tol, is_symmetric(),
-                                  /*owner_pinned=*/is_symmetric(), batch_granularity_,
+                                  owner_pinned, batch_granularity_,
                                   world.rank(), accumulation_mode_, cost_aware_assign_,
                                   exchange_batch_salt(mo_ket));
     // The owner-pinned path stores the orbitals as batches itself and fetches the two it
     // needs per task, so the cloud must hold pointers rather than copy every operand into
-    // every subworld. The algorithm therefore fixes the storage policy.
-    const MacroTaskInfo policy = is_symmetric() ? MacroTaskInfo::preset("small_memory_owner")
-                                                : macro_task_info;
+    // every subworld. Pinning therefore fixes the storage policy.
+    const MacroTaskInfo policy = owner_pinned ? MacroTaskInfo::preset("small_memory_owner")
+                                              : macro_task_info;
     if (taskq) taskq->set_printlevel(printlevel);
 
     // construct MacroTask with or without user-provided taskq -> deferred execution or immediate execution
@@ -143,8 +148,9 @@ Exchange<T, NDIM>::ExchangeImpl::K_macrotask_efficient(const vecfuncT& vf, const
 
     // Every tile ran on exactly one rank, so summing the per-rank cost buffers unions them and
     // leaves every rank holding the same matrix -- which is what lets the next call's placement
-    // be computed independently everywhere and still agree.
-    if (is_symmetric() and cost_aware_assign_) {
+    // be computed independently everywhere and still agree. Gated on pinning, not on symmetry,
+    // to match where the tiles record their cost.
+    if (owner_pinned and cost_aware_assign_) {
         auto& costs = MacroTaskExchangeSimple::cost_this_call();
         if (not costs.empty()) {
             world.gop.sum(costs.data(), costs.size());

--- a/src/madness/chem/exchangeoperator.cc
+++ b/src/madness/chem/exchangeoperator.cc
@@ -120,9 +120,12 @@ Exchange<T, NDIM>::ExchangeImpl::K_macrotask_efficient(const vecfuncT& vf, const
     // Owner-pinned placement applies to the symmetric case only: it needs bra == ket so
     // that one set of batches serves every operand role and both of a task's batches are
     // owned by some rank. The asymmetric case keeps the size-driven partition.
+    // the salt is formed here, once, where the ket is in hand: every rank builds the same task
+    // objects collectively, so passing it reaches every rank without a manifest
     MacroTaskExchangeSimple xtask(nresult, lo, mul_tol, is_symmetric(),
                                   /*owner_pinned=*/is_symmetric(), batch_granularity_,
-                                  world.rank(), accumulation_mode_, cost_aware_assign_);
+                                  world.rank(), accumulation_mode_, cost_aware_assign_,
+                                  exchange_batch_salt(mo_ket));
     // The owner-pinned path stores the orbitals as batches itself and fetches the two it
     // needs per task, so the cloud must hold pointers rather than copy every operand into
     // every subworld. The algorithm therefore fixes the storage policy.

--- a/src/madness/chem/exchangeoperator.cc
+++ b/src/madness/chem/exchangeoperator.cc
@@ -126,11 +126,11 @@ Exchange<T, NDIM>::ExchangeImpl::K_macrotask_efficient(const vecfuncT& vf, const
     if (symmetric != is_symmetric() and world.rank() == 0 and printlevel >= 4)
         print("MAD_EXCH_FORCE_GENERAL is set: routing exchange through the general path");
 
-    // Whether tasks are pinned to the ranks owning their batches. That needs one set of batches to
-    // serve every operand role, which is what bra == ket == vf buys, so it follows the symmetry the
-    // tiles actually use rather than the operator's own flag. Decided here, once, because pinning,
-    // the storage policy and the cost reduction have to agree.
-    const bool owner_pinned = symmetric;
+    // Whether tasks are pinned to the ranks owning their batches. Both symmetries support it now:
+    // the symmetric grid shares one stored set across all three operand roles, and the asymmetric
+    // one stores a set per role and holds its column batch while the row rotates. Decided here,
+    // once, because pinning, the storage policy and the cost reduction have to agree.
+    const bool owner_pinned = true;
 
     // the salt is formed here, once, where the ket is in hand: every rank builds the same task
     // objects collectively, so passing it reaches every rank without a manifest

--- a/src/madness/chem/exchangeoperator.cc
+++ b/src/madness/chem/exchangeoperator.cc
@@ -137,7 +137,9 @@ Exchange<T, NDIM>::ExchangeImpl::K_macrotask_efficient(const vecfuncT& vf, const
     MacroTaskExchangeSimple xtask(nresult, lo, mul_tol, symmetric,
                                   owner_pinned, batch_granularity_,
                                   world.rank(), accumulation_mode_, cost_aware_assign_,
-                                  exchange_batch_salt(mo_ket));
+                                  exchange_batch_salt(mo_ket),
+                                  exchange_same_operands(mo_bra, mo_ket),
+                                  exchange_same_operands(vf, mo_ket));
     // The owner-pinned path stores the orbitals as batches itself and fetches the two it
     // needs per task, so the cloud must hold pointers rather than copy every operand into
     // every subworld. Pinning therefore fixes the storage policy.

--- a/src/madness/chem/exchangeoperator.h
+++ b/src/madness/chem/exchangeoperator.h
@@ -58,6 +58,16 @@ inline std::vector<Batch_1D> exchange_sym_owner_split(const std::size_t n, const
     return out;
 }
 
+/// Batch boundaries for the asymmetric row/column split: one batch per rank.
+
+/// Deliberately the same boundaries as exchange_sym_owner_split at granularity 1, so batches stored
+/// for one dimension align with the partition. Named apart because "sym" reads wrong in the
+/// asymmetric path, and because granularity is not a knob here -- the column-to-rank assignment
+/// relies on there being exactly one batch per rank.
+inline std::vector<Batch_1D> exchange_row_owner_split(const std::size_t n, const long nsubworld) {
+    return exchange_sym_owner_split(n, nsubworld, 1);
+}
+
 /// Triangular index of a batch pair, collapsing (i,j) and (j,i): a*(a+1)/2 + b.
 
 /// The indexing convention of the per-task cost vector, shared by whoever records a

--- a/src/madness/chem/exchangeoperator.h
+++ b/src/madness/chem/exchangeoperator.h
@@ -1232,9 +1232,11 @@ private:
         /// the owners: serializing centrally instead funnels the whole orbital set through
         /// one rank's network interface.
         ///
-        /// The symmetric case stores one set: bra == ket == vf, so the same batch serves as
-        /// column, row and ket operand. The asymmetric case stores three, one per role, over two
-        /// splits -- vf along the column dimension, bra and ket along the row dimension they share.
+        /// A record is stored per *distinct* operand vector, not per role: HF exchange passes one
+        /// vector as all three and still stores a single set, nemo's bra = R^2 * ket makes two, and
+        /// three only when all three differ. The symmetric grid shares one split; the asymmetric one
+        /// puts vf on the column boundaries and bra/ket on the row ones, so vf needs its own record
+        /// there even when it is the ket.
         void store_batches(World& world, World& subworld, Cloud& cloud, const argtupleT& argtuple,
                            const long nsubworld) {
             if (not owner_pinned) return;
@@ -1544,9 +1546,9 @@ private:
                 prof_.wall_start = tile_wall_start;
             }
 
-            // Owner-pinned: fetch the two batches this task needs from the cloud. Because
-            // bra == ket == vf there, one batch per range serves every operand role, so the
-            // ket over a range is just that range's batch.
+            // Owner-pinned: fetch this task's operands from the cloud, one request per role and
+            // range. Roles that share a record resolve to the same key, so the repeats are cache
+            // hits rather than transfers.
             vecfuncT bra_owned, vf_owned, ket_row_owned, ket_column_owned;
             const vecfuncT* bra_work = &bra_batch;
             const vecfuncT* vf_work = &vf_batch;

--- a/src/madness/chem/exchangeoperator.h
+++ b/src/madness/chem/exchangeoperator.h
@@ -1337,11 +1337,16 @@ private:
 
         /// The result entries this tile actually wrote.
 
-        /// operator() scatters into the bra range and the vf range of a full-width Kf and
-        /// leaves everything else zero, so summing all `nresult` entries would gaxpy mostly
-        /// zeros -- a per-tile cost proportional to the whole result vector. The union of the
-        /// two input ranges is a correct superset of every entry the tile touched; a full-size
-        /// or absent range falls back to all of them.
+        /// operator() scatters into a full-width Kf and leaves everything else zero, so summing all
+        /// `nresult` entries would gaxpy mostly zeros -- a per-tile cost proportional to the whole
+        /// result vector. Every tile writes its column range; a symmetric off-diagonal tile also
+        /// writes its row range, reusing each intermediate for the transposed element, whereas an
+        /// asymmetric tile contributes to its column alone. A full-size or absent range falls back
+        /// to all of them.
+        ///
+        /// The result must be a *set*: the caller gaxpys one entry per index, so a repeated index is
+        /// added twice. Both ranges come from one split while the grid is triangular, where they are
+        /// always equal or disjoint, but from separate splits of different lengths otherwise.
         std::vector<long> touched_result_indices() const {
             std::vector<long> idx;
             auto add_range = [&](const Batch_1D& b) {
@@ -1354,7 +1359,10 @@ private:
                 return idx;
             }
             add_range(batch.input[0]);
-            if (batch.input.size() > 1 and not (batch.input[1] == batch.input[0])) add_range(batch.input[1]);
+            if (symmetric and batch.input.size() > 1 and not (batch.input[1] == batch.input[0]))
+                add_range(batch.input[1]);
+            std::sort(idx.begin(), idx.end());
+            idx.erase(std::unique(idx.begin(), idx.end()), idx.end());
             return idx;
         }
 

--- a/src/madness/chem/exchangeoperator.h
+++ b/src/madness/chem/exchangeoperator.h
@@ -86,6 +86,22 @@ exchange_row_owner_grid(const std::size_t ncolumn, const std::size_t nrow, const
     return out;
 }
 
+/// Owner of every task in the asymmetric grid: all tasks of a column go to one worker.
+
+/// The column operand is the one that stays put, so putting a whole column on one worker means the
+/// batch it holds is never fetched, and that worker computes the *complete* result for those
+/// columns -- there is no cross-rank reduction of results beyond the final gather. Handing columns
+/// out in order is balanced by construction, the grid being a full rectangle, so no cost model is
+/// needed here. Keyed by batch index, like exchange_sym_round_robin_assign.
+inline std::map<std::pair<long,long>,long>
+exchange_row_owner_assign(const long ncolumn, const long nrow, const long nworker) {
+    std::map<std::pair<long,long>,long> owner;
+    if (ncolumn <= 0 or nrow <= 0 or nworker <= 0) return owner;
+    for (long c = 0; c < ncolumn; ++c)
+        for (long r = 0; r < nrow; ++r) owner[{c, r}] = c % nworker;
+    return owner;
+}
+
 /// Triangular index of a batch pair, collapsing (i,j) and (j,i): a*(a+1)/2 + b.
 
 /// The indexing convention of the per-task cost vector, shared by whoever records a
@@ -1081,6 +1097,38 @@ private:
                                       const long nsubworld) {
             owner_map_.clear();
             if (not owner_pinned or nsubworld <= 0) return;
+
+            if (not symmetric) {
+                // Both dimensions are indexed from the partition rather than from nresult, which is
+                // the column length only: the row dimension carries bra and ket and has its own.
+                std::map<long,long> column_index, row_index;
+                for (const auto& [task_batch, priority] : partition) {
+                    MADNESS_CHECK_THROW(task_batch.input.size() >= 2,
+                                        "owner-pinned exchange expects two-dimensional task batches");
+                    column_index[task_batch.input[0].begin] = 0;   // renumbered below, in order
+                    row_index[task_batch.input[1].begin] = 0;
+                }
+                long next = 0;
+                for (auto& [begin, index] : column_index) index = next++;
+                next = 0;
+                for (auto& [begin, index] : row_index) index = next++;
+
+                const auto assignment = exchange_row_owner_assign(long(column_index.size()),
+                                                                  long(row_index.size()), nsubworld);
+                for (const auto& [task_batch, priority] : partition) {
+                    const long c = column_index[task_batch.input[0].begin];
+                    const long r = row_index[task_batch.input[1].begin];
+                    auto it = assignment.find({c, r});
+                    owner_map_[{task_batch.input[0].begin, task_batch.input[1].begin}] =
+                            (it != assignment.end()) ? it->second : (c % nsubworld);
+                }
+                // Cost-aware placement stays off here: its vector is indexed by exchange_sym_tri,
+                // which is meaningless for a rectangle, and a column-per-worker grid is already
+                // balanced. An empty vector is what stops the tiles recording into it.
+                cost_this_call_.clear();
+                batch_begin_to_index_.clear();
+                return;
+            }
 
             const std::vector<Batch_1D> split =
                     exchange_sym_owner_split(nresult, nsubworld, granularity_level);

--- a/src/madness/chem/exchangeoperator.h
+++ b/src/madness/chem/exchangeoperator.h
@@ -809,7 +809,8 @@ private:
     /// how the tile results are gathered: 1 = subworld buffer then universe, 2 = also reduce
     /// within a node first (default; degrades to 1 on a single node)
     int accumulation_mode_ = 2;
-    /// place tasks by measured cost instead of by counting them
+    /// place tasks by measured cost instead of by counting them; the first two applications
+    /// still count, having no representative reference to measure against
     bool cost_aware_assign_ = true;
 
     mutable nlohmann::json statistics;  ///< statistics of the Cloud (timings, memory)  and of the parameters of this run

--- a/src/madness/chem/exchangeoperator.h
+++ b/src/madness/chem/exchangeoperator.h
@@ -1206,7 +1206,8 @@ private:
         /// one rank's network interface.
         ///
         /// The symmetric case stores one set: bra == ket == vf, so the same batch serves as
-        /// column, row and ket operand.
+        /// column, row and ket operand. The asymmetric case stores three, one per role, over two
+        /// splits -- vf along the column dimension, bra and ket along the row dimension they share.
         void store_batches(World& world, World& subworld, Cloud& cloud, const argtupleT& argtuple,
                            const long nsubworld) {
             if (not owner_pinned) return;
@@ -1216,12 +1217,11 @@ private:
             // so say so rather than compute something wrong.
             MADNESS_CHECK_THROW(nsubworld == world.size(),
                                 "owner-pinned exchange needs one subworld per rank");
+            const vecfuncT& vf = std::get<0>(argtuple);
+            const vecfuncT& mo_bra = std::get<1>(argtuple);
             const vecfuncT& mo_ket = std::get<2>(argtuple);
             // one fence up front, so store_batch does not need one per function
             world.gop.fence();
-            const long salt = batch_salt_;
-            const std::vector<Batch_1D> split =
-                    exchange_sym_owner_split(mo_ket.size(), nsubworld, granularity_level);
 
             // A cross-world copy picks its process map from the target world, but anything
             // on that path reading the process-wide default would route to universe ranks
@@ -1231,16 +1231,35 @@ private:
             FunctionDefaults<NDIM>::set_default_pmap(subworld);
 
             std::vector<std::pair<long, vecfuncT>> owned;
-            for (long k = 0; k < long(split.size()); ++k) {
-                const Batch_1D& r = split[k];
-                const long record = exchange_batch_record_key(salt, EXCHANGE_BATCH_VF, r);
-                cloud.register_batch_owner(record, ProcessID(k % nsubworld));
-                if (k % nsubworld == world.rank()) {
-                    vecfuncT local(r.size());
-                    for (long i = r.begin; i < r.end; ++i)
-                        local[i - r.begin] = copy(subworld, mo_ket[i], /*fence=*/false);
-                    owned.emplace_back(record, std::move(local));
+            // register the routing for one operand set, and pull the batches this rank owns. Batch k
+            // goes to rank k, which is what puts a column batch on the rank running that column.
+            auto stage = [&](const vecfuncT& v, const int dim, const std::vector<Batch_1D>& split) {
+                for (long k = 0; k < long(split.size()); ++k) {
+                    const Batch_1D& r = split[k];
+                    const long record = exchange_batch_record_key(batch_salt_, dim, r);
+                    cloud.register_batch_owner(record, ProcessID(k % nsubworld));
+                    if (k % nsubworld == world.rank()) {
+                        vecfuncT local(r.size());
+                        for (long i = r.begin; i < r.end; ++i)
+                            local[i - r.begin] = copy(subworld, v[i], /*fence=*/false);
+                        owned.emplace_back(record, std::move(local));
+                    }
                 }
+            };
+
+            if (symmetric) {
+                stage(mo_ket, EXCHANGE_BATCH_VF,
+                      exchange_sym_owner_split(mo_ket.size(), nsubworld, granularity_level));
+            } else {
+                // bra and ket are indexed together by the operator's sum over pairs, so they share
+                // the row boundaries; vf is independent and gets the column ones
+                MADNESS_CHECK_THROW(mo_bra.size() == mo_ket.size(),
+                                    "exchange: bra and ket are a paired set and must have equal length");
+                const std::vector<Batch_1D> columns = exchange_row_owner_split(vf.size(), nsubworld);
+                const std::vector<Batch_1D> rows = exchange_row_owner_split(mo_bra.size(), nsubworld);
+                stage(vf, EXCHANGE_BATCH_VF, columns);
+                stage(mo_bra, EXCHANGE_BATCH_BRA, rows);
+                stage(mo_ket, EXCHANGE_BATCH_KET, rows);
             }
             // the source ranks' comm threads serve the pulls, so a fence on the size-1
             // subworld drains this owner's copies
@@ -1279,8 +1298,15 @@ private:
             if (not has_next or cloud_ptr == nullptr) return;
             Cloud& cloud = *cloud_ptr;
             const long salt = batch_salt_;
-            for (const Batch_1D& r : {next_col, next_row}) {
-                const long record = exchange_batch_record_key(salt, EXCHANGE_BATCH_VF, r);
+            // Symmetric: either of the task's two ranges may be the remote one, so try both. In the
+            // asymmetric case only the row rotates -- the column is held on this rank -- and of the
+            // two records it carries, the bra is the one requested; the ket follows synchronously.
+            const std::vector<std::pair<Batch_1D,int>> candidates =
+                    symmetric ? std::vector<std::pair<Batch_1D,int>>{{next_col, EXCHANGE_BATCH_VF},
+                                                                     {next_row, EXCHANGE_BATCH_VF}}
+                              : std::vector<std::pair<Batch_1D,int>>{{next_row, EXCHANGE_BATCH_BRA}};
+            for (const auto& [r, dim] : candidates) {
+                const long record = exchange_batch_record_key(salt, dim, r);
                 if (cloud.batch_owner(record) == universe_rank_) continue;   // reads locally
                 if (batch_cache_.contains(record)) continue;                 // already resident
                 if (prefetch_current_.valid and prefetch_current_.key == record) continue;
@@ -1345,8 +1371,8 @@ private:
         /// to all of them.
         ///
         /// The result must be a *set*: the caller gaxpys one entry per index, so a repeated index is
-        /// added twice. Both ranges come from one split while the grid is triangular, where they are
-        /// always equal or disjoint, but from separate splits of different lengths otherwise.
+        /// added twice. The two ranges do overlap in the asymmetric case, coming from separate splits
+        /// of different lengths rather than from one split, where they are always equal or disjoint.
         std::vector<long> touched_result_indices() const {
             std::vector<long> idx;
             auto add_range = [&](const Batch_1D& b) {
@@ -1486,21 +1512,35 @@ private:
             // Owner-pinned: fetch the two batches this task needs from the cloud. Because
             // bra == ket == vf there, one batch per range serves every operand role, so the
             // ket over a range is just that range's batch.
-            vecfuncT bra_owned, vf_owned;
+            vecfuncT bra_owned, vf_owned, ket_owned;
             const vecfuncT* bra_work = &bra_batch;
             const vecfuncT* vf_work = &vf_batch;
+            const vecfuncT* ket_work = nullptr;   // set only when the ket is fetched as its own role
             if (owner_pinned) {
                 MADNESS_CHECK_THROW(cloud_ptr != nullptr, "owner-pinned exchange: cloud_ptr is null");
                 Cloud& cloud = *cloud_ptr;
                 const long salt = batch_salt_;
                 // copy the handles out of the cache: the reference is only good until the
                 // entry is evicted, and the second fetch may evict the first
-                bra_owned = fetch_batch(world, cloud,
-                                        exchange_batch_record_key(salt, EXCHANGE_BATCH_VF, bra_range));
-                vf_owned = diagonal_block
-                        ? bra_owned                     // one range, so one batch
-                        : fetch_batch(world, cloud,
-                                      exchange_batch_record_key(salt, EXCHANGE_BATCH_VF, vf_range));
+                if (symmetric) {
+                    bra_owned = fetch_batch(world, cloud,
+                                            exchange_batch_record_key(salt, EXCHANGE_BATCH_VF, bra_range));
+                    vf_owned = diagonal_block
+                            ? bra_owned                     // one range, so one batch
+                            : fetch_batch(world, cloud,
+                                          exchange_batch_record_key(salt, EXCHANGE_BATCH_VF, vf_range));
+                } else {
+                    // The column batch is held: this task runs on the rank owning it, so the fetch
+                    // is a cache hit and those coefficients never move. The row batch is the one
+                    // that rotates, and it carries bra and ket over the same range.
+                    vf_owned = fetch_batch(world, cloud,
+                                           exchange_batch_record_key(salt, EXCHANGE_BATCH_VF, vf_range));
+                    bra_owned = fetch_batch(world, cloud,
+                                            exchange_batch_record_key(salt, EXCHANGE_BATCH_BRA, bra_range));
+                    ket_owned = fetch_batch(world, cloud,
+                                            exchange_batch_record_key(salt, EXCHANGE_BATCH_KET, bra_range));
+                    ket_work = &ket_owned;
+                }
                 bra_work = &bra_owned;
                 vf_work = &vf_owned;
             }
@@ -1529,8 +1569,11 @@ private:
                 for (int i = vf_range.begin; i < vf_range.end; ++i){
                     Kf[i] += resultrow[i - vf_range.begin];}
             } else {
-                auto ket_batch = bra_range.copy_batch(vket);
-                vecfuncT resultcolumn = compute_batch_in_asymmetric_matrix(world, ket_batch, bra_batch, vf_batch);
+                // the ket comes from its own record when pinned, and is sliced from the unbatched
+                // argument otherwise -- which is the only form available without the batch store
+                const vecfuncT ket_batch = ket_work ? *ket_work : bra_range.copy_batch(vket);
+                vecfuncT resultcolumn = compute_batch_in_asymmetric_matrix(world, ket_batch,
+                                                                           *bra_work, *vf_work);
                 for (int i = vf_range.begin; i < vf_range.end; ++i)
                     Kf[i] += resultcolumn[i - vf_range.begin];
             }

--- a/src/madness/chem/exchangeoperator.h
+++ b/src/madness/chem/exchangeoperator.h
@@ -68,6 +68,24 @@ inline std::vector<Batch_1D> exchange_row_owner_split(const std::size_t n, const
     return exchange_sym_owner_split(n, nsubworld, 1);
 }
 
+/// The asymmetric task grid: every (column, row) pair over two independent splits.
+
+/// The column dimension is the operand that stays put -- vf, whose batch the running rank holds --
+/// and the row dimension is the one that rotates, carrying bra and ket, which share this range
+/// because the operator sums over pairs. There is no symmetry to exploit, so the grid is the full
+/// rectangle rather than a triangle, and the two dimensions are split independently: bra and ket
+/// have the same length as each other but need not match vf's.
+inline std::vector<std::pair<Batch_1D, Batch_1D>>
+exchange_row_owner_grid(const std::size_t ncolumn, const std::size_t nrow, const long nsubworld) {
+    const std::vector<Batch_1D> columns = exchange_row_owner_split(ncolumn, nsubworld);
+    const std::vector<Batch_1D> rows = exchange_row_owner_split(nrow, nsubworld);
+    std::vector<std::pair<Batch_1D, Batch_1D>> out;
+    out.reserve(columns.size() * rows.size());
+    for (const auto& c : columns)
+        for (const auto& r : rows) out.emplace_back(c, r);
+    return out;
+}
+
 /// Triangular index of a batch pair, collapsing (i,j) and (j,i): a*(a+1)/2 + b.
 
 /// The indexing convention of the per-task cost vector, shared by whoever records a
@@ -960,6 +978,17 @@ private:
 
             partitionT do_partitioning(const std::size_t& vsize1, const std::size_t& vsize2,
                                        const std::string policy) const override {
+
+                if (owner_pinned and not symmetric) {
+                    // full grid over two independent splits; see exchange_row_owner_grid
+                    partitionT result;
+                    for (const auto& [column, row] : exchange_row_owner_grid(vsize1, vsize2,
+                                                                            long(nsubworld))) {
+                        Batch batch(column, row, _);
+                        result.push_back(std::make_pair(batch, compute_priority(batch)));
+                    }
+                    return result;
+                }
 
                 if (owner_pinned) {
                     // lower-triangular grid over one granularity-aware split, shared with

--- a/src/madness/chem/exchangeoperator.h
+++ b/src/madness/chem/exchangeoperator.h
@@ -86,6 +86,21 @@ exchange_row_owner_grid(const std::size_t ncolumn, const std::size_t nrow, const
     return out;
 }
 
+/// Are these the same functions, so that one stored record can serve both operand roles?
+
+/// Compares identity, not value: `Function` is a shallow handle, so equal implementation pointers
+/// mean the coefficients are literally shared and storing them twice would duplicate the largest
+/// thing the cloud holds. HF exchange passes the same vector as all three operands, and nemo passes
+/// the same one as ket and vf, so this is the common case rather than a corner.
+template<typename T, std::size_t NDIM>
+inline bool exchange_same_operands(const std::vector<Function<T, NDIM>>& a,
+                                   const std::vector<Function<T, NDIM>>& b) {
+    if (a.size() != b.size()) return false;
+    for (std::size_t i = 0; i < a.size(); ++i)
+        if (a[i].get_impl().get() != b[i].get_impl().get()) return false;
+    return true;
+}
+
 /// Owner of every task in the asymmetric grid: all tasks of a column go to one worker.
 
 /// The column operand is the one that stays put, so putting a whole column on one worker means the
@@ -816,6 +831,12 @@ private:
         /// be available in full wherever a key is formed. That is true only while the ket is
         /// passed unbatched.
         long batch_salt_ = 0;
+        /// Which role's record actually carries the bra and the vf. Identical operand vectors share
+        /// one stored record instead of duplicating coefficients: HF exchange passes one vector as
+        /// all three operands, nemo passes one as ket and vf. Set on the universe side, where all
+        /// three are in hand; see exchange_same_operands.
+        bool bra_shares_ket_ = true;
+        bool vf_shares_ket_ = true;
         /// 1 = sum into a subworld buffer and drain that into the universe;
         /// 2 = additionally reduce within a node first, so only one rank per node scatters
         ///     across nodes. Degrades to 1 automatically when there is a single node.
@@ -1059,10 +1080,12 @@ private:
                                 const bool symmetric, const bool owner_pinned = false,
                                 const long granularity_level = 1, const long universe_rank = 0,
                                 const int accumulation_mode = 2, const bool cost_aware = true,
-                                const long batch_salt = 0)
+                                const long batch_salt = 0, const bool bra_shares_ket = true,
+                                const bool vf_shares_ket = true)
                 : nresult(nresult), lo(lo), mul_tol(mul_tol), symmetric(symmetric),
                   owner_pinned(owner_pinned), granularity_level(granularity_level),
-                  batch_salt_(batch_salt),
+                  batch_salt_(batch_salt), bra_shares_ket_(bra_shares_ket),
+                  vf_shares_ket_(vf_shares_ket),
                   accumulation_mode_(accumulation_mode), cost_aware_(cost_aware),
                   universe_rank_(universe_rank) {
             partitioner.reset(new MacroTaskPartitionerExchange(symmetric, owner_pinned, granularity_level));
@@ -1168,6 +1191,10 @@ private:
             }
         }
 
+        /// the record role carrying the bra, and the one carrying the vf over a *shared* split
+        int bra_role() const { return bra_shares_ket_ ? EXCHANGE_BATCH_KET : EXCHANGE_BATCH_BRA; }
+        int vf_role() const { return vf_shares_ket_ ? EXCHANGE_BATCH_KET : EXCHANGE_BATCH_VF; }
+
         /// \return the rank this task is pinned to, or -1 to leave the choice to the queue
         long owner_hint(const Batch& task_batch, const long nsubworld) const override {
             if (not owner_pinned or nsubworld <= 0 or owner_map_.empty()) return -1;
@@ -1247,19 +1274,27 @@ private:
                 }
             };
 
+            // bra and ket are indexed together by the operator's sum over pairs, so wherever both
+            // are stored they share boundaries
+            MADNESS_CHECK_THROW(mo_bra.size() == mo_ket.size(),
+                                "exchange: bra and ket are a paired set and must have equal length");
             if (symmetric) {
-                stage(mo_ket, EXCHANGE_BATCH_VF,
-                      exchange_sym_owner_split(mo_ket.size(), nsubworld, granularity_level));
+                // One split serves every role, so a role whose vector is the ket's needs no record of
+                // its own. HF exchange therefore still stores exactly one set, while nemo -- whose bra
+                // is R^2 times its ket -- stores two over the same boundaries.
+                const std::vector<Batch_1D> split =
+                        exchange_sym_owner_split(mo_ket.size(), nsubworld, granularity_level);
+                stage(mo_ket, EXCHANGE_BATCH_KET, split);
+                if (not bra_shares_ket_) stage(mo_bra, EXCHANGE_BATCH_BRA, split);
+                if (not vf_shares_ket_) stage(vf, EXCHANGE_BATCH_VF, split);
             } else {
-                // bra and ket are indexed together by the operator's sum over pairs, so they share
-                // the row boundaries; vf is independent and gets the column ones
-                MADNESS_CHECK_THROW(mo_bra.size() == mo_ket.size(),
-                                    "exchange: bra and ket are a paired set and must have equal length");
+                // Two splits: vf gets the column boundaries, bra and ket the row ones. vf needs its
+                // own record even when it is the ket, the two splits having different boundaries.
                 const std::vector<Batch_1D> columns = exchange_row_owner_split(vf.size(), nsubworld);
                 const std::vector<Batch_1D> rows = exchange_row_owner_split(mo_bra.size(), nsubworld);
                 stage(vf, EXCHANGE_BATCH_VF, columns);
-                stage(mo_bra, EXCHANGE_BATCH_BRA, rows);
                 stage(mo_ket, EXCHANGE_BATCH_KET, rows);
+                if (not bra_shares_ket_) stage(mo_bra, EXCHANGE_BATCH_BRA, rows);
             }
             // the source ranks' comm threads serve the pulls, so a fence on the size-1
             // subworld drains this owner's copies
@@ -1298,15 +1333,15 @@ private:
             if (not has_next or cloud_ptr == nullptr) return;
             Cloud& cloud = *cloud_ptr;
             const long salt = batch_salt_;
-            // Symmetric: either of the task's two ranges may be the remote one, so try both. In the
-            // asymmetric case only the row rotates -- the column is held on this rank -- and of the
-            // two records it carries, the bra is the one requested; the ket follows synchronously.
-            const std::vector<std::pair<Batch_1D,int>> candidates =
-                    symmetric ? std::vector<std::pair<Batch_1D,int>>{{next_col, EXCHANGE_BATCH_VF},
-                                                                     {next_row, EXCHANGE_BATCH_VF}}
-                              : std::vector<std::pair<Batch_1D,int>>{{next_row, EXCHANGE_BATCH_BRA}};
-            for (const auto& [r, dim] : candidates) {
-                const long record = exchange_batch_record_key(salt, dim, r);
+            // Always the ket's record: it is the one role stored unconditionally, in both grids and on
+            // whichever split the range belongs to, so requesting it can never name a record nobody
+            // holds. Symmetric: either of the task's two ranges may be the remote one, so try both.
+            // Asymmetric: only the row rotates, the column being held on this rank.
+            const std::vector<Batch_1D> candidates =
+                    symmetric ? std::vector<Batch_1D>{next_col, next_row}
+                              : std::vector<Batch_1D>{next_row};
+            for (const auto& r : candidates) {
+                const long record = exchange_batch_record_key(salt, EXCHANGE_BATCH_KET, r);
                 if (cloud.batch_owner(record) == universe_rank_) continue;   // reads locally
                 if (batch_cache_.contains(record)) continue;                 // already resident
                 if (prefetch_current_.valid and prefetch_current_.key == record) continue;
@@ -1512,10 +1547,9 @@ private:
             // Owner-pinned: fetch the two batches this task needs from the cloud. Because
             // bra == ket == vf there, one batch per range serves every operand role, so the
             // ket over a range is just that range's batch.
-            vecfuncT bra_owned, vf_owned, ket_owned;
+            vecfuncT bra_owned, vf_owned, ket_row_owned, ket_column_owned;
             const vecfuncT* bra_work = &bra_batch;
             const vecfuncT* vf_work = &vf_batch;
-            const vecfuncT* ket_work = nullptr;   // set only when the ket is fetched as its own role
             if (owner_pinned) {
                 MADNESS_CHECK_THROW(cloud_ptr != nullptr, "owner-pinned exchange: cloud_ptr is null");
                 Cloud& cloud = *cloud_ptr;
@@ -1523,12 +1557,19 @@ private:
                 // copy the handles out of the cache: the reference is only good until the
                 // entry is evicted, and the second fetch may evict the first
                 if (symmetric) {
+                    // One split, so every role is available over either range. Where the roles alias
+                    // the ket these resolve to the same record and the repeats are cache hits, which
+                    // is why HF exchange pays nothing for the generality.
                     bra_owned = fetch_batch(world, cloud,
-                                            exchange_batch_record_key(salt, EXCHANGE_BATCH_VF, bra_range));
-                    vf_owned = diagonal_block
-                            ? bra_owned                     // one range, so one batch
+                                            exchange_batch_record_key(salt, bra_role(), bra_range));
+                    vf_owned = fetch_batch(world, cloud,
+                                           exchange_batch_record_key(salt, vf_role(), vf_range));
+                    ket_row_owned = fetch_batch(world, cloud,
+                                                exchange_batch_record_key(salt, EXCHANGE_BATCH_KET, bra_range));
+                    ket_column_owned = diagonal_block
+                            ? ket_row_owned                 // one range, so one batch
                             : fetch_batch(world, cloud,
-                                          exchange_batch_record_key(salt, EXCHANGE_BATCH_VF, vf_range));
+                                          exchange_batch_record_key(salt, EXCHANGE_BATCH_KET, vf_range));
                 } else {
                     // The column batch is held: this task runs on the rank owning it, so the fetch
                     // is a cache hit and those coefficients never move. The row batch is the one
@@ -1536,10 +1577,9 @@ private:
                     vf_owned = fetch_batch(world, cloud,
                                            exchange_batch_record_key(salt, EXCHANGE_BATCH_VF, vf_range));
                     bra_owned = fetch_batch(world, cloud,
-                                            exchange_batch_record_key(salt, EXCHANGE_BATCH_BRA, bra_range));
-                    ket_owned = fetch_batch(world, cloud,
-                                            exchange_batch_record_key(salt, EXCHANGE_BATCH_KET, bra_range));
-                    ket_work = &ket_owned;
+                                            exchange_batch_record_key(salt, bra_role(), bra_range));
+                    ket_row_owned = fetch_batch(world, cloud,
+                                                exchange_batch_record_key(salt, EXCHANGE_BATCH_KET, bra_range));
                 }
                 bra_work = &bra_owned;
                 vf_work = &vf_owned;
@@ -1549,17 +1589,20 @@ private:
             const double compute_cpu_start = process_cpu_time();
             if (profiling) prof_.wait_for_data_wall = compute_wall_start - tile_wall_start;
 
+            // the ket comes from its own record when pinned, and is sliced from the unbatched argument
+            // otherwise, which is the only form available without the batch store
+            const vecfuncT ket_rows = owner_pinned ? ket_row_owned : bra_range.copy_batch(vket);
+
             if (symmetric and diagonal_block) {
-                const vecfuncT ket_batch = owner_pinned ? *bra_work : bra_range.copy_batch(vket);
-                vecfuncT resultcolumn = compute_diagonal_batch_in_symmetric_matrix(world, ket_batch, *bra_work,
+                vecfuncT resultcolumn = compute_diagonal_batch_in_symmetric_matrix(world, ket_rows, *bra_work,
                                                                                    *vf_work);
 
                 for (int i = vf_range.begin; i < vf_range.end; ++i){
                     Kf[i] += resultcolumn[i - vf_range.begin];}
 
             } else if (symmetric and not diagonal_block) {
-                const vecfuncT ket_rows = owner_pinned ? *bra_work : bra_range.copy_batch(vket);
-                const vecfuncT ket_columns = owner_pinned ? *vf_work : vf_range.copy_batch(vket);
+                const vecfuncT ket_columns = owner_pinned ? ket_column_owned
+                                                          : vf_range.copy_batch(vket);
                 auto[resultcolumn, resultrow]=compute_offdiagonal_batch_in_symmetric_matrix(world, ket_rows,
                                                                                             ket_columns,
                                                                                             *bra_work, *vf_work);
@@ -1569,10 +1612,7 @@ private:
                 for (int i = vf_range.begin; i < vf_range.end; ++i){
                     Kf[i] += resultrow[i - vf_range.begin];}
             } else {
-                // the ket comes from its own record when pinned, and is sliced from the unbatched
-                // argument otherwise -- which is the only form available without the batch store
-                const vecfuncT ket_batch = ket_work ? *ket_work : bra_range.copy_batch(vket);
-                vecfuncT resultcolumn = compute_batch_in_asymmetric_matrix(world, ket_batch,
+                vecfuncT resultcolumn = compute_batch_in_asymmetric_matrix(world, ket_rows,
                                                                            *bra_work, *vf_work);
                 for (int i = vf_range.begin; i < vf_range.end; ++i)
                     Kf[i] += resultcolumn[i - vf_range.begin];

--- a/src/madness/chem/exchangeoperator.h
+++ b/src/madness/chem/exchangeoperator.h
@@ -266,6 +266,17 @@ inline bool exch_task_profile_enabled() {
     return on;
 }
 
+/// Send a symmetric application down the general (bra, ket, vf) path? Read once per process.
+
+/// A symmetric application computes the same numbers either way -- the general path just does the
+/// whole rectangle where the symmetric one does a triangle and reuses each intermediate twice. So
+/// with this set, moldft becomes a differential test of the general path on data whose answer is
+/// already known, which is otherwise reachable only from nemo and molresponse. Debug only.
+inline bool exch_force_general_path() {
+    static const bool on = (std::getenv("MAD_EXCH_FORCE_GENERAL") != nullptr);
+    return on;
+}
+
 /// Append one record to exch_taskprof.r<rank>.jsonl.
 
 /// The stream stays open for the life of the process: one file per rank appended across every

--- a/src/madness/chem/exchangeoperator.h
+++ b/src/madness/chem/exchangeoperator.h
@@ -873,7 +873,11 @@ private:
         struct PrefetchSlot {
             bool valid = false;
             long key = 0;
-            Future<batch_bytesT> fut;
+            /// Held by pointer, not by value: a slot is retired by overwriting it, and `Future`'s
+            /// assignment operator requires an unset target. Overwriting a slot whose reply has
+            /// already landed -- which is every consumed slot -- trips that assertion. Dropping
+            /// the pointer releases the future instead of assigning over it.
+            std::shared_ptr<Future<batch_bytesT>> fut;
         };
         static inline PrefetchSlot prefetch_current_;   ///< promoted from the previous task
         static inline PrefetchSlot prefetch_next_;      ///< requested during this task
@@ -982,7 +986,7 @@ private:
             for (PrefetchSlot* slot : {&prefetch_current_, &prefetch_next_}) {
                 if (slot->valid and slot->key == record) {
                     vecfuncT data = cloud.template deserialize_batch_p2p<T, NDIM>(
-                            world, slot->fut, record, /*cache_result=*/false);
+                            world, *slot->fut, record, /*cache_result=*/false);
                     *slot = PrefetchSlot();
                     ++batch_prefetch_hits_;
                     if (profile_active()) prof_.observe_fetch_tier(1);
@@ -1349,7 +1353,8 @@ private:
                 if (batch_cache_.contains(record)) continue;                 // already resident
                 if (prefetch_current_.valid and prefetch_current_.key == record) continue;
                 prefetch_next_.key = record;
-                prefetch_next_.fut = cloud.request_batch_bytes_async(record);
+                prefetch_next_.fut = std::make_shared<Future<batch_bytesT>>(
+                        cloud.request_batch_bytes_async(record));
                 prefetch_next_.valid = true;
                 break;                                                      // one per task
             }

--- a/src/madness/chem/exchangeoperator.h
+++ b/src/madness/chem/exchangeoperator.h
@@ -753,6 +753,14 @@ private:
         /// pin each task to a rank that owns one of its batches, over the owner-pinned split
         bool owner_pinned = false;
         long granularity_level = 1;
+        /// Per-application salt for the batch record keys, from exchange_batch_salt.
+
+        /// Carried on the task rather than re-derived where it is used: every rank builds the
+        /// same task objects collectively, so a constructor argument already reaches every
+        /// rank, and deriving it instead requires whichever operand vector it is taken from to
+        /// be available in full wherever a key is formed. That is true only while the ket is
+        /// passed unbatched.
+        long batch_salt_ = 0;
         /// 1 = sum into a subworld buffer and drain that into the universe;
         /// 2 = additionally reduce within a node first, so only one rank per node scatters
         ///     across nodes. Degrades to 1 automatically when there is a single node.
@@ -984,9 +992,11 @@ private:
         MacroTaskExchangeSimple(const long nresult, const double lo, const double mul_tol,
                                 const bool symmetric, const bool owner_pinned = false,
                                 const long granularity_level = 1, const long universe_rank = 0,
-                                const int accumulation_mode = 2, const bool cost_aware = true)
+                                const int accumulation_mode = 2, const bool cost_aware = true,
+                                const long batch_salt = 0)
                 : nresult(nresult), lo(lo), mul_tol(mul_tol), symmetric(symmetric),
                   owner_pinned(owner_pinned), granularity_level(granularity_level),
+                  batch_salt_(batch_salt),
                   accumulation_mode_(accumulation_mode), cost_aware_(cost_aware),
                   universe_rank_(universe_rank) {
             partitioner.reset(new MacroTaskPartitionerExchange(symmetric, owner_pinned, granularity_level));
@@ -1111,7 +1121,7 @@ private:
             const vecfuncT& mo_ket = std::get<2>(argtuple);
             // one fence up front, so store_batch does not need one per function
             world.gop.fence();
-            const long salt = exchange_batch_salt(mo_ket);
+            const long salt = batch_salt_;
             const std::vector<Batch_1D> split =
                     exchange_sym_owner_split(mo_ket.size(), nsubworld, granularity_level);
 
@@ -1154,7 +1164,10 @@ private:
         ///
         /// This is what makes the owner-pinned transport worth its machinery: without it every
         /// task pays the full latency of its remote batch with nothing to overlap it against.
-        void sym_pipeline_advance(World& subworld, const vecfuncT& mo_ket,
+        /// \param mo_ket  unused: the salt it used to be derived from is carried on the task.
+        ///                It stays in the signature because the queue's detection trait matches
+        ///                on it (has_sym_pipeline_advance_v).
+        void sym_pipeline_advance(World& subworld, const vecfuncT&,
                                   const Batch_1D& next_col, const Batch_1D& next_row,
                                   const bool has_next) const {
             if (not owner_pinned) return;
@@ -1167,7 +1180,7 @@ private:
             prefetch_next_ = PrefetchSlot();
             if (not has_next or cloud_ptr == nullptr) return;
             Cloud& cloud = *cloud_ptr;
-            const long salt = exchange_batch_salt(mo_ket);
+            const long salt = batch_salt_;
             for (const Batch_1D& r : {next_col, next_row}) {
                 const long record = exchange_batch_record_key(salt, EXCHANGE_BATCH_VF, r);
                 if (cloud.batch_owner(record) == universe_rank_) continue;   // reads locally
@@ -1373,7 +1386,7 @@ private:
             if (owner_pinned) {
                 MADNESS_CHECK_THROW(cloud_ptr != nullptr, "owner-pinned exchange: cloud_ptr is null");
                 Cloud& cloud = *cloud_ptr;
-                const long salt = exchange_batch_salt(vket);
+                const long salt = batch_salt_;
                 // copy the handles out of the cache: the reference is only good until the
                 // entry is evicted, and the second fetch may evict the first
                 bra_owned = fetch_batch(world, cloud,

--- a/src/madness/chem/nemo.cc
+++ b/src/madness/chem/nemo.cc
@@ -318,8 +318,15 @@ std::shared_ptr<Fock<double, 3>> Nemo::make_fock_operator() const {
   fock->add_operator("V", std::make_shared<Nuclear<double, 3>>(world, this));
   fock->add_operator("T", std::make_shared<Kinetic<double, 3>>(world));
   if (calc->xc.hf_exchange_coefficient() > 0.0) {
-    Exchange<double, 3> K =
-        Exchange<double, 3>(world, this, ispin).set_symmetric(false);
+    // The algorithm comes from the input rather than ExchangeImpl's built-in default, which this
+    // site used to take, ignoring the parameter. Only `multiworld` stores bra and ket apart, which
+    // is what nemo's asymmetric operands need before the triangle is usable -- see
+    // compute_nemo_potentials for why the exchange is symmetric even though the operands are not.
+    const auto alg = Exchange<double, 3>::string2algorithm(get_calc_param().hfexalg());
+    Exchange<double, 3> K = Exchange<double, 3>(world, this, ispin)
+                                .set_algorithm(alg)
+                                .set_symmetric(alg == Exchange<double, 3>::multiworld_efficient)
+                                .set_printlevel(get_calc_param().print_level());
     fock->add_operator("K", {-1.0, std::make_shared<Exchange<double, 3>>(K)});
   }
   if (calc->xc.is_dft()) {
@@ -635,11 +642,16 @@ void Nemo::compute_nemo_potentials(const vecfuncT &nemo, vecfuncT &Jnemo,
       Knemo = zero_functions_compressed<double, 3>(world, size_to_int(nemo.size()));
       // construction must happen outside the if-block to avoid pointers to
       // arguments going out of scope in the macrotaskq
+      //
+      // Symmetric even though the operands are not: bra = R^2 * ket, and a common weight leaves
+      // bra_i * vf_j symmetric in (i,j), which is all the triangle needs. The algorithm comes from
+      // the input instead of being fixed here, so `hfexalg multiworld` reaches nemo's SCF; the
+      // parameter defaults to the row algorithm this site hard-coded, so the default is unchanged.
       Exchange<double, 3> K = Exchange<double, 3>(world, this, ispin)
                                   .set_symmetric(true)
-                                  .set_taskq(taskq);
-      K.set_algorithm(
-          Exchange<double, 3>::ExchangeAlgorithm::multiworld_efficient_row);
+                                  .set_taskq(taskq)
+                                  .set_printlevel(get_calc_param().print_level());
+      K.set_algorithm(Exchange<double, 3>::string2algorithm(get_calc_param().hfexalg()));
       if (calc->xc.hf_exchange_coefficient() > 0.0)
         Knemo = K(nemo);
 

--- a/src/madness/chem/test_exchange_asymmetric.cc
+++ b/src/madness/chem/test_exchange_asymmetric.cc
@@ -98,6 +98,49 @@ int test_generic_exchange(World& world) {
     return t1.end();
 }
 
+/// nemo's shape: bra = w * ket with vf == ket, which keeps the symmetric task list
+int test_weighted_bra_exchange(World& world) {
+    test_output t1("testing exchange with bra = w * ket and vf == ket", world.rank() == 0);
+
+    // The symmetric kernel reuses each intermediate for the transposed element, which needs
+    // bra_i * vf_j to be symmetric in (i,j) -- true whenever bra is a common weight times vf, not
+    // only when they are equal. nemo is exactly this, with w = R^2, so it keeps the triangular task
+    // list while bra and ket remain different functions that have to be stored separately.
+    const long nocc = 5;
+    const auto ket = make_set(world, nocc, 1.1, 0.20);
+    const real_function_3d weight = real_factory_3d(world)
+                                            .functor(shifted_gaussian(0.15, coord_3d{0.1, -0.2, 0.3}))
+                                            .truncate_on_project();
+    std::vector<real_function_3d> bra = mul(world, weight, ket);
+    truncate(world, bra);
+
+    t1.checkpoint(not exchange_same_operands(bra, ket), "bra and ket are genuinely different functions");
+
+    const double lo = 1.e-4;
+    auto apply_with = [&](const Exchange<double, 3>::ExchangeAlgorithm alg, const bool sym) {
+        Exchange<double, 3> K(world, lo, FunctionDefaults<3>::get_thresh());
+        K.set_bra_and_ket(bra, ket);
+        K.set_symmetric(sym);
+        K.set_algorithm(alg);
+        return K(ket);                      // vf == ket, as in nemo's Fock operator
+    };
+
+    const auto reference = apply_with(Exchange<double, 3>::small_memory, false);
+    const auto got = apply_with(Exchange<double, 3>::multiworld_efficient, true);
+
+    double maxdiff = 0.0;
+    for (std::size_t i = 0; i < reference.size() and i < got.size(); ++i)
+        maxdiff = std::max(maxdiff, (reference[i] - got[i]).norm2());
+    if (world.rank() == 0) print("largest |K_symmetric - K_smallmem| over vf:", maxdiff);
+    t1.checkpoint(maxdiff < 10.0 * FunctionDefaults<3>::get_thresh(),
+                  "the symmetric task list over separate bra and ket records agrees with the reference");
+
+    double smallest = std::numeric_limits<double>::max();
+    for (const auto& f : reference) smallest = std::min(smallest, f.norm2());
+    t1.checkpoint(smallest > 1.e-6, "the reference result is non-trivial");
+    return t1.end();
+}
+
 int main(int argc, char** argv) {
     madness::initialize(argc, argv);
     int result = 0;
@@ -108,6 +151,7 @@ int main(int argc, char** argv) {
         FunctionDefaults<3>::set_k(7);
         FunctionDefaults<3>::set_cubic_cell(-16.0, 16.0);
         result += test_generic_exchange(world);
+        result += test_weighted_bra_exchange(world);
         world.gop.fence();
     }
     if (result == 0) print("\n --> all tests \033[32m passed \033[0m \n");

--- a/src/madness/chem/test_exchange_asymmetric.cc
+++ b/src/madness/chem/test_exchange_asymmetric.cc
@@ -1,0 +1,117 @@
+/// \file test_exchange_asymmetric.cc
+/// \brief tests the exchange operator with bra, ket and vf all distinct
+
+/// The generic form of the operator is K f_j = sum_i ket_i G[bra_i f_j], with bra and ket a paired
+/// set of one length and f a separate set of another. **No consumer has ever exercised that**: HF
+/// exchange has bra == ket == f, and nemo, oep and znemo have bra != ket but still apply K to the
+/// ket itself, so f == ket and the two lengths agree. molresponse is the first caller with f
+/// genuinely distinct from ket.
+///
+/// moldft cannot test this at all -- it always applies K to its own orbitals -- so a unit test is the
+/// only route to the case, which is why this file exists rather than a calculation.
+///
+/// The reference is `smallmem`, whose kernel is the plain double loop over distinct nocc and nf with
+/// no symmetry anywhere. Comparing one algorithm against another makes the test self-checking: there
+/// are no reference numbers to maintain, and both sides see the identical operands.
+
+#include <madness/chem/exchangeoperator.h>
+#include <madness/chem/SCFOperators.h>
+#include <madness/world/test_utilities.h>
+
+#include <vector>
+
+using namespace madness;
+
+namespace {
+
+/// a gaussian at an offset origin, so bra, ket and vf are genuinely different functions rather
+/// than scaled copies of one
+struct shifted_gaussian {
+    double exponent = 1.0;
+    coord_3d origin{};
+    shifted_gaussian() = default;
+    shifted_gaussian(const double e, const coord_3d& o) : exponent(e), origin(o) {}
+    double operator()(const coord_3d& r) const {
+        const double x = r[0] - origin[0], y = r[1] - origin[1], z = r[2] - origin[2];
+        return exp(-exponent * (x * x + y * y + z * z));
+    }
+};
+
+std::vector<real_function_3d> make_set(World& world, const long n, const double e0,
+                                       const double shift) {
+    std::vector<real_function_3d> v;
+    for (long i = 0; i < n; ++i) {
+        const coord_3d o{shift * double(i), 0.3 * shift, -0.2 * shift};
+        v.push_back(real_factory_3d(world)
+                            .functor(shifted_gaussian(e0 + 0.4 * double(i), o))
+                            .truncate_on_project());
+    }
+    truncate(world, v);
+    return v;
+}
+
+}   // namespace
+
+/// K with bra, ket and vf distinct, and nf != nocc, against the smallmem reference
+int test_generic_exchange(World& world) {
+    test_output t1("testing exchange with bra, ket and vf all distinct", world.rank() == 0);
+
+    // nf != nocc on purpose: an implementation that used one length for both dimensions would pass
+    // every existing test, since every consumer so far has had them equal
+    const long nocc = 5, nf = 3;
+    const auto bra = make_set(world, nocc, 1.0, 0.00);
+    const auto ket = make_set(world, nocc, 1.3, 0.25);
+    const auto vf = make_set(world, nf, 0.8, -0.35);
+
+    t1.checkpoint(bra.size() == std::size_t(nocc) and ket.size() == std::size_t(nocc)
+                          and vf.size() == std::size_t(nf),
+                  "the operands have the intended, differing lengths");
+
+    const double lo = 1.e-4;
+    auto apply_with = [&](const Exchange<double, 3>::ExchangeAlgorithm alg) {
+        Exchange<double, 3> K(world, lo, FunctionDefaults<3>::get_thresh());
+        K.set_bra_and_ket(bra, ket);
+        K.set_symmetric(false);
+        K.set_algorithm(alg);
+        return K(vf);
+    };
+
+    const auto reference = apply_with(Exchange<double, 3>::small_memory);
+    t1.checkpoint(reference.size() == std::size_t(nf), "the reference returns one function per vf");
+
+    const auto got = apply_with(Exchange<double, 3>::multiworld_efficient);
+    t1.checkpoint(got.size() == std::size_t(nf), "the macrotask path returns one function per vf");
+
+    // compare the functions themselves, not their norms: two different functions can share a norm
+    double maxdiff = 0.0;
+    for (std::size_t i = 0; i < reference.size() and i < got.size(); ++i)
+        maxdiff = std::max(maxdiff, (reference[i] - got[i]).norm2());
+    if (world.rank() == 0) print("largest |K_multiworld - K_smallmem| over vf:", maxdiff);
+    t1.checkpoint(maxdiff < 10.0 * FunctionDefaults<3>::get_thresh(),
+                  "the macrotask path agrees with the reference on every function");
+
+    // a non-trivial result, so agreement cannot be two zeroes matching
+    double smallest = std::numeric_limits<double>::max();
+    for (const auto& f : reference) smallest = std::min(smallest, f.norm2());
+    t1.checkpoint(smallest > 1.e-6, "the reference result is non-trivial");
+
+    return t1.end();
+}
+
+int main(int argc, char** argv) {
+    madness::initialize(argc, argv);
+    int result = 0;
+    {
+        World& world = World::get_default();
+        startup(world, argc, argv, true);
+        FunctionDefaults<3>::set_thresh(1.e-5);
+        FunctionDefaults<3>::set_k(7);
+        FunctionDefaults<3>::set_cubic_cell(-16.0, 16.0);
+        result += test_generic_exchange(world);
+        world.gop.fence();
+    }
+    if (result == 0) print("\n --> all tests \033[32m passed \033[0m \n");
+    else print("\n --> all tests \033[31m failed \033[0m \n");
+    madness::finalize();
+    return result;
+}

--- a/src/madness/chem/test_exchange_owner_assign.cc
+++ b/src/madness/chem/test_exchange_owner_assign.cc
@@ -95,6 +95,25 @@ int test_batch_split() {
     return t1.end();
 }
 
+int test_row_owner_split() {
+    test_output t1("testing exchange_row_owner_split");
+
+    t1.checkpoint(exchange_row_owner_split(0, 8).empty(), "empty split for an empty vector");
+
+    bool same = true, one_per_rank = true;
+    for (long n = 1; n <= 64; ++n) {
+        for (long nsw : {1L, 2L, 3L, 8L, 40L}) {
+            const auto row = exchange_row_owner_split(n, nsw);
+            if (row != exchange_sym_owner_split(n, nsw, 1)) same = false;
+            if (long(row.size()) != std::min<long>(std::max<long>(1, nsw), n)) one_per_rank = false;
+        }
+    }
+    // the contiguity, coverage and balance of these boundaries are covered by test_batch_split
+    t1.checkpoint(same, "the same boundaries as the granularity-1 symmetric split");
+    t1.checkpoint(one_per_rank, "exactly min(nsubworld, n) batches, which the column-to-rank assignment needs");
+    return t1.end();
+}
+
 int test_owner_assignment() {
     test_output t1("testing exchange owner assignment");
 
@@ -149,6 +168,7 @@ int main(int argc, char** argv) {
     madness::initialize(argc, argv);
     int result = 0;
     result += test_batch_split();
+    result += test_row_owner_split();
     result += test_owner_assignment();
     if (result == 0) print("\n --> all tests \033[32m passed \033[0m \n");
     else print("\n --> all tests \033[31m failed \033[0m \n");

--- a/src/madness/chem/test_exchange_owner_assign.cc
+++ b/src/madness/chem/test_exchange_owner_assign.cc
@@ -114,6 +114,40 @@ int test_row_owner_split() {
     return t1.end();
 }
 
+int test_row_owner_grid() {
+    test_output t1("testing exchange_row_owner_grid");
+
+    // deliberately ncolumn != nrow: vf and the bra/ket pair are independent lengths, and every
+    // consumer so far has had them equal, so an implementation that conflated them would pass
+    // every existing test
+    const long ncol = 3, nrow = 8, nsw = 4;
+    const auto grid = exchange_row_owner_grid(ncol, nrow, nsw);
+    const auto columns = exchange_row_owner_split(ncol, nsw);
+    const auto rows = exchange_row_owner_split(nrow, nsw);
+
+    t1.checkpoint(grid.size() == columns.size() * rows.size(), "the grid is the full rectangle");
+
+    // assert which split feeds which slot, not just the shape: a swap gives a grid of the same
+    // size whenever the two lengths happen to agree, which is the case that has always been run
+    bool sides_ok = true, pairs_unique = true;
+    std::set<std::pair<long,long>> seen;
+    for (const auto& [c, r] : grid) {
+        if (std::find(columns.begin(), columns.end(), c) == columns.end()) sides_ok = false;
+        if (std::find(rows.begin(), rows.end(), r) == rows.end()) sides_ok = false;
+        if (not seen.insert({c.begin, r.begin}).second) pairs_unique = false;
+    }
+    t1.checkpoint(sides_ok, "the column slot comes from the vf split and the row slot from the bra split");
+    t1.checkpoint(pairs_unique and seen.size() == grid.size(), "every column/row pair appears exactly once");
+
+    // one batch per rank per dimension, so the shorter dimension is what limits the columns
+    t1.checkpoint(long(columns.size()) == std::min(ncol, nsw) and long(rows.size()) == std::min(nrow, nsw),
+                  "each dimension is split to one batch per rank, clamped by its own length");
+    t1.checkpoint(exchange_row_owner_grid(0, nrow, nsw).empty() and
+                  exchange_row_owner_grid(ncol, 0, nsw).empty(),
+                  "an empty dimension gives an empty grid");
+    return t1.end();
+}
+
 int test_owner_assignment() {
     test_output t1("testing exchange owner assignment");
 
@@ -169,6 +203,7 @@ int main(int argc, char** argv) {
     int result = 0;
     result += test_batch_split();
     result += test_row_owner_split();
+    result += test_row_owner_grid();
     result += test_owner_assignment();
     if (result == 0) print("\n --> all tests \033[32m passed \033[0m \n");
     else print("\n --> all tests \033[31m failed \033[0m \n");

--- a/src/madness/chem/test_exchange_owner_assign.cc
+++ b/src/madness/chem/test_exchange_owner_assign.cc
@@ -148,6 +148,54 @@ int test_row_owner_grid() {
     return t1.end();
 }
 
+int test_row_owner_assignment() {
+    test_output t1("testing exchange_row_owner_assign");
+
+    // ncolumn != nrow throughout: the two dimensions are independent lengths
+    bool one_rank_per_column = true, complete = true, in_range = true, spread_ok = true;
+    for (long ncol : {1L, 2L, 3L, 5L, 8L}) {
+        for (long nrow : {1L, 4L, 7L}) {
+            for (long nworker : {1L, 2L, 4L, 8L}) {
+                const auto owner = exchange_row_owner_assign(ncol, nrow, nworker);
+                if (long(owner.size()) != ncol * nrow) complete = false;
+                std::map<long, std::set<long>> ranks_of_column;
+                std::vector<long> per_rank(nworker, 0);
+                for (const auto& [task, rank] : owner) {
+                    if (rank < 0 or rank >= nworker) in_range = false;
+                    ranks_of_column[task.first].insert(rank);
+                    ++per_rank[rank];
+                }
+                for (const auto& [column, ranks] : ranks_of_column)
+                    if (ranks.size() != 1) one_rank_per_column = false;
+                // each worker gets whole columns, so the counts differ by at most one column
+                const long mx = *std::max_element(per_rank.begin(), per_rank.end());
+                const long mn = *std::min_element(per_rank.begin(), per_rank.end());
+                if (mx - mn > nrow) spread_ok = false;
+            }
+        }
+    }
+    t1.checkpoint(complete, "every column/row task is assigned exactly once");
+    t1.checkpoint(in_range, "every owner is a valid worker");
+    t1.checkpoint(one_rank_per_column,
+                  "all tasks of a column share one worker, so its held batch is never fetched");
+    t1.checkpoint(spread_ok, "workers differ by at most one column's worth of tasks");
+
+    // distinct columns land on distinct workers while there are workers to spare -- that is what
+    // makes each rank hold a different vf batch
+    const auto owner = exchange_row_owner_assign(4, 3, 4);
+    std::set<long> distinct;
+    for (long c = 0; c < 4; ++c) distinct.insert(owner.at({c, 0}));
+    t1.checkpoint(distinct.size() == 4, "distinct columns go to distinct workers when enough exist");
+
+    t1.checkpoint(exchange_row_owner_assign(4, 3, 4) == exchange_row_owner_assign(4, 3, 4),
+                  "deterministic, so every rank agrees without communicating");
+    t1.checkpoint(exchange_row_owner_assign(0, 3, 4).empty() and
+                  exchange_row_owner_assign(4, 0, 4).empty() and
+                  exchange_row_owner_assign(4, 3, 0).empty(),
+                  "degenerate dimensions or worker count give an empty assignment");
+    return t1.end();
+}
+
 int test_owner_assignment() {
     test_output t1("testing exchange owner assignment");
 
@@ -204,6 +252,7 @@ int main(int argc, char** argv) {
     result += test_batch_split();
     result += test_row_owner_split();
     result += test_row_owner_grid();
+    result += test_row_owner_assignment();
     result += test_owner_assignment();
     if (result == 0) print("\n --> all tests \033[32m passed \033[0m \n");
     else print("\n --> all tests \033[31m failed \033[0m \n");

--- a/src/madness/mra/funcdefaults.h
+++ b/src/madness/mra/funcdefaults.h
@@ -262,14 +262,12 @@ namespace madness {
         	autorefine=value;
         }
 
-        /// Gets the default debug flag (is this used anymore?)
+        /// Gets the default debug flag, which gates verbose MRA diagnostics
         static bool get_debug() {
         	return debug;
         }
 
-        /// Sets the default debug flag (is this used anymore?)
-
-        /// Not sure if this does anything useful
+        /// Sets the default debug flag; see get_debug
         static void set_debug(bool value) {
         	debug=value;
         }

--- a/src/madness/mra/macrotaskq.h
+++ b/src/madness/mra/macrotaskq.h
@@ -1388,11 +1388,14 @@ private:
 			// maybe move this block to the cloud?
 			// A task that fetches its own operands must not have them copied in as well --
 			// that would pay for the coefficients twice, once per task instead of once per
-			// owned batch, which is the cost the owner-pinned path exists to avoid.
+			// owned batch, which is the cost the owner-pinned path exists to avoid. Both pointer
+			// policies store a pointer, so both would otherwise deep-copy here -- and which one is
+			// in force comes from the queue, so a task sharing a queue with another operator (nemo
+			// runs Coulomb and exchange through one) inherits that queue's policy, not its own.
 			const bool need_auto_copy =
-				(policy.storage_policy==MacroTaskInfo::StoreFunctionViaPointer) or
-				(policy.storage_policy==MacroTaskInfo::StorePointerToFunction
-					and not task.handles_own_data_movement());
+				(policy.storage_policy==MacroTaskInfo::StoreFunctionViaPointer or
+				 policy.storage_policy==MacroTaskInfo::StorePointerToFunction)
+					and not task.handles_own_data_movement();
     		if (need_auto_copy) {
     			double cpu0=wall_time();
     			Cloud::cloudtimer timer(subworld,cloud.copy_time);

--- a/src/madness/mra/mraimpl.h
+++ b/src/madness/mra/mraimpl.h
@@ -1469,9 +1469,16 @@ namespace madness {
         if (finalstate==get_tree_state()) return;
 
 
-        // go through reconstructed state -- requires fence!
+        // go through reconstructed state -- requires fence! The uncovered transitions need the
+        // reconstructed coefficients before the second pass, so the fence is unavoidable; report a
+        // broken no-fence promise once, from one rank, rather than per rank per call.
+        if (not fence and FunctionDefaults<NDIM>::get_debug() and world.rank() == 0) {
+            static std::atomic<bool> reported(false);
+            if (not reported.exchange(true))
+                print("change_tree_state:", current_state, "->", finalstate,
+                      "must reconstruct first and therefore fences, despite fence=false");
+        }
         change_tree_state(reconstructed,true);
-        print("could not respect  no-fence  parameter in change_tree_state");
         change_tree_state(finalstate,fence);
 
     }

--- a/src/madness/mra/test_cloud.cc
+++ b/src/madness/mra/test_cloud.cc
@@ -373,6 +373,10 @@ int test_batch_fetch_chunked(World& universe) {
 
     const std::size_t saved = BatchTransport::batch_chunk_bytes();
     BatchTransport::set_batch_chunk_bytes(chunk);
+    // Fenced because the owner reads the size when it serves. A rank whose own fetch resolves
+    // locally would otherwise run ahead and restore the default before serving, leaving the
+    // transfer a single chunk -- passing while exercising nothing.
+    universe.gop.fence();
     {
         auto subworld_ptr = MacroTaskQ::create_worlds(universe, universe.size());
         World& subworld = *subworld_ptr;
@@ -383,6 +387,24 @@ int test_batch_fetch_chunked(World& universe) {
             t1.checkpoint(got[i].norm2(), norms[i], 1.e-10, "chunked batch function norm");
         subworld.gop.fence();
     }
+    universe.gop.fence();
+
+    // The ends must not have to agree on the chunk size, so give them different ones. CI caught
+    // this as MPI_ERR_TRUNCATE at np=2 when a rank restored the default before serving.
+    BatchTransport::set_batch_chunk_bytes(universe.rank() == 0 ? chunk : saved);
+    universe.gop.fence();
+    {
+        auto subworld_ptr = MacroTaskQ::create_worlds(universe, universe.size());
+        World& subworld = *subworld_ptr;
+        MacroTaskQ::set_pmap(subworld);
+        auto got = cloud.fetch_batch_p2p<double, 3>(subworld, record);
+        t1.checkpoint(got.size() == nfunc, "the ends need not agree on the chunk size");
+        for (std::size_t i = 0; i < got.size(); ++i)
+            t1.checkpoint(got[i].norm2(), norms[i], 1.e-10, "mismatched-chunk batch function norm");
+        subworld.gop.fence();
+    }
+    universe.gop.fence();
+
     BatchTransport::set_batch_chunk_bytes(saved);
     universe.gop.fence();
     return t1.end();

--- a/src/madness/world/cloud.h
+++ b/src/madness/world/cloud.h
@@ -303,8 +303,11 @@ private:
     /// Must not throw: an exception here escapes every task-level handler.
     void on_trigger(batch_keyT record, ProcessID requester, int tag);
 
-    /// requester side, comm thread: size the buffer, post the Irecv, enqueue finish_recv
-    void on_reply(int tag, std::size_t size);
+    /// requester side, comm thread: size the buffer, post the Irecvs, enqueue finish_recv
+
+    /// \param chunk  the chunking the *owner* used, echoed back so the receiver never has to
+    ///               infer it. See on_trigger.
+    void on_reply(int tag, std::size_t size, std::size_t chunk);
 
     /// requester side, worker task: await the background-progressed Irecv and set the future
     void finish_recv(int tag);
@@ -1303,26 +1306,30 @@ inline void BatchTransport::on_trigger(batch_keyT record, ProcessID requester, i
         // Not held here -- reply with the sentinel and post nothing. Throwing instead
         // would escape this comm-thread handler past every task-level handler and abort
         // the run with no attribution; the requester raises it in task context.
-        this->send(requester, &BatchTransport::on_reply, tag, BATCH_NOT_FOUND);
+        this->send(requester, &BatchTransport::on_reply, tag, BATCH_NOT_FOUND, std::size_t(0));
         return;
     }
     const std::size_t n = ptr_size.second;
+    // Sent along rather than read again by the requester: the size is a process-local static, so
+    // the two ends can disagree, and a receiver that guessed would post Irecvs that do not match
+    // the messages -- MPI_ERR_TRUNCATE on the comm thread, where nothing catches it.
+    const std::size_t chunk = batch_chunk_bytes_;
     // MPI does not overtake between messages sharing source, tag and communicator, so posting
     // the chunks in ascending offset order matches the requester's Irecvs pairwise without a
     // per-chunk tag. That does rely on one transfer per tag, which alloc_tag's span makes true.
     {
         std::lock_guard<std::mutex> g(sends_mtx_);
-        for (std::size_t off = 0; off < n; off += batch_chunk_bytes_) {
-            const std::size_t len = std::min(batch_chunk_bytes_, n - off);
+        for (std::size_t off = 0; off < n; off += chunk) {
+            const std::size_t len = std::min(chunk, n - off);
             sends_.push_back(u.mpi.Isend(ptr_size.first + off, int(len), MPI_BYTE, requester, tag));
         }
     }
-    // the size rides in the reply so the requester can post its Irecv now, during its
+    // the size rides in the reply so the requester can post its Irecvs now, during its
     // own compute, and let the rendezvous finish in the background
-    this->send(requester, &BatchTransport::on_reply, tag, n);
+    this->send(requester, &BatchTransport::on_reply, tag, n, chunk);
 }
 
-inline void BatchTransport::on_reply(int tag, std::size_t size) {
+inline void BatchTransport::on_reply(int tag, std::size_t size, std::size_t chunk) {
     World& u = this->get_world();
     std::shared_ptr<PendingRecv> p;
     {
@@ -1342,9 +1349,10 @@ inline void BatchTransport::on_reply(int tag, std::size_t size) {
         return;
     }
     p->buf.resize(size);
-    // must match on_trigger's chunking exactly, in the same order; see batch_chunk_bytes
-    for (std::size_t off = 0; off < size; off += batch_chunk_bytes_) {
-        const std::size_t len = std::min(batch_chunk_bytes_, size - off);
+    // the owner's framing, not ours; see on_trigger. Positive whenever the record was found, and
+    // unguarded because a throw on this thread is what the framing exists to avoid
+    for (std::size_t off = 0; off < size; off += chunk) {
+        const std::size_t len = std::min(chunk, size - off);
         p->reqs.push_back(u.mpi.Irecv(p->buf.data() + off, int(len), MPI_BYTE, p->owner, tag));
     }
     u.taskq.add(this, &BatchTransport::finish_recv, tag);


### PR DESCRIPTION
## What this does

Extends the owner-pinned `multiworld` exchange to genuinely distinct operands, and gives nemo a
symmetric task list over asymmetric storage. Operands are stored and fetched per distinct vector
rather than per role.

`multiworld` gains a rectangular task grid for distinct bra, ket and vf; owner-pinned placement was
previously restricted to the symmetric case (`owner_pinned = is_symmetric()`). Other algorithms and
the `hfexalg` default, `multiworld_row`, are unchanged. Output changes are listed under Interface
changes.

**1. `chem/exchangeoperator.*` — generic exchange `bra != ket != vf`.**

- `K f_j = sum_i ket_i G[bra_i f_j]`: bra and ket are paired over `i`, `f` runs over `j`
- rectangular task grid over two independent splits, one batch per rank in each
- the column dimension is vf, its batch is held on the rank that owns it
- the row dimension carries bra and ket, which rotate between ranks
- each column runs entirely on one rank, which therefore holds the complete result for its columns
- placement is by column, cost-aware placement stays off
- callers with three distinct vectors exist (`nemo.cc:1380`, `zcis.cc:209`) but select `multiworld_row` by default

**2. `chem/exchangeoperator.h`, `chem/nemo.cc` — symmetric task list/asymmetric batch storage.**

- nemo's bra carries the nuclear correlation factor squared, `bra = R^2 * ket` but the symmetric task list
  still applies
- one record is stored per distinct operand vector: HF one set, nemo two over the same boundaries,
  three when all three are distinct
- nemo's two SCF exchange sites now read `hfexalg`, inheriting its default

**3. `chem/exchangeoperator.h`, `mra/macrotaskq.h` — fixes  **

- inconsistency in `touched_result_indices`
- removed unnecessary deep-copy of operands into subworld for tasks declaring `handles_own_data_movement` 
- retiring a prefetch slot assigned over a consumed `Future`, which its assignment operator forbids.

## Commits

| commit | what |
|---|---|
| `322b16b72` | carry the exchange batch record salt on the task |
| `d0e300b84` | decide owner-pinned placement separately from symmetry |
| `c3ed31ee0` | let the owner frame a chunked batch transfer |
| `f13437e99` | route symmetric exchange through the general path on request |
| `3641abbdb` | name the asymmetric row/column batch split |
| `bc5682695` | build the asymmetric task grid from two independent splits |
| `aa8fb73a8` | assign whole columns of the asymmetric grid to one worker each |
| `2453a1486` | test the exchange operator with bra, ket and vf all distinct |
| `51645fedb` | make the tile's touched-result index list a set |
| `86f1e073f` | store the three exchange operand roles and pin the asymmetric tiles |
| `cbe9c27ba` | store one exchange record per distinct operand, not per role |
| `045044df9` | let nemo's exchange algorithm come from the input |
| `5ccb20ce4` | never auto-copy operands for a task that fetches its own |
| `af536631a` | correct two comments the storage change left behind |
| `d9b32653b` | shorten the hf exchange parameter descriptions |
| `e88ee989b` | release the prefetch future instead of assigning over it |
| `8349c236b` | report an unhonoured no-fence request once, not per rank per call |
| `262ccb00f` | let the print level reach the MRA debug diagnostics |

18 commits, +634/−87 over 13 files.

## Interface changes

No parameters are added and no format changes. Four changes are visible in the output:

- nemo honours `hfexalg`. Both of its SCF exchange sites ignored it before; the parameter's default is
  the algorithm they hard-coded, so a calculation that does not set it behaves as before
- nemo's exchange operator is given a print level, so it reports at `print_level >= 4` where it was
  silent, as `SCF`'s already does
- the descriptions of `hfexalg` and the three `hfex_*` parameters are shortened, values and defaults are unchanged
- `could not respect no-fence parameter in change_tree_state` is now a debug diagnostic
  (`FunctionDefaults::get_debug()`, rank 0, once) and reports only a `fence=false` request that was
  actually broken.

`MAD_EXCH_FORCE_GENERAL` is added as a debug environment variable to test the general exchange path for symmetric problems as well.

## PR checklist

| item | answer |
|---|---|
| raw MPI calls | none added |
| blocking MPI collectives | none added |
| implicit default World | none added |
| non-collective container construction | none. Batch records are registered by every rank from the same rule, and pulled by their owner |
| threaded-BLAS assumptions | none |
| `Function` mutation from user threads | no. Kernels run in tasks; the comm-thread handlers touch only serialized bytes and MPI requests |
| tree-state preconditions | unchanged |
| checkpoint-format break | none |
| GENTENSOR coverage | the exchange tests build and pass under `-DENABLE_GENTENSOR=ON` at np=1/2/4, in a Debug build with assertions enabled and the Pthreads backend.