### PR TITLE
Fix: Correctness Follow-Up to PR #724

### DIFF
--- a/src/madness/mra/CMakeLists.txt
+++ b/src/madness/mra/CMakeLists.txt
@@ -54,6 +54,9 @@ if(BUILD_TESTING)
   add_mpi_tests(mra test_cloud "2" "MADmra;MADgtest" "unittests;short")
   add_mpi_tests(mra test_vectormacrotask "2" "MADmra;MADgtest" "unittests;short")
   add_mpi_tests(mra test_eval "2" "MADmra;MADgtest" "unittests;short")
+  # the tree-state and norm checkpoints use gop.max/gop.sum and branch on a
+  # replicated state, so only a multi-rank run exercises them
+  add_mpi_tests(mra test_mul_sparse "2" "MADmra;MADgtest" "unittests;short")
   # the halo only carries data between ranks, so the single-rank run above cannot exercise it
   add_mpi_tests(mra test_halo "2" "MADmra;MADgtest" "unittests;short")
 

--- a/src/madness/mra/funcimpl.h
+++ b/src/madness/mra/funcimpl.h
@@ -3057,8 +3057,12 @@ template<size_t NDIM>
 
             if (lc.size() == 0) {
                 MADNESS_CHECK(lit != left->coeffs.end());
+                // redundant form puts coefficients and computed norms on every
+                // node; without them the screen below reads garbage
+                MADNESS_CHECK(lit->second.has_coeff());
                 lnorm = lit->second.get_norm_tree();
                 ldnorm = lit->second.get_dnorm_tree();
+                MADNESS_CHECK(ldnorm < NORM_TREE_UNCOMPUTED);
                 l_is_leaf = !lit->second.has_children();
             }
             else {
@@ -3094,20 +3098,14 @@ template<size_t NDIM>
                 riterT rit = right->coeffs.find(key).get();
                 if (rc.size() == 0) {
                     MADNESS_CHECK(rit != right->coeffs.end());
+                    MADNESS_CHECK(rit->second.has_coeff());
                     rnorm = rit->second.get_norm_tree();
                     rdnorm = rit->second.get_dnorm_tree();
+                    MADNESS_CHECK(rdnorm < NORM_TREE_UNCOMPUTED);
                 }
                 else {
                     rnorm = rc.normf();
                     rdnorm = 0.0;
-                }
-
-                if (ldnorm >= NORM_TREE_UNCOMPUTED || rdnorm >= NORM_TREE_UNCOMPUTED) {
-                    static std::atomic<bool> warned{false};
-                    bool expected = false;
-                    if (warned.compare_exchange_strong(expected, true))
-                        print("WARNING: mul_sparse operand has an uncomputed dnorm_tree; "
-                              "screening is disabled for those nodes (missing make_redundant?)");
                 }
 
                 // the neglected cross terms are below threshold: multiply here (requires redundant form)
@@ -3137,7 +3135,11 @@ template<size_t NDIM>
                 std::vector< Tensor<R> > vrss(vresult.size());
                 for (unsigned int i=0; i<vresult.size(); ++i) {
                     riterT rit = vright[i]->coeffs.find(key).get();
+                    // coefficients handed down from the parent stand in for a node
+                    // that need not exist here; without them the node must exist
+                    MADNESS_CHECK(vrc[i].size() || rit != vright[i]->coeffs.end());
                     if (vrc[i].size() || !rit->second.has_children()) {
+                        MADNESS_CHECK(vrc[i].size() || rit->second.has_coeff());
                         Tensor<R> rd(cdata.v2k);
                         rd(cdata.s0) = (vrc[i].size() ? vrc[i] : rit->second.coeff().full_tensor_copy())(___);
                         vrss[i] = vright[i]->unfilter(rd);

--- a/src/madness/mra/funcimpl.h
+++ b/src/madness/mra/funcimpl.h
@@ -4765,7 +4765,8 @@ template<size_t NDIM>
 
         void broaden_op(const keyT& key, const std::vector< Future <bool> >& v);
 
-        // For each local node sets value of norm tree, snorm and dnorm to 0.0
+        // For each local node sets norm_tree, snorm and dnorm to 0.0, and marks
+        // dnorm_tree as uncomputed.
         void zero_norm_tree();
 
         // Broaden tree

--- a/src/madness/mra/funcimpl.h
+++ b/src/madness/mra/funcimpl.h
@@ -1442,6 +1442,25 @@ template<size_t NDIM>
 
         bool is_on_demand() const;
 
+        /// Returns true if only the leaves of this tree carry its coefficients
+
+        /// redundant and nonstandard_with_leaves keep s coefficients on the
+        /// internal nodes as well, so a sum over all nodes counts the function
+        /// more than once; the leaves alone are exactly the reconstructed tree,
+        /// which is why change_tree_state(reconstructed) is nothing but
+        /// remove_internal_coefficients() for these two states.
+        bool has_coefficients_on_leaves_only() const;
+
+        /// Returns true if summing over the local nodes yields the function
+
+        /// The precondition of norm2sq_local() and trace_local(): the tree holds
+        /// its coefficients exactly once.  reconstructed and compressed do so
+        /// outright, the two states above once the internal nodes are skipped.
+        /// redundant_after_merge is a sum that has not been collapsed yet, and
+        /// nonstandard / nonstandard_after_apply have no leaf coefficients to
+        /// single out, so neither qualifies.
+        bool has_summable_coefficients() const;
+
         bool has_leaves() const;
 
         void set_tree_state(const TreeState& state) {
@@ -5752,8 +5771,15 @@ template<size_t NDIM>
         T trace_local() const;
 
         struct do_norm2sq_local {
+            /// skip the internal nodes, cf. has_coefficients_on_leaves_only()
+            bool leaves_only = false;
+
+            do_norm2sq_local() = default;
+            explicit do_norm2sq_local(bool leaves_only) : leaves_only(leaves_only) {}
+
             double operator()(typename dcT::const_iterator& it) const {
                 const nodeT& node = it->second;
+                if (leaves_only and node.has_children()) return 0.0;
                 if (node.has_coeff()) {
                     double norm = node.coeff().normf();
                     return norm*norm;
@@ -5774,6 +5800,11 @@ template<size_t NDIM>
 
 
         /// Returns the square of the local norm ... no comms
+
+        /// Requires has_summable_coefficients(); throws otherwise, because on a
+        /// tree that carries its coefficients on more than one level the sum is
+        /// not the norm.  Internal nodes are skipped where they are the
+        /// duplicates, so no state change is needed to ask for the norm.
         double norm2sq_local() const;
 
         /// compute the inner product of this range with other

--- a/src/madness/mra/funcimpl.h
+++ b/src/madness/mra/funcimpl.h
@@ -6577,12 +6577,10 @@ template<size_t NDIM>
 
                     // make child's s coeffs if it doesn't exist or if is has no s coeffs
                     bool childnode_exists=get_coeffs().find(acc,child);
-                    // snorm > 0 stands in for "this node holds coefficients", which
-                    // holds only because innerXX() runs compute_snorm_and_dnorm()
-                    // over both trees first (mra.h, the prepare step) and that zeroes
-                    // snorm on an empty node.  A compressed leaf left by
-                    // compress_spawn(keepleaves=false) carries a non-zero snorm and
-                    // no coefficients, so without that step this test reads false.
+                    // snorm > 0 stands in for "this node holds s coefficients":
+                    // every writer zeroes snorm when it clears them, cf.
+                    // FunctionNode::recompute_snorm_and_dnorm() and the
+                    // keepleaves=false path of compress_spawn().
                     bool need_s_coeffs= childnode_exists ? (acc->second.get_snorm()<=0.0) : true;
 
                     coeffT child_s_coeffs;

--- a/src/madness/mra/funcimpl.h
+++ b/src/madness/mra/funcimpl.h
@@ -6576,6 +6576,12 @@ template<size_t NDIM>
 
                     // make child's s coeffs if it doesn't exist or if is has no s coeffs
                     bool childnode_exists=get_coeffs().find(acc,child);
+                    // snorm > 0 stands in for "this node holds coefficients", which
+                    // holds only because innerXX() runs compute_snorm_and_dnorm()
+                    // over both trees first (mra.h, the prepare step) and that zeroes
+                    // snorm on an empty node.  A compressed leaf left by
+                    // compress_spawn(keepleaves=false) carries a non-zero snorm and
+                    // no coefficients, so without that step this test reads false.
                     bool need_s_coeffs= childnode_exists ? (acc->second.get_snorm()<=0.0) : true;
 
                     coeffT child_s_coeffs;

--- a/src/madness/mra/mra.h
+++ b/src/madness/mra/mra.h
@@ -825,11 +825,25 @@ namespace madness {
         /// reconstructed first -- summing norm2sq_local over e.g. a redundant tree
         /// counts every level and overcounts.  See comments for err() w.r.t.
         /// applying to many functions.
+        ///
+        /// Throws if the function is on-demand: it carries no coefficients, so
+        /// its norm is not defined until it is materialized.
+        ///
+        /// N.B. that reconstruction is a mutation -- it discards the interior
+        /// coefficients of a redundant tree -- so this (logically const) method
+        /// fences before it changes state: any task still reading those
+        /// coefficients, e.g. a mul_sparse() invoked with fence=false, must be
+        /// done with them before they are removed.
         double norm2() const {
             PROFILE_MEMBER_FUNC(Function);
             verify();
             if (VERIFY_TREE) verify_tree();
-            if (!(is_compressed() or is_reconstructed())) reconstruct();
+            if (!(is_compressed() or is_reconstructed())) {
+                MADNESS_CHECK_THROW(not is_on_demand(),
+                    "norm2 is not defined for an on-demand function; materialize it first");
+                impl->world.gop.fence();
+                reconstruct();
+            }
             double local = impl->norm2sq_local();
 
             impl->world.gop.sum(local);
@@ -1261,10 +1275,18 @@ namespace madness {
         /// reconstructed first.  For efficient use especially with many functions,
         /// reconstruct them all first and use trace_local instead, so you can
         /// perform a global sum on all at the same time.
+        ///
+        /// Throws if the function is on-demand, and fences before reconstructing;
+        /// see norm2() for both.
         T trace() const {
             PROFILE_MEMBER_FUNC(Function);
             if (!impl) return 0.0;
-            if (!(is_compressed() or is_reconstructed())) reconstruct();
+            if (!(is_compressed() or is_reconstructed())) {
+                MADNESS_CHECK_THROW(not is_on_demand(),
+                    "trace is not defined for an on-demand function; materialize it first");
+                impl->world.gop.fence();
+                reconstruct();
+            }
             if (VERIFY_TREE) verify_tree();
             T sum = impl->trace_local();
             impl->world.gop.sum(sum);

--- a/src/madness/mra/mra.h
+++ b/src/madness/mra/mra.h
@@ -995,6 +995,10 @@ namespace madness {
         }
 
         /// Inplace broadens support in scaling function basis
+
+        /// N.B. with fence=false the per-node norm reset is skipped: norm_tree
+        /// keeps the -1.0 broadened marker and dnorm_tree its previous value,
+        /// so broadening cannot be repeated until the norms are recomputed.
         void broaden(const BoundaryConditions<NDIM>& bc=FunctionDefaults<NDIM>::get_bc(),
                      bool fence = true) const {
             verify();

--- a/src/madness/mra/mra.h
+++ b/src/madness/mra/mra.h
@@ -821,11 +821,15 @@ namespace madness {
 
         /// Returns the 2-norm of the function ... global sum ... works in either basis
 
-        /// See comments for err() w.r.t. applying to many functions.
+        /// If the function is neither compressed nor reconstructed, it is
+        /// reconstructed first -- summing norm2sq_local over e.g. a redundant tree
+        /// counts every level and overcounts.  See comments for err() w.r.t.
+        /// applying to many functions.
         double norm2() const {
             PROFILE_MEMBER_FUNC(Function);
             verify();
             if (VERIFY_TREE) verify_tree();
+            if (!(is_compressed() or is_reconstructed())) reconstruct();
             double local = impl->norm2sq_local();
 
             impl->world.gop.sum(local);
@@ -1244,15 +1248,24 @@ namespace madness {
         T trace_local() const {
             PROFILE_MEMBER_FUNC(Function);
             if (!impl) return 0.0;
+            MADNESS_CHECK_THROW(is_compressed() or is_reconstructed(),
+                "function must be compressed or reconstructed for trace_local");
             if (VERIFY_TREE) verify_tree();
             return impl->trace_local();
         }
 
 
         /// Returns global value of \c int(f(x),x) ... global comm required
+
+        /// If the function is neither compressed nor reconstructed, it is
+        /// reconstructed first.  For efficient use especially with many functions,
+        /// reconstruct them all first and use trace_local instead, so you can
+        /// perform a global sum on all at the same time.
         T trace() const {
             PROFILE_MEMBER_FUNC(Function);
             if (!impl) return 0.0;
+            if (!(is_compressed() or is_reconstructed())) reconstruct();
+            if (VERIFY_TREE) verify_tree();
             T sum = impl->trace_local();
             impl->world.gop.sum(sum);
             impl->world.gop.fence();

--- a/src/madness/mra/mra.h
+++ b/src/madness/mra/mra.h
@@ -1459,9 +1459,7 @@ namespace madness {
             // if this and g are the same, use norm2()
             if constexpr (std::is_same_v<T,R>) {
               if (this->get_impl() == g.get_impl()) {
-                TreeState state = this->get_impl()->get_tree_state();
-                if (not(state == reconstructed or state == compressed))
-                  change_tree_state(reconstructed);
+                // let norm2() handle tree state
                 double norm = this->norm2();
                 return norm * norm;
               }

--- a/src/madness/mra/mra.h
+++ b/src/madness/mra/mra.h
@@ -834,6 +834,9 @@ namespace madness {
         /// fences before it changes state: any task still reading those
         /// coefficients, e.g. a mul_sparse() invoked with fence=false, must be
         /// done with them before they are removed.
+        ///
+        /// The branch is taken on the tree state, which is replicated, so all
+        /// ranks take the same branch and the global ops stay collective.
         double norm2() const {
             PROFILE_MEMBER_FUNC(Function);
             verify();
@@ -1277,7 +1280,7 @@ namespace madness {
         /// perform a global sum on all at the same time.
         ///
         /// Throws if the function is on-demand, and fences before reconstructing;
-        /// see norm2() for both.
+        /// see norm2() for both, including why the branch stays collective.
         T trace() const {
             PROFILE_MEMBER_FUNC(Function);
             if (!impl) return 0.0;

--- a/src/madness/mra/mra.h
+++ b/src/madness/mra/mra.h
@@ -809,31 +809,32 @@ namespace madness {
 
         /// Returns the square of the norm of the local function ... no communication
 
-        /// Works in either basis
+        /// Works in any state that holds its coefficients once, cf.
+        /// FunctionImpl::has_summable_coefficients()
         double norm2sq_local() const {
             PROFILE_MEMBER_FUNC(Function);
             verify();
-            MADNESS_CHECK_THROW(is_compressed() or is_reconstructed(),
-                "function must be compressed or reconstructed for norm2sq_local");
+            MADNESS_CHECK_THROW(impl->has_summable_coefficients(),
+                "norm2sq_local needs a tree that holds its coefficients once");
             return impl->norm2sq_local();
         }
 
 
         /// Returns the 2-norm of the function ... global sum ... works in either basis
 
-        /// If the function is neither compressed nor reconstructed, it is
-        /// reconstructed first -- summing norm2sq_local over e.g. a redundant tree
-        /// counts every level and overcounts.  See comments for err() w.r.t.
-        /// applying to many functions.
+        /// Works in any state whose coefficients norm2sq_local() can sum, which
+        /// includes the redundant and nonstandard-with-leaves trees left behind
+        /// by mul_sparse() and friends; the remaining states are reconstructed
+        /// first.  See comments for err() w.r.t. applying to many functions.
         ///
         /// Throws if the function is on-demand: it carries no coefficients, so
         /// its norm is not defined until it is materialized.
         ///
         /// N.B. that reconstruction is a mutation -- it discards the interior
-        /// coefficients of a redundant tree -- so this (logically const) method
-        /// fences before it changes state: any task still reading those
-        /// coefficients, e.g. a mul_sparse() invoked with fence=false, must be
-        /// done with them before they are removed.
+        /// coefficients -- so this (logically const) method fences before it
+        /// changes state: any task still reading those coefficients, e.g. a
+        /// mul_sparse() invoked with fence=false, must be done with them before
+        /// they are removed.
         ///
         /// The branch is taken on the tree state, which is replicated, so all
         /// ranks take the same branch and the global ops stay collective.
@@ -841,7 +842,7 @@ namespace madness {
             PROFILE_MEMBER_FUNC(Function);
             verify();
             if (VERIFY_TREE) verify_tree();
-            if (!(is_compressed() or is_reconstructed())) {
+            if (!impl->has_summable_coefficients()) {
                 MADNESS_CHECK_THROW(not is_on_demand(),
                     "norm2 is not defined for an on-demand function; materialize it first");
                 impl->world.gop.fence();
@@ -1269,8 +1270,8 @@ namespace madness {
         T trace_local() const {
             PROFILE_MEMBER_FUNC(Function);
             if (!impl) return 0.0;
-            MADNESS_CHECK_THROW(is_compressed() or is_reconstructed(),
-                "function must be compressed or reconstructed for trace_local");
+            MADNESS_CHECK_THROW(impl->has_summable_coefficients(),
+                "trace_local needs a tree that holds its coefficients once");
             if (VERIFY_TREE) verify_tree();
             return impl->trace_local();
         }
@@ -1278,17 +1279,18 @@ namespace madness {
 
         /// Returns global value of \c int(f(x),x) ... global comm required
 
-        /// If the function is neither compressed nor reconstructed, it is
-        /// reconstructed first.  For efficient use especially with many functions,
-        /// reconstruct them all first and use trace_local instead, so you can
-        /// perform a global sum on all at the same time.
+        /// Works in any state whose coefficients trace_local() can sum; the
+        /// remaining states are reconstructed first.  For efficient use
+        /// especially with many functions, reconstruct them all first and use
+        /// trace_local instead, so you can perform a global sum on all at the
+        /// same time.
         ///
         /// Throws if the function is on-demand, and fences before reconstructing;
         /// see norm2() for both, including why the branch stays collective.
         T trace() const {
             PROFILE_MEMBER_FUNC(Function);
             if (!impl) return 0.0;
-            if (!(is_compressed() or is_reconstructed())) {
+            if (!impl->has_summable_coefficients()) {
                 MADNESS_CHECK_THROW(not is_on_demand(),
                     "trace is not defined for an on-demand function; materialize it first");
                 impl->world.gop.fence();

--- a/src/madness/mra/mraimpl.h
+++ b/src/madness/mra/mraimpl.h
@@ -1983,8 +1983,15 @@ namespace madness {
         const double d=sizeof(T);
         const double fac=1024*1024*1024;
 
+        // norm2sq_local sums the coefficients of every node, which is ||f||^2
+        // only when the tree carries them once -- on a redundant or nonstandard
+        // tree it counts every level and overcounts (cf. Function::norm2()).
+        // This is a diagnostic and must not mutate the tree, so report the norm
+        // only where it means something.  The tree state is replicated, so all
+        // ranks take the same branch and the global ops stay collective.
+        const bool norm_is_meaningful = is_compressed() or is_reconstructed();
         double norm=0.0;
-        {
+        if (norm_is_meaningful) {
             double local = norm2sq_local();
             this->world.gop.sum(local);
             this->world.gop.fence();
@@ -1995,8 +2002,12 @@ namespace madness {
 
             constexpr std::size_t bufsize=128;
             char buf[bufsize];
-            snprintf(buf, bufsize, "%40s at time %.1fs: norm/tree/#coeff/size: %7.5f %zu, %6.3f m, %6.3f GByte",
-                   (name.c_str()), wall, norm, tsize,double(ncoeff)*1.e-6,double(ncoeff)/fac*d);
+            if (norm_is_meaningful)
+                snprintf(buf, bufsize, "%40s at time %.1fs: norm/tree/#coeff/size: %7.5f %zu, %6.3f m, %6.3f GByte",
+                       (name.c_str()), wall, norm, tsize,double(ncoeff)*1.e-6,double(ncoeff)/fac*d);
+            else
+                snprintf(buf, bufsize, "%40s at time %.1fs: norm/tree/#coeff/size: %7s %zu, %6.3f m, %6.3f GByte",
+                       (name.c_str()), wall, "n/a", tsize,double(ncoeff)*1.e-6,double(ncoeff)/fac*d);
             print(std::string(buf));
         }
     }

--- a/src/madness/mra/mraimpl.h
+++ b/src/madness/mra/mraimpl.h
@@ -1301,12 +1301,14 @@ namespace madness {
         }
     }
 
-    // For each local node sets value of norm tree, snorm and dnorm to 0.0
+    // For each local node sets norm_tree, snorm and dnorm to 0.0, and marks
+    // dnorm_tree as uncomputed.
     template <typename T, std::size_t NDIM>
     void FunctionImpl<T,NDIM>::zero_norm_tree() {
         typename dcT::iterator end = coeffs.end();
         for (typename dcT::iterator it=coeffs.begin(); it!=end; ++it) {
             it->second.set_norm_tree(0.0);
+            it->second.set_dnorm_tree(NORM_TREE_UNCOMPUTED);
             it->second.set_snorm(0.0);
             it->second.set_dnorm(0.0);
         }

--- a/src/madness/mra/mraimpl.h
+++ b/src/madness/mra/mraimpl.h
@@ -1716,14 +1716,22 @@ namespace madness {
         TensorArgs targs2=targs;
         targs2.thresh*=0.1;
 
-        // need the deep copy for contiguity
-        coeffT ss=coeffT(copy(d(cdata.s0)));
-        double snorm=ss.normf();
+        // need the deep copy for contiguity; ss shares it rather than taking a
+        // second one, so this k^NDIM block is the only temporary on the path
+        const tensorT s0block = copy(d(cdata.s0));
+        coeffT ss = coeffT(s0block);
+        double snorm = ss.normf();
 
-        if (key.level()> 0 && !nonstandard1) d(cdata.s0) = 0.0;
+        // dnorm must mean ||d|| in every tree state. The stored tensor keeps its
+        // s0 block at the root and everywhere in nonstandard form, so zero s0
+        // unconditionally to measure and put it back when the stored tensor is
+        // one that keeps it.
+        const bool stored_tensor_keeps_s0 = (key.level() == 0) or nonstandard1;
+        d(cdata.s0) = 0.0;
+        const double dnorm = d.normf();
+        if (stored_tensor_keeps_s0) d(cdata.s0) = s0block;
 
         coeffT dd=coeffT(d,targs2);
-        double dnorm=dd.normf();
         double norm_tree=sqrt(norm_tree2);
         // dnorm_tree accumulates this node's d coefficients and all those below it
         double dnorm_tree=sqrt(dnorm_tree2+dnorm*dnorm);

--- a/src/madness/mra/mraimpl.h
+++ b/src/madness/mra/mraimpl.h
@@ -2004,12 +2004,14 @@ namespace madness {
 
             constexpr std::size_t bufsize=128;
             char buf[bufsize];
-            if (norm_is_meaningful)
-                snprintf(buf, bufsize, "%40s at time %.1fs: norm/tree/#coeff/size: %7.5f %zu, %6.3f m, %6.3f GByte",
-                       (name.c_str()), wall, norm, tsize,double(ncoeff)*1.e-6,double(ncoeff)/fac*d);
-            else
-                snprintf(buf, bufsize, "%40s at time %.1fs: norm/tree/#coeff/size: %7s %zu, %6.3f m, %6.3f GByte",
-                       (name.c_str()), wall, "n/a", tsize,double(ncoeff)*1.e-6,double(ncoeff)/fac*d);
+            // the two cases differ in one field only, so format that field first
+            // and keep a single line format.  32 chars holds "%7.5f" of any
+            // norm below 1e25, well past anything a converged tree carries.
+            char normbuf[32];
+            if (norm_is_meaningful) snprintf(normbuf, sizeof(normbuf), "%7.5f", norm);
+            else                    snprintf(normbuf, sizeof(normbuf), "%7s", "n/a");
+            snprintf(buf, bufsize, "%40s at time %.1fs: norm/tree/#coeff/size: %s %zu, %6.3f m, %6.3f GByte",
+                   (name.c_str()), wall, normbuf, tsize,double(ncoeff)*1.e-6,double(ncoeff)/fac*d);
             print(std::string(buf));
         }
     }

--- a/src/madness/mra/mraimpl.h
+++ b/src/madness/mra/mraimpl.h
@@ -3453,9 +3453,10 @@ template <typename T, std::size_t NDIM>
 
             } else { // this is a leaf node
                 Future<coeffT > result(node.coeff());
+                const double snorm = node.coeff().normf();
+
                 if (not keepleaves) node.clear_coeff();
 
-                auto snorm=(keepleaves) ? node.coeff().normf() : 0.0;
                 node.set_norm_tree(snorm);
                 node.set_dnorm_tree(0.0);
                 node.set_snorm(snorm);

--- a/src/madness/mra/mraimpl.h
+++ b/src/madness/mra/mraimpl.h
@@ -287,6 +287,16 @@ namespace madness {
     }
 
     template <typename T, std::size_t NDIM>
+    bool FunctionImpl<T,NDIM>::has_coefficients_on_leaves_only() const {
+        return (tree_state==redundant) or (tree_state==nonstandard_with_leaves);
+    }
+
+    template <typename T, std::size_t NDIM>
+    bool FunctionImpl<T,NDIM>::has_summable_coefficients() const {
+        return is_reconstructed() or is_compressed() or has_coefficients_on_leaves_only();
+    }
+
+    template <typename T, std::size_t NDIM>
     bool FunctionImpl<T,NDIM>::has_leaves() const {
     	return (tree_state==nonstandard_with_leaves);
     }
@@ -1870,9 +1880,11 @@ namespace madness {
     template <typename T, std::size_t NDIM>
     double FunctionImpl<T,NDIM>::norm2sq_local() const {
         PROFILE_MEMBER_FUNC(FunctionImpl);
+        MADNESS_CHECK_THROW(has_summable_coefficients(),
+            "norm2sq_local() needs a tree that holds its coefficients once");
         typedef Range<typename dcT::const_iterator> rangeT;
         return world.taskq.reduce<double,rangeT,do_norm2sq_local>(rangeT(coeffs.begin(),coeffs.end()),
-                                                                  do_norm2sq_local());
+                                                                  do_norm2sq_local(has_coefficients_on_leaves_only()));
     }
 
 
@@ -1987,13 +1999,11 @@ namespace madness {
         const double d=sizeof(T);
         const double fac=1024*1024*1024;
 
-        // norm2sq_local sums the coefficients of every node, which is ||f||^2
-        // only when the tree carries them once -- on a redundant or nonstandard
-        // tree it counts every level and overcounts (cf. Function::norm2()).
         // This is a diagnostic and must not mutate the tree, so report the norm
-        // only where it means something.  The tree state is replicated, so all
+        // only in the states where norm2sq_local() is defined (cf.
+        // has_summable_coefficients()).  The tree state is replicated, so all
         // ranks take the same branch and the global ops stay collective.
-        const bool norm_is_meaningful = is_compressed() or is_reconstructed();
+        const bool norm_is_meaningful = has_summable_coefficients();
         double norm=0.0;
         if (norm_is_meaningful) {
             double local = norm2sq_local();
@@ -3330,6 +3340,8 @@ template <typename T, std::size_t NDIM>
     template <typename T, std::size_t NDIM>
     T FunctionImpl<T,NDIM>::trace_local() const {
         PROFILE_MEMBER_FUNC(FunctionImpl);
+        MADNESS_CHECK_THROW(has_summable_coefficients(),
+            "trace_local() needs a tree that holds its coefficients once");
         std::vector<long> v0(NDIM,0);
         T sum = 0.0;
         if (is_compressed()) {
@@ -3342,9 +3354,13 @@ template <typename T, std::size_t NDIM>
             }
         }
         else {
+            // on a redundant or nonstandard-with-leaves tree the internal nodes
+            // repeat what the leaves already carry, cf. norm2sq_local()
+            const bool leaves_only = has_coefficients_on_leaves_only();
             for (typename dcT::const_iterator it=coeffs.begin(); it!=coeffs.end(); ++it) {
                 const keyT& key = it->first;
                 const nodeT& node = it->second;
+                if (leaves_only and node.has_children()) continue;
                 if (node.has_coeff()) sum += node.coeff().full_tensor()(v0)*pow(0.5,NDIM*key.level()*0.5);
             }
         }

--- a/src/madness/mra/mraimpl.h
+++ b/src/madness/mra/mraimpl.h
@@ -40,7 +40,8 @@
 #include <memory>
 #include <math.h>
 #include <cmath>
-#include <madness/misc/misc.h>
+#include <iomanip>
+#include <sstream>
 #include <madness/world/world_object.h>
 #include <madness/world/worlddc.h>
 #include <madness/world/worldhashmap.h>

--- a/src/madness/mra/mraimpl.h
+++ b/src/madness/mra/mraimpl.h
@@ -3483,9 +3483,17 @@ template <typename T, std::size_t NDIM>
 
                 if (not keepleaves) node.clear_coeff();
 
+                // norm_tree is the norm of this subtree and the value the parent
+                // filters with, so it is the leaf norm either way -- reading it
+                // after clear_coeff() would propagate a zero up to the root.
                 node.set_norm_tree(snorm);
                 node.set_dnorm_tree(0.0);
-                node.set_snorm(snorm);
+                // snorm, in contrast, describes the coefficients this node still
+                // holds: zero when they were just cleared, matching
+                // FunctionNode::recompute_snorm_and_dnorm().  The invariant
+                // "snorm > 0 implies the node has coefficients" is what
+                // recur_down_for_contraction_map() screens on.
+                node.set_snorm(keepleaves ? snorm : 0.0);
                 node.set_dnorm(0.0);
 
                 return Future<compressT>(std::make_pair(result,std::make_pair(snorm,0.0)));

--- a/src/madness/mra/mraimpl.h
+++ b/src/madness/mra/mraimpl.h
@@ -40,6 +40,7 @@
 #include <memory>
 #include <math.h>
 #include <cmath>
+#include <madness/misc/misc.h>
 #include <madness/world/world_object.h>
 #include <madness/world/worlddc.h>
 #include <madness/world/worldhashmap.h>
@@ -2001,18 +2002,19 @@ namespace madness {
         }
 
         if (this->world.rank()==0) {
-
-            constexpr std::size_t bufsize=128;
-            char buf[bufsize];
-            // the two cases differ in one field only, so format that field first
-            // and keep a single line format.  32 chars holds "%7.5f" of any
-            // norm below 1e25, well past anything a converged tree carries.
-            char normbuf[32];
-            if (norm_is_meaningful) snprintf(normbuf, sizeof(normbuf), "%7.5f", norm);
-            else                    snprintf(normbuf, sizeof(normbuf), "%7s", "n/a");
-            snprintf(buf, bufsize, "%40s at time %.1fs: norm/tree/#coeff/size: %s %zu, %6.3f m, %6.3f GByte",
-                   (name.c_str()), wall, normbuf, tsize,double(ncoeff)*1.e-6,double(ncoeff)/fac*d);
-            print(std::string(buf));
+            std::ostringstream oss;
+            oss << std::setw(40) << name << " at time "
+                << std::fixed << std::setprecision(1) << wall
+                << "s: norm/tree/#coeff/size: ";
+            if (norm_is_meaningful)
+                oss << std::setw(7) << std::setprecision(5) << norm;
+            else
+                oss << std::setw(7) << "n/a";
+            oss << " " << tsize
+                << ", " << std::setw(6) << std::setprecision(3) << double(ncoeff)*1.e-6
+                << " m, " << std::setw(6) << std::setprecision(3) << double(ncoeff)/fac*d
+                << " GByte";
+            print(oss.str());
         }
     }
 

--- a/src/madness/mra/test_mul_sparse.cc
+++ b/src/madness/mra/test_mul_sparse.cc
@@ -436,6 +436,25 @@ int test_broaden_resets_norms(World& world, std::vector<operand_pair>& pairs) {
     return t.end();
 }
 
+/// T9: the vector norms accept an empty vector. norm2s()/norm2s_T() index
+/// norms[0] to get the buffer address, which is undefined behaviour on an
+/// empty container even with a length of zero.
+int test_empty_vector_norms(World& world) {
+    test_output t("mul_sparse T9: the vector norms on an empty vector");
+    t.set_do_print(world.rank() == 0);
+
+    const std::vector<Function<double,D>> empty;
+
+    const std::vector<double> ns = norm2s(world, empty);
+    t.checkpoint(ns.empty(), "T9 norm2s returns an empty vector");
+
+    const Tensor<double> nt = norm2s_T(world, empty);
+    t.checkpoint(nt.size() == 0, "T9 norm2s_T returns an empty tensor");
+
+    t.checkpoint(norm2(world, empty), 0.0, 1.e-15, "T9 norm2 returns zero");
+    return t.end();
+}
+
 int main(int argc, char** argv) {
     World& world = initialize(argc, argv);
     startup(world, argc, argv, true);
@@ -458,6 +477,7 @@ int main(int argc, char** argv) {
         success += test_operand_state(world, pairs);
         success += test_norm_tree_states(world, pairs);
         success += test_broaden_resets_norms(world, pairs);
+        success += test_empty_vector_norms(world);
     }
 
     world.gop.fence();

--- a/src/madness/mra/test_mul_sparse.cc
+++ b/src/madness/mra/test_mul_sparse.cc
@@ -308,6 +308,24 @@ int test_norm_tree_states(World& world, std::vector<operand_pair>& pairs) {
         return nt;
     };
 
+    auto root_dnorm_tree = [&world](const Function<double,D>& g) {
+        const Key<D> key0 = g.get_impl()->get_cdata().key0;
+        double dnt = 0.0;
+        if (g.get_impl()->get_coeffs().probe(key0))
+            dnt = g.get_impl()->get_coeffs().find(key0).get()->second.get_dnorm_tree();
+        world.gop.max(dnt);
+        return dnt;
+    };
+
+    auto root_snorm = [&world](const Function<double,D>& g) {
+        const Key<D> key0 = g.get_impl()->get_cdata().key0;
+        double sn = 0.0;
+        if (g.get_impl()->get_coeffs().probe(key0))
+            sn = g.get_impl()->get_coeffs().find(key0).get()->second.get_snorm();
+        world.gop.max(sn);
+        return sn;
+    };
+
     f.make_redundant(true);
     const double nt_redundant = root_norm_tree(f);
     f.reconstruct();
@@ -322,6 +340,30 @@ int test_norm_tree_states(World& world, std::vector<operand_pair>& pairs) {
                  "T7 root norm_tree on a redundant tree equals ||f||");
     t.checkpoint(std::abs(nt_compressed - exact) < 1.e-10,
                  "T7 root norm_tree on a compressed tree equals ||f||");
+
+    // ||f||^2 = ||s||^2 + ||d||^2, so dnorm_tree at the root must be strictly
+    // below ||f||: equality means the scaling block was counted as detail
+    const double dnt_compressed = root_dnorm_tree(f);
+    if (world.rank() == 0)
+        printf("  T7 root dnorm_tree compressed %.10e  (||f|| %.10e)\n",
+               dnt_compressed, exact);
+    t.checkpoint(dnt_compressed < 0.999 * exact,
+                 "T7 root dnorm_tree excludes the scaling block");
+
+    // The multiwavelet basis is orthonormal, so the root scaling block and every
+    // difference coefficient below it are mutually orthogonal:
+    //   ||f||^2 == ||s_root||^2 + sum_nodes ||d||^2 == snorm^2 + dnorm_tree^2
+    // This pins dnorm_tree rather than merely bounding it, and so also catches a
+    // dnorm that comes out too small.
+    const double sn_compressed = root_snorm(f);
+    const double recomposed = std::sqrt(sn_compressed * sn_compressed
+                                      + dnt_compressed * dnt_compressed);
+    if (world.rank() == 0)
+        printf("  T7 snorm %.14e  dnorm_tree %.14e\n"
+               "  T7 sqrt(s^2+d^2) %.14e  ||f|| %.14e\n",
+               sn_compressed, dnt_compressed, recomposed, exact);
+    t.checkpoint(std::abs(recomposed - exact) < 1.e-12 * exact,
+                 "T7 snorm^2 + dnorm_tree^2 == ||f||^2 at the root");
     return t.end();
 }
 

--- a/src/madness/mra/test_mul_sparse.cc
+++ b/src/madness/mra/test_mul_sparse.cc
@@ -261,8 +261,10 @@ int test_operand_state(World& world, std::vector<operand_pair>& pairs) {
 
     // reference values, taken while the operands are still reconstructed
     p.f.reconstruct();
-    const double norm_before  = p.f.norm2();
-    const double trace_before = p.f.trace();
+    p.g.reconstruct();
+    const double norm_before    = p.f.norm2();
+    const double trace_before   = p.f.trace();
+    const double g_trace_before = p.g.trace();
 
     Function<double,D> q = mul_sparse(p.f, p.g, 1.e-6);
     world.gop.fence();
@@ -272,19 +274,34 @@ int test_operand_state(World& world, std::vector<operand_pair>& pairs) {
     t.checkpoint(get_tree_state(p.g) == redundant,
                  "T6 right operand is left redundant");
 
-    const double norm_after  = p.f.norm2();
-    const double trace_after = p.f.trace();
+    // each entry point has to be called on a tree that is still redundant at
+    // the point of the call, and norm2()/trace() reconstruct as a side effect
+    // -- so they cannot be measured one after the other on the same operand
+    const double norm_after  = p.f.norm2();     // p.f: redundant -> reconstructed
+    const double trace_after = p.g.trace();     // p.g: redundant -> reconstructed
     if (world.rank() == 0)
         printf("  T6 norm2  %.10e -> %.10e\n  T6 trace  %.10e -> %.10e\n",
-               norm_before, norm_after, trace_before, trace_after);
+               norm_before, norm_after, g_trace_before, trace_after);
 
-    t.checkpoint(norm_after,  norm_before,  1.e-10, "T6 norm2 on a redundant function");
-    t.checkpoint(trace_after, trace_before, 1.e-10, "T6 trace on a redundant function");
+    t.checkpoint(norm_after,  norm_before,    1.e-10, "T6 norm2 on a redundant function");
+    t.checkpoint(trace_after, g_trace_before, 1.e-10, "T6 trace on a redundant function");
+    t.checkpoint(get_tree_state(p.f) == reconstructed and
+                 get_tree_state(p.g) == reconstructed,
+                 "T6 norm2/trace leave the operand reconstructed");
 
-    // the vector overload already reconstructs; it must still agree
+    // the vector overload already reconstructs; it must still agree.  p.f is
+    // reconstructed by now, so put it back into redundant form first
+    p.f.make_redundant(true);
+    t.checkpoint(get_tree_state(p.f) == redundant,
+                 "T6 norm2s operand is redundant on entry");
     std::vector<Function<double,D>> v = {p.f};
     t.checkpoint(norm2s(world, v)[0], norm_before, 1.e-10,
                  "T6 vector norm2s agrees");
+
+    // p.f has now been through reconstructed -> redundant -> reconstructed;
+    // its trace must still be the value measured at the top
+    t.checkpoint(p.f.trace(), trace_before, 1.e-10,
+                 "T6 trace round-trips through redundant form");
     return t.end();
 }
 

--- a/src/madness/mra/test_mul_sparse.cc
+++ b/src/madness/mra/test_mul_sparse.cc
@@ -257,7 +257,10 @@ int test_dot_sparse(World& world, std::vector<operand_pair>& pairs) {
 int test_operand_state(World& world, std::vector<operand_pair>& pairs) {
     test_output t("mul_sparse T6: operand state and the norms read off it");
     t.set_do_print(world.rank() == 0);
-    operand_pair& p = pairs.front();
+    // this test changes the state of both operands, and the
+    // pairs are shared with every test that runs after it
+    operand_pair p{pairs.front().name, copy(pairs.front().f),
+                   copy(pairs.front().g), copy(pairs.front().fg)};
 
     // reference values, taken while the operands are still reconstructed
     p.f.reconstruct();
@@ -353,9 +356,9 @@ int test_norm_tree_states(World& world, std::vector<operand_pair>& pairs) {
         printf("  T7 ||f|| %.10e  redundant %.10e  compressed %.10e\n",
                exact, nt_redundant, nt_compressed);
 
-    t.checkpoint(std::abs(nt_redundant  - exact) < 1.e-10,
+    t.checkpoint(std::abs(nt_redundant  - exact) < 1.e-10 * exact,
                  "T7 root norm_tree on a redundant tree equals ||f||");
-    t.checkpoint(std::abs(nt_compressed - exact) < 1.e-10,
+    t.checkpoint(std::abs(nt_compressed - exact) < 1.e-10 * exact,
                  "T7 root norm_tree on a compressed tree equals ||f||");
 
     // ||f||^2 = ||s||^2 + ||d||^2, so dnorm_tree at the root must be strictly

--- a/src/madness/mra/test_mul_sparse.cc
+++ b/src/madness/mra/test_mul_sparse.cc
@@ -277,32 +277,35 @@ int test_operand_state(World& world, std::vector<operand_pair>& pairs) {
     t.checkpoint(get_tree_state(p.g) == redundant,
                  "T6 right operand is left redundant");
 
-    // each entry point has to be called on a tree that is still redundant at
-    // the point of the call, and norm2()/trace() reconstruct as a side effect
-    // -- so they cannot be measured one after the other on the same operand
-    const double norm_after  = p.f.norm2();     // p.f: redundant -> reconstructed
-    const double trace_after = p.g.trace();     // p.g: redundant -> reconstructed
+    // norm2()/trace() read the redundant tree instead of converting it, so both
+    // can be measured on the same operand, and the operand a caller hands to
+    // the next mul_sparse() is the one it had
+    const double norm_after    = p.f.norm2();
+    const double trace_after   = p.f.trace();
+    const double g_trace_after = p.g.trace();
     if (world.rank() == 0)
         printf("  T6 norm2  %.10e -> %.10e\n  T6 trace  %.10e -> %.10e\n",
-               norm_before, norm_after, g_trace_before, trace_after);
+               norm_before, norm_after, g_trace_before, g_trace_after);
 
-    t.checkpoint(norm_after,  norm_before,    1.e-10, "T6 norm2 on a redundant function");
-    t.checkpoint(trace_after, g_trace_before, 1.e-10, "T6 trace on a redundant function");
-    t.checkpoint(get_tree_state(p.f) == reconstructed and
-                 get_tree_state(p.g) == reconstructed,
-                 "T6 norm2/trace leave the operand reconstructed");
+    t.checkpoint(norm_after,    norm_before,    1.e-10, "T6 norm2 on a redundant function");
+    t.checkpoint(trace_after,   trace_before,   1.e-10, "T6 trace on a redundant function");
+    t.checkpoint(g_trace_after, g_trace_before, 1.e-10, "T6 trace on the other redundant operand");
+    t.checkpoint(get_tree_state(p.f) == redundant and
+                 get_tree_state(p.g) == redundant,
+                 "T6 norm2/trace leave the operand redundant");
 
-    // the vector overload already reconstructs; it must still agree.  p.f is
-    // reconstructed by now, so put it back into redundant form first
-    p.f.make_redundant(true);
+    // the vector overload takes the same path and must agree
     t.checkpoint(get_tree_state(p.f) == redundant,
                  "T6 norm2s operand is redundant on entry");
     std::vector<Function<double,D>> v = {p.f};
     t.checkpoint(norm2s(world, v)[0], norm_before, 1.e-10,
                  "T6 vector norm2s agrees");
+    t.checkpoint(get_tree_state(p.f) == redundant,
+                 "T6 norm2s leaves the operand redundant");
 
-    // p.f has now been through reconstructed -> redundant -> reconstructed;
-    // its trace must still be the value measured at the top
+    // p.f has been through reconstructed -> redundant and back; its trace must
+    // still be the value measured at the top
+    p.f.reconstruct();
     t.checkpoint(p.f.trace(), trace_before, 1.e-10,
                  "T6 trace round-trips through redundant form");
     return t.end();
@@ -458,6 +461,56 @@ int test_empty_vector_norms(World& world) {
     return t.end();
 }
 
+/// T10: norm2() and trace() answer from a redundant or nonstandard-with-leaves
+/// tree without converting it. Adding up every node overcounts there -- the
+/// scaling coefficients sit on every level -- but the leaves alone are exactly
+/// the reconstructed tree, so the answer costs no mutation and no extra fence.
+/// mul_sparse() leaves its operands redundant and callers take norms of them in
+/// a loop, so converting here would be paid back by the next multiplication.
+int test_norms_preserve_tree_state(World& world, std::vector<operand_pair>& pairs) {
+    test_output t("mul_sparse T10: norm2/trace do not convert the tree");
+    t.set_do_print(world.rank() == 0);
+
+    Function<double,D> f = copy(pairs.front().f);
+    f.reconstruct();
+    const double exact_norm = f.norm2();
+    const double exact_trace = f.trace();
+
+    for (const TreeState state : {redundant, nonstandard_with_leaves}) {
+        f.reconstruct();
+        f.change_tree_state(state, true);
+        t.checkpoint(f.get_impl()->get_tree_state() == state,
+                     "T10 operand is in the state under test");
+        // without this the internal nodes would not be there to overcount
+        t.checkpoint(f.get_impl()->has_coefficients_on_leaves_only(),
+                     "T10 the state keeps coefficients on the internal nodes too");
+
+        const double n = f.norm2();
+        const double tr = f.trace();
+        if (world.rank() == 0)
+            printf("  T10 %s: norm %.14e (exact %.14e)  trace %.14e (exact %.14e)\n",
+                   (state == redundant ? "redundant" : "nonstandard_with_leaves"),
+                   n, exact_norm, tr, exact_trace);
+        t.checkpoint(std::abs(n - exact_norm) < 1.e-12 * exact_norm,
+                     "T10 norm2 equals ||f||");
+        t.checkpoint(std::abs(tr - exact_trace) < 1.e-12 * std::abs(exact_trace),
+                     "T10 trace equals int(f)");
+        t.checkpoint(f.get_impl()->get_tree_state() == state,
+                     "T10 norm2/trace leave the tree state alone");
+
+        // the vector forms take the same path
+        const std::vector<Function<double,D>> v{f};
+        const std::vector<double> ns = norm2s(world, v);
+        t.checkpoint(std::abs(ns[0] - exact_norm) < 1.e-12 * exact_norm,
+                     "T10 norm2s equals ||f||");
+        t.checkpoint(std::abs(norm2(world, v) - exact_norm) < 1.e-12 * exact_norm,
+                     "T10 vector norm2 equals ||f||");
+        t.checkpoint(f.get_impl()->get_tree_state() == state,
+                     "T10 the vector norms leave the tree state alone");
+    }
+    return t.end();
+}
+
 /// T11: compress() clears the leaf coefficients, and snorm has to go with them.
 /// recur_down_for_contraction_map() reads snorm > 0 as "this node holds s
 /// coefficients" and then skips building them, so a stale snorm on an emptied
@@ -519,6 +572,7 @@ int main(int argc, char** argv) {
         success += test_norm_tree_states(world, pairs);
         success += test_broaden_resets_norms(world, pairs);
         success += test_empty_vector_norms(world);
+        success += test_norms_preserve_tree_state(world, pairs);
         success += test_compress_clears_snorm(world, pairs);
     }
 

--- a/src/madness/mra/test_mul_sparse.cc
+++ b/src/madness/mra/test_mul_sparse.cc
@@ -384,6 +384,58 @@ int test_norm_tree_states(World& world, std::vector<operand_pair>& pairs) {
     return t.end();
 }
 
+/// T8: broaden() resets the per-node norms through zero_norm_tree(). The
+/// screening criterion reads norm_tree and dnorm_tree as a pair, so a reset
+/// that clears one and leaves the other in place is worse than no reset at
+/// all: norm_tree = 0 with a small stale dnorm_tree passes the test in
+/// mulXXveca() and multiplies at a level that is too coarse.
+int test_broaden_resets_norms(World& world, std::vector<operand_pair>& pairs) {
+    test_output t("mul_sparse T8: broaden resets norm_tree and dnorm_tree");
+    t.set_do_print(world.rank() == 0);
+
+    Function<double,D> f = copy(pairs.front().f);
+    f.reconstruct();
+
+    // redundant form writes both norms on every node, and undoing it only
+    // drops the internal coefficients -- so the tree carries computed norms
+    // into broaden()
+    f.make_redundant(true);
+    f.reconstruct();
+
+    // counts local nodes, summed over ranks: (computed dnorm_tree, nonzero
+    // norm_tree)
+    auto count = [&world](const Function<double,D>& g) {
+        long computed = 0, nonzero = 0;
+        const auto& c = g.get_impl()->get_coeffs();
+        for (auto it = c.begin(); it != c.end(); ++it) {
+            if (it->second.get_dnorm_tree() != NORM_TREE_UNCOMPUTED) ++computed;
+            if (it->second.get_norm_tree() != 0.0) ++nonzero;
+        }
+        world.gop.sum(computed);
+        world.gop.sum(nonzero);
+        return std::make_pair(computed, nonzero);
+    };
+
+    const auto before = count(f);
+    if (world.rank() == 0)
+        printf("  T8 before broaden: %ld nodes with a computed dnorm_tree, "
+               "%ld with a nonzero norm_tree\n", before.first, before.second);
+    // without this the test would pass on an empty premise
+    t.checkpoint(before.first > 0 and before.second > 0,
+                 "T8 the tree carries computed norms into broaden");
+
+    f.broaden();
+    world.gop.fence();
+
+    const auto after = count(f);
+    if (world.rank() == 0)
+        printf("  T8 after broaden:  %ld nodes with a computed dnorm_tree, "
+               "%ld with a nonzero norm_tree\n", after.first, after.second);
+    t.checkpoint(after.second == 0, "T8 broaden clears norm_tree");
+    t.checkpoint(after.first == 0,  "T8 broaden clears dnorm_tree");
+    return t.end();
+}
+
 int main(int argc, char** argv) {
     World& world = initialize(argc, argv);
     startup(world, argc, argv, true);
@@ -405,6 +457,7 @@ int main(int argc, char** argv) {
         success += test_dot_sparse(world, pairs);
         success += test_operand_state(world, pairs);
         success += test_norm_tree_states(world, pairs);
+        success += test_broaden_resets_norms(world, pairs);
     }
 
     world.gop.fence();

--- a/src/madness/mra/test_mul_sparse.cc
+++ b/src/madness/mra/test_mul_sparse.cc
@@ -252,6 +252,42 @@ int test_dot_sparse(World& world, std::vector<operand_pair>& pairs) {
     return t.end();
 }
 
+/// T6: mul_sparse leaves its operands redundant. The global norm2()/trace()
+/// entry points must stay correct across that state.
+int test_operand_state(World& world, std::vector<operand_pair>& pairs) {
+    test_output t("mul_sparse T6: operand state and the norms read off it");
+    t.set_do_print(world.rank() == 0);
+    operand_pair& p = pairs.front();
+
+    // reference values, taken while the operands are still reconstructed
+    p.f.reconstruct();
+    const double norm_before  = p.f.norm2();
+    const double trace_before = p.f.trace();
+
+    Function<double,D> q = mul_sparse(p.f, p.g, 1.e-6);
+    world.gop.fence();
+
+    t.checkpoint(get_tree_state(p.f) == redundant,
+                 "T6 left operand is left redundant");
+    t.checkpoint(get_tree_state(p.g) == redundant,
+                 "T6 right operand is left redundant");
+
+    const double norm_after  = p.f.norm2();
+    const double trace_after = p.f.trace();
+    if (world.rank() == 0)
+        printf("  T6 norm2  %.10e -> %.10e\n  T6 trace  %.10e -> %.10e\n",
+               norm_before, norm_after, trace_before, trace_after);
+
+    t.checkpoint(norm_after,  norm_before,  1.e-10, "T6 norm2 on a redundant function");
+    t.checkpoint(trace_after, trace_before, 1.e-10, "T6 trace on a redundant function");
+
+    // the vector overload already reconstructs; it must still agree
+    std::vector<Function<double,D>> v = {p.f};
+    t.checkpoint(norm2s(world, v)[0], norm_before, 1.e-10,
+                 "T6 vector norm2s agrees");
+    return t.end();
+}
+
 int main(int argc, char** argv) {
     World& world = initialize(argc, argv);
     startup(world, argc, argv, true);
@@ -271,6 +307,7 @@ int main(int argc, char** argv) {
         success += test_screening_accuracy(world, pairs);
         success += test_self_consistency(world, pairs);
         success += test_dot_sparse(world, pairs);
+        success += test_operand_state(world, pairs);
     }
 
     world.gop.fence();

--- a/src/madness/mra/test_mul_sparse.cc
+++ b/src/madness/mra/test_mul_sparse.cc
@@ -458,6 +458,44 @@ int test_empty_vector_norms(World& world) {
     return t.end();
 }
 
+/// T11: compress() clears the leaf coefficients, and snorm has to go with them.
+/// recur_down_for_contraction_map() reads snorm > 0 as "this node holds s
+/// coefficients" and then skips building them, so a stale snorm on an emptied
+/// node sends the recursion into unfilter() with an empty tensor. The norm the
+/// parent filters with is norm_tree, which does keep the leaf norm -- reading it
+/// after the coefficients are gone is what propagates a zero to the root.
+int test_compress_clears_snorm(World& world, std::vector<operand_pair>& pairs) {
+    test_output t("mul_sparse T11: compress clears snorm with the coefficients");
+    t.set_do_print(world.rank() == 0);
+
+    Function<double,D> f = copy(pairs.front().f);
+    f.reconstruct();
+    const double exact = f.norm2();
+    f.compress();
+
+    long empty_nodes = 0, empty_with_snorm = 0;
+    const auto& c = f.get_impl()->get_coeffs();
+    for (auto it = c.begin(); it != c.end(); ++it) {
+        if (it->second.has_coeff()) continue;
+        ++empty_nodes;
+        if (it->second.get_snorm() > 0.0) ++empty_with_snorm;
+    }
+    world.gop.sum(empty_nodes);
+    world.gop.sum(empty_with_snorm);
+
+    if (world.rank() == 0)
+        printf("  T11 %ld nodes without coefficients, %ld of them with a positive snorm\n",
+               empty_nodes, empty_with_snorm);
+    // without this the test would pass on an empty premise
+    t.checkpoint(empty_nodes > 0, "T11 compress leaves nodes without coefficients");
+    t.checkpoint(empty_with_snorm == 0,
+                 "T11 no coefficient-less node carries a positive snorm");
+
+    // ... and the leaf norm still reached the root
+    t.checkpoint(f.norm2(), exact, 1.e-12 * exact, "T11 the compressed norm is still ||f||");
+    return t.end();
+}
+
 int main(int argc, char** argv) {
     World& world = initialize(argc, argv);
     startup(world, argc, argv, true);
@@ -481,6 +519,7 @@ int main(int argc, char** argv) {
         success += test_norm_tree_states(world, pairs);
         success += test_broaden_resets_norms(world, pairs);
         success += test_empty_vector_norms(world);
+        success += test_compress_clears_snorm(world, pairs);
     }
 
     world.gop.fence();

--- a/src/madness/mra/test_mul_sparse.cc
+++ b/src/madness/mra/test_mul_sparse.cc
@@ -288,6 +288,43 @@ int test_operand_state(World& world, std::vector<operand_pair>& pairs) {
     return t.end();
 }
 
+/// T7: norm_tree means ||f|| on the box, in every tree state. compress()
+/// clears leaf coefficients, and the leaf norm has to be read before that
+/// happens or a zero propagates to the root.
+int test_norm_tree_states(World& world, std::vector<operand_pair>& pairs) {
+    test_output t("mul_sparse T7: norm_tree across tree states");
+    t.set_do_print(world.rank() == 0);
+
+    Function<double,D> f = copy(pairs.front().f);
+    f.reconstruct();
+    const double exact = f.norm2();
+
+    auto root_norm_tree = [&world](const Function<double,D>& g) {
+        const Key<D> key0 = g.get_impl()->get_cdata().key0;
+        double nt = 0.0;
+        if (g.get_impl()->get_coeffs().probe(key0))
+            nt = g.get_impl()->get_coeffs().find(key0).get()->second.get_norm_tree();
+        world.gop.max(nt);
+        return nt;
+    };
+
+    f.make_redundant(true);
+    const double nt_redundant = root_norm_tree(f);
+    f.reconstruct();
+    f.compress();
+    const double nt_compressed = root_norm_tree(f);
+
+    if (world.rank() == 0)
+        printf("  T7 ||f|| %.10e  redundant %.10e  compressed %.10e\n",
+               exact, nt_redundant, nt_compressed);
+
+    t.checkpoint(std::abs(nt_redundant  - exact) < 1.e-10,
+                 "T7 root norm_tree on a redundant tree equals ||f||");
+    t.checkpoint(std::abs(nt_compressed - exact) < 1.e-10,
+                 "T7 root norm_tree on a compressed tree equals ||f||");
+    return t.end();
+}
+
 int main(int argc, char** argv) {
     World& world = initialize(argc, argv);
     startup(world, argc, argv, true);
@@ -308,6 +345,7 @@ int main(int argc, char** argv) {
         success += test_self_consistency(world, pairs);
         success += test_dot_sparse(world, pairs);
         success += test_operand_state(world, pairs);
+        success += test_norm_tree_states(world, pairs);
     }
 
     world.gop.fence();

--- a/src/madness/mra/vmra.h
+++ b/src/madness/mra/vmra.h
@@ -901,6 +901,8 @@ namespace madness {
         /// tasks race a task still reading those coefficients, e.g. a
         /// mul_sparse(..., fence=false) that has not been fenced yet.
         /// Cf. Function::norm2(), which does the same for a single function.
+        /// The branch is taken on the tree state, which is replicated, so all
+        /// ranks take the same branch and the global ops stay collective.
         template <typename T, std::size_t NDIM>
         void reconstruct_for_norm(World& world, const std::vector<Function<T,NDIM>>& v) {
             if (v.size()==0) return;    // nothing to sum, and nothing to fence for

--- a/src/madness/mra/vmra.h
+++ b/src/madness/mra/vmra.h
@@ -891,13 +891,39 @@ namespace madness {
         if (fence) world.gop.fence();
     }
 
+    namespace detail {
+        /// put a vector of functions into a state whose coefficients sum to ||f||^2
+
+        /// norm2sq_local() adds up the coefficients of every node, which is the
+        /// norm only in a state that carries them once -- a redundant tree holds
+        /// them on every level and overcounts.  Reconstructing is a mutation: it
+        /// discards the interior coefficients.  So fence first, or the removal
+        /// tasks race a task still reading those coefficients, e.g. a
+        /// mul_sparse(..., fence=false) that has not been fenced yet.
+        /// Cf. Function::norm2(), which does the same for a single function.
+        template <typename T, std::size_t NDIM>
+        void reconstruct_for_norm(World& world, const std::vector<Function<T,NDIM>>& v) {
+            if (v.size()==0) return;    // nothing to sum, and nothing to fence for
+            const TreeState state=get_tree_state(v);
+            if (state==compressed or state==reconstructed) return;
+            MADNESS_CHECK_THROW(std::none_of(v.begin(), v.end(),
+                [](const Function<T,NDIM>& f) {return f.is_initialized() and f.is_on_demand();}),
+                "norm2/norm2s are not defined for an on-demand function; materialize it first");
+            world.gop.fence();
+            reconstruct(world,v);
+        }
+    }
+
     /// Computes the 2-norms of a vector of functions
+
+    /// Reconstructs the functions if their state does not admit a direct sum;
+    /// see detail::reconstruct_for_norm for what that costs.
     template <typename T, std::size_t NDIM>
     std::vector<double> norm2s(World& world,
                               const std::vector< Function<T,NDIM> >& v) {
         PROFILE_BLOCK(Vnorm2);
         std::vector<double> norms(v.size());
-        if (not (get_tree_state(v)==compressed or get_tree_state(v)==reconstructed)) reconstruct(world,v);
+        detail::reconstruct_for_norm(world,v);
         for (unsigned int i=0; i<v.size(); ++i) norms[i] = v[i].norm2sq_local();
         world.gop.sum(&norms[0], norms.size());
         for (unsigned int i=0; i<v.size(); ++i) norms[i] = sqrt(norms[i]);
@@ -905,11 +931,14 @@ namespace madness {
         return norms;
     }
     /// Computes the 2-norms of a vector of functions
+
+    /// Reconstructs the functions if their state does not admit a direct sum;
+    /// see detail::reconstruct_for_norm for what that costs.
     template <typename T, std::size_t NDIM>
     Tensor<double> norm2s_T(World& world, const std::vector<Function<T, NDIM>>& v) {
         PROFILE_BLOCK(Vnorm2);
         Tensor<double> norms(v.size());
-        if (not (get_tree_state(v)==compressed or get_tree_state(v)==reconstructed)) reconstruct(world,v);
+        detail::reconstruct_for_norm(world,v);
         for (unsigned int i = 0; i < v.size(); ++i) norms[i] = v[i].norm2sq_local();
         world.gop.sum(&norms[0], norms.size());
         for (unsigned int i = 0; i < v.size(); ++i) norms[i] = sqrt(norms[i]);
@@ -918,11 +947,14 @@ namespace madness {
     }
 
     /// Computes the 2-norm of a vector of functions
+
+    /// Reconstructs the functions if their state does not admit a direct sum;
+    /// see detail::reconstruct_for_norm for what that costs.
     template <typename T, std::size_t NDIM>
     double norm2(World& world,const std::vector< Function<T,NDIM> >& v) {
         PROFILE_BLOCK(Vnorm2);
         if (v.size()==0) return 0.0;
-        if (not (get_tree_state(v)==compressed or get_tree_state(v)==reconstructed)) reconstruct(world,v);
+        detail::reconstruct_for_norm(world,v);
         std::vector<double> norms(v.size());
         for (unsigned int i=0; i<v.size(); ++i) norms[i] = v[i].norm2sq_local();
         world.gop.sum(&norms[0], norms.size());

--- a/src/madness/mra/vmra.h
+++ b/src/madness/mra/vmra.h
@@ -894,11 +894,13 @@ namespace madness {
     namespace detail {
         /// put a vector of functions into a state whose coefficients sum to ||f||^2
 
-        /// norm2sq_local() adds up the coefficients of every node, which is the
-        /// norm only in a state that carries them once -- a redundant tree holds
-        /// them on every level and overcounts.  Reconstructing is a mutation: it
-        /// discards the interior coefficients.  So fence first, or the removal
-        /// tasks race a task still reading those coefficients, e.g. a
+        /// norm2sq_local() adds up the nodes of a tree, which is the norm only in
+        /// a state that carries the coefficients once; where the duplicates are
+        /// the interior nodes it skips them, so the redundant and
+        /// nonstandard-with-leaves trees left behind by mul_sparse() and friends
+        /// need no conversion at all.  The rest are reconstructed, and that is a
+        /// mutation: it discards the interior coefficients.  So fence first, or
+        /// the removal tasks race a task still reading those coefficients, e.g. a
         /// mul_sparse(..., fence=false) that has not been fenced yet.
         /// Cf. Function::norm2(), which does the same for a single function.
         /// The branch is taken on the tree state, which is replicated, so all
@@ -906,8 +908,9 @@ namespace madness {
         template <typename T, std::size_t NDIM>
         void reconstruct_for_norm(World& world, const std::vector<Function<T,NDIM>>& v) {
             if (v.size()==0) return;    // nothing to sum, and nothing to fence for
-            const TreeState state=get_tree_state(v);
-            if (state==compressed or state==reconstructed) return;
+            if (std::all_of(v.begin(), v.end(), [](const Function<T,NDIM>& f) {
+                    return (not f.is_initialized()) or f.get_impl()->has_summable_coefficients();}))
+                return;
             MADNESS_CHECK_THROW(std::none_of(v.begin(), v.end(),
                 [](const Function<T,NDIM>& f) {return f.is_initialized() and f.is_on_demand();}),
                 "norm2/norm2s are not defined for an on-demand function; materialize it first");

--- a/src/madness/mra/vmra.h
+++ b/src/madness/mra/vmra.h
@@ -923,6 +923,7 @@ namespace madness {
                               const std::vector< Function<T,NDIM> >& v) {
         PROFILE_BLOCK(Vnorm2);
         std::vector<double> norms(v.size());
+        if (v.size()==0) return norms;  // &norms[0] below is UB on an empty container
         detail::reconstruct_for_norm(world,v);
         for (unsigned int i=0; i<v.size(); ++i) norms[i] = v[i].norm2sq_local();
         world.gop.sum(&norms[0], norms.size());
@@ -938,6 +939,7 @@ namespace madness {
     Tensor<double> norm2s_T(World& world, const std::vector<Function<T, NDIM>>& v) {
         PROFILE_BLOCK(Vnorm2);
         Tensor<double> norms(v.size());
+        if (v.size()==0) return norms;  // &norms[0] below is UB on an empty container
         detail::reconstruct_for_norm(world,v);
         for (unsigned int i = 0; i < v.size(); ++i) norms[i] = v[i].norm2sq_local();
         world.gop.sum(&norms[0], norms.size());


### PR DESCRIPTION
## Description

Four independent correctness bugs in `src/madness/mra`, all silent — wrong numbers, no exception and no warning. Three are wrong MRA norms (`norm2`/`trace` summed over a redundant tree, `norm_tree` identically zero on a compressed tree, `dnorm_tree` counting the scaling block everywhere); the fourth is an unchecked precondition in the screened-multiply kernel that lets an unassigned tensor reach `do_mul`. One commit per bug.

A follow-up review then added four more commits, covering the fallout of making two `const` read methods reconstruct, one remaining instance of the same overcount, and a test that was passing without measuring anything. See the [follow-up report](https://github.com/m-a-d-n-e-s-s/madness/pull/753#issuecomment-5299157580) below for the details and for the retraction of an earlier claim about the 6D screen.

## Details

- [X] **`norm2()`/`trace()` overcounted on a redundant tree** — [a864545](https://github.com/m-a-d-n-e-s-s/madness/commit/a8645452a54e72e2a425d98e3022f2bb2638fb41). `norm2()` bypassed the tree-state guard that `norm2sq_local()` carries and `trace()` had none, so both summed every level of a redundant tree. #724 made that reachable from `SCF.cc`, `MolecularOrbitals.cc`, and ~14 `mul_sparse` sites in `src/apps/molresponse`. The global entry points now reconstruct on entry, matching `madness::norm2(world, v)`; the local no-comm variants throw instead. Test T6.
- [X] **`norm_tree` was identically zero on a compressed tree** — [bde9acb](https://github.com/m-a-d-n-e-s-s/madness/commit/bde9acba39162dc741cbd99ec45f044c06294d97). `compress_op`'s leaf case read the norm *after* `clear_coeff()` and substituted `0.0`, which propagated to the root. Reordered to read it while the value is still in hand; `norm_tree` now means `||f||` on the box in every tree state. Test T7.
- [X] **`dnorm` counted the scaling block** — [304bd09](https://github.com/m-a-d-n-e-s-s/madness/commit/304bd0995f39f23a3471e7185f4bb65632985b48). `s0` was zeroed before measuring only under `key.level() > 0 && !nonstandard1`, so root `dnorm_tree` came out equal to `||f||` exactly. Now zeroed unconditionally to measure and restored where the stored tensor keeps it, reusing the copy already made for contiguity. Test T7 pins `sqrt(snorm^2 + dnorm_tree^2) == ||f||` at the root to 1e-12 relative, so a too-small `dnorm` fails too. Checked with `-DENABLE_GENTENSOR=ON`. **This is a consistency fix, not a change in numbers**: tracing all three non-printing readers shows none of them ever saw the inflated value — the two `get_dnorm_tree()` readers in `mulXXveca` and the `ShallowNode`/`CoeffTracker` reader both run on redundant trees, where `make_redundant_op` already zeroed `s0` unconditionally, and the `get_dnorm()` reader in `get_contraction_node_lists` is reached only through `innerXX`, whose `prepare` step runs `recompute_snorm_and_dnorm()` and overwrites whatever `compress_op` left behind. (An earlier revision of this description claimed the 6D partial inner product screen tightens; it does not. See the follow-up report.)
- [X] **`mulXXveca` could reach `do_mul` with an unassigned tensor** — [3874c62](https://github.com/m-a-d-n-e-s-s/madness/commit/3874c62240007c482a03b2dd3f3b9a6ae1c2b622). `full_tensor_copy()` was called without a `has_coeff()` check, and the "uncomputed dnorm_tree" warning did not cover it — one-shot, and it did not disable screening as its message claimed. Replaced by `MADNESS_CHECK` on the redundant-form invariants. The second right-operand fetch keeps its node-existence check conditional on `vrc[i]`: parent coefficients legitimately stand in there, and an unconditional check fires 108 times in the existing tests.
- [X] **`cross()` did not fence after `reconstruct` and `compress`** — [90d9968](https://github.com/m-a-d-n-e-s-s/madness/commit/90d9968a6fca74ee57ec2386f5b4c56ec8050d6e). `cross()` fenced only through the second call of each pair. That call does a fast return when its functions are already in the correct state. Thus it does not fence, and the tasks of the first call stay incomplete. This caused failures in `testvmra`. Each pair now uses `fence=false` and one explicit `world.gop.fence()`.

### Follow-up commits

- [X] **T6 was passing without testing anything** — [fe5ce81](https://github.com/m-a-d-n-e-s-s/madness/commit/fe5ce81cc). `norm2()` and `trace()` reconstruct as a side effect, so calling them back to back on the same operand left only the first one measuring a redundant tree. Each entry point now gets its own redundant tree, with state assertions on entry. Verified by mutation: dropping the `reconstruct` from `trace()` now fails T6.
- [X] **Reconstructing inside a `const` read is an unfenced mutation** — [d830652](https://github.com/m-a-d-n-e-s-s/madness/commit/d830652c4), [3aef9e5](https://github.com/m-a-d-n-e-s-s/madness/commit/3aef9e51d). Both entry points were previously safe to call on an operand of a `mul_sparse(..., fence=false)` that had not been fenced yet — `SCF::twoint` has exactly this shape — and the removal tasks can now strip coefficients out from under a `mulXXveca` still reading them. Fence before changing state, in `Function::norm2`/`trace` and in `norm2s`/`norm2s_T`/`norm2(world,v)`. Also names the on-demand case instead of dying in `change_tree_state`.
- [X] **`print_size` printed the same overcounted norm** — [dbf1b16](https://github.com/m-a-d-n-e-s-s/madness/commit/dbf1b161c). It is a diagnostic and must not mutate the tree, so it reports the norm only where it means something and `n/a` otherwise.
- [X] **`inner()` hid the tree state of an on-demand function** — [fed1c1a](https://github.com/m-a-d-n-e-s-s/madness/commit/fed1c1abe9e21664b32e9b276f91e2f0181db200). In the self-inner shortcut, `inner()` changed the tree state to reconstructed before it called `norm2()`. This made an on-demand function give a value in place of an error. The shortcut now calls `norm2()` directly, which does the state check.
- - [x] **`zero_norm_tree()` left `dnorm_tree` stale** — [1360307](https://github.com/m-a-d-n-e-s-s/madness/commit/1360307fe8e1f59f55e28753775b78670742dbbf). It cleared `norm_tree`, `snorm`, and `dnorm` but not `dnorm_tree`, which `mulXXveca()` reads together with `norm_tree` for screening. `broaden()` calls `zero_norm_tree()`, so a broadened tree was left with `norm_tree == 0` paired against a stale `dnorm_tree` from the last `make_redundant()`/`compress()` — latent today, but a screen against that pair would be too coarse. `dnorm_tree` is now reset to `NORM_TREE_UNCOMPUTED`, not `0.0`, since `0.0` would also pass the screening check. Test T8.

Verification (RelWithDebInfo, Apple clang, arm64, OpenMPI 5.0.9), np=1 and np=2:

```
./src/madness/mra/test_mul_sparse    # exit 0, T1–T8, no `failed` lines
./src/madness/mra/testsuite          # testsuite passed:  true, exit 0
```

Screening numbers do not move: every `err` and `C` column in the T3/T4 output is bit-identical to a baseline taken before these commits, the only diff hunks being wall-clock strings on lines that all report `passed`.

## Questions

- [X] ~~The `dnorm_tree` fix tightens screening for the 6D partial inner product (`mp2`/`cc2` paths) — worth a look from someone with those timings in hand?~~ **Resolved: it does not tighten.** No in-tree consumer reads the inflated value; see the `dnorm` bullet above and the follow-up report. No production 6D cost changes.
- [x] The `MADNESS_CHECK_THROW` added to `trace_local()`/`norm2sq_local()` turns a previously silent wrong answer into a hard failure for any caller passing a non-{compressed,reconstructed} function. I believe there are none in-tree, but it is a behaviour change for downstream consumers. The same applies to `norm2()`/`trace()`/`norm2s*()` on an **on-demand** function, which now throw instead of returning `0.0`.

## AI
- Bug-seeking, derivation, and drafting: the four bugs came out of an AI-assisted re-review of PR #724 against current master, and the T6-T8 test cases and their tolerances were drafted with AI assistance. The four follow-up commits came out of an AI-assisted review of this PR. Every finding was reproduced and every tolerance measured against real runs before being written down; the numbers quoted above are from those runs, not from the model.
