### PR TITLE
Pr disentangle cyclic dependencies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ Tests live next to the sources they exercise and are registered through
 
 Both entries carry the `labels` passed to the macro. There is no filename
 convention — most test sources follow `test*.cc` / `test_*.cc` by habit,
-but the macro accepts any source name (e.g. `src/madness/misc/interp3.cc`,
+but the macro accepts any source name (e.g. `src/madness/mra/interp3.cc`,
 `src/examples/periodic/erfcr.cc`).
 
 The `check-short-madness` target runs everything labeled `short` or `medium`

--- a/src/madness/CMakeLists.txt
+++ b/src/madness/CMakeLists.txt
@@ -1,5 +1,9 @@
 # src/madness
 
+### MADmisc is the leaf component: it depends on nothing and MADworld links it,
+### so it must be configured first and must exist even in madworld-only builds.
+add_subdirectory(misc)
+
 ### MADWorld runtime
 add_subdirectory(world)
 # may need to build elemental as part of MADWorld
@@ -14,8 +18,8 @@ if (ENABLE_ELEMENTAL)
 				${ELEMENTAL_BINARY_DIR}/include)
 	endif ()
 endif(ENABLE_ELEMENTAL)
-if(MADNESS_BUILD_MADWORLD_ONLY)  # madness library includes just madworld
-	add_library(madness $<TARGET_OBJECTS:MADworld-obj>)
+if(MADNESS_BUILD_MADWORLD_ONLY)  # madness library includes just madworld (+ the misc leaf it links)
+	add_library(madness $<TARGET_OBJECTS:MADworld-obj> $<TARGET_OBJECTS:MADmisc-obj>)
 endif(MADNESS_BUILD_MADWORLD_ONLY)
 
 ### CLAPACK will be build if BLAS/LAPACK is available
@@ -35,7 +39,6 @@ endif(LAPACK_FOUND)
 
 ### numerics + apps
 if (NOT MADNESS_BUILD_MADWORLD_ONLY)
-	add_subdirectory(misc)
 	add_subdirectory(tensor)
 	add_subdirectory(mra)
 	add_subdirectory(chem)

--- a/src/madness/chem/SAP.h
+++ b/src/madness/chem/SAP.h
@@ -5,7 +5,7 @@
 #ifndef MPQC_SAP_INTERPOLATORS_H
 #define MPQC_SAP_INTERPOLATORS_H
 
-#include <madness/misc/interpolation_1d.h>
+#include <madness/mra/interpolation_1d.h>
 
 namespace madness {
     extern std::vector<CubicInterpolationTable<double>> SAPCharges;

--- a/src/madness/chem/localizer.cc
+++ b/src/madness/chem/localizer.cc
@@ -6,6 +6,7 @@
 #include <madness/mra/mra.h>
 #include <madness/mra/function_factory.h>
 #include <madness/tensor/jacobi.h>
+#include <madness/misc/ran.h>
 
 namespace madness {
 
@@ -197,12 +198,24 @@ DistributedMatrix<T> Localizer::localize_boys(World& world, const std::vector<Fu
         for (long iter = 0; iter < 1200; ++iter) {
             tensorT g(nmo, nmo);
             double W = 0.0;
+            // Draw the nmo*(nmo-1)/2 symmetry-breaking perturbations in one batch:
+            // RandomVector takes the generator's lock once rather than once per
+            // element. getv() consumes the same stream positions in the same order
+            // as successive RandomValue<double>() calls, so the values -- and hence
+            // the localization it seeds -- are unchanged.
+            const bool do_randomize = randomize && iter == 0;
+            std::vector<double> rnd;
+            if (do_randomize && nmo > 1) {
+                rnd.resize(static_cast<std::size_t>(nmo) * (nmo - 1) / 2);
+                RandomVector<double>(static_cast<int>(rnd.size()), rnd.data());
+            }
             // cannot restrict size of individual gradients if want to do line search --- should instead modify line search direction
             for (long i = 0; i < nmo; ++i) {
                 W += DIP(dip, i, i, i, i);
                 for (long j = 0; j < i; ++j) {
                     g(j, i) = (DIP(dip, i, i, i, j) - DIP(dip, j, j, j, i));
-                    if (randomize && iter == 0) g(j, i) += 0.1 * (RandomValue<double>() - 0.5);
+                    // index of pair (i,j), j<i, in i-outer/j-inner traversal order
+                    if (do_randomize) g(j, i) += 0.1 * (rnd[i * (i - 1) / 2 + j] - 0.5);
                     g(i, j) = -g(j, i);
                 }
             }
@@ -463,10 +476,14 @@ DistributedMatrix<T> Localizer::localize_new(World& world, const std::vector<Fun
 
             makeGW(C, W, g);
 
-            if (randomize && iter == 0) {
+            if (randomize && iter == 0 && nmo > 1) {
+                // one batched draw instead of nmo*(nmo-1)/2 individually locked ones;
+                // same stream, same order, so the values are unchanged (see localize_boys)
+                std::vector<double> rnd(static_cast<std::size_t>(nmo) * (nmo - 1) / 2);
+                RandomVector<double>(static_cast<int>(rnd.size()), rnd.data());
                 for (int i = 0; i < nmo; ++i) {
                     for (int j = 0; j < i; ++j) {
-                        g(i, j) += 0.1 * (RandomValue<double>() - 0.5);
+                        g(i, j) += 0.1 * (rnd[static_cast<std::size_t>(i) * (i - 1) / 2 + j] - 0.5);
                         g(j, i) = -g(i, j);
                     }
                 }

--- a/src/madness/chem/potentialmanager.h
+++ b/src/madness/chem/potentialmanager.h
@@ -52,7 +52,7 @@
 #include <cmath>
 #include <madness/tensor/tensor.h>
 #include <madness/misc/misc.h>
-#include <madness/misc/interpolation_1d.h>
+#include <madness/mra/interpolation_1d.h>
 #include <madness/mra/mra.h>
 
 namespace madness {

--- a/src/madness/misc/CMakeLists.txt
+++ b/src/madness/misc/CMakeLists.txt
@@ -18,6 +18,7 @@ set_source_files_properties(
 # MADmisc is a leaf: it must not include anything from world/tensor/mra/chem, so that
 # MADworld can depend on it (see world/CMakeLists.txt).
 add_mad_library(misc MADMISC_SOURCES MADMISC_HEADERS "" "madness/misc/")
+target_link_libraries(MADmisc PUBLIC Threads::Threads)
 
 # No unit tests registered here: interp3.cc moved to src/madness/mra along with
 # interpolation_1d.h, and test_gnuplot.cc stays disabled (gnuplot missing in CI).

--- a/src/madness/misc/CMakeLists.txt
+++ b/src/madness/misc/CMakeLists.txt
@@ -1,6 +1,6 @@
 # src/madness/misc
 
-set(MADMISC_HEADERS misc.h ran.h phandler.h interpolation_1d.h cfft.h info.h gnuplot.h array_of_bools.h kahan_accumulator.h)
+set(MADMISC_HEADERS misc.h ran.h cfft.h info.h gnuplot.h array_of_bools.h kahan_accumulator.h)
 set(MADMISC_SOURCES
     checksum_file.cc position_stream.cc gprofexit.cc ran.cc cfft.cc info.cc numerics.cc unique_filename.cc)
 # retrieve git metadata
@@ -14,14 +14,10 @@ set_source_files_properties(
           "MADNESS_GIT_REVISION=\"${MADNESS_GIT_REVISION}\";MADNESS_GIT_DESCRIPTION=\"${MADNESS_GIT_DESCRIPTION}\""
 )
 
-# Create the MADmisc library
-add_mad_library(misc MADMISC_SOURCES MADMISC_HEADERS "world" "madness/misc/")
+# Create the MADmisc library.
+# MADmisc is a leaf: it must not include anything from world/tensor/mra/chem, so that
+# MADworld can depend on it (see world/CMakeLists.txt).
+add_mad_library(misc MADMISC_SOURCES MADMISC_HEADERS "" "madness/misc/")
 
-if(BUILD_TESTING)
-  # The list of unit test source files
-  # test_gnuplot.cc breaks the CI since gnuplot missing so disable 
-  set(MISC_TEST_SOURCES interp3.cc )
-  
-  add_unittests(misc "${MISC_TEST_SOURCES}" "MADmisc;MADgtest" "unittests;short")
-
-endif()
+# No unit tests registered here: interp3.cc moved to src/madness/mra along with
+# interpolation_1d.h, and test_gnuplot.cc stays disabled (gnuplot missing in CI).

--- a/src/madness/misc/misc.h
+++ b/src/madness/misc/misc.h
@@ -35,7 +35,6 @@
 /// \file misc.h
 /// \brief Header to declare stuff which has not yet found a home
 
-#include <madness/world/madness_exception.h>
 #include <iostream>
 #include <string>
 

--- a/src/madness/misc/position_stream.cc
+++ b/src/madness/misc/position_stream.cc
@@ -32,17 +32,17 @@
 */
 #include <madness/misc/misc.h>
 #include <sstream>
+#include <stdexcept>
 
 namespace madness {
 
     /// message thrown when a tag cannot be found
 
-    /// MadnessException keeps the message as a bare `const char*`, so it must
-    /// have static storage duration -- passing a local std::string's c_str()
-    /// leaves what() dangling. Callers that classify the exception by its
-    /// message prefix (QCCalculationParametersBase, to tell a missing data
-    /// group from a malformed one) rely on what() being readable, and the
-    /// caller knows the tag it asked for anyway.
+    /// Callers classify the exception by its message prefix
+    /// (QCCalculationParametersBase::is_missing_datagroup_exception, to tell a
+    /// missing data group from a malformed one), so this text is load-bearing --
+    /// keep it in sync with the prefix there. The tag itself is deliberately not
+    /// interpolated: the caller knows the tag it asked for anyway.
     static constexpr const char* not_found_msg = "position_stream: failed to locate the requested tag";
 
     std::istream& position_stream(std::istream& f, const std::string& tag, bool rewind) {
@@ -52,7 +52,7 @@ namespace madness {
             std::string::size_type loc = s.find(tag, 0);
             if(loc != std::string::npos) return f;
         }
-        MADNESS_EXCEPTION(not_found_msg,0);
+        throw std::runtime_error(not_found_msg);
     }
 
     /// position the input stream to tag, which must be a word (not part of a word)
@@ -83,10 +83,10 @@ namespace madness {
         }
 
         if (silent) {
-            throw MadnessException(not_found_msg,0,0,__LINE__,__FUNCTION__,__FILE__);
+            throw std::runtime_error(not_found_msg);
         } else {
             printf("position_stream: failed to locate %s\n",tag.c_str());
-            MADNESS_EXCEPTION(not_found_msg,0);
+            throw std::runtime_error(not_found_msg);
         }
         return f;
     }

--- a/src/madness/misc/ran.cc
+++ b/src/madness/misc/ran.cc
@@ -80,7 +80,7 @@ namespace madness {
     }
 
     void Random::setstate(unsigned int seed) {
-        ScopedMutex<Mutex> safe(this);
+        std::lock_guard<std::mutex> safe(mutex_);
         // Initialize startup generator
         if ((seed&1) == 0) seed += 1;
         simple_state = seed;
@@ -152,7 +152,7 @@ namespace madness {
     //     };
 
     void Random::getbytes(int n, unsigned char * MADNESS_RESTRICT v) {
-        ScopedMutex<Mutex> safe(this);
+        std::lock_guard<std::mutex> safe(mutex_);
         while (n) {
             if (cur >= r) generate();
             int ndo = std::min(n,r-cur);
@@ -165,7 +165,7 @@ namespace madness {
     }
 
     RandomState Random::getstate() const {
-        ScopedMutex<Mutex> safe(this);
+        std::lock_guard<std::mutex> safe(mutex_);
         RandomState s;
         s.cur = cur;
         for (int i=0; i<r; ++i) s.u[i] = u[i];
@@ -173,7 +173,7 @@ namespace madness {
     }
 
     void Random::setstate(const RandomState &s) {
-        ScopedMutex<Mutex> safe(this);
+        std::lock_guard<std::mutex> safe(mutex_);
         cur = s.cur;
         for (int i=0; i<r; ++i) u[i] = s.u[i];
     }

--- a/src/madness/misc/ran.h
+++ b/src/madness/misc/ran.h
@@ -33,7 +33,7 @@
 #define MADNESS_MISC_RAN_H__INCLUDED
 
 #include <madness/madness_config.h>
-
+#include <algorithm>
 #include <mutex>
 
 #include <complex>

--- a/src/madness/misc/ran.h
+++ b/src/madness/misc/ran.h
@@ -33,7 +33,8 @@
 #define MADNESS_MISC_RAN_H__INCLUDED
 
 #include <madness/madness_config.h>
-#include <madness/world/thread.h>
+
+#include <mutex>
 
 #include <complex>
 typedef std::complex<float> float_complex;
@@ -68,8 +69,9 @@ namespace madness {
     /// The streams are thread safe.
     ///
     /// A default stream is provided as madness::default_random_generator.
-    class Random : private Mutex {
+    class Random {
     private:
+        mutable std::mutex mutex_;  ///< serializes access to the stream; mutable so getstate() can be const
         const int r;
         const int s;
         const double beta;
@@ -87,7 +89,7 @@ namespace madness {
         virtual ~Random();
 
         double get() {
-            ScopedMutex<Mutex> safe(this);
+            std::lock_guard<std::mutex> safe(mutex_);
             if (cur >= r) generate();
             return u[cur++];
         }
@@ -95,7 +97,7 @@ namespace madness {
         /// Returns a vector of uniform doubles in [0,1)
         template <typename T>
         void getv(int n, T * MADNESS_RESTRICT v) {
-            ScopedMutex<Mutex> safe(this);
+            std::lock_guard<std::mutex> safe(mutex_);
             while (n) {
                 if (cur >= r) generate();
                 int ndo = std::min(n,r-cur);

--- a/src/madness/mra/CMakeLists.txt
+++ b/src/madness/mra/CMakeLists.txt
@@ -10,7 +10,8 @@ set(MADMRA_HEADERS
     function_interface.h gfit.h convolution1d.h simplecache.h derivative.h
     displacements.h functypedefs.h sdf_shape_3D.h sdf_domainmask.h
     leafop.h nonlinsol.h macrotaskq.h macrotaskpartitioner.h QCCalculationParametersBase.h
-    commandlineparser.h operatorinfo.h bc.h kernelrange.h mw.h memory_measurement.h)
+    commandlineparser.h operatorinfo.h bc.h kernelrange.h mw.h memory_measurement.h
+    interpolation_1d.h phandler.h)
 set(MADMRA_SOURCES
     mra1.cc mra2.cc mra3.cc mra4.cc mra5.cc mra6.cc startup.cc legendre.cc 
     twoscale.cc qmprop.cc QCCalculationParametersBase.cc)
@@ -38,7 +39,7 @@ if(BUILD_TESTING)
       testpdiff.cc testdiff1Db.cc testgconv.cc testopdir.cc testinnerext.cc
       testgaxpyext.cc testvmra.cc test_vectormacrotask.cc test_cloud.cc test_tree_state.cc testsolver.cc
       test_macrotaskpartitioner.cc test_QCCalculationParametersBase.cc test_memory_measurement.cc
-      test_keybox.cc test_eval.cc test_mul_sparse.cc test_halo.cc)
+      test_keybox.cc test_eval.cc test_mul_sparse.cc test_halo.cc interp3.cc)
   add_unittests(mra "${MRA_TEST_SOURCES}" "MADmra;MADgtest" "unittests;short")
   set(MRA_SEPOP_TEST_SOURCES testsuite.cc
       testper.cc)

--- a/src/madness/mra/interp3.cc
+++ b/src/madness/mra/interp3.cc
@@ -34,7 +34,7 @@
 #include <cmath>
 #include <vector>
 #include <madness/world/worldinit.h>
-#include <madness/misc/interpolation_1d.h>
+#include <madness/mra/interpolation_1d.h>
 
 using namespace std;
 

--- a/src/madness/mra/interpolation_1d.h
+++ b/src/madness/mra/interpolation_1d.h
@@ -30,26 +30,26 @@
 
   $Id$
 */
-#ifndef MADNESS_MISC_INTERPOLATION_1D_H__INCLUDED
-#define MADNESS_MISC_INTERPOLATION_1D_H__INCLUDED
+#ifndef MADNESS_MRA_INTERPOLATION_1D_H__INCLUDED
+#define MADNESS_MRA_INTERPOLATION_1D_H__INCLUDED
 
 #include <iostream>
 #include <cmath>
 #include <vector>
 
-#include "../world/world_task_queue.h"
+#include <madness/world/world_task_queue.h>
 
 namespace madness {
 
 /*!
-  \file misc/interpolation_1d.h
+  \file mra/interpolation_1d.h
   \brief Provides 1D cubic interpolation class
-  \ingroup misc
+  \ingroup mra
  */
 
 /// An class for 1-D data interpolation based on cubic polynomials.
 
-/// \ingroup misc
+/// \ingroup mra
 /// Needs to be passed the endpoints of the interpolation: [lo,hi] and the
 /// number of grid points.
 ///
@@ -279,4 +279,4 @@ int CubicInterpolationTable<T>::min_npts_per_task_default = 1024;
 
 }  // namespace madness
 
-#endif // MADNESS_MISC_INTERPOLATION_1D_H__INCLUDED
+#endif // MADNESS_MRA_INTERPOLATION_1D_H__INCLUDED

--- a/src/madness/mra/mraplot.cc
+++ b/src/madness/mra/mraplot.cc
@@ -39,7 +39,7 @@
 #include <unistd.h>
 #include <cstdio>
 #include <madness/constants.h>
-#include <madness/misc/phandler.h>
+#include <madness/mra/phandler.h>
 
 using namespace madness;
 

--- a/src/madness/mra/phandler.h
+++ b/src/madness/mra/phandler.h
@@ -29,15 +29,15 @@
   fax:   865-572-0680
 */
 
-#ifndef MADNESS_MISC_PHANDLER_H__INCLUDED
-#define MADNESS_MISC_PHANDLER_H__INCLUDED
+#ifndef MADNESS_MRA_PHANDLER_H__INCLUDED
+#define MADNESS_MRA_PHANDLER_H__INCLUDED
 
-/// \file misc/phandler.h
+/// \file mra/phandler.h
 /// \brief Interface for the muParser library for turning user-defined functions into bytecode.
 
 /* Example:
 
-   #include <madness/misc/phandler.h>
+   #include <madness/mra/phandler.h>
 
     typedef FunctionFactory<double,3> factoryT;
     typedef std::shared_ptr< FunctionFunctorInterface<double, 3> > functorT;
@@ -110,4 +110,4 @@ class ParserHandler : public madness::FunctionFunctorInterface<T, NDIM> {
     }
 }; // end class parserhandler
 
-#endif // MADNESS_MISC_PHANDLER_H__INCLUDED
+#endif // MADNESS_MRA_PHANDLER_H__INCLUDED

--- a/src/madness/mra/qmprop.cc
+++ b/src/madness/mra/qmprop.cc
@@ -34,7 +34,7 @@
 #include <madness/mra/operator.h>
 #include <madness/mra/adquad.h>
 #include <madness/misc/cfft.h>
-#include <madness/misc/interpolation_1d.h>
+#include <madness/mra/interpolation_1d.h>
 #include <cmath>
 #include <complex>
 #include <madness/constants.h>

--- a/src/madness/tensor/CMakeLists.txt
+++ b/src/madness/tensor/CMakeLists.txt
@@ -42,7 +42,7 @@ set(MADGENTENSOR_HEADERS gentensor.h srconf.h distributed_matrix.h tensortrain.h
 set(MADGENTENSOR_SOURCES SVDTensor.cc RandomizedMatrixDecomposition.cc)
 
 # Create libraries MADtensor and MADlinalg
-add_mad_library(tensor MADTENSOR_SOURCES MADTENSOR_HEADERS "misc" "madness/tensor")
+add_mad_library(tensor MADTENSOR_SOURCES MADTENSOR_HEADERS "misc;world" "madness/tensor")
 #add_mad_library(clapack MADLINALG_HEADERS "" "madness/tensor")
 add_mad_library(linalg MADLINALG_SOURCES MADLINALG_HEADERS "tensor" "madness/tensor")
 

--- a/src/madness/world/CMakeLists.txt
+++ b/src/madness/world/CMakeLists.txt
@@ -27,7 +27,7 @@ if(MADNESS_ENABLE_CEREAL)
 endif()
 
 # Create the MADworld-obj and MADworld library targets
-add_mad_library(world MADWORLD_SOURCES MADWORLD_HEADERS "common;${ELEMENTAL_PACKAGE_NAME}" "madness/world")
+add_mad_library(world MADWORLD_SOURCES MADWORLD_HEADERS "misc;common;${ELEMENTAL_PACKAGE_NAME}" "madness/world")
 
 # DISABLEPIE flag can break linking of dependent libraries (e.g. on Linux using gcc6)
 # instead for each dependent executable target T do:

--- a/src/madness/world/ranks_and_hosts.cpp
+++ b/src/madness/world/ranks_and_hosts.cpp
@@ -4,6 +4,14 @@
 
 #include<ranks_and_hosts.h>
 
+#include <algorithm>
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <string>
+#include <sys/resource.h>
+#include <unistd.h>
+
 namespace madness {
 
 


### PR DESCRIPTION
addresses issue #765 . misc now depends on nothing, @robertjharrison : madness mutex is replaced by c++ mutex for the random value generator
