### PR TITLE
Add `#include <memory>` to `periodic/test.cc`

### DIFF
--- a/src/examples/periodic/test.cc
+++ b/src/examples/periodic/test.cc
@@ -1,5 +1,6 @@
 #include "testpc.h"
 #include <fftw3.h>
+#include <memory>
 
 /*****************
 

--- a/src/examples/periodic/test.cc
+++ b/src/examples/periodic/test.cc
@@ -1,6 +1,9 @@
 #include "testpc.h"
 #include <fftw3.h>
+#include <algorithm>
+#include <iostream>
 #include <memory>
+#include <vector>
 
 /*****************
 


### PR DESCRIPTION
Fix a missing include leading to this test failing to compile on Linux. Smart pointers require the memory header.