### PR TITLE
Fix compilation warnings across MADNESS codebase and applications

### DIFF
--- a/src/apps/molresponse/calc/calc_executor.hpp
+++ b/src/apps/molresponse/calc/calc_executor.hpp
@@ -1672,9 +1672,10 @@ inline void assemble_tpa(ExecutorContext &ctx, const ResponsePlan &plan,
   const bool loaded =
       es_full ? load_tpa_es_xy<Full>(world, ctx.calc_dir, omegas, Xfs)
               : load_tpa_es_xy<TDA>(world, ctx.calc_dir, omegas, Xfs);
-  if (world.rank() == 0)
+  if (world.rank() == 0) {
     printf("[TPA timing] ES bundle load: %.1f s\n", madness::wall_time() - t_es0);
     fflush(stdout);
+  }
   if (!loaded) {
     if (world.rank() == 0)
       print("[TPA] no ES bundle under", ctx.calc_dir, "— SKIPPED");

--- a/src/apps/molresponse/solvers/fd_save_load.hpp
+++ b/src/apps/molresponse/solvers/fd_save_load.hpp
@@ -385,7 +385,6 @@ try_load_fd_state(madness::World &world,
                   const std::string &dir,
                   const Perturbation &pert,
                   double freq) {
-  using State   = typename FDSolver<Type, Shell>::State;
   using Storage = typename FDSolver<Type, Shell>::Storage;
 
   const std::string active_key = protocol_key();

--- a/src/apps/molresponse/solvers/response_state.hpp
+++ b/src/apps/molresponse/solvers/response_state.hpp
@@ -171,7 +171,7 @@ inline IoBackend save_state(World &world, const std::string &filename,
 template <class LoadCb>
 inline void load_state(World &world, const std::string &filename,
                        IoBackend backend, LoadCb &&cb) {
-  bool use_h5 = false;
+  [[maybe_unused]] bool use_h5 = false;
   if (backend == IoBackend::Hdf5) {
 #ifdef MADNESS_HAS_HDF5
     use_h5 = true;

--- a/src/apps/molresponse/tests/test_calc_manager.cpp
+++ b/src/apps/molresponse/tests/test_calc_manager.cpp
@@ -38,7 +38,7 @@ bool wave_has(const std::vector<WorkItem> &w, const std::string &id) {
   return false;
 }
 
-NodeAction action_in(const std::vector<WorkItem> &w, const std::string &id) {
+[[maybe_unused]] NodeAction action_in(const std::vector<WorkItem> &w, const std::string &id) {
   for (const auto &it : w)
     if (it.node->id == id) return it.action;
   return NodeAction::Skip; // sentinel "not present"

--- a/src/apps/molresponse/tests/test_calc_manager_run.cpp
+++ b/src/apps/molresponse/tests/test_calc_manager_run.cpp
@@ -7,10 +7,9 @@
 // converged.
 //
 // This is an ALLOCATION test (it runs real MRA solves). Usage:
-//   test_calc_manager_run --archive=<moldft restartdata> \
+//   test_calc_manager_run --archive=<moldft restartdata>
 //       [--omega=0.0,0.057] [--axes=xyz] [--protocol=1e-4,1e-6] [--es-roots=N]
-//       \
-//       [--maxiter=N] [--dconv=X] [--calc-dir=DIR] [--print-level=0..3] \
+//       [--maxiter=N] [--dconv=X] [--calc-dir=DIR] [--print-level=0..3]
 //       [--conv-factor=F | --bsh-factor=F --density-factor=F]
 //   --conv-factor loosens/tightens both convergence gates (target = F*dconv,
 //   default F=5); --bsh-factor / --density-factor set each gate independently.

--- a/src/apps/molresponse/tests/test_diagonalize_slots.cpp
+++ b/src/apps/molresponse/tests/test_diagonalize_slots.cpp
@@ -39,7 +39,7 @@ static void check(bool ok, const char *what) {
 }
 
 int main(int argc, char **argv) {
-  World &world = initialize(argc, argv);
+  [[maybe_unused]] World &world = initialize(argc, argv);
   {
     const double thr = 1.0e-6;
 

--- a/src/apps/molresponse/tests/test_fd_subworld_fanout.cpp
+++ b/src/apps/molresponse/tests/test_fd_subworld_fanout.cpp
@@ -13,7 +13,7 @@
 // then re-read by the universe in assemble_alpha. F1 tests BOTH directions of
 // nio/nproc round-tripping.
 //
-//   mpirun -np <N> ./test_fd_subworld_fanout --archive=<moldft restart> \
+//   mpirun -np <N> ./test_fd_subworld_fanout --archive=<moldft restart>
 //          [--thresh=1e-4] [--maxiter=25] [--calc-dir=<scratch>]
 // PASS iff  max|α_sub − α_ref| < 1e-9.  Needs ≥2 nodes for a real partition;
 // 1 node is a no-op partition and MUST still match exactly (free regression).

--- a/src/examples/periodic/testpercoul.cc
+++ b/src/examples/periodic/testpercoul.cc
@@ -300,7 +300,6 @@ int main(int argc, char**argv) {
         const auto twonm3 = 1 << std::max((n - 1), 0);
         Key<ND> key(n, {twonm3, twonm1, 0});
 
-        std::size_t disp_count = 0;
         std::array<std::optional<std::int64_t>, ND> box_radius;
         std::array<std::optional<std::int64_t>, ND> surface_thickness;
         auto &range = op_rr.get_range();
@@ -399,13 +398,11 @@ int main(int argc, char**argv) {
 
           for (int l = 0; l != (1 << (n - 1)) + 5; ++l) {
             process_displacement(Key<3>(n, Vector<Translation, 3>({l, 0, 0})));
-            ++disp_count;
           }
 
           if (n <= 3) {
             for (auto &&disp : range_boundary_face_displacements) {
               process_displacement(disp);
-              ++disp_count;
             }
           }
 

--- a/src/madness/chem/Applications.hpp
+++ b/src/madness/chem/Applications.hpp
@@ -1057,7 +1057,6 @@ struct moldft_lib {
 
     SCFResultsTuple results;
     auto &scf_res = std::get<0>(results);
-    auto &opt_res = std::get<3>(results);
     auto &prop_res = std::get<1>(results);
     auto &conv_res = std::get<2>(results);
 

--- a/src/madness/chem/CalculationParameters.h
+++ b/src/madness/chem/CalculationParameters.h
@@ -333,10 +333,10 @@ struct CalculationParameters : public QCCalculationParametersBase {
         // and erroring rather than being deleted, because ignore_unknown_keys is
         // true by default and a deleted key would run the deck as a plain single
         // point after one warning nobody reads.
-        for (const std::string& key : {"gopt","gtol","gtest","gval","gprec",
+        for (const char* key : {"gopt","gtol","gtest","gval","gprec",
                                        "gmaxiter","ginitial_hessian","algopt"}) {
         	if (is_user_defined(key))
-        		error(("\n\n`" + key + "` has been retired: geometry optimization is now a task of "
+        		error(("\n\n`" + std::string(key) + "` has been retired: geometry optimization is now a task of "
         		       "its own.\nUse `madqc --optimize --wf=<scf|nemo>` and the `optimization` "
         		       "parameter group\n(see `madqc --print_parameters=optimization`).\n\n").c_str());
         }

--- a/src/madness/chem/GuessFactory.cc
+++ b/src/madness/chem/GuessFactory.cc
@@ -159,7 +159,6 @@ std::vector<std::vector<double> > PolynomialFunctor::read_string(const std::stri
 {
 	std::stringstream line(string);
 	std::string name;
-	size_t counter = 0;
 	std::vector<double> current_data = vector_factory(0.0, 0.0, 0.0, 1.0);
 	std::vector<std::vector<double> > read_data;
 	while (line >> name) {
@@ -176,7 +175,6 @@ std::vector<std::vector<double> > PolynomialFunctor::read_string(const std::stri
 		line >> current_data[2];
 		else
 		if (name == ",") {
-			counter++;
 			read_data.push_back(current_data);
 			current_data = vector_factory(0.0, 0.0, 0.0, 1.0);
 		}

--- a/src/madness/chem/ccpairfunction.cc
+++ b/src/madness/chem/ccpairfunction.cc
@@ -168,8 +168,6 @@ std::vector<CCPairFunction<T,NDIM>> CCPairFunction<T,NDIM>::collect_same_types(c
     if (other.size()==0) return other;
     if (is_collected(other)) return other;
 
-    World& world=other.front().world();
-
     /// vector includes OT_ONE, meaning no operator
     std::vector<std::vector<Function<T,NDIM>>> op_pure(OT_SIZE);
     std::vector<std::vector<Function<T,LDIM>>> op_decomposed_a(OT_SIZE);

--- a/src/madness/chem/molecule.cc
+++ b/src/madness/chem/molecule.cc
@@ -143,7 +143,7 @@ std::string Molecule::GeometryParameters::absolute_path(const std::string &path)
 }
 
 std::string Molecule::GeometryParameters::input_tag(const commandlineparser &parser) {
-  for (const std::string &tag : {"geometry", "molecule"}) {
+  for (const char *tag : {"geometry", "molecule"}) {
     std::ifstream f(parser.value("input"));
     try {
       madness::position_stream_to_word(f, tag, '#', true, true);

--- a/src/madness/chem/molecule.h
+++ b/src/madness/chem/molecule.h
@@ -195,7 +195,7 @@ class Molecule {
       // `--geometry=<name>` is the documented spelling (see the help text of
       // moldft/nemo/cc2/madqc); `--molecule=<name>` is accepted as an alias.
       // value_raw, not value: this may be a path, and paths are case-sensitive.
-      for (const std::string &key : {"geometry", "molecule"}) {
+      for (const char *key : {"geometry", "molecule"}) {
         if (parser.key_exists(key)) {
           set_user_defined_value("source_name", parser.value_raw(key));
         }

--- a/src/madness/chem/mp3.cc
+++ b/src/madness/chem/mp3.cc
@@ -698,12 +698,10 @@ double MP3::compute_mp3_ef(World& world,
     std::vector<permutation> all_tau_permutations;
     std::vector<CCPairFunction<double,6>> tmp_tau;
 
-    long counter=0;
     timer timer_prep(world);
     // loop over all k and l
     for (std::size_t k=nfrozen; k<nocc; ++k) {
         for (std::size_t l=nfrozen; l<nocc; ++l) {
-            counter++;
 
             // make all possible permutations of the 4 indices i,j,k,l
             permutation p0(i,j,k,l);

--- a/src/madness/external/tinyxml/tinyxmlparser.cc
+++ b/src/madness/external/tinyxml/tinyxmlparser.cc
@@ -111,14 +111,17 @@ void TiXmlBase::ConvertUTF32ToUTF8( unsigned long input, char* output, int* leng
 			--output; 
 			*output = (char)((input | BYTE_MARK) & BYTE_MASK); 
 			input >>= 6;
+			[[fallthrough]];
 		case 3:
 			--output; 
 			*output = (char)((input | BYTE_MARK) & BYTE_MASK); 
 			input >>= 6;
+			[[fallthrough]];
 		case 2:
 			--output; 
 			*output = (char)((input | BYTE_MARK) & BYTE_MASK); 
 			input >>= 6;
+			[[fallthrough]];
 		case 1:
 			--output; 
 			*output = (char)(input | FIRST_BYTE_MARK[*length]);

--- a/src/madness/mra/funcimpl.h
+++ b/src/madness/mra/funcimpl.h
@@ -852,6 +852,8 @@ template<size_t NDIM>
     	CoeffTracker(const CoeffTracker& other) : impl(other.impl), key_(other.key_),
     			is_leaf_(other.is_leaf_), coeff_(other.coeff_), dnorm_(other.dnorm_) {};
 
+    	CoeffTracker& operator=(const CoeffTracker& other) = default;
+
     	/// const reference to impl
     	const implT* get_impl() const {return impl;}
 

--- a/src/madness/mra/function_interface.h
+++ b/src/madness/mra/function_interface.h
@@ -84,7 +84,7 @@ namespace madness {
 	    }
 
 	    /// Can we screen this function based on the bounding box information?
-	    virtual bool screened(const Vector<double,NDIM>& c1, const Vector<double,NDIM>& c2) const {
+	    virtual bool screened(const Vector<double,NDIM>&, const Vector<double,NDIM>&) const {
 	        return false;
 	    }
 
@@ -96,27 +96,27 @@ MADNESS_PRAGMA_GCC(diagnostic ignored "-Woverloaded-virtual")
 MADNESS_PRAGMA_CLANG(diagnostic push)
 MADNESS_PRAGMA_CLANG(diagnostic ignored "-Woverloaded-virtual")
 
-	    virtual void operator()(const Vector<double*,1>& xvals, T* fvals, int npts) const {
+	    virtual void operator()(const Vector<double*,1>&, T*, int) const {
 	        MADNESS_EXCEPTION("FunctionFunctorInterface: This function should not be called!", 0);
 	    }
 
-	    virtual void operator()(const Vector<double*,2>& xvals, T* fvals, int npts) const {
+	    virtual void operator()(const Vector<double*,2>&, T*, int) const {
 	        MADNESS_EXCEPTION("FunctionFunctorInterface: This function should not be called!", 0);
 	    }
 
-	    virtual void operator()(const Vector<double*,3>& xvals, T* fvals, int npts) const {
+	    virtual void operator()(const Vector<double*,3>&, T*, int) const {
 	        MADNESS_EXCEPTION("FunctionFunctorInterface: This function should not be called!", 0);
 	    }
 
-	    virtual void operator()(const Vector<double*,4>& xvals, T* fvals, int npts) const {
+	    virtual void operator()(const Vector<double*,4>&, T*, int) const {
 	        MADNESS_EXCEPTION("FunctionFunctorInterface: This function should not be called!", 0);
 	    }
 
-	    virtual void operator()(const Vector<double*,5>& xvals, T* fvals, int npts) const {
+	    virtual void operator()(const Vector<double*,5>&, T*, int) const {
 	        MADNESS_EXCEPTION("FunctionFunctorInterface: This function should not be called!", 0);
 	    }
 
-	    virtual void operator()(const Vector<double*,6>& xvals, T* fvals, int npts) const {
+	    virtual void operator()(const Vector<double*,6>&, T*, int) const {
 	        MADNESS_EXCEPTION("FunctionFunctorInterface: This function should not be called!", 0);
 	    }
 MADNESS_PRAGMA_CLANG(diagnostic pop)
@@ -140,7 +140,7 @@ MADNESS_PRAGMA_GCC(diagnostic pop)
 	        return coeffT();
 	    }
 
-	    virtual coeffT values(const keyT& key, const Tensor<double>& tensor) const {
+	    virtual coeffT values(const keyT&, const Tensor<double>&) const {
 	        MADNESS_EXCEPTION("implement values for FunctionFunctorInterface",0);
 	        return coeffT();
 	    }
@@ -376,7 +376,7 @@ MADNESS_PRAGMA_GCC(diagnostic pop)
             return coeffT(map_coeff(c),FunctionDefaults<NDIM>::get_thresh(),TT_FULL);
 		}
 
-		T operator()(const Vector<double, NDIM>& x) const {
+		T operator()(const Vector<double, NDIM>&) const {
 			print("there is no operator()(coordT&) in TwoElectronInterface, for good reason");
 			MADNESS_ASSERT(0);
 			return T(0);

--- a/src/madness/mra/key.h
+++ b/src/madness/mra/key.h
@@ -74,15 +74,15 @@ namespace madness {
 
     private:
         friend class KeyChildIterator<NDIM> ;
-        Level n;
-        Vector<Translation, NDIM> l;
-        hashT hashval;
+        Level n = 0;
+        Vector<Translation, NDIM> l = Vector<Translation, NDIM>(0);
+        hashT hashval = 0;
 
 
     public:
 
-        /// Default constructor makes an \em uninitialized key
-        Key() {}
+        /// Default constructor makes an initialized key
+        Key() : n(0), l(0), hashval(0) {}
 
         /// Constructor with given n, l
         Key(Level n, const Vector<Translation, NDIM>& l) : n(n), l(l) 

--- a/src/madness/mra/operator.h
+++ b/src/madness/mra/operator.h
@@ -653,30 +653,18 @@ namespace madness {
         double munorm2_ns(Level n, const ConvolutionData1D<Q>* ops[]) const {
             //PROFILE_MEMBER_FUNC(SeparatedConvolution);
             
-            double prodR=1.0, prodT=1.0;
+            double prod=1.0, sum=0.0;
             for (std::size_t d=0; d<NDIM; ++d) {
-                prodR *= ops[d]->Rnormf;
-                prodT *= ops[d]->Tnormf;
-
+                double a = ops[d]->NSnormf;
+                double b = ops[d]->Tnormf;
+                double aa = std::min(a,b);
+                double bb = std::max(a,b);
+                prod *= bb;
+                if (bb > 0.0) sum +=(aa/bb);
             }
-//            if (n) prodR = sqrt(std::max(prodR*prodR - prodT*prodT,0.0));
+            if (n) prod *= sum;
 
-            // this kicks in if the line above has no numerically significant digits.
-//            if (prodR < 1e-8*prodT) {
-                double prod=1.0, sum=0.0;
-                for (std::size_t d=0; d<NDIM; ++d) {
-                    double a = ops[d]->NSnormf;
-                    double b = ops[d]->Tnormf;
-                    double aa = std::min(a,b);
-                    double bb = std::max(a,b);
-                    prod *= bb;
-                    if (bb > 0.0) sum +=(aa/bb);
-                }
-                if (n) prod *= sum;
-                prodR = prod;
-//            }
-
-            return prodR;
+            return prod;
         }
 
 

--- a/src/madness/mra/test_memory_measurement.cc
+++ b/src/madness/mra/test_memory_measurement.cc
@@ -36,7 +36,7 @@ int test_size(World& world) {
     auto mmap=MemoryMeasurer::measure_and_print(world);
 
     // check that we have one entry per rank
-    if (world.rank()==0) t1.checkpoint(mmap.size()==world.size(),"memory map has one entry per rank");
+    if (world.rank()==0) t1.checkpoint(mmap.size()==size_t(world.size()),"memory map has one entry per rank");
 
     // check total memory size
     double total_mem_size=MemoryMeasurer::total_memory(mmap);

--- a/src/madness/mra/test_tree_state.cc
+++ b/src/madness/mra/test_tree_state.cc
@@ -224,5 +224,5 @@ int main(int argc, char **argv) {
     success+=test_conversion(world);
 
     madness::finalize();
-    return 0;
+    return success;
 }

--- a/src/madness/mra/vmra.h
+++ b/src/madness/mra/vmra.h
@@ -574,7 +574,7 @@ namespace madness {
     	lindep *= s(s.size() - 1);  // eigenvalues are in ascending order
 
     	// transform s to s^{-1/2} in-place
-    	int rank = 0, nlindep = 0;
+    	size_t rank = 0, nlindep = 0;
     	for(size_t i = 0; i < n; ++i) {
             const auto s_i = s(i);
     		if (s_i > lindep) {

--- a/src/madness/tensor/gentensor.h
+++ b/src/madness/tensor/gentensor.h
@@ -180,13 +180,13 @@ namespace madness {
 		GenTensor() : Tensor<T>() {}
 
 		GenTensor(const Tensor<T>& t1) : Tensor<T>(t1) {}
-		GenTensor(const Tensor<T>& t1, const TensorArgs& targs) : Tensor<T>(t1) {}
-		GenTensor(const Tensor<T>& t1, double eps, const TensorType tt) : Tensor<T>(t1) {}
-		GenTensor(const TensorType tt): Tensor<T>() {}
-		GenTensor(std::vector<long> v, const TensorType& tt) : Tensor<T>(v) {}
-		GenTensor(std::vector<long> v, const TensorArgs& targs) : Tensor<T>(v) {}
-		GenTensor(const SRConf<T>& sr1) : Tensor<T>() {MADNESS_EXCEPTION("no ctor with SRConf: use HAVE_GENTENSOR",1);}
-		GenTensor(long nd, const long d[], const TensorType& tt) : Tensor<T>(nd,d){};
+		GenTensor(const Tensor<T>& t1, const TensorArgs&) : Tensor<T>(t1) {}
+		GenTensor(const Tensor<T>& t1, double, const TensorType) : Tensor<T>(t1) {}
+		GenTensor(const TensorType): Tensor<T>() {}
+		GenTensor(std::vector<long> v, const TensorType&) : Tensor<T>(v) {}
+		GenTensor(std::vector<long> v, const TensorArgs&) : Tensor<T>(v) {}
+		GenTensor(const SRConf<T>&) : Tensor<T>() {MADNESS_EXCEPTION("no ctor with SRConf: use HAVE_GENTENSOR",1);}
+		GenTensor(long nd, const long d[], const TensorType&) : Tensor<T>(nd,d){};
 
         /// Type conversion makes a deep copy
         template <class Q> operator GenTensor<Q>() const { // type conv => deep copy
@@ -195,7 +195,7 @@ namespace madness {
             return result;
         }
 
-        GenTensor convert(const TensorArgs& targs) const {return copy(*this);}
+        GenTensor convert(const TensorArgs&) const {return copy(*this);}
         Tensor<T> reconstruct_tensor() const {return *this;}
         const Tensor<T>& full_tensor() const {return *this;}
         Tensor<T>& full_tensor() {return *this;}
@@ -214,7 +214,7 @@ namespace madness {
 		size_t real_size() const {return this->size();}
 		size_t nCoeff() const {return this->size();}
 
-        void reduce_rank(const double& eps) {return;};
+        void reduce_rank(const double&) {return;};
         void normalize() {return;}
 
         std::string what_am_i() const {return "GenTensor, aliased to Tensor";};
@@ -232,10 +232,10 @@ namespace madness {
 
 
 
-		void add_SVD(const GenTensor<T>& rhs, const double& eps) {*this+=rhs;}
+		void add_SVD(const GenTensor<T>& rhs, const double&) {*this+=rhs;}
 
 		SRConf<T> config() const {MADNESS_EXCEPTION("no SRConf in complex GenTensor",1);}
-        SRConf<T> get_configs(const int& start, const int& end) const {MADNESS_EXCEPTION("no SRConf in complex GenTensor",1);}
+        SRConf<T> get_configs(const int&, const int&) const {MADNESS_EXCEPTION("no SRConf in complex GenTensor",1);}
 
 		/// return the additional safety for rank reduction
 		static double fac_reduce() {return -1.0;};
@@ -243,7 +243,7 @@ namespace madness {
 	};
 
     template <class T>
-	GenTensor<T> reduce(std::list<GenTensor<T> >& addends, double eps, bool are_optimal=false) {
+	GenTensor<T> reduce(std::list<GenTensor<T> >& addends, double, bool =false) {
     	typedef typename std::list<GenTensor<T> >::iterator iterT;
     	GenTensor<T> result=copy(addends.front());
     	for (iterT it=++addends.begin(); it!=addends.end(); ++it) {
@@ -257,7 +257,7 @@ namespace madness {
     /// \ingroup tensor
     template <class T>
     GenTensor<T> outer(const GenTensor<T>& left, const GenTensor<T>& right,
-            const TensorArgs final_tensor_args) {
+            const TensorArgs) {
         return madness::outer(static_cast<Tensor<T> >(left),static_cast<Tensor<T> >(right));
     }
 
@@ -266,7 +266,7 @@ namespace madness {
      /// \ingroup tensor
      template <class T>
      GenTensor<T> outer(const Tensor<T>& left, const Tensor<T>& right,
-             const TensorArgs final_tensor_args) {
+             const TensorArgs) {
          return madness::outer(left,right);
      }
 
@@ -281,7 +281,7 @@ namespace madness {
 
      /// change representation to targ.tt
      template<typename T>
-     void change_tensor_type(GenTensor<T>& t, const TensorArgs& targs) {
+     void change_tensor_type(GenTensor<T>&, const TensorArgs& targs) {
      	MADNESS_ASSERT(targs.tt==TT_FULL);
      }
 

--- a/src/madness/tensor/slice.h
+++ b/src/madness/tensor/slice.h
@@ -109,12 +109,8 @@ namespace madness {
         
         inline Slice() : start(0), end(-1), step(1) {};
         inline Slice(long s, long e, long stp=1) : start(s), end(e), step(stp) {};
-        inline Slice& operator=(const Slice& s) {
-            start=s.start;
-            end=s.end;
-            step=s.step;
-            return *this;
-        };
+        Slice(const Slice&) = default;
+        Slice& operator=(const Slice&) = default;
         template <typename Archive>
         void serialize(Archive& ar) {
         	ar & start & end & step;

--- a/src/madness/tensor/tensor_macros.h
+++ b/src/madness/tensor/tensor_macros.h
@@ -205,23 +205,23 @@ this last instance, or for ease of rapid implementation, use the general
 
 
 #define ITERATOR1(t,exp) do { \
-        long __xd0=t.dim(0),_index=0;                                   \
+        long __xd0=t.dim(0); [[maybe_unused]] long _index=0;                                   \
         for (long _i=0; _i<__xd0; ++_i) {exp;_index++;} } while (0)
 
 #define ITERATOR2(t,exp) do { \
-        long __xd0=t.dim(0), __xd1=t.dim(1), _index=0;  \
+        long __xd0=t.dim(0), __xd1=t.dim(1); [[maybe_unused]] long _index=0;  \
 for (long _i=0; _i<__xd0; ++_i) { \
   for (long _j=0; _j<__xd1; ++_j) {exp;_index++;} } } while (0)
 
 #define ITERATOR3(t,exp) do { \
-        long __xd0=t.dim(0), __xd1=t.dim(1), __xd2=t.dim(2), _index=0;  \
+        long __xd0=t.dim(0), __xd1=t.dim(1), __xd2=t.dim(2); [[maybe_unused]] long _index=0;  \
 for (long _i=0; _i<__xd0; ++_i) { \
   for (long _j=0; _j<__xd1; ++_j) { \
     for (long _k=0; _k<__xd2; ++_k) {exp;_index++;} } } } while (0)
 
 #define ITERATOR4(t,exp) do { \
         long __xd0=t.dim(0), __xd1=t.dim(1), __xd2=t.dim(2),        \
-            __xd3=t.dim(3), _index=0;                               \
+            __xd3=t.dim(3); [[maybe_unused]] long _index=0;         \
 for (long _i=0; _i<__xd0; ++_i) { \
   for (long _j=0; _j<__xd1; ++_j) { \
     for (long _k=0; _k<__xd2; ++_k) { \
@@ -229,7 +229,7 @@ for (long _i=0; _i<__xd0; ++_i) { \
 
 #define ITERATOR5(t,exp) do { \
         long __xd0=t.dim(0), __xd1=t.dim(1), __xd2=t.dim(2),      \
-            __xd3=t.dim(3), __xd4=t.dim(4), _index=0;             \
+            __xd3=t.dim(3), __xd4=t.dim(4); [[maybe_unused]] long _index=0; \
 for (long _i=0; _i<__xd0; ++_i) { \
   for (long _j=0; _j<__xd1; ++_j) { \
     for (long _k=0; _k<__xd2; ++_k) { \
@@ -238,7 +238,7 @@ for (long _i=0; _i<__xd0; ++_i) { \
 
 #define ITERATOR6(t,exp) do { \
         long __xd0=t.dim(0), __xd1=t.dim(1), __xd2=t.dim(2),            \
-            __xd3=t.dim(3), __xd4=t.dim(4), __xd5=t.dim(5), _index=0;;  \
+            __xd3=t.dim(3), __xd4=t.dim(4), __xd5=t.dim(5); [[maybe_unused]] long _index=0; \
 for (long _i=0; _i<__xd0; ++_i) { \
   for (long _j=0; _j<__xd1; ++_j) { \
     for (long _k=0; _k<__xd2; ++_k) { \
@@ -701,14 +701,14 @@ for (long _i=0; _i<__xd0; ++_i, __xp0+=__xs0, __yp0+=__ys0, __zp0+=__zs0) { \
 #define BINARY_OPTIMIZED_ITERATOR(X,x,Y,y,exp) do { \
   if (x.iscontiguous() && y.iscontiguous() && x.size()==y.size()) { \
     X* MADNESS_RESTRICT _p0 = x.ptr(); \
-    Y* MADNESS_RESTRICT _p1 = y.ptr(); \
+    [[maybe_unused]] Y* MADNESS_RESTRICT _p1 = y.ptr(); \
     for (long _j=0; _j<x.size(); ++_j,++_p0,++_p1) {exp;} \
   } \
   else { \
     for (TensorIterator<REMCONST(X),REMCONST(Y)> iter=x.binary_iterator(y,1); iter._p0; ++iter) { \
         long _dimj = iter.dimj; \
         X* MADNESS_RESTRICT _p0 = iter._p0; \
-        Y* MADNESS_RESTRICT _p1 = iter._p1; \
+        [[maybe_unused]] Y* MADNESS_RESTRICT _p1 = iter._p1; \
         long _s0 = iter._s0; \
         long _s1 = iter._s1; \
         for (long _j=0; _j<_dimj; ++_j, _p0+=_s0, _p1+=_s1) { \
@@ -719,16 +719,16 @@ for (long _i=0; _i<__xd0; ++_i, __xp0+=__xs0, __yp0+=__ys0, __zp0+=__zs0) { \
 #define TERNARY_OPTIMIZED_ITERATOR(X,x,Y,y,Z,z,exp) do { \
   if (x.iscontiguous() && y.iscontiguous() && z.iscontiguous() && x.size()==y.size() && x.size()==z.size()) { \
     X* MADNESS_RESTRICT _p0 = x.ptr(); \
-    Y* MADNESS_RESTRICT _p1 = y.ptr(); \
-    Z* MADNESS_RESTRICT _p2 = z.ptr(); \
+    [[maybe_unused]] Y* MADNESS_RESTRICT _p1 = y.ptr(); \
+    [[maybe_unused]] Z* MADNESS_RESTRICT _p2 = z.ptr(); \
     for (long _j=0; _j<x.size(); ++_j,++_p0,++_p1,++_p2) {exp;} \
   } \
   else { \
     for (TensorIterator<REMCONST(X),REMCONST(Y),REMCONST(Z)> iter=x.ternary_iterator(y,z,1); iter._p0; ++iter) { \
         long _dimj = iter.dimj; \
         X* MADNESS_RESTRICT _p0 = iter._p0; \
-        Y* MADNESS_RESTRICT _p1 = iter._p1; \
-        Z* MADNESS_RESTRICT _p2 = iter._p2; \
+        [[maybe_unused]] Y* MADNESS_RESTRICT _p1 = iter._p1; \
+        [[maybe_unused]] Z* MADNESS_RESTRICT _p2 = iter._p2; \
         long _s0 = iter._s0; \
         long _s1 = iter._s1; \
         long _s2 = iter._s2; \

--- a/src/madness/tensor/test_jacobi.cc
+++ b/src/madness/tensor/test_jacobi.cc
@@ -21,7 +21,7 @@ void jacobi(Tensor<double>& A, Tensor<double>& V, const std::vector<int>& set) {
     MADNESS_CHECK(n == V.dim(0) && n == V.dim(1));
     MADNESS_CHECK(n == long(set.size()));
     
-    int i, j, k, iter, nrotsum, nrot;
+    int i, j, k, iter, nrot;
     double tolmin = std::sqrt(n) * 5.0e-16, tol = 0.05;
     double maxd;
     
@@ -63,7 +63,6 @@ void jacobi(Tensor<double>& A, Tensor<double>& V, const std::vector<int>& set) {
       } \
     }
     
-    nrotsum = 0;
     for (iter=0; iter<5000; iter++) {
         double maxdaij = 0.0;
         nrot = 0;
@@ -127,7 +126,6 @@ void jacobi(Tensor<double>& A, Tensor<double>& V, const std::vector<int>& set) {
             }
         }
         //printf("iter=%d nrot=%d err=%e\n", iter, nrot, maxdaij);
-        nrotsum += nrot;
         if (nrot == 0 && tol <= tolmin) break;
         tol = std::min(tol,maxdaij*1e-1);
         //tol = std::min(tol,maxdaij*maxdaij); // is not quadratic if only block diagonalizing?

--- a/src/madness/tensor/test_systolic.cc
+++ b/src/madness/tensor/test_systolic.cc
@@ -54,59 +54,62 @@ public:
 
 int main(int argc, char** argv) {
     initialize(argc, argv);
-    World world(SafeMPI::COMM_WORLD);
-    redirectio(world);
+    {
+        World world(SafeMPI::COMM_WORLD);
+        redirectio(world);
 
-    try {
-        for (int64_t n=1; n<100; ++n) {
-            int64_t m = 2*n;
-            DistributedMatrix<double> A = column_distributed_matrix<double>(world, n, m);
-            int64_t ilo, ihi;
-            A.local_colrange(ilo, ihi);
-            for (int i=ilo; i<=ihi; ++i) A.data()(i-ilo,_) = i;
+        try {
+            for (int64_t n=1; n<100; ++n) {
+                int64_t m = 2*n;
+                DistributedMatrix<double> A = column_distributed_matrix<double>(world, n, m);
+                int64_t ilo, ihi;
+                A.local_colrange(ilo, ihi);
+                for (int i=ilo; i<=ihi; ++i) A.data()(i-ilo,_) = i;
 
-            world.taskq.add(new TestSystolicMatrixAlgorithm<double>(A, 3333));
-            world.taskq.fence();
+                world.taskq.add(new TestSystolicMatrixAlgorithm<double>(A, 3333));
+                world.taskq.fence();
 
-            for (int i=ilo; i<=ihi; ++i) {
-                for (int k=0; k<m; ++k) {
-                    MADNESS_CHECK(A.data()(i-ilo,k) == i);
+                for (int i=ilo; i<=ihi; ++i) {
+                    for (int k=0; k<m; ++k) {
+                        MADNESS_CHECK(A.data()(i-ilo,k) == i);
+                    }
                 }
             }
         }
-    }
-    catch (const SafeMPI::Exception& e) {
-        print(e);
-        error("caught an MPI exception");
-    }
-    catch (const madness::MadnessException& e) {
-        print(e);
-        error("caught a MADNESS exception");
-    }
-    catch (const madness::TensorException& e) {
-        print(e);
-        error("caught a Tensor exception");
-    }
-    catch (char* s) {
-        print(s);
-        error("caught a c-string exception");
-    }
-//    catch (const char* s) {
-//        print(s);
-//        error("caught a c-string exception");
-//    }
-    catch (const std::string& s) {
-        print(s);
-        error("caught a string (class) exception");
-    }
-    catch (const std::exception& e) {
-        print(e.what());
-        error("caught an STL exception");
-    }
-    catch (...) {
-        error("caught unhandled exception");
-    }
+        catch (const SafeMPI::Exception& e) {
+            print(e);
+            error("caught an MPI exception");
+        }
+        catch (const madness::MadnessException& e) {
+            print(e);
+            error("caught a MADNESS exception");
+        }
+        catch (const madness::TensorException& e) {
+            print(e);
+            error("caught a Tensor exception");
+        }
+        catch (char* s) {
+            print(s);
+            error("caught a c-string exception");
+        }
+    //    catch (const char* s) {
+    //        print(s);
+    //        error("caught a c-string exception");
+    //    }
+        catch (const std::string& s) {
+            print(s);
+            error("caught a string (class) exception");
+        }
+        catch (const std::exception& e) {
+            print(e.what());
+            error("caught an STL exception");
+        }
+        catch (...) {
+            error("caught unhandled exception");
+        }
 
-    world.gop.fence();
+        world.gop.fence();
+    }
     finalize();
+    return 0;
 }

--- a/src/madness/world/stubmpi.h
+++ b/src/madness/world/stubmpi.h
@@ -159,12 +159,12 @@ inline int MPI_Group_translate_ranks(MPI_Group, int, const int [],
 }
 
 /* TODO The NO-OP implementation of may not be adequate. */
-inline int MPI_Group_incl(MPI_Group group, int n, const int ranks[], MPI_Group *newgroup) {
+inline int MPI_Group_incl(MPI_Group, int, const int [], MPI_Group *) {
     return MPI_SUCCESS;
 }
 
 /* TODO The NO-OP implementation may not be adequate. */
-inline int MPI_Group_free(MPI_Group *group) {
+inline int MPI_Group_free(MPI_Group *) {
     return MPI_SUCCESS;
 }
 
@@ -178,7 +178,7 @@ inline int MPI_Query_thread(int *provided) { *provided = MADNESS_MPI_THREAD_LEVE
 
 // Buffer functions (do nothing since no messages may be sent)
 inline int MPI_Buffer_attach(void*, int) { return MPI_SUCCESS; }
-inline int MPI_Buffer_detach(void* buffer, int* size) { return MPI_SUCCESS; }
+inline int MPI_Buffer_detach(void*, int*) { return MPI_SUCCESS; }
 
 inline int MPI_Test(MPI_Request *, int *flag, MPI_Status *) {
     *flag = 1;
@@ -216,8 +216,8 @@ inline int MPI_Recv(void*, int, MPI_Datatype, int, int, MPI_Comm, MPI_Status*) {
 
 // Gather = copy
 inline int MPI_Gatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                void *recvbuf, const int recvcounts[], const int displs[], MPI_Datatype recvtype,
-                int root, MPI_Comm) {
+                void *recvbuf, const int recvcounts[], const int [], MPI_Datatype recvtype,
+                int, MPI_Comm) {
   MPI_Aint recvtype_extent;
   MPI_Aint recvtype_lb;
   MPI_Type_get_extent(recvtype, &recvtype_lb, &recvtype_extent);
@@ -252,13 +252,13 @@ inline int MPI_Allreduce(void *sendbuf, void *recvbuf, int count, MPI_Datatype, 
 
 inline int MPI_Comm_get_attr(MPI_Comm, int, void*, int*) { return MPI_ERR_COMM; }
 
-inline int MPI_Comm_split(MPI_Comm comm, int color, int key, MPI_Comm *newcomm) {
+inline int MPI_Comm_split(MPI_Comm, int, int, MPI_Comm *newcomm) {
   //*newcomm = MPI_COMM_NULL;
   *newcomm = MPI_COMM_WORLD; // So that can successfully split a 1 process communicator
   return MPI_SUCCESS;
 }
 
-inline int MPI_Comm_split_type(MPI_Comm comm, int split_type, int key, MPI_Info info, MPI_Comm *newcomm) {
+inline int MPI_Comm_split_type(MPI_Comm comm, int split_type, int, MPI_Info, MPI_Comm *newcomm) {
   *newcomm = (split_type == MPI_UNDEFINED) ? MPI_COMM_NULL : comm;
   return MPI_SUCCESS;
 }
@@ -315,19 +315,19 @@ inline int MPI_Error_string(int errorcode, char *string, int *resultlen) {
     return MPI_SUCCESS;
 }
 
-inline int MPI_Comm_set_errhandler(MPI_Comm comm, MPI_Errhandler errhandler) {return MPI_SUCCESS;}
+inline int MPI_Comm_set_errhandler(MPI_Comm, MPI_Errhandler) {return MPI_SUCCESS;}
 
 inline double MPI_Wtime() { return madness::wall_time(); }
 
-inline int MPI_Op_create(MPI_User_function *user_fn, int commute, MPI_Op *op) {
+inline int MPI_Op_create(MPI_User_function *, int, MPI_Op *) {
   return MPI_SUCCESS;
 }
 
-inline int MPI_Op_free(MPI_Op *op) {
+inline int MPI_Op_free(MPI_Op *) {
   return MPI_SUCCESS;
 }
 
-inline int MPI_Info_create (MPI_Info *info) { return MPI_SUCCESS; }
-inline int MPI_Info_free (MPI_Info *info) { return MPI_SUCCESS; }
+inline int MPI_Info_create (MPI_Info *) { return MPI_SUCCESS; }
+inline int MPI_Info_free (MPI_Info *) { return MPI_SUCCESS; }
 
 #endif

--- a/src/madness/world/worlddc.h
+++ b/src/madness/world/worlddc.h
@@ -786,12 +786,12 @@ namespace madness
                 }
                 else
                 {
-                    size_t sz;
+                    size_t sz = 0;
                     world.gop.broadcast_serializable(sz, rank);
                     for (size_t i = 0; i < sz; i++)
                     {
-                        keyT key;
-                        valueT value;
+                        keyT key{};
+                        valueT value{};
                         world.gop.broadcast_serializable(key, rank);
                         world.gop.broadcast_serializable(value, rank);
                         insert(pairT(key, value));


### PR DESCRIPTION
## Description

This PR fixes all compilation warnings across the MADNESS codebase and associated applications, allowing all targets to compile and link cleanly with `-Wall` and `-Werror` (warnings treated as errors) in both non-MPI and MPI configurations.

### Summary of Fixes Applied

1. **`-Wdeprecated-copy` Fixes**:
   - `src/madness/tensor/slice.h`: Explicitly declared defaulted copy constructor and copy assignment operator (`Slice(const Slice&) = default;` and `operator=`) on `Slice`.
   - `src/madness/mra/funcimpl.h`: Added defaulted copy assignment operator to `CoeffTracker`.

2. **`-Wunused-parameter` Fixes**:
   - `src/madness/world/stubmpi.h`: Removed unused parameter names across stub MPI function definitions in non-MPI builds.
   - `src/madness/tensor/gentensor.h`: Removed unused parameter names in `GenTensor` stub constructor overloads and functions.
   - `src/madness/mra/function_interface.h`: Removed unused parameter names in virtual interface method definitions and dummy fallbacks.

3. **`-Wrange-loop-construct` Fixes**:
   - `src/madness/chem/CalculationParameters.h`, `src/madness/chem/molecule.h`, `src/madness/chem/molecule.cc`: Changed range loops over initializer lists of string literals from `const std::string&` to `const char*` to avoid constructing temporary `std::string` objects.

4. **`-Wunused-variable` / `-Wunused-but-set-variable` / `-Wunused-local-typedefs` Fixes**:
   - `src/madness/tensor/tensor_macros.h`: Added `[[maybe_unused]]` to macro variables `_index`, `_p1`, `_p2` in optimized iterators.
   - `src/madness/mra/operator.h`: Removed dead / unused `prodR`/`prodT` computation in `munorm2_ns`.
   - `src/madness/chem/ccpairfunction.cc`: Removed unused `World& world` reference in `collect_same_types`.
   - `src/madness/chem/mp3.cc`, `src/madness/chem/GuessFactory.cc`: Removed unused `counter` variables.
   - `src/madness/tensor/test_jacobi.cc`: Removed unused `nrotsum` accumulator variable.
   - `src/madness/mra/test_tree_state.cc`: Returned `success` result from `main()`.
   - `src/apps/molresponse/solvers/fd_save_load.hpp`: Removed unused local typedef `State`.
   - `src/apps/molresponse/solvers/response_state.hpp`: Added `[[maybe_unused]]` to `use_h5` when built without HDF5.
   - `src/apps/molresponse/tests/test_calc_manager.cpp`: Added `[[maybe_unused]]` to `action_in`.
   - `src/apps/molresponse/tests/test_diagonalize_slots.cpp`: Added `[[maybe_unused]]` to `world` initialization.
   - `src/madness/chem/Applications.hpp`: Removed unused `opt_res` variable.
   - `src/examples/periodic/testpercoul.cc`: Removed unused `disp_count` variable.

5. **`-Wmaybe-uninitialized` Fixes**:
   - `src/madness/world/worlddc.h`: Value-initialized `size_t sz = 0;`, `keyT key{};`, and `valueT value{};` in `do_replicate()`.
   - `src/madness/mra/key.h`: Initialized member variables `Level n = 0;`, `Vector<Translation, NDIM> l(0);`, and `hashT hashval = 0;` in `Key` default constructor.

6. **`-Wsign-compare` Fixes**:
   - `src/madness/mra/vmra.h`: Changed `int rank = 0, nlindep = 0;` to `size_t` in `orthonormalize_canonical`.
   - `src/madness/mra/test_memory_measurement.cc`: Added explicit `size_t(world.size())` cast in map size checkpoint.

7. **Formatting & Syntax Warnings**:
   - `src/madness/external/tinyxml/tinyxmlparser.cc`: Added `[[fallthrough]];` annotations on intentional switch fallthrough branches.
   - `src/apps/molresponse/calc/calc_executor.hpp`: Added compound block braces around the rank-0 guarded output in `assemble_tpa`.
   - `src/apps/molresponse/tests/test_calc_manager_run.cpp`, `src/apps/molresponse/tests/test_fd_subworld_fanout.cpp`: Removed trailing backslashes from comments.

8. **Runtime Invariants**:
   - `src/madness/tensor/test_systolic.cc`: Corrected `World world` lifecycle scoping prior to `madness::finalize()`.

### Testing

- **Non-MPI Build**: Compiled with `ENABLE_MPI=OFF` and verified all unit and short tests.
- **MPI Build**: Compiled all 471 targets with `ENABLE_MPI=ON -DMADNESS_WERROR=ON` cleanly with 0 warnings / errors.
- **Multi-Process MPI Execution**:
  - `mpirun -np 2 ./src/madness/mra/testsuite` with `MAD_NUM_THREADS=3` (`testsuite passed: true`).
  - `mpirun -np 2 ./src/apps/madqc/madqc --geometry=water` with `MAD_NUM_THREADS=3` (converged cleanly with 0 errors).