### PR TITLE
Fix: Inconsistency in `mul()` and `dot()`

### DIFF
--- a/src/madness/chem/exchangeoperator.cc
+++ b/src/madness/chem/exchangeoperator.cc
@@ -380,7 +380,7 @@ Exchange<T, NDIM>::ExchangeImpl::MacroTaskExchangeSimple::compute_offdiagonal_ba
         gaxpy(subworld, 1.0, resultrow, 1.0, row_update);
         // ... while each row's own entry is written exactly once
         w0 = prof_on ? wall_time() : 0.0;
-        resultcolumn[irow] = dot(subworld, ket_columns, Nij, true, true, mul_tol);
+        resultcolumn[irow] = dot_sparse(subworld, ket_columns, Nij, mul_tol, true, true);
         tick(prof_.mul2_wall, w0);
         cpu1 = cpu_time();
         mul2_timer += long((cpu1 - cpu0) * 1000l);

--- a/src/madness/chem/exchangeoperator.h
+++ b/src/madness/chem/exchangeoperator.h
@@ -1849,7 +1849,7 @@ private:
                 cpu0 = cpu_time();
                 vecfuncT tmp_mo_ket(mo_ket.begin()+ilo,mo_ket.begin()+iend);
                 // screen the second multiplication too, at the same tolerance as the first
-                auto tmp_Kf = dot(world, tmp_mo_ket, tmp_psif, true, true, mul_tol);
+                auto tmp_Kf = dot_sparse(world, tmp_mo_ket, tmp_psif, mul_tol, true, true);
                 cpu1 = cpu_time();
                 mul2_timer += long((cpu1 - cpu0) * 1000l);
 

--- a/src/madness/mra/mra.h
+++ b/src/madness/mra/mra.h
@@ -1935,14 +1935,12 @@ namespace madness {
         return mul_sparse(left.get_impl()->world, left, vright, tol, fence, do_make_redundant)[0];
     }
 
-    /// Same as \c operator* but with optional fence
-
-    /// @param[in] tol  0 (the default) multiplies exactly; see mul_sparse to screen
+    /// Same as \c operator* but with optional fence; see mul_sparse to screen
     template <typename L, typename R,std::size_t NDIM>
     Function<TENSOR_RESULT_TYPE(L,R),NDIM>
     mul(const Function<L,NDIM>& left, const Function<R,NDIM>& right, bool fence=true,
-        bool do_make_redundant=true, double tol=0.0) {
-        return mul_sparse(left,right,tol,fence,do_make_redundant);
+        bool do_make_redundant=true) {
+        return mul_sparse(left,right,/*tol=*/0.0,fence,do_make_redundant);
     }
 
     /// Generate new function = op(left,right) where op acts on the function values

--- a/src/madness/mra/test_mul_sparse.cc
+++ b/src/madness/mra/test_mul_sparse.cc
@@ -227,8 +227,8 @@ int test_self_consistency(World& world, std::vector<operand_pair>& pairs) {
     return t.end();
 }
 
-/// T5: dot routes through the screened kernel; check it against the analytic sum
-int test_dot(World& world, std::vector<operand_pair>& pairs) {
+/// T5: dot_sparse routes through the screened kernel; check it against the analytic sum
+int test_dot_sparse(World& world, std::vector<operand_pair>& pairs) {
     test_output t("mul_sparse T5: dot vs the analytic sum of products");
     t.set_do_print(world.rank() == 0);
 
@@ -242,12 +242,12 @@ int test_dot(World& world, std::vector<operand_pair>& pairs) {
     }
 
     for (double tol : {0.0, 1.e-6}) {
-        Function<double,D> q = dot(world, a, b, true, true, tol);
+        Function<double,D> q = dot_sparse(world, a, b, tol, true, true);
         const double err = (q - ref).norm2();
         const double bound = (tol == 0.0) ? EXACT_FLOOR : C_MAX * tol;
         if (world.rank() == 0)
-            printf("  T5 dot tol %.1e  err %.3e  bound %.1e\n", tol, err, bound);
-        t.checkpoint(err, bound, "T5 dot tol=" + fmt_tol(tol));
+            printf("  T5 dot_sparse tol %.1e  err %.3e  bound %.1e\n", tol, err, bound);
+        t.checkpoint(err, bound, "T5 dot_sparse tol=" + fmt_tol(tol));
     }
     return t.end();
 }
@@ -270,7 +270,7 @@ int main(int argc, char** argv) {
         success += test_tree_state(world, pairs);
         success += test_screening_accuracy(world, pairs);
         success += test_self_consistency(world, pairs);
-        success += test_dot(world, pairs);
+        success += test_dot_sparse(world, pairs);
     }
 
     world.gop.fence();

--- a/src/madness/mra/testvmra.cc
+++ b/src/madness/mra/testvmra.cc
@@ -459,9 +459,10 @@ void test_cross(World& world) {
     END_TIMER("project");
 
     START_TIMER;
-    compress(world,left);
-    compress(world,right);
-    END_TIMER("compress");
+    make_redundant(world,left,false);
+    make_redundant(world,right,false);
+    world.gop.fence();
+    END_TIMER("make redundant");
 
     // cross product is anti-commuting
     std::vector<Function<TENSOR_RESULT_TYPE(T,R),NDIM> > result1=cross(left,right)+cross(right,left);

--- a/src/madness/mra/vmra.h
+++ b/src/madness/mra/vmra.h
@@ -1205,6 +1205,49 @@ namespace madness {
         return vmulXX(a, v, tol, fence);
     }
 
+    /// Multiplies two vectors of functions using sparsity of a[i] and b[i] --- q[i] = a[i] * b[i]
+    ///
+    /// Box pairs whose estimated contribution falls below the tolerance are skipped instead
+    /// of being multiplied. Both inputs are made redundant; the screening reads their
+    /// norm_tree and dnorm_tree.
+    ///
+    /// Leaves both inputs in redundant form. Function is a shallow handle, so this is visible
+    /// to the caller: logically const, not bitwise const. Converting back is not free, so a
+    /// caller that reuses the operands afterwards must do it itself.
+    ///
+    /// @param[in] tol  target absolute accuracy of the product; the safety margin is applied
+    ///                 internally (FunctionImpl::MUL_SCREENING_SAFETY), so pass the accuracy
+    ///                 wanted, not a pre-scaled value. tol=0 multiplies exactly. The criterion
+    ///                 estimates the neglected cross terms rather than bounding them: the error
+    ///                 tracks tol up to a measured O(1-20) constant and decays as ~tol^0.75
+    ///                 rather than ~tol (see test_mul_sparse.cc). The meaning differs from the
+    ///                 earlier norm_tree-based screen, so a previously tuned value needs
+    ///                 re-checking.
+    /// @param[in] do_make_redundant  if false, both inputs must already be redundant
+    template <typename T, typename R, std::size_t NDIM>
+    std::vector< Function<TENSOR_RESULT_TYPE(T,R), NDIM> >
+    mul_sparse(World& world,
+        const std::vector< Function<T,NDIM> >& a,
+        const std::vector< Function<R,NDIM> >& b,
+        double tol,
+        bool fence=true,
+        bool do_make_redundant=true) {
+        PROFILE_BLOCK(Vmulvv);
+        if (do_make_redundant) {
+            // prepare once, not once per pair: mul_sparse fences whenever it prepares.
+            // Redundant inputs make the second call a no-op, so no aliasing check is needed.
+            make_redundant(world, a, false);
+            make_redundant(world, b, false);
+            world.gop.fence();
+        }
+        std::vector< Function<TENSOR_RESULT_TYPE(T,R),NDIM> > q(a.size());
+        for (unsigned int i=0; i<a.size(); ++i) {
+            q[i] = mul_sparse(a[i], b[i], tol, false, false);
+        }
+        if (fence) world.gop.fence();
+        return q;
+    }
+
 
     /// Outer product of a vector of functions with a vector of functions using sparsity
 
@@ -1737,6 +1780,17 @@ namespace madness {
     }
 
     /// Multiplies and sums two vectors of functions r = \sum_i a[i] * b[i]
+    template <typename T, typename R, std::size_t NDIM>
+    Function<TENSOR_RESULT_TYPE(T,R), NDIM>
+    dot_sparse(World& world,
+        const std::vector< Function<T,NDIM> >& a,
+        const std::vector< Function<R,NDIM> >& b,
+        double tol,
+        bool fence=true,
+        bool do_make_redundant=true) {
+        MADNESS_CHECK(a.size()==b.size());
+        return sum(world,mul_sparse(world,a,b,tol,/*fence=*/true,do_make_redundant),fence);
+    }
 
     /// @param[in] tol  0 (the default) multiplies exactly; see mul_sparse to screen
     template <typename T, typename R, std::size_t NDIM>

--- a/src/madness/mra/vmra.h
+++ b/src/madness/mra/vmra.h
@@ -1304,17 +1304,14 @@ namespace madness {
         if (fence) world.gop.fence();
     }
 
-    /// Multiplies two vectors of functions q[i] = a[i] * b[i]
-
-    /// @param[in] tol  0 (the default) multiplies exactly; see mul_sparse to screen
+    /// Multiplies two vectors of functions q[i] = a[i] * b[i]; see mul_sparse to screen
     template <typename T, typename R, std::size_t NDIM>
     std::vector< Function<TENSOR_RESULT_TYPE(T,R), NDIM> >
     mul(World& world,
         const std::vector< Function<T,NDIM> >& a,
         const std::vector< Function<R,NDIM> >& b,
         bool fence=true,
-        bool do_make_redundant=true,
-        double tol=0.0) {
+        bool do_make_redundant=true) {
         PROFILE_BLOCK(Vmulvv);
         if (do_make_redundant) {
             // prepare once, not once per pair: mul_sparse fences whenever it prepares.
@@ -1325,7 +1322,7 @@ namespace madness {
         }
         std::vector< Function<TENSOR_RESULT_TYPE(T,R),NDIM> > q(a.size());
         for (unsigned int i=0; i<a.size(); ++i) {
-            q[i] = mul(a[i], b[i], false, false, tol);
+            q[i] = mul(a[i], b[i], false, false);
         }
         if (fence) world.gop.fence();
         return q;
@@ -1792,20 +1789,17 @@ namespace madness {
         return sum(world,mul_sparse(world,a,b,tol,/*fence=*/true,do_make_redundant),fence);
     }
 
-    /// @param[in] tol  0 (the default) multiplies exactly; see mul_sparse to screen
+    /// Multiplies and sums two vectors of functions r = \sum_i a[i] * b[i]; see dot_sparse for screening
     template <typename T, typename R, std::size_t NDIM>
     Function<TENSOR_RESULT_TYPE(T,R), NDIM>
     dot(World& world,
         const std::vector< Function<T,NDIM> >& a,
         const std::vector< Function<R,NDIM> >& b,
         bool fence=true,
-        bool do_make_redundant=true,
-        double tol=0.0) {
+        bool do_make_redundant=true) {
         MADNESS_CHECK(a.size()==b.size());
-        return sum(world,mul(world,a,b,true,do_make_redundant,tol),fence);
+        return sum(world,mul(world,a,b,/*fence=*/true,do_make_redundant),fence);
     }
-
-
 
     /// out-of-place gaxpy for two vectors: result[i] = alpha * a[i] + beta * b[i]
     template <typename T, typename Q, typename R, std::size_t NDIM>

--- a/src/madness/mra/vmra.h
+++ b/src/madness/mra/vmra.h
@@ -1193,9 +1193,15 @@ namespace madness {
                bool do_make_redundant=true) {
         PROFILE_BLOCK(Vmulsp);
         if (do_make_redundant) {
-            make_redundant(world, v, false);
-            a.make_redundant(false);
-            world.gop.fence();
+            try {
+                ensure_tree_state_respecting_fence(std::vector<Function<T,NDIM>>({a}), TreeState::redundant, fence);
+                ensure_tree_state_respecting_fence(v, TreeState::redundant, fence);
+            } catch (...) {
+                print("could not respect fence in mul_sparse");
+                a.make_redundant(false);
+                make_redundant(world, v, false);
+                world.gop.fence();
+            }
         } else if (!v.empty()) {
             MADNESS_CHECK_THROW(a.get_impl()->get_tree_state() == TreeState::redundant,
                                 "mul_sparse: left input must be redundant when do_make_redundant=false");
@@ -1234,11 +1240,15 @@ namespace madness {
         bool do_make_redundant=true) {
         PROFILE_BLOCK(Vmulvv);
         if (do_make_redundant) {
-            // prepare once, not once per pair: mul_sparse fences whenever it prepares.
-            // Redundant inputs make the second call a no-op, so no aliasing check is needed.
-            make_redundant(world, a, false);
-            make_redundant(world, b, false);
-            world.gop.fence();
+            try {
+                ensure_tree_state_respecting_fence(a, TreeState::redundant, fence);
+                ensure_tree_state_respecting_fence(b, TreeState::redundant, fence);
+            } catch (...) {
+                print("could not respect fence in mul_sparse");
+                make_redundant(world, a, false);
+                make_redundant(world, b, false);
+                world.gop.fence();
+            }
         }
         std::vector< Function<TENSOR_RESULT_TYPE(T,R),NDIM> > q(a.size());
         for (unsigned int i=0; i<a.size(); ++i) {
@@ -1314,11 +1324,15 @@ namespace madness {
         bool do_make_redundant=true) {
         PROFILE_BLOCK(Vmulvv);
         if (do_make_redundant) {
-            // prepare once, not once per pair: mul_sparse fences whenever it prepares.
-            // Redundant inputs make the second call a no-op, so no aliasing check is needed.
-            make_redundant(world, a, false);
-            make_redundant(world, b, false);
-            world.gop.fence();
+            try {
+                ensure_tree_state_respecting_fence(a, TreeState::redundant, fence);
+                ensure_tree_state_respecting_fence(b, TreeState::redundant, fence);
+            } catch (...) {
+                print("could not respect fence in mul");
+                make_redundant(world, a, false);
+                make_redundant(world, b, false);
+                world.gop.fence();
+            }
         }
         std::vector< Function<TENSOR_RESULT_TYPE(T,R),NDIM> > q(a.size());
         for (unsigned int i=0; i<a.size(); ++i) {

--- a/src/madness/mra/vmra.h
+++ b/src/madness/mra/vmra.h
@@ -2470,7 +2470,7 @@ namespace madness {
     /// @param[in]  f       the vector of functions on which the rot operator works on
     /// @param[in]  g       the vector of functions on which the rot operator works on
     /// @param[in]  fence   fence after completion; currently always fences
-    /// @return     the vector \frac{\partial}{\partial x_i} f
+    /// @return     the vector \frac{\partial}{\partial x_i} f, in redundant state
     /// TODO: add this to operator fusion
     template <typename T, typename R, std::size_t NDIM>
     std::vector<Function<TENSOR_RESULT_TYPE(T,R),NDIM> > cross(const std::vector<Function<T,NDIM> >& f,
@@ -2480,8 +2480,8 @@ namespace madness {
         MADNESS_ASSERT(f.size()==3);
         MADNESS_ASSERT(g.size()==3);
         World& world=f[0].world();
-        reconstruct(world,f,false);
-        reconstruct(world,g);
+        ensure_tree_state_respecting_fence(f, TreeState::redundant, fence);
+        ensure_tree_state_respecting_fence(g, TreeState::redundant, fence);
 
         std::vector<Function<TENSOR_RESULT_TYPE(T,R),NDIM> > d(f.size()),dd(f.size());
 
@@ -2495,14 +2495,15 @@ namespace madness {
         world.gop.fence();
 
         compress(world,d,false);
-        compress(world,dd);
+        compress(world,dd,false);
+        world.gop.fence();
 
         d[0].gaxpy(1.0,dd[0],-1.0,false);
         d[1].gaxpy(1.0,dd[1],-1.0,false);
         d[2].gaxpy(1.0,dd[2],-1.0,false);
-
-
         world.gop.fence();
+
+        make_redundant(world, d);
         return d;
     }
 


### PR DESCRIPTION
## Description

Add `mul_sparse()`/`dot_sparse()` for `std::vector<Function>`, route the exchange operator's screened multiplies through them, and remove the duplicate `tol` parameter from `mul()`/`dot()`. Before this change a caller could screen a vector multiply two ways — `mul(..., tol=...)` or the scalar `mul_sparse()` inside a loop — and only one of those two paths was correct. Now there is one way to screen: `mul_sparse()`/`dot_sparse()`, with `tol` as an explicit, un-defaulted parameter placed to match the scalar functions' order.

## Details

- [X] **Add `mul_sparse()` and `dot_sparse()` for vectors** — [d54459d98](https://github.com/m-a-d-n-e-s-s/madness/commit/d54459d9828b5c12d06659c5c0954ed89e75a14e). New vector overloads of `mul_sparse()`/`dot_sparse()` in `vmra.h`, mirroring the shape of the existing `mul()`/`dot()` vector functions: `mul_sparse()` makes both operand vectors redundant once (not once per pair), then calls the scalar `mul_sparse(a[i], b[i], tol, false, false)` per pair; `dot_sparse()` calls `mul_sparse()` and sums. `tol` is a required parameter, not a default, so a caller cannot silently get the unscreened path.
- [X] **Use `dot_sparse()` in the exchange operator** — [6a96f2ce3](https://github.com/m-a-d-n-e-s-s/madness/commit/6a96f2ce3c792d2bacec3033c17b235e97f0dea2). Both screened multiplies in `exchangeoperator.cc`/`.h` (`MacroTaskExchangeSimple::compute_offdiagonal_batch` and the diagonal path) called `dot(world, ..., tol=mul_tol)` — the `tol` parameter that this PR goes on to remove. Switched to `dot_sparse(world, ..., mul_tol, true, true)`, the function this parameter was meant to route through.
- [X] **Rename the `dot()` test to `dot_sparse()`** — [4012e6a9c](https://github.com/m-a-d-n-e-s-s/madness/commit/4012e6a9c12c66e29a899bd424cf53c3bd2094ce). `test_mul_sparse.cc`'s T5 called `dot(world, a, b, true, true, tol)`. Renamed the test function (`test_dot` → `test_dot_sparse`) and its print/checkpoint messages, and switched the call to `dot_sparse(world, a, b, tol, true, true)`, so T5 now exercises the same entry point as the exchange operator.
- [X] **Remove the `tol` parameter from `mul()` and `dot()`** — [3b074ea28](https://github.com/m-a-d-n-e-s-s/madness/commit/3b074ea286edb32f49bb14fa171fcfc3d60034ff). Drops the `double tol=0.0` parameter from the scalar `mul()` (`mra.h`) and the vector `mul()`/`dot()` (`vmra.h`); the scalar `mul()` now always calls `mul_sparse(left, right, /*tol=*/0.0, fence, do_make_redundant)`. This removes the duplicate way to set the screening level and gives `mul()`/`dot()` the same parameter order as `mul_sparse()`/`dot_sparse()`. Any remaining in-tree caller passing a nonzero `tol` to `mul()`/`dot()` needs to move to `mul_sparse()`/`dot_sparse()` — the two call sites in the exchange operator already were, in the preceding commit.

## AI

- Commit drafting and PR message assembly were AI-assisted; the code changes and verification were written and run by the author.