### PR TITLE
Improve Probe Displacement Selection for All-Even Case

### DIFF
--- a/src/madness/mra/CMakeLists.txt
+++ b/src/madness/mra/CMakeLists.txt
@@ -39,7 +39,7 @@ if(BUILD_TESTING)
       testpdiff.cc testdiff1Db.cc testgconv.cc testopdir.cc testinnerext.cc
       testgaxpyext.cc testvmra.cc test_vectormacrotask.cc test_cloud.cc test_tree_state.cc testsolver.cc
       test_macrotaskpartitioner.cc test_QCCalculationParametersBase.cc test_memory_measurement.cc
-      test_keybox.cc test_eval.cc test_mul_sparse.cc test_halo.cc interp3.cc)
+      test_keybox.cc test_eval.cc test_mul_sparse.cc test_halo.cc interp3.cc test_displacements.cc)
   add_unittests(mra "${MRA_TEST_SOURCES}" "MADmra;MADgtest" "unittests;short")
   set(MRA_SEPOP_TEST_SOURCES testsuite.cc
       testper.cc)

--- a/src/madness/mra/displacements.h
+++ b/src/madness/mra/displacements.h
@@ -355,8 +355,8 @@ namespace madness {
       Hollowness hollowness_;    ///< does box contain non-surface points along each dimension?
       Periodicity is_lattice_summed_;  ///< which dimensions are lattice summed?
       Validator validator_;      ///< optional validator function
-      // TODO: Double-check legitimacy of choosing probing displacement arbitrarily. For isotropic kernels, wouldn't you want it on the face where the boundary is closest (in real-space)?
-      //       That depends on both the surface thickness and the side lengths of the simulation cell.
+      std::optional<Translation> probe_offset_radius_; ///< least N such that being N boxes away from origin guarantees
+                                                       ///   the point was not a short-range point already considered
       Displacement probing_displacement_;  ///< displacement to a nearby point on the surface; it may not be able to pass the filter, but is sufficiently representative of the surface displacements to allow screening with isotropic kernels
 
       /**
@@ -687,15 +687,18 @@ namespace madness {
        * @param is_lattice_summed whether each dimension is lattice summed; along lattice summed dimensions only one side of the box is iterated over.
        * @param validator Optional filter function (if returns false, displacement is dropped; default: no filter); it may update the displacement to make it valid as needed (e.g. map displacement to the simulation cell)
        * @pre `surface_radius[d]>0 && surface_thickness[d]<=surface_radius[d]`
+       * @param probe_offset_radius the smallest displacement magnitude, in boxes, that `validator` does *not* discard as a duplicate of the standard/short-range displacement list, Pass 0 to signal that nothing is filtered out (the surface then reaches all the way in to `center` and no probe can screen it). Omit if unknown, in which case the half-simulation-cell offset is used.
        *
        */
       explicit BoxSurfaceDisplacementRange(const Key<NDIM>& center,
                                            const std::array<std::optional<std::int64_t>, NDIM>& box_radius,
                                            const std::array<std::optional<std::int64_t>, NDIM>& surface_thickness,
                                            const array_of_bools<NDIM>& is_lattice_summed,
-                                           Validator validator = {})
+                                           Validator validator = {},
+                                           std::optional<Translation> probe_offset_radius = {})
           : center_(center), box_radius_(box_radius),
-            surface_thickness_(surface_thickness), is_lattice_summed_(is_lattice_summed), validator_(std::move(validator)) {
+            surface_thickness_(surface_thickness), is_lattice_summed_(is_lattice_summed), validator_(std::move(validator)),
+            probe_offset_radius_(probe_offset_radius) {
         // initialize bounds
         bool has_finite_dimensions = false;
         const auto n = center_.level();
@@ -772,74 +775,107 @@ namespace madness {
 
     private:
       const Displacement compute_probing_displacement() {
-        // Our probe displacement must satisfy two criteria:
-        // (1) It is on a boundary face, perpendicular to a dimension with finite box_radius_.
-        //     Define the dimension perpendicular to the target face as the face dimension.
-        // (2) To the extent possible, it is not lattice-equivalent to center_.
-        // The furthest away you can get from lattice-equivalent to center_ is differing from center_
-        //     by a half-simulation cell. If the face dimension has an odd box_radius_, the entire cell
-        //     is already half-away for one dimension. Any cell will do.
-        //     But if the face dimension has even box_radius_, we choose a different dimension
-        //     to be half a simulation cell away.
+        // Large boxes we must consider are both those near the center (because 1/r is large
+        // for small r), and near the box radius (because going from 1/r to 0 is a sharp change).
+        // The probe displacement is a way to screen out cases where the box radius is negligible.
+        // Our probe displacement must satisfy:
+        // (1) It must actually be on the box, e.g., on a boundary face, perpendicular to a
+        //     dimension with finite box_radius_. We call those the target face and dimensions.
+        // To ensure we're probing the box radius effect and not the near-center effect, we require:
+        // (2) If at all possible, it must be distinct from the zero displacement and
+        //     from the displacements "near" the center, both of which should have already been considered.
+        //     Zero displacements are especially pernicious, because self-interaction is always large.
+        //  n.b.: Beware that for lattice summed-dimensions, displacements must be distinct in the space
+        //     of equivalence classes. For lattice-summed dimensions of an even number of boxes, the origin
+        //     of the target face is equivalent the origin.
+        //  n.b.: If N even and lattice-summed and 1D, the entire boundary is already equivalent to
+        //     the displacements "near" the center.
+        // To keep the estimate sharp, we prefer:
+        // (3) We want the displacement of minimal real-space r within the above constraints.
+        //     Such displacements are more suitable as a heuristic upper bound of the matrix element
+        //     controlling the 1/r to 0 change. Not explicitly accounting for this does not seem to
+        //     affect whether we're within epsilon, but it's still good practice.
+        //     For the same reason, the sigma should matter as well.
 
-        const auto n = center_.level();
-        // minimal_X.first == NDIM is our check that an X was never found.
-        std::pair<size_t, Translation> minimal_odd = {NDIM, std::numeric_limits<Translation>::max()};
-        std::pair<size_t, Translation> minimal_even = {NDIM, std::numeric_limits<Translation>::max()};
+        const auto face_origin_is_center = [this](size_t d) {
+          return is_lattice_summed_[d] && (*box_radius_[d] % 2 == 0);
+        };
+
+        // Create a sort key on candidates for the target dimension.
+        // 1. The "effective number of half cells away" the face is. Even cells are treated as 1,
+        //    even though they're actually 0, to account for the offset we'll need to add.
+        // 2. Is an offset needed? Avoiding it is preferred.
+        // 3. Choose the smallest N possible.
+        // Requirement (3) would be better formulated in real-space, but the expected
+        // bound improvement doesn't justify expanding the argument signature.
+        const auto sort_key = [&](size_t d) {
+          const auto N = *box_radius_[d];
+          return std::make_tuple(is_lattice_summed_[d] ? Translation(1) : N, face_origin_is_center(d), N);
+        };
+
+        // The initial value registers "not set yet".
+        size_t face_dimension = NDIM;
         for (size_t d=0; d != NDIM; ++d) {
-          if (box_radius_[d]) {
-            auto r = *box_radius_[d];
-            if (r % 2 and r < minimal_odd.second) {
-              minimal_odd = {d, r};
-            } else if (!(r % 2) and r < minimal_even.second) {
-              minimal_even = {d, r};
-            }
-          }
+          if (!box_radius_[d]) continue;
+          if (face_dimension == NDIM || sort_key(d) < sort_key(face_dimension)) face_dimension = d;
         }
+        MADNESS_ASSERT(face_dimension != NDIM);  // guaranteed by has_finite_dimensions in the ctor
 
+        // Enforce requirement (1)
         Vector<Translation, NDIM> probing_displacement_vec(0);
-        // If NDIM = 1 for an even dimension or if n = 0, the boundary is already equivalent to the face
-        // and thus accounted for it. We can choose any displacement we wish, and to make life easy
-        // we're going to make the same choice as in the case of an odd dimension.
-        // We get rid of these special cases because they would break our standard algorithm below.
-        if ((NDIM == 1 || n == 0) && minimal_odd.first == NDIM) minimal_odd = minimal_even;
-        auto face_dimension = minimal_odd.first < NDIM ? minimal_odd.first : minimal_even.first;
-
-        // d defines our face dimension. Requirement one will now be satisfied.
+        const auto n = center_.level();
         auto r = *box_radius_[face_dimension];  // in units of 2^{n-1}
         // n = 0 is special b/c << -1 is undefined
         r = (n == 0) ? (r+1)/2 : (r * Translation(1) << (n-1));
         MADNESS_ASSERT(r > 0);
         probing_displacement_vec[face_dimension] = r;
 
-        if (minimal_odd.first < NDIM) {
+        // In these cases, requirement (2) is already satisfied or unsatisfiable.
+        // Choosing 0 for all other dimensions satisfies requirement (3).
+        if (!face_origin_is_center(face_dimension) || n == 0 || NDIM == 1)
           return Displacement(n, probing_displacement_vec);
-        }
 
-        // If we haven't returned, minimal_even gives our face dimension.
-        // It remains to choose a dimension on this face which we'll move by one half-SimulationCell.
-        // We can always do this because NDIM == 1 and n == 0 cases have already been eliminated.
-        MADNESS_ASSERT(face_dimension != NDIM);
-        std::pair<size_t, Translation> minimal_second_even = {NDIM, std::numeric_limits<Translation>::max()};
-        size_t minimal_undefined = NDIM;
+        // No (or negative) radius means none of the surface points have been processed
+        // 
+        if (probe_offset_radius_ && *probe_offset_radius_ <= 0)
+          return Displacement(n, probing_displacement_vec);
+
+        // Else, we still need to satisfy requirement (2) while trying to obey (3). We need to displace along
+        // a different dimension.
+
+        // choose the dimension to displace along. The offset magnitude is dimension-independent;
+        // prefer the narrowest finite dimension, else the first unrestricted one.
+        size_t offset_dimension = NDIM;
+        size_t unrestricted_dimension = NDIM;
         for (size_t d=0; d != NDIM; ++d) {
           if (d == face_dimension) continue;
           if (box_radius_[d]) {
-            auto r = *box_radius_[d];
-            if (r < minimal_second_even.second)
-                minimal_second_even = {d, r};
-          } else {
-            minimal_undefined = std::min(minimal_undefined, d);
-          }
+            if (offset_dimension == NDIM || *box_radius_[d] < *box_radius_[offset_dimension])
+              offset_dimension = d;
+          } else if (unrestricted_dimension == NDIM) {
+              unrestricted_dimension = d;
+            }
         }
-        if (minimal_second_even.first < NDIM) {
-            probing_displacement_vec[minimal_second_even.first] = Translation(1) << (n-1);
+
+        // Cap the offset at half a cell. If our dimension is lattice-summed, it's even, and half a cell
+        // is where it's furthest from the origin. Else, half a cell is the furthest away we can
+        // guarantee we can displace to, in the case of an open dimension and the center_ is the origin.
+        const Translation half_cell = Translation(1) << (n-1);
+        const Translation offset = probe_offset_radius_
+                                       ? std::clamp(*probe_offset_radius_, Translation(1), half_cell)
+                                       : half_cell;
+        if (offset_dimension != NDIM) {
+          // the offset stays on the face: box_radius_ >= 1 means the box spans at least a half
+          // simulation cell along this dimension, and offset <= half_cell
+          probing_displacement_vec[offset_dimension] = offset;
         } else {
-            auto d = minimal_undefined;
-            auto left_distance = center_[d] - box_[d].first;
-            auto right_distance = box_[d].second - center_[d];
-            auto sign = right_distance >= left_distance ? +1 : -1;
-            probing_displacement_vec[d] = sign * Translation(1) << (n-1);
+          // we're bounded by the simulation cell; displace toward whichever side of center_ has more room
+          MADNESS_ASSERT(unrestricted_dimension != NDIM);  // NDIM > 1, so some dimension was found
+          const auto d = unrestricted_dimension;
+          const auto left_distance = center_[d] - box_[d].first;
+          const auto right_distance = box_[d].second - center_[d];
+          const auto sign = right_distance >= left_distance ? +1 : -1;
+          probing_displacement_vec[d] = sign * offset;
         }
         return Displacement(n, probing_displacement_vec);
       }   // compute_probing_displacement

--- a/src/madness/mra/displacements.h
+++ b/src/madness/mra/displacements.h
@@ -782,6 +782,7 @@ namespace madness {
         //     to be half a simulation cell away.
 
         const auto n = center_.level();
+        // minimal_X.first == NDIM is our check that an X was never found.
         std::pair<size_t, Translation> minimal_odd = {NDIM, std::numeric_limits<Translation>::max()};
         std::pair<size_t, Translation> minimal_even = {NDIM, std::numeric_limits<Translation>::max()};
         for (size_t d=0; d != NDIM; ++d) {
@@ -794,28 +795,29 @@ namespace madness {
             }
           }
         }
-        // Possibility One. The face dimension is odd. Choose the simplest possible displacement onto it.
+
         Vector<Translation, NDIM> probing_displacement_vec(0);
         // If NDIM = 1 for an even dimension or if n = 0, the boundary is already equivalent to the face
         // and thus accounted for it. We can choose any displacement we wish, and to make life easy
         // we're going to make the same choice as in the case of an odd dimension.
-        // We get rid of these special cases becuase they would break our standard algorithm below.
-        if (NDIM == 1 || n == 0) minimal_odd = {0, 0};
+        // We get rid of these special cases because they would break our standard algorithm below.
+        if ((NDIM == 1 || n == 0) && minimal_odd.first == NDIM) minimal_odd = minimal_even;
+        auto face_dimension = minimal_odd.first < NDIM ? minimal_odd.first : minimal_even.first;
+
+        // d defines our face dimension. Requirement one will now be satisfied.
+        auto r = *box_radius_[face_dimension];  // in units of 2^{n-1}
+        // n = 0 is special b/c << -1 is undefined
+        r = (n == 0) ? (r+1)/2 : (r * Translation(1) << (n-1));
+        MADNESS_ASSERT(r > 0);
+        probing_displacement_vec[face_dimension] = r;
+
         if (minimal_odd.first < NDIM) {
-          auto d = minimal_odd.first;
-          // minimal_odd.first defines our face dimension. Both requirements are satisfied automatically.
-          auto r = *box_radius_[d];  // in units of 2^{n-1}
-          // n = 0 is special b/c << -1 is undefined
-          r = (n == 0) ? (r+1)/2 : (r * Translation(1) << (n-1));
-          MADNESS_ASSERT(r > 0);
-          probing_displacement_vec[d] = r;
           return Displacement(n, probing_displacement_vec);
         }
 
         // If we haven't returned, minimal_even gives our face dimension.
         // It remains to choose a dimension on this face which we'll move by one half-SimulationCell.
         // We can always do this because NDIM == 1 and n == 0 cases have already been eliminated.
-        auto face_dimension = minimal_even.first;
         MADNESS_ASSERT(face_dimension != NDIM);
         std::pair<size_t, Translation> minimal_second_even = {NDIM, std::numeric_limits<Translation>::max()};
         size_t minimal_undefined = NDIM;
@@ -829,17 +831,14 @@ namespace madness {
             minimal_undefined = std::min(minimal_undefined, d);
           }
         }
-        if (minimal_even.first < NDIM) {
-            probing_displacement_vec[minimal_even.first] = minimal_second_even.second * Translation(1) << (n-1);
+        if (minimal_second_even.first < NDIM) {
+            probing_displacement_vec[minimal_second_even.first] = Translation(1) << (n-1);
         } else {
             auto d = minimal_undefined;
             auto left_distance = center_[d] - box_[d].first;
             auto right_distance = box_[d].second - center_[d];
-            if (right_distance >= left_distance) {
-                probing_displacement_vec[d] = right_distance * Translation(1) << (n-1);
-            } else {
-                probing_displacement_vec[d] = -left_distance * Translation(1) << (n-1);
-            }
+            auto sign = right_distance >= left_distance ? +1 : -1;
+            probing_displacement_vec[d] = sign * Translation(1) << (n-1);
         }
         return Displacement(n, probing_displacement_vec);
       }   // compute_probing_displacement

--- a/src/madness/mra/displacements.h
+++ b/src/madness/mra/displacements.h
@@ -41,6 +41,7 @@
 #include <array>
 #include <functional>
 #include <iterator>
+#include <limits>
 #include <optional>
 #include <tuple>
 #include <utility>

--- a/src/madness/mra/displacements.h
+++ b/src/madness/mra/displacements.h
@@ -698,7 +698,6 @@ namespace madness {
         // initialize bounds
         bool has_finite_dimensions = false;
         const auto n = center_.level();
-        Vector<Translation, NDIM> probing_displacement_vec(0);
         for (size_t d=0; d!= NDIM; ++d) {
           if (box_radius_[d]) {
             auto r = *box_radius_[d];  // in units of 2^{n-1}
@@ -706,15 +705,13 @@ namespace madness {
             r = (n == 0) ? (r+1)/2 : (r * Translation(1) << (n-1));
             MADNESS_ASSERT(r > 0);
             box_[d] = {center_[d] - r, center_[d] + r};
-            if (!has_finite_dimensions) // first finite dimension? probing displacement will be nonzero along it, zero along all others
-              probing_displacement_vec[d] = r;
             has_finite_dimensions = true;
           } else {
             box_[d] = {0, (1 << center_.level()) - 1};
           }
         }
         MADNESS_ASSERT(has_finite_dimensions);
-        probing_displacement_ = Displacement(n, probing_displacement_vec);
+        probing_displacement_ = compute_probing_displacement();
         for (size_t d=0; d!= NDIM; ++d) {
           // surface thickness should be only given for finite-radius dimensions
           MADNESS_ASSERT(!(box_radius_[d].has_value() ^ surface_thickness_[d].has_value()));
@@ -771,6 +768,81 @@ namespace madness {
       const Displacement& probing_displacement() const {
         return probing_displacement_;
       }
+
+    private:
+      const Displacement compute_probing_displacement() {
+        // Our probe displacement must satisfy two criteria:
+        // (1) It is on a boundary face, perpendicular to a dimension with finite box_radius_.
+        //     Define the dimension perpendicular to the target face as the face dimension.
+        // (2) To the extent possible, it is not lattice-equivalent to center_.
+        // The furthest away you can get from lattice-equivalent to center_ is differing from center_
+        //     by a half-simulation cell. If the face dimension has an odd box_radius_, the entire cell
+        //     is already half-away for one dimension. Any cell will do.
+        //     But if the face dimension has even box_radius_, we choose a different dimension
+        //     to be half a simulation cell away.
+
+        const auto n = center_.level();
+        std::pair<size_t, Translation> minimal_odd = {NDIM, std::numeric_limits<Translation>::max()};
+        std::pair<size_t, Translation> minimal_even = {NDIM, std::numeric_limits<Translation>::max()};
+        for (size_t d=0; d != NDIM; ++d) {
+          if (box_radius_[d]) {
+            auto r = *box_radius_[d];
+            if (r % 2 and r < minimal_odd.second) {
+              minimal_odd = {d, r};
+            } else if (!(r % 2) and r < minimal_even.second) {
+              minimal_even = {d, r};
+            }
+          }
+        }
+        // Possibility One. The face dimension is odd. Choose the simplest possible displacement onto it.
+        Vector<Translation, NDIM> probing_displacement_vec(0);
+        // If NDIM = 1 for an even dimension or if n = 0, the boundary is already equivalent to the face
+        // and thus accounted for it. We can choose any displacement we wish, and to make life easy
+        // we're going to make the same choice as in the case of an odd dimension.
+        // We get rid of these special cases becuase they would break our standard algorithm below.
+        if (NDIM == 1 || n == 0) minimal_odd = {0, 0};
+        if (minimal_odd.first < NDIM) {
+          auto d = minimal_odd.first;
+          // minimal_odd.first defines our face dimension. Both requirements are satisfied automatically.
+          auto r = *box_radius_[d];  // in units of 2^{n-1}
+          // n = 0 is special b/c << -1 is undefined
+          r = (n == 0) ? (r+1)/2 : (r * Translation(1) << (n-1));
+          MADNESS_ASSERT(r > 0);
+          probing_displacement_vec[d] = r;
+          return Displacement(n, probing_displacement_vec);
+        }
+
+        // If we haven't returned, minimal_even gives our face dimension.
+        // It remains to choose a dimension on this face which we'll move by one half-SimulationCell.
+        // We can always do this because NDIM == 1 and n == 0 cases have already been eliminated.
+        auto face_dimension = minimal_even.first;
+        MADNESS_ASSERT(face_dimension != NDIM);
+        std::pair<size_t, Translation> minimal_second_even = {NDIM, std::numeric_limits<Translation>::max()};
+        size_t minimal_undefined = NDIM;
+        for (size_t d=0; d != NDIM; ++d) {
+          if (d == face_dimension) continue;
+          if (box_radius_[d]) {
+            auto r = *box_radius_[d];
+            if (r < minimal_second_even.second)
+                minimal_second_even = {d, r};
+          } else {
+            minimal_undefined = std::min(minimal_undefined, d);
+          }
+        }
+        if (minimal_even.first < NDIM) {
+            probing_displacement_vec[minimal_even.first] = minimal_second_even.second * Translation(1) << (n-1);
+        } else {
+            auto d = minimal_undefined;
+            auto left_distance = center_[d] - box_[d].first;
+            auto right_distance = box_[d].second - center_[d];
+            if (right_distance >= left_distance) {
+                probing_displacement_vec[d] = right_distance * Translation(1) << (n-1);
+            } else {
+                probing_displacement_vec[d] = -left_distance * Translation(1) << (n-1);
+            }
+        }
+        return Displacement(n, probing_displacement_vec);
+      }   // compute_probing_displacement
     };  // BoxSurfaceDisplacementRange
 
 

--- a/src/madness/mra/funcimpl.h
+++ b/src/madness/mra/funcimpl.h
@@ -5199,13 +5199,29 @@ template<size_t NDIM>
             if (max_distsq_reached)
               validator = BoxSurfaceDisplacementValidator<opdim>(/* is_infinite_domain= */ op->func_domain_is_periodic(), /* is_lattice_summed= */ op->lattice_summed(), range, default_real_distance_squared, *max_distsq_reached);
 
+            // Least N such that being N boxes away from origin_ guarantees you're outside of the short-range region.
+            std::optional<Translation> probe_offset_radius;
+            if (max_distsq_reached) {
+              // default_real_distance_squared measures cell_width*(|l|-1) per axis (see Key::real_distsq_bc);
+              // invert it. The offset axis is not known here, so use the widest one, which yields the
+              // smallest radius and hence the most conservative probe.
+              const auto &cell_width = FunctionDefaults<NDIM>::get_cell_width();
+              const std::size_t d0 = (op->particle() == 1) ? 0 : NDIM - opdim;
+              double widest = 0.;
+              for (std::size_t d = d0; d != d0 + opdim; ++d) widest = std::max(widest, cell_width(d));
+              const Translation reach = 1 + static_cast<Translation>(std::sqrt(*max_distsq_reached) / widest);
+              probe_offset_radius = std::min<Translation>(reach, Displacements<opdim>::bmax_default()) + 1;
+            } else  // no validator => no treatment of short-range point. let surface handle everything
+              probe_offset_radius = 0;
+
             // this range iterates over the entire surface layer(s), and provides a probing displacement that can be used to screen out the entire box
             auto opkey = op->particle() == 1 ? key.template extract_front<opdim>() : key.template extract_back<opdim>();
             BoxSurfaceDisplacementRange<opdim>
                 range_boundary_face_displacements(opkey, box_radius,
                                                   surface_thickness,
                                                   op->lattice_summed(),
-                                                  validator);
+                                                  validator,
+                                                  probe_offset_radius);
             for_each(
                 range_boundary_face_displacements,
                 // surface displacements are not screened, all are included

--- a/src/madness/mra/funcimpl.h
+++ b/src/madness/mra/funcimpl.h
@@ -5200,7 +5200,7 @@ template<size_t NDIM>
               validator = BoxSurfaceDisplacementValidator<opdim>(/* is_infinite_domain= */ op->func_domain_is_periodic(), /* is_lattice_summed= */ op->lattice_summed(), range, default_real_distance_squared, *max_distsq_reached);
 
             // this range iterates over the entire surface layer(s), and provides a probing displacement that can be used to screen out the entire box
-            auto opkey = op->particle() == 1 ? key.template extract_front<opdim>() : key.template extract_front<opdim>();
+            auto opkey = op->particle() == 1 ? key.template extract_front<opdim>() : key.template extract_back<opdim>();
             BoxSurfaceDisplacementRange<opdim>
                 range_boundary_face_displacements(opkey, box_radius,
                                                   surface_thickness,

--- a/src/madness/mra/test_displacements.cc
+++ b/src/madness/mra/test_displacements.cc
@@ -97,7 +97,7 @@ int test_odds(World& world) {
                                             array_of_bools<NDIM>{true} /* lattice_summed */);
     const auto probe = range.probing_displacement().translation();
     for (size_t d = 0; d < NDIM; d++) {
-      t.checkpoint(probe[d] == expected[d], "3D n=4 N=" + what + " component " + std::to_string(d));
+      t.checkpoint(probe[d] == expected[d], "3D n=" + std::to_string(n) + " N=" + what + " component " + std::to_string(d));
     }
   };
 
@@ -108,7 +108,7 @@ int test_odds(World& world) {
   return t.end();
 }
 
-/// Test the cases where there is an odd box radius.
+/// Test the degenerate cases in which criterion 2 is out of reach: a single dimension, and level 0.
 int test_singular(World& world) {
   test_output t("BoxSurfaceDisplacementRange: singular cases", world.rank() == 0);
 
@@ -128,7 +128,7 @@ int test_singular(World& world) {
   };
 
   Level level = 4;
-  check_probe(level, std::array<std::int64_t, 1>{4}, {radius_in_boxes(4, level)}, "{2}");
+  check_probe(level, std::array<std::int64_t, 1>{4}, {radius_in_boxes(4, level)}, "{4}");
   check_probe(0, std::array<std::int64_t, 3>{3, 2, 1}, {0, 0, 1}, "{3,2,1}");
   return t.end();
 }
@@ -166,7 +166,8 @@ int test_mixed(World& world) {
   return t.end();
 }
 
-/// Test the cases where there is an odd box radius.
+/// Test the case in which every box radius is even, so that the face dimension alone cannot satisfy
+/// criterion 2 and a half-simulation-cell offset along a second dimension is needed.
 int test_all_evens(World& world) {
   test_output t("BoxSurfaceDisplacementRange: pure evens", world.rank() == 0);
 
@@ -192,7 +193,103 @@ int test_all_evens(World& world) {
   check_probe(level, {6, 2, 2}, {0, radius_in_boxes(2, level), radius_in_boxes(1, level)}, "{6,2,2}");
   check_probe(level, {8, 2, 2}, {0, radius_in_boxes(2, level), radius_in_boxes(1, level)}, "{8,2,2}");
   check_probe(level, {6, 4, 2}, {0, radius_in_boxes(1, level), radius_in_boxes(2, level)}, "{6,4,2}");
-  check_probe(level, {4, 6, 4}, {radius_in_boxes(4, level), 0, radius_in_boxes(1, level)}, "{4,6,2}");
+  check_probe(level, {4, 6, 4}, {radius_in_boxes(4, level), 0, radius_in_boxes(1, level)}, "{4,6,4}");
+
+  return t.end();
+}
+
+/// Test differences between lattice-summed and non-lattice summed axes. In particular, offsets
+/// are only needed for lattice-summed axes.
+int test_lattice_summation_awareness(World& world) {
+  test_output t("BoxSurfaceDisplacementRange: offset only where lattice summed", world.rank() == 0);
+
+  const auto check_probe = [&]<std::size_t NDIM>(Level n, Radii<NDIM> box_radius,
+                                                 array_of_bools<NDIM> is_lattice_summed,
+                                                 std::array<std::int64_t, NDIM> expected,
+                                                 const std::string& what) {
+    Radii<NDIM> surface_thickness;
+    for (std::size_t d = 0; d != NDIM; ++d) {
+      if (box_radius[d]) surface_thickness[d] = 1;
+    }
+    BoxSurfaceDisplacementRange<NDIM> range(centered_key<NDIM>(n), box_radius, surface_thickness,
+                                            is_lattice_summed);
+    const auto probe = range.probing_displacement().translation();
+    for (size_t d = 0; d < NDIM; d++) {
+      t.checkpoint(probe[d] == expected[d], what + " component " + std::to_string(d));
+    }
+  };
+
+  Level level = 4;
+  const auto r = [&](std::int64_t N) { return radius_in_boxes(N, level); };
+
+  // all even, nothing lattice summed => no offset, and the probe is the nearest surface point
+  check_probe(level, Radii<3>{2, 2, 2}, array_of_bools<3>{false}, {r(2), 0, 0}, "3D N={2,2,2} not summed");
+  check_probe(level, Radii<3>{4, 2, 6}, array_of_bools<3>{false}, {0, r(2), 0}, "3D N={4,2,6} not summed");
+  // ... the same radii with lattice summation on do need the offset
+  check_probe(level, Radii<3>{2, 2, 2}, array_of_bools<3>{true}, {r(2), r(1), 0}, "3D N={2,2,2} summed");
+
+  // with only the first dimension lattice summed, that dimension is the best face even though it has to
+  // pay for an offset: it folds to a half cell (8 boxes), whereas y or z would leave the probe a full
+  // 2 half-cells out with nothing to fold it back
+  check_probe(level, Radii<3>{2, 2, 2}, array_of_bools<3>{true, false, false}, {r(2), r(1), 0},
+                 "3D N={2,2,2} summed along x only");
+  // ... and all the more so when the unsummed dimensions are wider
+  check_probe(level, Radii<3>{2, 4, 4}, array_of_bools<3>{true, false, false}, {r(2), r(1), 0},
+                 "3D N={2,4,4} summed along x only");
+
+  // an unrestricted dimension absorbs the offset, but again only when one is needed
+  Radii<2> radii2d;
+  radii2d[1] = 2;
+  check_probe(level, radii2d, array_of_bools<2>{false, true}, {-r(1), r(2)}, "2D N={*,2} summed along y");
+  check_probe(level, radii2d, array_of_bools<2>{false, false}, {0, r(2)}, "2D N={*,2} not summed");
+
+  return t.end();
+}
+
+/// The offset for all-even radii is set by the caller.
+int test_probe_offset_radius(World& world) {
+  test_output t("BoxSurfaceDisplacementRange: offset magnitude follows the filter shortrange", world.rank() == 0);
+
+  constexpr std::size_t NDIM = 3;
+  const Level n = 6;                       // half-cell = 32 boxes, so the clamp is far away
+  const auto check = [&](std::optional<Translation> cutoff, std::array<std::int64_t, NDIM> expected,
+                         const std::string& what) {
+    Radii<NDIM> box_radius, surface_thickness;
+    for (std::size_t d = 0; d != NDIM; ++d) { box_radius[d] = 2; surface_thickness[d] = 1; }  // all even
+    BoxSurfaceDisplacementRange<NDIM> range(centered_key<NDIM>(n), box_radius, surface_thickness,
+                                            array_of_bools<NDIM>{true} /* lattice_summed */,
+                                            typename BoxSurfaceDisplacementRange<NDIM>::Validator{}, cutoff);
+    const auto probe = range.probing_displacement().translation();
+    for (size_t d = 0; d < NDIM; d++)
+      t.checkpoint(probe[d] == expected[d], what + " component " + std::to_string(d));
+  };
+
+  const auto face = radius_in_boxes(2, n);         // 64
+  const auto half_cell = radius_in_boxes(1, n);    // 32
+
+  // unknown shortrange cutoff => the maximal (half-cell) offset, i.e. the behavior when nothing better is known
+  check(std::nullopt, {face, half_cell, 0}, "cutoff unknown");
+  // a cutoff inside the half cell is used verbatim -- this is the case that matters in practice, since
+  // the cutoff is capped by bmax_default() (4 in 3D) while the half cell grows as 2^{n-1}
+  check(Translation(5), {face, 5, 0}, "cutoff=5");
+  check(Translation(2), {face, 2, 0}, "cutoff=2");
+  // a cutoff beyond the half cell is clamped: a step of 2^{n-1}+k folds back down to 2^{n-1}-k
+  check(Translation(1000), {face, half_cell, 0}, "cutoff beyond half cell");
+  // a cutoff of zero says nothing is filtered, so the surface reaches the source and no offset helps;
+  // fall back to the bare face probe, whose norm is the on-site norm and screens nothing
+  check(Translation(0), {face, 0, 0}, "cutoff=0 (nothing filtered)");
+
+  // the same clamping applies when the offset lands on an unrestricted dimension
+  {
+    Radii<2> box_radius, surface_thickness;
+    box_radius[1] = 2; surface_thickness[1] = 1;
+    BoxSurfaceDisplacementRange<2> range(centered_key<2>(n), box_radius, surface_thickness,
+                                         array_of_bools<2>{true},
+                                         typename BoxSurfaceDisplacementRange<2>::Validator{}, Translation(3));
+    const auto probe = range.probing_displacement().translation();
+    t.checkpoint(probe[0] == -3, "2D N={*,2} cutoff=3 component 0");
+    t.checkpoint(probe[1] == radius_in_boxes(2, n), "2D N={*,2} cutoff=3 component 1");
+  }
 
   return t.end();
 }
@@ -209,6 +306,8 @@ int main(int argc, char** argv) {
   errors += test_singular(world);
   errors += test_mixed(world);
   errors += test_all_evens(world);
+  errors += test_lattice_summation_awareness(world);
+  errors += test_probe_offset_radius(world);
 
   world.gop.fence();
   madness::finalize();

--- a/src/madness/mra/test_displacements.cc
+++ b/src/madness/mra/test_displacements.cc
@@ -1,0 +1,216 @@
+#include <madness/mra/mra.h>
+#include <madness/mra/displacements.h>
+#include <madness/world/test_utilities.h>
+
+using namespace madness;
+
+namespace {
+
+template <std::size_t NDIM>
+using Radii = std::array<std::optional<std::int64_t>, NDIM>;
+
+/// the range boundary, in boxes, for a kernel range of \p N half-simulation-cells at level \p n
+/// mirrors the conversion in the BoxSurfaceDisplacementRange constructor
+Translation radius_in_boxes(std::int64_t N, Level n) {
+  return (n == 0) ? (N + 1) / 2 : (N * Translation(1) << (n - 1));
+}
+
+/// the center box of the level-\p n grid
+template <std::size_t NDIM>
+Key<NDIM> centered_key(Level n) {
+  return Key<NDIM>(n, Vector<Translation, NDIM>(n == 0 ? 0 : (Translation(1) << (n - 1))));
+}
+
+/// keeps only destinations inside the simulation cell
+template <std::size_t NDIM>
+typename BoxSurfaceDisplacementRange<NDIM>::Validator in_domain_only() {
+  return [](const Level level, const typename BoxSurfaceDisplacementRange<NDIM>::PointPattern& dest,
+            std::optional<Key<NDIM>>&) -> bool {
+    const auto twon = (Translation(1) << level);
+    for (std::size_t d = 0; d != NDIM; ++d)
+      if (dest[d].has_value() && (*dest[d] < 0 || *dest[d] >= twon)) return false;
+    return true;
+  };
+}
+
+/// No displacement may be enumerated twice.
+/// We test any and cases where the logic splits, including lattice summed or not,
+/// and odd vs even N
+int test_no_duplicates(World& world) {
+  test_output t("BoxSurfaceDisplacementRange: no duplicate displacements", world.rank() == 0);
+
+  const auto check_unique = [&](auto ndim_tag, Level n, std::array<std::int64_t, decltype(ndim_tag)::value> N,
+                                bool lattice_summed, bool filter_to_domain, const std::string& what) {
+    constexpr std::size_t NDIM = decltype(ndim_tag)::value;
+    Radii<NDIM> box_radius, surface_thickness;
+    for (std::size_t d = 0; d != NDIM; ++d) {
+      box_radius[d] = N[d];
+      surface_thickness[d] = 1;
+    }
+    // N.B. the domain filter is only meaningful when the range boundary can land
+    // inside the cell at all.
+    BoxSurfaceDisplacementRange<NDIM> range(
+        centered_key<NDIM>(n), box_radius, surface_thickness, array_of_bools<NDIM>{lattice_summed},
+        filter_to_domain ? in_domain_only<NDIM>() : typename BoxSurfaceDisplacementRange<NDIM>::Validator{});
+    std::vector<Key<NDIM>> disps;
+    for (auto&& disp : range) disps.push_back(disp);
+    std::sort(disps.begin(), disps.end());
+    const auto last = std::unique(disps.begin(), disps.end());
+    t.checkpoint(!disps.empty(), what + ": surface is non-empty");
+    t.checkpoint(last == disps.end(), what + ": all displacements distinct");
+  };
+
+  constexpr auto d2 = std::integral_constant<std::size_t, 2>{};
+  constexpr auto d3 = std::integral_constant<std::size_t, 3>{};
+
+  // odd N and its even counterpart
+  check_unique(d2, 4, {1, 1}, false, true, "2D n=4 N={1,1} plain, in-domain");
+  check_unique(d2, 4, {1, 1}, false, false, "2D n=4 N={1,1} plain");
+  check_unique(d2, 4, {2, 2}, false, false, "2D n=4 N={2,2} plain");
+  // ... and both parities again with lattice summation on
+  check_unique(d2, 4, {1, 1}, true, false, "2D n=4 N={1,1} lattice-summed");
+  check_unique(d2, 4, {2, 2}, true, false, "2D n=4 N={2,2} lattice-summed");
+  check_unique(d2, 4, {2, 3}, true, false, "2D n=4 N={2,3} lattice-summed (mixed parity)");
+  // ... and in 3D, where each face has two free axes rather than one
+  check_unique(d3, 3, {1, 1, 1}, true, false, "3D n=3 N={1,1,1} lattice-summed");
+  check_unique(d3, 3, {2, 2, 2}, true, false, "3D n=3 N={2,2,2} lattice-summed");
+  check_unique(d3, 3, {1, 2, 3}, true, false, "3D n=3 N={1,2,3} lattice-summed (mixed parity)");
+
+  return t.end();
+}
+
+/// Test the cases where there is an odd box radius.
+int test_odds(World& world) {
+  test_output t("BoxSurfaceDisplacementRange: odd dimensions", world.rank() == 0);
+
+  Level level = 4;
+
+  const auto check_probe = [&](Level n, std::array<std::int64_t, 3> N, std::array<std::int64_t, 3> expected,
+                               const std::string& what) {
+    constexpr std::size_t NDIM = 3;
+    Radii<NDIM> box_radius, surface_thickness;
+    for (std::size_t d = 0; d != NDIM; ++d) {
+      box_radius[d] = N[d];
+      surface_thickness[d] = 1;
+    }
+    BoxSurfaceDisplacementRange<NDIM> range(centered_key<NDIM>(n), box_radius, surface_thickness,
+                                            array_of_bools<NDIM>{true} /* lattice_summed */);
+    const auto probe = range.probing_displacement().translation();
+    for (size_t d = 0; d < NDIM; d++) {
+      t.checkpoint(probe[d] == expected[d], "3D n=4 N=" + what + " component " + std::to_string(d));
+    }
+  };
+
+  check_probe(level, {3, 2, 1}, {0, 0, radius_in_boxes(1, level)}, "{3,2,1}");
+  check_probe(level, {1, 2, 3}, {radius_in_boxes(1, level), 0, 0}, "{1,2,3}");
+  check_probe(level, {1, 2, 1}, {radius_in_boxes(1, level), 0, 0}, "{1,2,1}");
+  check_probe(level, {3, 2, 3}, {radius_in_boxes(3, level), 0, 0}, "{3,2,3}");
+  return t.end();
+}
+
+/// Test the cases where there is an odd box radius.
+int test_singular(World& world) {
+  test_output t("BoxSurfaceDisplacementRange: singular cases", world.rank() == 0);
+
+  const auto check_probe = [&]<std::size_t NDIM>(Level n, std::array<std::int64_t, NDIM> N, std::array<std::int64_t, NDIM> expected,
+                               const std::string& what) {
+    Radii<NDIM> box_radius, surface_thickness;
+    for (std::size_t d = 0; d != NDIM; ++d) {
+      box_radius[d] = N[d];
+      surface_thickness[d] = 1;
+    }
+    BoxSurfaceDisplacementRange<NDIM> range(centered_key<NDIM>(n), box_radius, surface_thickness,
+                                            array_of_bools<NDIM>{true} /* lattice_summed */);
+    const auto probe = range.probing_displacement().translation();
+    for (size_t d = 0; d < NDIM; d++) {
+      t.checkpoint(probe[d] == expected[d], "1D n=" + std::to_string(n) + "N=" + what + " component " + std::to_string(d));
+    }
+  };
+
+  Level level = 4;
+  check_probe(level, std::array<std::int64_t, 1>{4}, {radius_in_boxes(4, level)}, "{2}");
+  check_probe(0, std::array<std::int64_t, 3>{3, 2, 1}, {0, 0, 1}, "{3,2,1}");
+  return t.end();
+}
+
+/// Test mixed boundary conditions
+int test_mixed(World& world) {
+  test_output t("BoxSurfaceDisplacementRange: mixed cases", world.rank() == 0);
+
+  Level level = 4;
+
+  const auto check_probe = [&]<std::size_t NDIM>(Level n, Radii<NDIM> box_radius, std::array<std::int64_t, NDIM> expected,
+                               const std::string& what) {
+    Radii<NDIM> surface_thickness;
+    for (std::size_t d = 0; d != NDIM; ++d) {
+      if (box_radius[d]) surface_thickness[d] = 1;
+    }
+    BoxSurfaceDisplacementRange<NDIM> range(centered_key<NDIM>(n), box_radius, surface_thickness,
+                                            array_of_bools<NDIM>{true} /* lattice_summed */);
+    const auto probe = range.probing_displacement().translation();
+    for (size_t d = 0; d < NDIM; d++) {
+      t.checkpoint(probe[d] == expected[d], what + " component " + std::to_string(d));
+    }
+  };
+
+
+  Radii<2> radii2d;
+  radii2d[1] = 2;
+  check_probe(level, radii2d, {-radius_in_boxes(1, level), radius_in_boxes(2, level)}, "2D n=4 N={*,2}");
+  radii2d[1] = 3;
+  check_probe(level, radii2d, {0, radius_in_boxes(3, level)}, "2D n=4 N={*,3}");
+  Radii<3> radii3d;
+  radii3d[1] = 2;
+  radii3d[2] = 3;
+  check_probe(level, radii3d, {0, 0, radius_in_boxes(3, level)}, "3D n=4 N={*,2,3}");
+  return t.end();
+}
+
+/// Test the cases where there is an odd box radius.
+int test_all_evens(World& world) {
+  test_output t("BoxSurfaceDisplacementRange: pure evens", world.rank() == 0);
+
+  Level level = 4;
+
+  const auto check_probe = [&](Level n, std::array<std::int64_t, 3> N, std::array<std::int64_t, 3> expected,
+                               const std::string& what) {
+    constexpr std::size_t NDIM = 3;
+    Radii<NDIM> box_radius, surface_thickness;
+    for (std::size_t d = 0; d != NDIM; ++d) {
+      box_radius[d] = N[d];
+      surface_thickness[d] = 1;
+    }
+    BoxSurfaceDisplacementRange<NDIM> range(centered_key<NDIM>(n), box_radius, surface_thickness,
+                                            array_of_bools<NDIM>{true} /* lattice_summed */);
+    const auto probe = range.probing_displacement().translation();
+    for (size_t d = 0; d < NDIM; d++) {
+      t.checkpoint(probe[d] == expected[d], "2D n=4 component " + std::to_string(d));
+    }
+  };
+
+  check_probe(level, {4, 6, 2}, {radius_in_boxes(1, level), 0, radius_in_boxes(2, level)}, "3D n=4 N={4,6,2}");
+  check_probe(level, {6, 2, 2}, {0, radius_in_boxes(2, level), radius_in_boxes(1, level)}, "3D n=4 N={6,2,2}");
+  check_probe(level, {8, 2, 2}, {0, radius_in_boxes(2, level), radius_in_boxes(1, level)}, "3D n=4 N={8,2,2}");
+  check_probe(level, {6, 4, 2}, {0, radius_in_boxes(1, level), radius_in_boxes(2, level)}, "3D n=4 N={6,4,2}");
+  check_probe(level, {4, 6, 4}, {radius_in_boxes(4, level), 0, radius_in_boxes(1, level)}, "3D n=4 N={4,6,2}");
+
+  return t.end();
+}
+
+}
+
+int main(int argc, char** argv) {
+  World& world = madness::initialize(argc, argv);
+  startup(world, argc, argv, true);
+
+  int errors = 0;
+  errors += test_no_duplicates(world);
+  errors += test_odds(world);
+  errors += test_singular(world);
+  errors += test_mixed(world);
+  errors += test_all_evens(world);
+
+  world.gop.fence();
+  madness::finalize();
+  return errors;
+}

--- a/src/madness/mra/test_displacements.cc
+++ b/src/madness/mra/test_displacements.cc
@@ -123,7 +123,7 @@ int test_singular(World& world) {
                                             array_of_bools<NDIM>{true} /* lattice_summed */);
     const auto probe = range.probing_displacement().translation();
     for (size_t d = 0; d < NDIM; d++) {
-      t.checkpoint(probe[d] == expected[d], "1D n=" + std::to_string(n) + "N=" + what + " component " + std::to_string(d));
+      t.checkpoint(probe[d] == expected[d], std::to_string(NDIM) + "D n=" + std::to_string(n) + " N=" + what + " component " + std::to_string(d));
     }
   };
 
@@ -184,15 +184,15 @@ int test_all_evens(World& world) {
                                             array_of_bools<NDIM>{true} /* lattice_summed */);
     const auto probe = range.probing_displacement().translation();
     for (size_t d = 0; d < NDIM; d++) {
-      t.checkpoint(probe[d] == expected[d], "2D n=4 component " + std::to_string(d));
+      t.checkpoint(probe[d] == expected[d], std::to_string(NDIM) + "D n=" + std::to_string(n) + " N=" + what + " component " + std::to_string(d));
     }
   };
 
-  check_probe(level, {4, 6, 2}, {radius_in_boxes(1, level), 0, radius_in_boxes(2, level)}, "3D n=4 N={4,6,2}");
-  check_probe(level, {6, 2, 2}, {0, radius_in_boxes(2, level), radius_in_boxes(1, level)}, "3D n=4 N={6,2,2}");
-  check_probe(level, {8, 2, 2}, {0, radius_in_boxes(2, level), radius_in_boxes(1, level)}, "3D n=4 N={8,2,2}");
-  check_probe(level, {6, 4, 2}, {0, radius_in_boxes(1, level), radius_in_boxes(2, level)}, "3D n=4 N={6,4,2}");
-  check_probe(level, {4, 6, 4}, {radius_in_boxes(4, level), 0, radius_in_boxes(1, level)}, "3D n=4 N={4,6,2}");
+  check_probe(level, {4, 6, 2}, {radius_in_boxes(1, level), 0, radius_in_boxes(2, level)}, "{4,6,2}");
+  check_probe(level, {6, 2, 2}, {0, radius_in_boxes(2, level), radius_in_boxes(1, level)}, "{6,2,2}");
+  check_probe(level, {8, 2, 2}, {0, radius_in_boxes(2, level), radius_in_boxes(1, level)}, "{8,2,2}");
+  check_probe(level, {6, 4, 2}, {0, radius_in_boxes(1, level), radius_in_boxes(2, level)}, "{6,4,2}");
+  check_probe(level, {4, 6, 4}, {radius_in_boxes(4, level), 0, radius_in_boxes(1, level)}, "{4,6,2}");
 
   return t.end();
 }

--- a/src/madness/mra/testgconv.cc
+++ b/src/madness/mra/testgconv.cc
@@ -367,55 +367,7 @@ int test_gconv(World& world) {
     // test convolution with range restricted Gaussians
     ///////////////////////////////////////////////////
 
-    // validate BoxSurfaceDisplacementRange by making sure
-    // - it does not produce duplicate displacements
-    {
-      constexpr auto ND = 2;
-      const int n = 4;
-      Key<ND> key(n, Vector<Translation, ND>(1<<(n-1)));
-
-      std::size_t disp_count = 0;
-      const auto process_surface_displacements =
-          [&]() {
-            std::array<std::optional<std::int64_t>, ND> box_radius;
-            std::array<std::optional<std::int64_t>, ND> surface_thickness;
-            for (int d = 0; d != ND; ++d) {
-              box_radius[d] = 1;
-              surface_thickness[d] = 1;
-            }
-            BoxSurfaceDisplacementRange<ND> range_boundary_face_displacements(
-                key, box_radius, surface_thickness, array_of_bools<ND>{false},
-                [&](const auto level, const auto &dest, const auto &displacement) -> bool {
-                  // skip displacements not in domain
-                  const auto twon = (1 << level);
-                  for (auto d = 0; d != ND; ++d) {
-                    if (dest[d].has_value()) {
-                      if (dest[d] < 0 ||
-                          dest[d] >= twon)
-                        return false;
-                    }
-                  }
-                  return true;
-                });
-            std::vector<Key<ND>> disps;
-            for (auto &&disp : range_boundary_face_displacements) {
-//              std::cout << "disp = " << disp << " dest = " << key.neighbor(disp)
-//                        << std::endl;
-              disps.push_back(disp);
-              ++disp_count;
-            }
-            std::sort(disps.begin(), disps.end());
-            auto it = std::unique(disps.begin(), disps.end());
-
-            if (it != disps.end()) {
-              std::cout << "Duplicates found!!" << std::endl;
-              success++;
-            }
-          };
-      process_surface_displacements();
-    }
-
-    // now test the convolutions
+    // test the convolutions
     if constexpr (NDIM == 1) {
 
       int nerrors = 0;


### PR DESCRIPTION
Supercedes #732. The new algorithm is much simpler.

1. Displace on the origin of the smallest odd-radius face if possible.
2. If we can't do that, choose the smallest even-radius face. That's equivalent to the origin, so now we displace a half-radius along another dimension. Choose the second-smallest even radius face. Failing that, just choose the first open face.

Tests pass locally. Testing on cluster in-progress. Don't merge until that's done.

Changes are expected all across the board, but the even ones are the most important.

