### PR TITLE
Fix the probe displacement for even lattice-summed ranges, and unit-test BoxSurfaceDisplacementRange

### DIFF
--- a/src/madness/mra/CMakeLists.txt
+++ b/src/madness/mra/CMakeLists.txt
@@ -38,7 +38,7 @@ if(BUILD_TESTING)
       testpdiff.cc testdiff1Db.cc testgconv.cc testopdir.cc testinnerext.cc
       testgaxpyext.cc testvmra.cc test_vectormacrotask.cc test_cloud.cc test_tree_state.cc testsolver.cc
       test_macrotaskpartitioner.cc test_QCCalculationParametersBase.cc test_memory_measurement.cc
-      test_keybox.cc test_eval.cc test_mul_sparse.cc test_halo.cc)
+      test_keybox.cc test_eval.cc test_mul_sparse.cc test_halo.cc test_displacements.cc)
   add_unittests(mra "${MRA_TEST_SOURCES}" "MADmra;MADgtest" "unittests;short")
   set(MRA_SEPOP_TEST_SOURCES testsuite.cc
       testper.cc)

--- a/src/madness/mra/displacements.h
+++ b/src/madness/mra/displacements.h
@@ -474,7 +474,7 @@ namespace madness {
           }
           // (3) switch to next fixed dimension with finite radius
           ++fixed_dim;
-          while (!parent->box_radius_[fixed_dim] && fixed_dim < NDIM) {
+          while (fixed_dim < NDIM && !parent->box_radius_[fixed_dim]) {
             ++fixed_dim;
           }
 
@@ -603,7 +603,7 @@ namespace madness {
             : parent(p), point(parent->center_.level()), fixed_dim(type == End ? NDIM : 0), done(type == End) {
           if (type != End) {
             // skip to first dimensions with limited range
-            while (!parent->box_radius_[fixed_dim] && fixed_dim < NDIM) {
+            while (fixed_dim < NDIM && !parent->box_radius_[fixed_dim]) {
               ++fixed_dim;
             }
 
@@ -799,59 +799,57 @@ namespace madness {
         // through the cube origin, and the screening test above would screen out the box iff the origin displacement has a small norm.
         // That screening test isn't viable. We need to choose our probe displacement differently.
         // Instead, we'll probe on target_face, but not on its origin.
-        // (We know the face has non-orign points because if we're in this clause, NDIM > 1, and there's more than one box.)
+        // (We know the face has non-origin points because if we're in this clause, NDIM > 1, and there's more than one box.)
         // Now, the operator norm decays as the displacement magnitude increases.
         // The challenge is to find a displacement *just big enough* for it to be valid, but no larger.
         probing_displacement_vec[backup_face.value()] = (*box_radius_[backup_face.value()]) * Translation(1) << (n-1);
 
         // As a special case, if there is no validator, that means that even the boxes closest to origin could be filtered out.
-        // So then *every* displacement will say to filter this out. Let's choose the easiest one.'
+        // So then *every* displacement will say to filter this out. Let's choose the easiest one.
         if (!validator_) return Displacement(n, probing_displacement_vec);
         // From here on, we can assume the validator exists.
 
         // We're going to be greedy. Let's try choosing one dimension's displacement to exceed bmax_default.
         // If we can do that, keep shrinking the distance if possible.
         // If we wanted the *best* direction for this trick, we'd start with the smallest real-space length.
+        const Translation bmax = Displacements<NDIM>::bmax_default();
         for (size_t d = 0; d != NDIM; ++d) {
           if (d == backup_face.value()) continue;
-          if (center_[d] - Displacements<NDIM>::bmax_default() - 1 >= box_[d].first) {
-            // If displacing past bmax_default *to the left* keeps us in the box...
-            for (Translation disp = Displacements<NDIM>::bmax_default(); disp != 0; --disp) {
-              probing_displacement_vec[d] = -disp;
-              auto trial_disp = std::make_optional<Key<NDIM>>(center_.level(),  probing_displacement_vec);
-              if (!validator_(n, center_.translation() + probing_displacement_vec, trial_disp)) {
-                // Let's use the last valid key.
-                probing_displacement_vec[d] -= 1;
-                return Displacement(n, probing_displacement_vec);
-              }
-              probing_displacement_vec[d] = 0;
+          // Displace past bmax_default, in whichever direction stays inside the box.
+          Translation sign = 0;
+          if (center_[d] - bmax - 1 >= box_[d].first)
+            sign = -1;
+          else if (center_[d] + bmax + 1 <= box_[d].second)
+            sign = +1;
+          else
+            continue;
+
+          for (Translation disp = bmax; disp != 0; --disp) {
+            probing_displacement_vec[d] = sign * disp;
+            auto trial_disp = std::make_optional<Key<NDIM>>(center_.level(),  probing_displacement_vec);
+            if (!validator_(n, center_.translation() + probing_displacement_vec, trial_disp)) {
+              // This one is filtered out, so the last valid key was one step longer.
+              probing_displacement_vec[d] = sign * (disp + 1);
+              break;
             }
-            return Displacement(n, probing_displacement_vec);
-          } else if (center_[d] + Displacements<NDIM>::bmax_default() + 1 <= box_[d].second) {
-            // If displacing past bmax_default *to the right* keeps us in the box...
-            for (Translation disp = Displacements<NDIM>::bmax_default(); disp != 0; --disp) {
-              probing_displacement_vec[d] = +disp;
-              auto trial_disp = std::make_optional<Key<NDIM>>(center_.level(),  probing_displacement_vec);
-              if (!validator_(n, center_.translation() + probing_displacement_vec, trial_disp)) {
-                // Let's use the last valid key.
-                probing_displacement_vec[d] += 1;
-                return Displacement(n, probing_displacement_vec);
-              }
-              probing_displacement_vec[d] = 0;
-            }
-          return Displacement(n, probing_displacement_vec);
           }
-	}
+          // Either the loop broke out holding the last valid displacement, or every trial
+          // down to |disp| == 1 was valid and that shortest one is the one we want.
+          return Displacement(n, probing_displacement_vec);
+        }
         // If we can't, set all the distances to the maximum and greedily reduce until we get something invalid.
         // We could maybe decay some more, but this is fine.
         Translation max_permissible_abs = 0;
         for (size_t d = 0; d != NDIM; ++d) {
           if (d == backup_face.value()) continue;
-          // n.b.: If !box_radius_[d]_, we should have returned by now - dimension d isn't lattice-summed.'
-          max_permissible_abs = std::max({max_permissible_abs, *box_radius_[d]});
+          // dimensions of unlimited extent have no surface to probe; leave their component at 0
+          if (!box_radius_[d]) continue;
+          // N.B. box_ is in boxes, box_radius_ is in units of 2^{n-1}; the probe must be in boxes.
+          const Translation r = box_[d].second - center_[d];
+          max_permissible_abs = std::max(max_permissible_abs, r);
           // +/- displacements are equivalent for lattice-summed dimensions.
-          // + is the canonical choice the displacment code makes.
-          probing_displacement_vec[d] = max_permissible_abs;
+          // + is the canonical choice the displacement code makes.
+          probing_displacement_vec[d] = r;
         }
         bool can_shrink = true;
         max_permissible_abs--;
@@ -880,9 +878,8 @@ namespace madness {
             return Displacement(n, probing_displacement_vec);
           } else {
             if (max_permissible_abs == 0) {
-              // I want a case where this happens "in the wild," but if we end up here, we probably just need to compute all. The probe doesn't matter.'
-	          MADNESS_EXCEPTION("Attempt to generate a probe displacement failed. Contact developers immediately.", 0)
-	          throw;
+              // I want a case where this happens "in the wild," but if we end up here, we probably just need to compute all. The probe doesn't matter.
+              MADNESS_EXCEPTION("Attempt to generate a probe displacement failed. Contact developers immediately.", 0);
             }
             max_permissible_abs -= 1;
           }

--- a/src/madness/mra/displacements.h
+++ b/src/madness/mra/displacements.h
@@ -485,10 +485,7 @@ namespace madness {
           }
 
           // reset our search along all non-fixed dimensions
-          // the reset along the fixed_dim returns silently
-          for (size_t i = 0; i < NDIM; ++i) {
-            reset_along_dim(i);
-          }
+          reset_all_dims_and_select_face();
         }
 
         /// Perform advance, repeating if you are at a filtered point
@@ -512,7 +509,29 @@ namespace madness {
 
         // Recall that the surface is a union of hyperfaces, i.e., direct products of intervals.
         // Reset state on dimension `dim` to initialize for the start of interval `dim` in the the current direct product
-        void reset_along_dim(size_t dim) {
+        /// Restarts the sweep of the current fixed dimension's face, skipping ahead
+        /// to the next finite dimension for as long as a face turns out to be
+        /// entirely filtered out. Sets `done` if no face has a usable layer left,
+        /// which makes the range simply empty rather than an error.
+        void reset_all_dims_and_select_face() {
+          while (fixed_dim < NDIM) {
+            bool face_has_a_layer = true;
+            for (size_t d = 0; d != NDIM; ++d) {
+              if (!reset_along_dim(d)) face_has_a_layer = false;
+            }
+            if (face_has_a_layer) return;
+            ++fixed_dim;
+            while (fixed_dim < NDIM && !parent->box_radius_[fixed_dim]) {
+              ++fixed_dim;
+            }
+          }
+          done = true;
+        }
+
+        /// @return false iff \p dim is the fixed dimension and every one of its
+        ///         remaining surface layers is filtered out by the validator, i.e.
+        ///         this face contributes nothing
+        bool reset_along_dim(size_t dim) {
           const auto is_fixed_dim = dim == fixed_dim;
           Vector<Translation, NDIM> l = point.translation();
           Translation l_dim_min;
@@ -569,10 +588,15 @@ namespace madness {
                 if (!filtered_out())
                   break;
               }
-              MADNESS_ASSERT(have_another_surface_layer);
+              // N.B. a face all of whose layers are filtered out is not an error:
+              // e.g. for an even range on a non-lattice-summed axis the range
+              // boundary lies a full period away, hence entirely outside a finite
+              // domain. Report it and let the caller move on to the next face.
+              return have_another_surface_layer;
             }
 
           }
+          return true;
         };
 
         /**
@@ -613,9 +637,9 @@ namespace madness {
                                 parent->surface_thickness_[d].value_or(0),
                          parent->box_[d].second +
                              parent->surface_thickness_[d].value_or(0)} : parent->box_[d];
-              reset_along_dim(d);
             }
-            advance_till_valid();
+            reset_all_dims_and_select_face();
+            if (!done) advance_till_valid();
           }
         }
 

--- a/src/madness/mra/funcimpl.h
+++ b/src/madness/mra/funcimpl.h
@@ -5190,7 +5190,9 @@ template<size_t NDIM>
               validator = BoxSurfaceDisplacementValidator<opdim>(/* is_infinite_domain= */ op->func_domain_is_periodic(), /* is_lattice_summed= */ op->lattice_summed(), range, default_real_distance_squared, *max_distsq_reached);
 
             // this range iterates over the entire surface layer(s), and provides a probing displacement that can be used to screen out the entire box
-            auto opkey = op->particle() == 1 ? key.template extract_front<opdim>() : key.template extract_front<opdim>();
+            // N.B. must match how the displacement is merged back into a full key below:
+            // particle 1 occupies the front opdim axes, particle 2 the back ones
+            auto opkey = op->particle() == 1 ? key.template extract_front<opdim>() : key.template extract_back<opdim>();
             BoxSurfaceDisplacementRange<opdim>
                 range_boundary_face_displacements(opkey, box_radius,
                                                   surface_thickness,

--- a/src/madness/mra/test_displacements.cc
+++ b/src/madness/mra/test_displacements.cc
@@ -191,6 +191,56 @@ int test_no_duplicates(World& world) {
   return t.end();
 }
 
+/// A face whose every layer is filtered out makes the range shorter, not fatal.
+///
+/// For an even N on a non-lattice-summed axis the range boundary sits a full
+/// period from the center, so with a finite domain every layer of every face is
+/// out of bounds and the surface is legitimately empty. Iterating it must yield
+/// nothing rather than tripping an assertion.
+int test_fully_filtered_faces(World& world) {
+  test_output t("BoxSurfaceDisplacementRange: an entirely filtered face is not an error", world.rank() == 0);
+
+  // every face out of the domain => empty range
+  {
+    constexpr std::size_t NDIM = 2;
+    const Level n = 4;
+    Radii<NDIM> box_radius, surface_thickness;
+    for (std::size_t d = 0; d != NDIM; ++d) {
+      box_radius[d] = 2;  // r = 2*2^3 = 16 boxes from the center of a 16-box axis
+      surface_thickness[d] = 1;
+    }
+    BoxSurfaceDisplacementRange<NDIM> range(centered_key<NDIM>(n), box_radius, surface_thickness,
+                                            array_of_bools<NDIM>{false}, in_domain_only<NDIM>());
+    std::size_t count = 0;
+    for (auto&& disp : range) {
+      (void)disp;
+      ++count;
+    }
+    t.checkpoint(count == 0, "2D n=4 N={2,2} in-domain: surface is empty, not fatal");
+    t.checkpoint(range.begin() == range.end(), "2D n=4 N={2,2} in-domain: begin() == end()");
+  }
+
+  // one face entirely out of the domain, the other partly inside => the survivors
+  // are still enumerated, and still without duplicates
+  {
+    constexpr std::size_t NDIM = 2;
+    const Level n = 4;
+    Radii<NDIM> box_radius, surface_thickness;
+    box_radius[0] = 2;  surface_thickness[0] = 1;  // boundary a full period away
+    box_radius[1] = 1;  surface_thickness[1] = 1;  // boundary at the cell edge
+    BoxSurfaceDisplacementRange<NDIM> range(centered_key<NDIM>(n), box_radius, surface_thickness,
+                                            array_of_bools<NDIM>{false}, in_domain_only<NDIM>());
+    std::vector<Key<NDIM>> disps;
+    for (auto&& disp : range) disps.push_back(disp);
+    std::sort(disps.begin(), disps.end());
+    t.checkpoint(!disps.empty(), "2D n=4 N={2,1} in-domain: the surviving face is enumerated");
+    t.checkpoint(std::unique(disps.begin(), disps.end()) == disps.end(),
+                 "2D n=4 N={2,1} in-domain: all displacements distinct");
+  }
+
+  return t.end();
+}
+
 /// Whenever the hyperface origin is a usable probe, it is the one chosen.
 ///
 /// That covers every case except "lattice-summed with even N on all finite
@@ -433,6 +483,7 @@ int main(int argc, char** argv) {
   int errors = 0;
   errors += test_surface_extent(world);
   errors += test_no_duplicates(world);
+  errors += test_fully_filtered_faces(world);
   errors += test_probe_hyperface_origin(world);
   errors += test_probe_even_lattice_sum(world);
   errors += test_probe_fallback_is_in_box_units(world);

--- a/src/madness/mra/test_displacements.cc
+++ b/src/madness/mra/test_displacements.cc
@@ -1,0 +1,446 @@
+/// \file test_displacements.cc
+/// \brief Tests for BoxSurfaceDisplacementRange — the surface-of-the-box
+///        displacement enumerator used for range-restricted operators.
+///
+/// The pre-existing coverage in testgconv.cc only exercises `box_radius == 1`,
+/// i.e. the minimal *odd* box, with lattice summation switched off. That misses
+/// the case this class is hardest to get right: an **even** `box_radius` on a
+/// lattice-summed axis.
+///
+/// Why even is special. `box_radius[d] == N` is the kernel range in
+/// half-simulation-cells, so at level `n` the range boundary sits `r = N*2^{n-1}`
+/// boxes from the center while the lattice period is `2^n` boxes. For odd `N`,
+/// `r` is a half-period offset and the boundary hyperface maps onto a cell face.
+/// For even `N`, `r` is an exact multiple of the period, so under lattice
+/// summation the hyperface is equivalent to a hyperplane through the origin —
+/// and the natural probing displacement (the hyperface origin, `r` along one
+/// axis) canonicalizes to the *zero* displacement. Screening the whole surface
+/// on the norm of a zero displacement is meaningless, so `compute_probe()` has
+/// to pick a different representative.
+///
+/// The tests below cover both the iteration bounds and each branch of
+/// `compute_probe()`.
+
+#include <madness/mra/mra.h>
+#include <madness/mra/displacements.h>
+#include <madness/world/test_utilities.h>
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+using namespace madness;
+
+namespace {
+
+template <std::size_t NDIM>
+using Radii = std::array<std::optional<std::int64_t>, NDIM>;
+
+/// the range boundary, in boxes, for a kernel range of \p N half-simulation-cells at level \p n
+/// mirrors the conversion in the BoxSurfaceDisplacementRange constructor
+Translation radius_in_boxes(std::int64_t N, Level n) {
+  return (n == 0) ? (N + 1) / 2 : (N * Translation(1) << (n - 1));
+}
+
+/// the center box of the level-\p n grid
+template <std::size_t NDIM>
+Key<NDIM> centered_key(Level n) {
+  return Key<NDIM>(n, Vector<Translation, NDIM>(n == 0 ? 0 : (Translation(1) << (n - 1))));
+}
+
+/// least nonnegative residue of \p x modulo \p m
+Translation mod_positive(Translation x, Translation m) {
+  const auto r = x % m;
+  return (r < 0) ? r + m : r;
+}
+
+/// a validator that rejects everything it is asked about
+/// forces compute_probe()'s shrink loop to stop on its first trial, exposing the
+/// displacement vector exactly as the fallback block initialized it
+template <std::size_t NDIM>
+typename BoxSurfaceDisplacementRange<NDIM>::Validator reject_all() {
+  return [](Level, const typename BoxSurfaceDisplacementRange<NDIM>::PointPattern&,
+            std::optional<Key<NDIM>>&) -> bool { return false; };
+}
+
+/// a validator that accepts everything it is asked about
+/// drives compute_probe()'s greedy stage all the way down to |disp| == 1, so the
+/// shortest still-valid trial is the one that has to come back
+template <std::size_t NDIM>
+typename BoxSurfaceDisplacementRange<NDIM>::Validator accept_all() {
+  return [](Level, const typename BoxSurfaceDisplacementRange<NDIM>::PointPattern&,
+            std::optional<Key<NDIM>>&) -> bool { return true; };
+}
+
+/// keeps only destinations inside the simulation cell; the filter used by the
+/// legacy testgconv.cc check
+template <std::size_t NDIM>
+typename BoxSurfaceDisplacementRange<NDIM>::Validator in_domain_only() {
+  return [](const Level level, const typename BoxSurfaceDisplacementRange<NDIM>::PointPattern& dest,
+            std::optional<Key<NDIM>>&) -> bool {
+    const auto twon = (Translation(1) << level);
+    for (std::size_t d = 0; d != NDIM; ++d)
+      if (dest[d].has_value() && (*dest[d] < 0 || *dest[d] >= twon)) return false;
+    return true;
+  };
+}
+
+}  // namespace
+
+/// The surface must span the full extent of *every* dimension.
+///
+/// Regression guard: the per-dimension bounds are computed in one loop in the
+/// constructor. If that loop ever returns early again (it used to, once the
+/// probe computation was folded into it), the trailing dimensions keep
+/// default-constructed bounds and the surface silently collapses along them.
+/// Deliberately uses a different radius per axis so a collapsed axis cannot
+/// hide behind a neighbour's bounds.
+int test_surface_extent(World& world) {
+  test_output t("BoxSurfaceDisplacementRange: surface spans every dimension", world.rank() == 0);
+
+  const auto check_extent = [&](auto ndim_tag, Level n, std::array<std::int64_t, decltype(ndim_tag)::value> N,
+                                std::int64_t thickness, const std::string& what) {
+    constexpr std::size_t NDIM = decltype(ndim_tag)::value;
+    Radii<NDIM> box_radius, surface_thickness;
+    for (std::size_t d = 0; d != NDIM; ++d) {
+      box_radius[d] = N[d];
+      surface_thickness[d] = thickness;
+    }
+    BoxSurfaceDisplacementRange<NDIM> range(centered_key<NDIM>(n), box_radius, surface_thickness,
+                                            array_of_bools<NDIM>{false});
+
+    Vector<Translation, NDIM> lo(std::numeric_limits<Translation>::max());
+    Vector<Translation, NDIM> hi(std::numeric_limits<Translation>::min());
+    std::size_t count = 0;
+    for (auto&& disp : range) {
+      for (std::size_t d = 0; d != NDIM; ++d) {
+        lo[d] = std::min(lo[d], disp.translation()[d]);
+        hi[d] = std::max(hi[d], disp.translation()[d]);
+      }
+      ++count;
+    }
+    t.checkpoint(count > 0, what + ": surface is non-empty");
+    for (std::size_t d = 0; d != NDIM; ++d) {
+      const auto expected = radius_in_boxes(N[d], n) + thickness;
+      t.checkpoint(lo[d] == -expected, what + ": dim " + std::to_string(d) + " reaches -" + std::to_string(expected));
+      t.checkpoint(hi[d] == expected, what + ": dim " + std::to_string(d) + " reaches +" + std::to_string(expected));
+    }
+  };
+
+  check_extent(std::integral_constant<std::size_t, 2>{}, 4, {1, 1}, 1, "2D n=4 N={1,1}");
+  check_extent(std::integral_constant<std::size_t, 2>{}, 4, {1, 2}, 1, "2D n=4 N={1,2}");
+  check_extent(std::integral_constant<std::size_t, 2>{}, 3, {2, 2}, 0, "2D n=3 N={2,2} hard");
+  check_extent(std::integral_constant<std::size_t, 3>{}, 3, {1, 2, 3}, 1, "3D n=3 N={1,2,3}");
+
+  return t.end();
+}
+
+/// No displacement may be enumerated twice.
+///
+/// The `2D n=4 N={1,1} plain, in-domain` case below is the check that used to
+/// live inline in testgconv.cc, moved here and paired with its even-radius and
+/// lattice-summed counterparts. Both parities matter to this invariant: the
+/// bookkeeping that keeps shared edge boxes from being emitted twice is
+/// `unprocessed_bounds` shrinking as each face is consumed, and on a
+/// lattice-summed axis `reset_along_dim()` additionally clips the sweep to one
+/// period and visits only the + hyperface.
+int test_no_duplicates(World& world) {
+  test_output t("BoxSurfaceDisplacementRange: no duplicate displacements", world.rank() == 0);
+
+  const auto check_unique = [&](auto ndim_tag, Level n, std::array<std::int64_t, decltype(ndim_tag)::value> N,
+                                bool lattice_summed, bool filter_to_domain, const std::string& what) {
+    constexpr std::size_t NDIM = decltype(ndim_tag)::value;
+    Radii<NDIM> box_radius, surface_thickness;
+    for (std::size_t d = 0; d != NDIM; ++d) {
+      box_radius[d] = N[d];
+      surface_thickness[d] = 1;
+    }
+    // N.B. the domain filter is only meaningful when the range boundary can land
+    // inside the cell at all. For an even N on a non-lattice-summed axis the
+    // boundary sits a whole period away, so every layer would be rejected.
+    BoxSurfaceDisplacementRange<NDIM> range(
+        centered_key<NDIM>(n), box_radius, surface_thickness, array_of_bools<NDIM>{lattice_summed},
+        filter_to_domain ? in_domain_only<NDIM>() : typename BoxSurfaceDisplacementRange<NDIM>::Validator{});
+    std::vector<Key<NDIM>> disps;
+    for (auto&& disp : range) disps.push_back(disp);
+    std::sort(disps.begin(), disps.end());
+    const auto last = std::unique(disps.begin(), disps.end());
+    t.checkpoint(!disps.empty(), what + ": surface is non-empty");
+    t.checkpoint(last == disps.end(), what + ": all displacements distinct");
+  };
+
+  constexpr auto d2 = std::integral_constant<std::size_t, 2>{};
+  constexpr auto d3 = std::integral_constant<std::size_t, 3>{};
+
+  // odd N (the migrated testgconv.cc case) and its even counterpart
+  check_unique(d2, 4, {1, 1}, false, true, "2D n=4 N={1,1} plain, in-domain");
+  check_unique(d2, 4, {1, 1}, false, false, "2D n=4 N={1,1} plain");
+  check_unique(d2, 4, {2, 2}, false, false, "2D n=4 N={2,2} plain");
+  // ... and both parities again with lattice summation on
+  check_unique(d2, 4, {1, 1}, true, false, "2D n=4 N={1,1} lattice-summed");
+  check_unique(d2, 4, {2, 2}, true, false, "2D n=4 N={2,2} lattice-summed");
+  check_unique(d2, 4, {2, 3}, true, false, "2D n=4 N={2,3} lattice-summed (mixed parity)");
+  // ... and in 3D, where each face has two free axes rather than one
+  check_unique(d3, 3, {1, 1, 1}, true, false, "3D n=3 N={1,1,1} lattice-summed");
+  check_unique(d3, 3, {2, 2, 2}, true, false, "3D n=3 N={2,2,2} lattice-summed");
+  check_unique(d3, 3, {1, 2, 3}, true, false, "3D n=3 N={1,2,3} lattice-summed (mixed parity)");
+
+  return t.end();
+}
+
+/// Whenever the hyperface origin is a usable probe, it is the one chosen.
+///
+/// That covers every case except "lattice-summed with even N on all finite
+/// axes": no lattice summation at all, or an odd N, or NDIM==1, or n==0.
+int test_probe_hyperface_origin(World& world) {
+  test_output t("BoxSurfaceDisplacementRange: probe on the hyperface origin", world.rank() == 0);
+
+  const auto check_probe = [&](Level n, std::array<std::int64_t, 3> N, bool lattice_summed,
+                               const std::string& what) {
+    constexpr std::size_t NDIM = 3;
+    Radii<NDIM> box_radius, surface_thickness;
+    for (std::size_t d = 0; d != NDIM; ++d) {
+      box_radius[d] = N[d];
+      surface_thickness[d] = 1;
+    }
+    BoxSurfaceDisplacementRange<NDIM> range(centered_key<NDIM>(n), box_radius, surface_thickness,
+                                            array_of_bools<NDIM>{lattice_summed}, in_domain_only<NDIM>());
+    const auto probe = range.probing_displacement().translation();
+    t.checkpoint(probe[0] == radius_in_boxes(N[0], n), what + ": probe[0] == range boundary");
+    t.checkpoint(probe[1] == 0 && probe[2] == 0, what + ": probe is axial");
+  };
+
+  check_probe(4, {1, 1, 1}, false, "3D n=4 N={1,1,1} plain");
+  check_probe(4, {2, 2, 2}, false, "3D n=4 N={2,2,2} plain");
+  check_probe(4, {1, 1, 1}, true, "3D n=4 N={1,1,1} lattice-summed (odd)");
+  check_probe(4, {3, 2, 2}, true, "3D n=4 N={3,2,2} lattice-summed (leading odd)");
+  check_probe(0, {2, 2, 2}, true, "3D n=0 N={2,2,2} lattice-summed");
+
+  return t.end();
+}
+
+/// The point of the whole exercise: for an even, lattice-summed range the probe
+/// must not be lattice-equivalent to the zero displacement.
+///
+/// The hyperface origin is `r = N*2^{n-1}` along one axis, an exact multiple of
+/// the period `2^n` when N is even, so it canonicalizes to zero. Screening the
+/// entire range boundary on the norm of a zero displacement is meaningless —
+/// `op->norm(level, probe, source)` would report the on-site norm and the
+/// surface would never be screened correctly.
+int test_probe_even_lattice_sum(World& world) {
+  test_output t("BoxSurfaceDisplacementRange: even lattice-summed probe avoids the origin", world.rank() == 0);
+
+  constexpr std::size_t NDIM = 3;
+  const auto lattice_summed = array_of_bools<NDIM>{true};
+
+  const auto check_probe = [&](Level n, std::array<std::int64_t, NDIM> N, const std::string& what) {
+    Radii<NDIM> box_radius, surface_thickness;
+    std::array<KernelRange, NDIM> kernel_range;
+    for (std::size_t d = 0; d != NDIM; ++d) {
+      box_radius[d] = N[d];
+      surface_thickness[d] = 1;
+      kernel_range[d] = KernelRange(static_cast<unsigned int>(N[d]));
+    }
+    const auto distsq = [&](const Key<NDIM>& disp) -> double {
+      return disp.real_distsq_bc(lattice_summed, FunctionDefaults<NDIM>::get_cell_width());
+    };
+    // a standard-displacement loop that already reached everything nearby, so the
+    // validator rejects any displacement it recognizes as already-computed
+    BoxSurfaceDisplacementValidator<NDIM> validator(/* is_infinite_domain= */ array_of_bools<NDIM>{true},
+                                                    lattice_summed, kernel_range, distsq, 1.e9);
+    BoxSurfaceDisplacementRange<NDIM> range(centered_key<NDIM>(n), box_radius, surface_thickness,
+                                            lattice_summed, validator);
+
+    const auto probe = range.probing_displacement().translation();
+    const auto period = Translation(1) << n;
+
+    bool equivalent_to_origin = true;
+    for (std::size_t d = 0; d != NDIM; ++d)
+      if (mod_positive(probe[d], period) != 0) equivalent_to_origin = false;
+    t.checkpoint(!equivalent_to_origin, what + ": probe is not lattice-equivalent to the origin");
+
+    for (std::size_t d = 0; d != NDIM; ++d) {
+      const auto bound = radius_in_boxes(N[d], n) + 1;  // surface thickness 1
+      t.checkpoint(std::abs(probe[d]) <= bound, what + ": probe[" + std::to_string(d) + "] inside the box");
+    }
+  };
+
+  check_probe(4, {2, 2, 2}, "3D n=4 N={2,2,2}");
+  check_probe(5, {2, 2, 2}, "3D n=5 N={2,2,2}");
+  check_probe(4, {4, 4, 4}, "3D n=4 N={4,4,4}");
+  check_probe(4, {2, 4, 6}, "3D n=4 N={2,4,6}");
+
+  // Same requirement when the validator never rejects anything: the greedy stage
+  // then runs its trial displacement all the way down to |disp| == 1 without ever
+  // being told to stop. That shortest trial is still valid, so it is the answer —
+  // abandoning it and falling back to the bare face displacement would put the
+  // probe right back on the origin.
+  {
+    const Level n = 4;
+    Radii<NDIM> box_radius, surface_thickness;
+    for (std::size_t d = 0; d != NDIM; ++d) {
+      box_radius[d] = 2;
+      surface_thickness[d] = 1;
+    }
+    BoxSurfaceDisplacementRange<NDIM> range(centered_key<NDIM>(n), box_radius, surface_thickness,
+                                            lattice_summed, accept_all<NDIM>());
+    const auto probe = range.probing_displacement().translation();
+    const auto period = Translation(1) << n;
+    bool equivalent_to_origin = true;
+    for (std::size_t d = 0; d != NDIM; ++d)
+      if (mod_positive(probe[d], period) != 0) equivalent_to_origin = false;
+    t.checkpoint(!equivalent_to_origin, "3D n=4 N={2,2,2} accept-all: probe is not lattice-equivalent to the origin");
+  }
+
+  return t.end();
+}
+
+/// The fallback block builds its displacement in *boxes*, not in units of the
+/// kernel range.
+///
+/// `box_radius` is in half-simulation-cells; a displacement is in boxes, and the
+/// two differ by 2^{n-1}. Using the raw radius yields a probe that is 2^{n-1}
+/// times too short — an interior displacement rather than a boundary one, and
+/// inconsistent with the backup-face component, which is scaled.
+///
+/// The configuration below (small level, small even radii) is the one that
+/// reaches the fallback: no axis can be displaced past bmax_default while
+/// staying inside the box, so the greedy stage declines every dimension.
+int test_probe_fallback_is_in_box_units(World& world) {
+  test_output t("BoxSurfaceDisplacementRange: fallback probe is in box units", world.rank() == 0);
+
+  constexpr std::size_t NDIM = 3;
+  const Level n = 2;
+  const std::array<std::int64_t, NDIM> N = {2, 2, 2};
+
+  Radii<NDIM> box_radius, surface_thickness;
+  for (std::size_t d = 0; d != NDIM; ++d) {
+    box_radius[d] = N[d];
+    surface_thickness[d] = 0;
+  }
+  BoxSurfaceDisplacementRange<NDIM> range(centered_key<NDIM>(n), box_radius, surface_thickness,
+                                          array_of_bools<NDIM>{true}, reject_all<NDIM>());
+  const auto probe = range.probing_displacement().translation();
+
+  // r = N * 2^{n-1} = 2*2 = 4 boxes; the raw radius would be 2
+  for (std::size_t d = 0; d != NDIM; ++d) {
+    const auto r = radius_in_boxes(N[d], n);
+    t.checkpoint(probe[d] == r, "probe[" + std::to_string(d) + "] == " + std::to_string(r) + " boxes");
+  }
+
+  return t.end();
+}
+
+/// Every component of the fallback probe must respect *its own* axis' radius.
+///
+/// The running maximum across axes is the loop bound for the shrink stage, not
+/// the value to assign: handing axis d the largest radius seen so far puts the
+/// probe outside the box whenever a later axis is shorter than an earlier one,
+/// and makes the result depend on iteration order.
+///
+/// N={2,4,2} at n=1 keeps r == N, so this isolates the per-axis question from
+/// the units question tested above.
+int test_probe_fallback_respects_each_radius(World& world) {
+  test_output t("BoxSurfaceDisplacementRange: fallback probe respects each axis' radius", world.rank() == 0);
+
+  constexpr std::size_t NDIM = 3;
+  const Level n = 1;
+  const std::array<std::int64_t, NDIM> N = {2, 4, 2};  // shorter axis *after* the longer one
+
+  Radii<NDIM> box_radius, surface_thickness;
+  for (std::size_t d = 0; d != NDIM; ++d) {
+    box_radius[d] = N[d];
+    surface_thickness[d] = 0;
+  }
+  BoxSurfaceDisplacementRange<NDIM> range(centered_key<NDIM>(n), box_radius, surface_thickness,
+                                          array_of_bools<NDIM>{true}, reject_all<NDIM>());
+  const auto probe = range.probing_displacement().translation();
+
+  for (std::size_t d = 0; d != NDIM; ++d) {
+    const auto r = radius_in_boxes(N[d], n);
+    t.checkpoint(std::abs(probe[d]) <= r,
+                 "probe[" + std::to_string(d) + "] = " + std::to_string(probe[d]) + " within its own radius " +
+                     std::to_string(r));
+  }
+
+  return t.end();
+}
+
+/// An axis of unlimited extent has no surface, so it contributes nothing to the
+/// probe — and must not be asked for a radius it does not have.
+int test_probe_partial_range(World& world) {
+  test_output t("BoxSurfaceDisplacementRange: unrestricted axis contributes no probe component",
+                world.rank() == 0);
+
+  constexpr std::size_t NDIM = 3;
+  const Level n = 2;
+
+  Radii<NDIM> box_radius, surface_thickness;
+  box_radius[0] = 2;               surface_thickness[0] = 0;
+  box_radius[1] = std::nullopt;    surface_thickness[1] = std::nullopt;  // unlimited along axis 1
+  box_radius[2] = 2;               surface_thickness[2] = 0;
+
+  BoxSurfaceDisplacementRange<NDIM> range(centered_key<NDIM>(n), box_radius, surface_thickness,
+                                          array_of_bools<NDIM>{true}, reject_all<NDIM>());
+  const auto probe = range.probing_displacement().translation();
+
+  t.checkpoint(probe[1] == 0, "unrestricted axis 1 has a zero probe component");
+  t.checkpoint(probe[0] == radius_in_boxes(2, n), "axis 0 probe is the range boundary");
+  t.checkpoint(probe[2] == radius_in_boxes(2, n), "axis 2 probe is the range boundary");
+
+  return t.end();
+}
+
+/// Constructing without a validator must work.
+///
+/// `Validator` is a std::function and the constructor defaults it to empty;
+/// funcimpl.h leaves it empty whenever the standard-displacement loop screened
+/// everything out. compute_probe() must not call through it.
+int test_probe_without_validator(World& world) {
+  test_output t("BoxSurfaceDisplacementRange: empty validator is not called", world.rank() == 0);
+
+  constexpr std::size_t NDIM = 3;
+  const Level n = 4;
+
+  Radii<NDIM> box_radius, surface_thickness;
+  for (std::size_t d = 0; d != NDIM; ++d) {
+    box_radius[d] = 2;  // even + lattice-summed => the branch that wants a validator
+    surface_thickness[d] = 1;
+  }
+
+  bool threw = false;
+  Translation probe0 = 0;
+  try {
+    BoxSurfaceDisplacementRange<NDIM> range(centered_key<NDIM>(n), box_radius, surface_thickness,
+                                            array_of_bools<NDIM>{true});
+    probe0 = range.probing_displacement().translation()[0];
+  } catch (...) {
+    threw = true;
+  }
+  t.checkpoint(!threw, "construction with a default-constructed validator does not throw");
+  t.checkpoint(probe0 == radius_in_boxes(2, n), "probe falls back to the plain face displacement");
+
+  return t.end();
+}
+
+int main(int argc, char** argv) {
+  World& world = madness::initialize(argc, argv);
+  startup(world, argc, argv, true);
+
+  int errors = 0;
+  errors += test_surface_extent(world);
+  errors += test_no_duplicates(world);
+  errors += test_probe_hyperface_origin(world);
+  errors += test_probe_even_lattice_sum(world);
+  errors += test_probe_fallback_is_in_box_units(world);
+  errors += test_probe_fallback_respects_each_radius(world);
+  errors += test_probe_partial_range(world);
+  errors += test_probe_without_validator(world);
+
+  world.gop.fence();
+  madness::finalize();
+  return errors;
+}

--- a/src/madness/mra/testgconv.cc
+++ b/src/madness/mra/testgconv.cc
@@ -367,53 +367,9 @@ int test_gconv(World& world) {
     // test convolution with range restricted Gaussians
     ///////////////////////////////////////////////////
 
-    // validate BoxSurfaceDisplacementRange by making sure
-    // - it does not produce duplicate displacements
-    {
-      constexpr auto ND = 2;
-      const int n = 4;
-      Key<ND> key(n, Vector<Translation, ND>(1<<(n-1)));
-
-      std::size_t disp_count = 0;
-      const auto process_surface_displacements =
-          [&]() {
-            std::array<std::optional<std::int64_t>, ND> box_radius;
-            std::array<std::optional<std::int64_t>, ND> surface_thickness;
-            for (int d = 0; d != ND; ++d) {
-              box_radius[d] = 1;
-              surface_thickness[d] = 1;
-            }
-            BoxSurfaceDisplacementRange<ND> range_boundary_face_displacements(
-                key, box_radius, surface_thickness, array_of_bools<ND>{false},
-                [&](const auto level, const auto &dest, const auto &displacement) -> bool {
-                  // skip displacements not in domain
-                  const auto twon = (1 << level);
-                  for (auto d = 0; d != ND; ++d) {
-                    if (dest[d].has_value()) {
-                      if (dest[d] < 0 ||
-                          dest[d] >= twon)
-                        return false;
-                    }
-                  }
-                  return true;
-                });
-            std::vector<Key<ND>> disps;
-            for (auto &&disp : range_boundary_face_displacements) {
-//              std::cout << "disp = " << disp << " dest = " << key.neighbor(disp)
-//                        << std::endl;
-              disps.push_back(disp);
-              ++disp_count;
-            }
-            std::sort(disps.begin(), disps.end());
-            auto it = std::unique(disps.begin(), disps.end());
-
-            if (it != disps.end()) {
-              std::cout << "Duplicates found!!" << std::endl;
-              success++;
-            }
-          };
-      process_surface_displacements();
-    }
+    // N.B. BoxSurfaceDisplacementRange itself is covered by test_displacements.cc,
+    // over both odd and even box radii; this file only exercises it indirectly,
+    // through the range-restricted convolutions below.
 
     // now test the convolutions
     if constexpr (NDIM == 1) {


### PR DESCRIPTION
Follow-up to #732, targeting `jm/fix-even-lattice-sums` so it can be merged into that branch before it goes to master.

Five commits: four defects in `compute_probe()`, two pre-existing bugs the new tests exposed, and a unit test for `BoxSurfaceDisplacementRange` covering both range parities.

## `compute_probe()`

The fallback that handles "every finite axis lattice-summed with an even range" had four problems. Concrete probe vectors, same program built against both versions:

| configuration | before | after |
|---|---|---|
| 3D n=4 N={2,2,2}, accept-all validator | `(16, 0, 0)` | `(16, -1, 0)` |
| 3D n=2 N={2,2,2}, reject-all validator | `(4, 2, 2)` | `(4, 4, 4)` |
| 3D n=1 N={2,4,2}, reject-all validator | `(2, 4, 4)` | `(2, 4, 2)` |
| 3D n=2 N={2,–,2}, reject-all validator | `(4, 4313644800, 4313644800)` | `(4, 0, 4)` |

**Row 1 is the branch's own subject failing.** The greedy stage reset its trial component to `0` at the bottom of each iteration, so a validator that never rejects made the loop fall out having thrown away its answer and return the bare face displacement. At level 4 the period is 16 and `16 mod 16 == 0` — every component is zero modulo the period, so the probe is lattice-equivalent to the **zero displacement**. That is exactly the degenerate probe this code path exists to avoid: `do_apply()` screens the entire range boundary on `op->norm(level, probe, source)`, and a zero displacement reports the on-site norm. Fixed by keeping the shortest still-valid trial. The two mirror-image direction branches are now one, parameterized by a sign.

**Row 2 — units.** `box_radius_` is in half-simulation-cells, a displacement is in boxes, and the two differ by `2^{n-1}`. The fallback assigned the raw radius while the backup-face component was scaled, so the probe mixed two unit systems in one vector. 8x off at n=4, 512x at n=10.

**Row 3 — per-axis radius.** `max_permissible_abs` is the shrink loop's bound, not the value to assign. Handing axis *d* the largest radius seen so far puts the probe outside the box whenever a shorter axis follows a longer one, and makes the result depend on axis order.

**Row 4 — empty optional.** An axis of unlimited extent is *skipped* by the first loop (its body is entirely inside `if (box_radius_[d])`), not returned from, so `*box_radius_[d]` dereferenced an empty optional. `4313644800` is what came back here; being UB it could as easily have looked plausible, and it fed the running maximum so it corrupted the next axis too.

Also dropped the unreachable `throw;` after `MADNESS_EXCEPTION`, and hoisted the bounds test above the `box_radius_[fixed_dim]` index in the two iterator loops that scan for the next finite axis — they read one past the end of the array when the trailing axes were unrestricted.

## Two pre-existing bugs the tests exposed

**`MADNESS_ASSERT(have_another_surface_layer)` aborted on an empty face.** Not a logic error but a reachable state: for an even range on a non-lattice-summed axis the boundary lies a full period from the center, so against a finite domain every layer of every face is out of bounds and the surface is legitimately empty. `do_apply()` installs exactly such a validator whenever the standard displacement loop set `max_distsq_reached`, so a range-restricted operator with an even `N` on a non-periodic axis would abort the job. `reset_along_dim()` now reports an empty face and both callers share a helper that advances to the next one, marking the range done only when no face has a usable layer. An empty surface yields an empty range.

**`do_apply()` centered particle 2's surface on particle 1's axes:**

```cpp
auto opkey = op->particle() == 1 ? key.extract_front<opdim>() : key.extract_front<opdim>();
```

Both arms identical. A few lines below the displacement is merged back as `displacement.merge_with(nullkey)` for particle 1 and `nullkey.merge_with(displacement)` for particle 2 — particle 1 occupies the front `opdim` axes, particle 2 the back. So for particle 2 the range-boundary displacements were generated about the wrong half of the key. Now uses `extract_back<opdim>()`, matching the merge. **This is the change worth a second opinion** — it is a real numerical fix for 6D range-restricted operators and I have no test exercising that path.

## Tests

New `src/madness/mra/test_displacements.cc`, 9 groups. The inline check that lived in `testgconv.cc` is moved here (it built one range — 2D, level 4, `box_radius` 1, no lattice summation — and asserted only the absence of duplicates), and paired with its even-radius and lattice-summed counterparts.

Odd and even are not interchangeable here: `box_radius[d] == N` is the kernel range in half-simulation-cells, so the boundary sits at `r = N*2^{n-1}` boxes against a period of `2^n`. Odd `N` is a half-period offset and the boundary maps onto a cell face; even `N` is an exact multiple of the period, so under lattice summation the hyperface is equivalent to a hyperplane through the origin and the natural probe collapses to zero.

Coverage: surface extent along every axis (different radius per axis, so a collapsed axis cannot hide behind a neighbour's bounds); no duplicate displacements across both parities in 2D and 3D; the probe is the hyperface origin whenever usable; for an even lattice-summed range the probe is not lattice-equivalent to the origin and stays in the box; the fallback probe is in box units and respects each axis' own radius; an unrestricted axis contributes no component; a default-constructed validator is never called through; and an entirely filtered face gives an empty range rather than an abort.

Every one of these fails against the code as it stands on #732 — the four probe groups with the values tabulated above, the empty-face group with SIGABRT.

## Verification

`ctest -L short -R madness/test/mra/` — **27/27 pass**. clang-tidy clean on both changed files. Debug build, Pthreads backend, MPI on, macOS/arm64.

One note for whoever runs this locally: `test_eval_mpi2` times out under the default `MAD_NUM_THREADS` on a laptop (2 ranks x 11 threads oversubscribes the machine); at `MAD_NUM_THREADS=4` it finishes in 10s. Not related to these changes — `test_eval.cc` never touches displacements.
