### PR TITLE
docs(molresponse): excited-states guide showed a deck grammar that does not exist

### DIFF
--- a/src/apps/molresponse/docs/guides/excited_states.md
+++ b/src/apps/molresponse/docs/guides/excited_states.md
@@ -75,9 +75,9 @@ dft
     protocol  [1e-4, 1e-6]
 end
 response
-    excited_states  true
-    es.n_states     4          # number of roots
-    es.full         true       # Full/RPA (omit for TDA)
+    excited.enable      true
+    excited.num_states  4          # number of roots
+    excited.tda         false      # false = Full/RPA (default); true = TDA
 end
 ```
 


### PR DESCRIPTION
Small docs fix. The excited-states guide's example deck used `excited_states` / `es.n_states` / `es.full`, which aren't recognized parameters — a deck copied from the guide runs but doesn't actually compute excited states. Changed to the keys the code reads (`excited.enable`, `excited.num_states`, `excited.tda`).

Noticed while generating inputs from an external tool and checking them against the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vn5VcqgPWNcd9pEcTWjj5d