### PR TITLE
Pr bsh apply

### DIFF
--- a/src/madness/chem/CalculationParameters.h
+++ b/src/madness/chem/CalculationParameters.h
@@ -68,10 +68,10 @@ struct CalculationParameters : public QCCalculationParametersBase {
 		initialize<double>("charge",0.0,"total molecular charge");
 		initialize<std::string> ("xc","hf","XC input line");
 		initialize<std::string> ("hfexalg","multiworld_row","hf exchange algorithm; multiworld bounds memory, needs one subworld per rank",{"multiworld","multiworld_row","fetch_compute","smallmem","largemem"});
-		initialize<long>  ("hfex_batch_granularity",1,"hfexalg=multiworld: orbital batches per rank; >1 balances better");
-		initialize<bool>  ("hfex_cost_aware_assign",true,"hfexalg=multiworld: place tasks by measured cost, not by count");
-		initialize<int>   ("hfex_local_accumulation",2,"hfexalg=multiworld: gather tile results 1=per subworld, 2=per node");
-		initialize<std::string>("bsh_apply","auto","BSH operator apply backend in compute_residual: auto=macrotask multinode or at tight thresh, tile otherwise; tile=rank-aware memory-bounded loop; macrotask=distribute across subworlds (rank-local apply, memory-frugal); plain=single un-tiled apply",{"auto","tile","macrotask","plain"});
+		initialize<long>  ("hfex_granularity",1,"hfexalg=multiworld: orbital batches per rank; >1 balances better");
+		initialize<bool>  ("hfex_cost_aware",true,"hfexalg=multiworld: place tasks by measured cost, not by count");
+		initialize<int>   ("hfex_accumulation",2,"hfexalg=multiworld: gather tile results 1=per subworld, 2=per node");
+		initialize<std::string>("bsh_apply","auto","BSH apply backend; auto=macrotask when multinode or at tight thresh, else tile",{"auto","tile","macrotask","plain"});
 		initialize<std::vector<std::string>>("memory",{"storefunction","nodereplicated","distributed"},"memory algorithm for storing functions (storing,cloud,target)");
 		initialize<double>("smear",0.0,"smearing parameter");
 		initialize<double>("econv",1.e-5,"energy convergence");
@@ -209,9 +209,9 @@ struct CalculationParameters : public QCCalculationParametersBase {
 	std::string ac_data() const {return get<std::string>("ac_data");}
 	std::string xc() const {return get<std::string>("xc");}
     std::string hfexalg() const {return get<std::string>("hfexalg");}
-    long hfex_batch_granularity() const {return get<long>("hfex_batch_granularity");}
-    bool hfex_cost_aware_assign() const {return get<bool>("hfex_cost_aware_assign");}
-    int hfex_local_accumulation() const {return get<int>("hfex_local_accumulation");}
+    long hfex_granularity() const {return get<long>("hfex_granularity");}
+    bool hfex_cost_aware() const {return get<bool>("hfex_cost_aware");}
+    int hfex_accumulation() const {return get<int>("hfex_accumulation");}
 	std::string bsh_apply() const {return get<std::string>("bsh_apply");}
 
 	std::vector<std::string> memory() const {return get<std::vector<std::string>>("memory");}

--- a/src/madness/chem/CalculationParameters.h
+++ b/src/madness/chem/CalculationParameters.h
@@ -72,12 +72,6 @@ struct CalculationParameters : public QCCalculationParametersBase {
 		initialize<bool>  ("hfex_cost_aware_assign",true,"hfexalg=multiworld: place tasks by measured cost, not by count");
 		initialize<int>   ("hfex_local_accumulation",2,"hfexalg=multiworld: gather tile results 1=per subworld, 2=per node");
 		initialize<std::string>("bsh_apply","auto","BSH operator apply backend in compute_residual: auto=macrotask multinode or at tight thresh, tile otherwise; tile=rank-aware memory-bounded loop; macrotask=distribute across subworlds (rank-local apply, memory-frugal); plain=single un-tiled apply",{"auto","tile","macrotask","plain"});
-		initialize<int>   ("bsh_apply_nworld",0,"bsh_apply=macrotask: number of subworlds for the BSH apply (0=auto=nrank, i.e. 1 rank/subworld); lower it (e.g. 2) for more ranks per apply");
-		initialize<int>   ("bsh_apply_max_batch",0,"bsh_apply=macrotask: max orbitals per BSH apply task (0=partitioner default); smaller = less memory per task");
-		initialize<int>   ("bsh_apply_min_batch",0,"bsh_apply=macrotask: min orbitals per BSH apply task (0=partitioner default)");
-		initialize<int>   ("bsh_apply_max_tile",0,"bsh_apply=tile: cap orbitals per tile (0=auto=min(nmo,10*nproc)); set it to bound peak memory on large/tight-thresh runs where the auto tile is the whole MO vector");
-		initialize<std::string>("bsh_apply_policy","small_memory","bsh_apply=macrotask: cloud storage preset. small_memory=StoreFunctionViaPointer (pointers in cloud, coeffs streamed to subworlds); default/large_memory=StoreFunction (full functions replicated per rank)",{"small_memory","small_memory_owner","default","large_memory","node_replicated_target"});
-		initialize<bool>  ("bsh_apply_memcheck",false,"if true, print a MemoryMeasurer map after each BSH apply (adds fences; use for memory comparison, not timing)");
 		initialize<std::vector<std::string>>("memory",{"storefunction","nodereplicated","distributed"},"memory algorithm for storing functions (storing,cloud,target)");
 		initialize<double>("smear",0.0,"smearing parameter");
 		initialize<double>("econv",1.e-5,"energy convergence");
@@ -219,12 +213,6 @@ struct CalculationParameters : public QCCalculationParametersBase {
     bool hfex_cost_aware_assign() const {return get<bool>("hfex_cost_aware_assign");}
     int hfex_local_accumulation() const {return get<int>("hfex_local_accumulation");}
 	std::string bsh_apply() const {return get<std::string>("bsh_apply");}
-	int bsh_apply_nworld() const {return get<int>("bsh_apply_nworld");}
-	int bsh_apply_max_batch() const {return get<int>("bsh_apply_max_batch");}
-	int bsh_apply_min_batch() const {return get<int>("bsh_apply_min_batch");}
-	int bsh_apply_max_tile() const {return get<int>("bsh_apply_max_tile");}
-	std::string bsh_apply_policy() const {return get<std::string>("bsh_apply_policy");}
-	bool bsh_apply_memcheck() const {return get<bool>("bsh_apply_memcheck");}
 
 	std::vector<std::string> memory() const {return get<std::vector<std::string>>("memory");}
 

--- a/src/madness/chem/CalculationParameters.h
+++ b/src/madness/chem/CalculationParameters.h
@@ -71,6 +71,13 @@ struct CalculationParameters : public QCCalculationParametersBase {
 		initialize<long>  ("hfex_batch_granularity",1,"hfexalg=multiworld: orbital batches per rank; >1 balances better");
 		initialize<bool>  ("hfex_cost_aware_assign",true,"hfexalg=multiworld: place tasks by measured cost, not by count");
 		initialize<int>   ("hfex_local_accumulation",2,"hfexalg=multiworld: gather tile results 1=per subworld, 2=per node");
+		initialize<std::string>("bsh_apply","auto","BSH operator apply backend in compute_residual: auto=macrotask multinode or at tight thresh, tile otherwise; tile=rank-aware memory-bounded loop; macrotask=distribute across subworlds (rank-local apply, memory-frugal); plain=single un-tiled apply",{"auto","tile","macrotask","plain"});
+		initialize<int>   ("bsh_apply_nworld",0,"bsh_apply=macrotask: number of subworlds for the BSH apply (0=auto=nrank, i.e. 1 rank/subworld); lower it (e.g. 2) for more ranks per apply");
+		initialize<int>   ("bsh_apply_max_batch",0,"bsh_apply=macrotask: max orbitals per BSH apply task (0=partitioner default); smaller = less memory per task");
+		initialize<int>   ("bsh_apply_min_batch",0,"bsh_apply=macrotask: min orbitals per BSH apply task (0=partitioner default)");
+		initialize<int>   ("bsh_apply_max_tile",0,"bsh_apply=tile: cap orbitals per tile (0=auto=min(nmo,10*nproc)); set it to bound peak memory on large/tight-thresh runs where the auto tile is the whole MO vector");
+		initialize<std::string>("bsh_apply_policy","small_memory","bsh_apply=macrotask: cloud storage preset. small_memory=StoreFunctionViaPointer (pointers in cloud, coeffs streamed to subworlds); default/large_memory=StoreFunction (full functions replicated per rank)",{"small_memory","small_memory_owner","default","large_memory","node_replicated_target"});
+		initialize<bool>  ("bsh_apply_memcheck",false,"if true, print a MemoryMeasurer map after each BSH apply (adds fences; use for memory comparison, not timing)");
 		initialize<std::vector<std::string>>("memory",{"storefunction","nodereplicated","distributed"},"memory algorithm for storing functions (storing,cloud,target)");
 		initialize<double>("smear",0.0,"smearing parameter");
 		initialize<double>("econv",1.e-5,"energy convergence");
@@ -211,6 +218,13 @@ struct CalculationParameters : public QCCalculationParametersBase {
     long hfex_batch_granularity() const {return get<long>("hfex_batch_granularity");}
     bool hfex_cost_aware_assign() const {return get<bool>("hfex_cost_aware_assign");}
     int hfex_local_accumulation() const {return get<int>("hfex_local_accumulation");}
+	std::string bsh_apply() const {return get<std::string>("bsh_apply");}
+	int bsh_apply_nworld() const {return get<int>("bsh_apply_nworld");}
+	int bsh_apply_max_batch() const {return get<int>("bsh_apply_max_batch");}
+	int bsh_apply_min_batch() const {return get<int>("bsh_apply_min_batch");}
+	int bsh_apply_max_tile() const {return get<int>("bsh_apply_max_tile");}
+	std::string bsh_apply_policy() const {return get<std::string>("bsh_apply_policy");}
+	bool bsh_apply_memcheck() const {return get<bool>("bsh_apply_memcheck");}
 
 	std::vector<std::string> memory() const {return get<std::vector<std::string>>("memory");}
 

--- a/src/madness/chem/SCF.cc
+++ b/src/madness/chem/SCF.cc
@@ -39,7 +39,6 @@
 #include "tensor_json.hpp"
 #include <madness/world/worldmem.h>
 #include <madness/world/ranks_and_hosts.h>
-#include <madness/mra/memory_measurement.h>
 #include <madness.h>
 #include <madness/chem/SCF.h>
 #include <madchem.h>
@@ -1579,13 +1578,11 @@ void SCF::vector_stats(const std::vector<double>& v, double& rms,
     rms = sqrt(rms / v.size());
 }
 
-/// ~10 orbitals per rank in flight, capped by bsh_apply_max_tile; nmo (one chunk) for
-/// small systems. Shared by the tiled BSH apply and the residual transform.
-static size_t bsh_tile_size(size_t nmo, size_t nranks, long max_tile) {
+/// ~10 orbitals per rank in flight; nmo (one chunk) for small systems.
+/// Shared by the tiled BSH apply and the residual transform.
+static size_t bsh_tile_size(size_t nmo, size_t nranks) {
     const size_t min_tile = 10;
-    size_t ntile = std::min(std::max<size_t>(nmo, 1), min_tile * std::max<size_t>(nranks, 1));
-    if (max_tile > 0) ntile = std::min(ntile, size_t(max_tile));
-    return ntile;
+    return std::min(std::max<size_t>(nmo, 1), min_tile * std::max<size_t>(nranks, 1));
 }
 
 /// loose/tight divide of the bsh_apply dispatch: at thresh <= this, auto switches to
@@ -1658,14 +1655,8 @@ vecfuncT SCF::apply_bsh_macrotask(World& world, vecfuncT& Vpsi, const tensorT& e
 
     START_TIMER(world);
     ApplyTask apply_task;
-    const long nw = param.bsh_apply_nworld();
-    // Owner-pinning needs nworld==nranks (slot == physical rank) and batch=1 (one owner
-    // per task); an explicit conflicting request wins and the redistribute is skipped.
-    if (redistribute && ((nw > 0 && nw != world.size()) || batch != 1)) {
-        if (param.print_level() >= 2 && world.rank() == 0)
-            print("BSH apply: skipping the operand redistribute (needs nworld=nranks and batch=1)");
-        redistribute = false;
-    }
+    MADNESS_CHECK_THROW(!redistribute || batch == 1,
+                        "the BSH operand redistribute requires batch=1 (one owner per task)");
     // cost-balanced assignment, computed UP FRONT from Vpsi's original distribution;
     // it drives BOTH the redistribute and owner_hint -- they MUST share one assignment
     std::vector<ProcessID> bsh_owner;
@@ -1673,16 +1664,15 @@ vecfuncT SCF::apply_bsh_macrotask(World& world, vecfuncT& Vpsi, const tensorT& e
         bsh_owner = assign_cost_aware(function_costs(world, Vpsi), world.size());
         apply_task.owner_ = bsh_owner;
     }
-    // batch > 0 (from the auto dispatch) overrides the explicit params; 0 = default
-    const long maxb = batch > 0 ? batch : param.bsh_apply_max_batch();
-    const long minb = batch > 0 ? batch : param.bsh_apply_min_batch();
-    if (maxb > 0) apply_task.partitioner->set_max_batch_size(maxb);
-    if (minb > 0) apply_task.partitioner->set_min_batch_size(minb);
+    if (batch > 0) {
+        apply_task.partitioner->set_max_batch_size(batch);
+        apply_task.partitioner->set_min_batch_size(batch);
+    }
     auto factory = MacroTaskQFactory(world);
     // small_memory = StoreFunctionViaPointer: pointers in the cloud, coeffs streamed
-    factory.set_policy(MacroTaskInfo::preset(param.bsh_apply_policy()));
+    factory.set_policy(MacroTaskInfo::preset("small_memory"));
+    // owner-pinning needs nworld==nranks (subworld slot == physical rank)
     if (redistribute) factory.set_nworld(world.size());
-    else if (nw > 0) factory.set_nworld(nw);
     // printlevel 5 (not 3) so printtimings_detail fires -> the BSH taskq prints its own
     // "finalize gaxpy (sw->universe)" line; still <10 so no per-task debug flood.
     if (param.print_level() >= 10) factory.set_printlevel(5);
@@ -1733,7 +1723,7 @@ vecfuncT SCF::apply_bsh_tiled(World& world, vecfuncT& Vpsi, const tensorT& eps,
                               const CalculationParameters& param) {
     START_TIMER(world);
     const size_t nfunc = Vpsi.size();
-    const size_t ntile = bsh_tile_size(nfunc, world.size(), param.bsh_apply_max_tile());
+    const size_t ntile = bsh_tile_size(nfunc, world.size());
     vecfuncT new_psi(nfunc);
     for (size_t ilo=0; ilo<nfunc; ilo+=ntile) {
         size_t iend = std::min(ilo+ntile,nfunc);
@@ -1806,7 +1796,7 @@ vecfuncT SCF::compute_residual(World& world, tensorT& occ, tensorT& fock,
     // a single chunk (identical path) for small systems. fock keeps the -eps shift
     // across chunks (restored after the loop).
     {
-        const size_t ntile = bsh_tile_size(nmo, world.size(), param.bsh_apply_max_tile());
+        const size_t ntile = bsh_tile_size(nmo, world.size());
         for (size_t ilo = 0; ilo < size_t(nmo); ilo += ntile) {
             size_t iend = std::min(ilo + ntile, size_t(nmo));
             vecfuncT fpsi = transform(world, psi,
@@ -1832,7 +1822,7 @@ vecfuncT SCF::compute_residual(World& world, tensorT& occ, tensorT& fock,
     // binds); tile on a single node at loose/medium (no gather, no subworld copy).
     std::string bsh_apply_mode = param.bsh_apply();
     const bool tight = FunctionDefaults<3>::get_thresh() <= BSH_TIGHT_THRESH;
-    long batch = 0;   // 0 = bsh_apply_{min,max}_batch or partitioner default
+    long batch = 0;   // 0 = partitioner default
     if (bsh_apply_mode == "auto") {
         const long n_nodes = long(ranks_per_host(world).size());   // collective
         bsh_apply_mode = (n_nodes >= 2 or tight) ? "macrotask" : "tile";
@@ -1847,22 +1837,13 @@ vecfuncT SCF::compute_residual(World& world, tensorT& occ, tensorT& fock,
     // the redistribute + local fetch collapse it; at loose/medium the move is a net
     // loss. Applies to auto and to explicit bsh_apply=macrotask.
     bool redistribute = (bsh_apply_mode == "macrotask") and tight;
-    if (redistribute and batch == 0
-        and param.bsh_apply_max_batch() == 0 and param.bsh_apply_min_batch() == 0)
-        batch = 1;   // explicit macrotask mode at tight: default to owner-coherent tasks
+    if (redistribute) batch = 1;   // one owner per task (explicit macrotask mode included)
     if (redistribute and param.print_level() >= 2 and world.rank() == 0)
         print("BSH apply: redistribute operand to single-owner batches (tight protocol)");
     vecfuncT new_psi;
     if (bsh_apply_mode == "macrotask")  new_psi = apply_bsh_macrotask(world, Vpsi, eps, param, batch, redistribute);
     else if (bsh_apply_mode == "plain") new_psi = apply_bsh_plain(world, Vpsi, eps, param);
     else                                new_psi = apply_bsh_tiled(world, Vpsi, eps, param);
-
-    // memory snapshot at a consistent point (inputs freed, new_psi built); the RSS
-    // still shows the in-apply high water. Adds fences -- memory runs only.
-    if (param.bsh_apply_memcheck()) {
-        if (world.rank() == 0) print("=== BSH apply memcheck, mode:", param.bsh_apply(), "===");
-        MemoryMeasurer::measure_and_print(world);
-    }
 
     // Thought it was a bad idea to truncate *before* computing the residual
     // but simple tests suggest otherwise ... no more iterations and

--- a/src/madness/chem/SCF.cc
+++ b/src/madness/chem/SCF.cc
@@ -1756,14 +1756,29 @@ vecfuncT SCF::compute_residual(World& world, tensorT& occ, tensorT& fock,
         eps(i) = std::min(-0.05, fock(i, i));
         fock(i, i) -= eps(i);
     }
-    vecfuncT fpsi = transform(world, psi, fock, trantol, true);
 
-    for (int i = 0; i < nmo; ++i) { // Undo the damage
+    // Vpsi -= psi*fock, tiled over output columns: untiled transform() materializes all
+    // nmo fpsi next to psi+Vpsi, ~3x orbital memory at tight thresh -- an OOM upstream
+    // of the (memory-frugal) BSH apply. ntile fpsi live at once -> ~2x + one chunk;
+    // a single chunk (identical path) for small systems. fock keeps the -eps shift
+    // across chunks (restored after the loop).
+    {
+        const size_t ntile = bsh_tile_size(nmo, world.size(), param.bsh_apply_max_tile());
+        for (size_t ilo = 0; ilo < size_t(nmo); ilo += ntile) {
+            size_t iend = std::min(ilo + ntile, size_t(nmo));
+            vecfuncT fpsi = transform(world, psi,
+                                      fock(_, Slice(long(ilo), long(iend) - 1)), trantol, true);
+            for (size_t i = ilo; i < iend; ++i)
+                Vpsi[i].gaxpy(1.0, fpsi[i - ilo], -1.0, false);
+            world.gop.fence();
+            fpsi.clear();   // free this chunk before building the next
+        }
+    }
+
+    for (int i = 0; i < nmo; ++i) { // Undo the damage (after all chunks used the shift)
         fock(i, i) += eps(i);
     }
 
-    gaxpy(world, 1.0, Vpsi, -1.0, fpsi);
-    fpsi.clear();
     std::vector<double> fac(nmo, -2.0);
     scale(world, Vpsi, fac);
     END_TIMER(world, "Compute residual stuff");

--- a/src/madness/chem/SCF.cc
+++ b/src/madness/chem/SCF.cc
@@ -1383,9 +1383,9 @@ vecfuncT SCF::apply_potential(World& world, const tensorT& occ,
         K.set_symmetric(true).set_printlevel(param.print_level());
         K.set_macro_task_info(MacroTaskInfo::preset("default"));
         K.set_macro_task_info(param.memory());
-        K.set_batch_granularity(param.hfex_batch_granularity());
-        K.set_accumulation_mode(param.hfex_local_accumulation());
-        K.set_cost_aware_assignment(param.hfex_cost_aware_assign());
+        K.set_batch_granularity(param.hfex_granularity());
+        K.set_accumulation_mode(param.hfex_accumulation());
+        K.set_cost_aware_assignment(param.hfex_cost_aware());
 
         vecfuncT Kamo = K(amo);
         tensorT excv = inner(world, Kamo, amo);

--- a/src/madness/chem/SCF.cc
+++ b/src/madness/chem/SCF.cc
@@ -38,6 +38,8 @@
 #include "funcdefaults.h"
 #include "tensor_json.hpp"
 #include <madness/world/worldmem.h>
+#include <madness/world/ranks_and_hosts.h>
+#include <madness/mra/memory_measurement.h>
 #include <madness.h>
 #include <madness/chem/SCF.h>
 #include <madchem.h>
@@ -1577,43 +1579,172 @@ void SCF::vector_stats(const std::vector<double>& v, double& rms,
     rms = sqrt(rms / v.size());
 }
 
-vecfuncT SCF::compute_residual(World& world, tensorT& occ, tensorT& fock,
-                               const vecfuncT& psi, vecfuncT& Vpsi, double& err) {
+/// ~10 orbitals per rank in flight, capped by bsh_apply_max_tile; nmo (one chunk) for
+/// small systems. Shared by the tiled BSH apply and the residual transform.
+static size_t bsh_tile_size(size_t nmo, size_t nranks, long max_tile) {
+    const size_t min_tile = 10;
+    size_t ntile = std::min(std::max<size_t>(nmo, 1), min_tile * std::max<size_t>(nranks, 1));
+    if (max_tile > 0) ntile = std::min(ntile, size_t(max_tile));
+    return ntile;
+}
 
+/// loose/tight divide of the bsh_apply dispatch: at thresh <= this, auto switches to
+/// the memory-conservative macrotask configuration (one orbital per task).
+static constexpr double BSH_TIGHT_THRESH = 1.0e-7;
 
-    // apply the BSH operator in a Macrotask to reduce communication and possible hangs
+vecfuncT SCF::apply_bsh_macrotask(World& world, vecfuncT& Vpsi, const tensorT& eps,
+                                  const CalculationParameters& param, long batch) {
     class ApplyTask : public MacroTaskOperationBase {
     public:
         ApplyTask() {
-            name="applytask";
+            name="apply_bsh";
         }
-        // you need to define the exact argument(s) of operator() as tuple
         typedef std::tuple<const std::vector<real_function_3d> &, const Tensor<double>&,
         const CalculationParameters&> argtupleT;
-
-        // you need to define the result type
-        // resultT must implement gaxpy(alpha, result, beta, contribution)
-        // with resultT result, contribution;
         using resultT = std::vector<real_function_3d>;
 
-        // you need to define an empty constructor for the result
+        // called in the universe (full argtuple -> full-size result) and in each subworld
+        // (batched argtuple -> batch-size result); sizing from the input vector fits both.
         resultT allocator(World &world, const argtupleT &argtuple) const {
             std::size_t n = std::get<0>(argtuple).size();
-            resultT result = zero_functions_compressed<double, 3>(world, n);
-            return result;
+            return zero_functions_compressed<double, 3>(world, n);
         }
 
         resultT operator()(const std::vector<real_function_3d> &Vpsi,
             const Tensor<double>& eps, const CalculationParameters& param) const {
-            World& world=Vpsi.front().world();
+            // the framework deep-copied the batch into the subworld;
+            // Vpsi.front().world() IS the subworld
+            World& world = Vpsi.front().world();
             MADNESS_CHECK_THROW(eps.ndim()==1,"need a 1D tensor for eps in ApplyTask");
-            Tensor<double> batched_eps=eps(Slice(batch.input[0].begin,batch.input[0].end-1));
-            MADNESS_CHECK_THROW(batched_eps.size()==batch.input[0].size(),"batched eps size mismatch");
+            // slice eps to this task's batch (Slice end inclusive; full-size batch -> -1).
+            const long b = batch.input[0].begin;
+            const long e = batch.input[0].is_full_size() ? eps.size() : batch.input[0].end;
+            Tensor<double> batched_eps=eps(Slice(b, e-1));
+            MADNESS_CHECK_THROW(batched_eps.size()==static_cast<long>(Vpsi.size()),
+                                "batched eps size mismatch in ApplyTask");
             std::vector<poperatorT> ops = make_bsh_operators(world, batched_eps,param);
-            vecfuncT new_psi = apply(world, ops, Vpsi);
+            vecfuncT tmp_Vpsi = Vpsi;   // shallow copies; set_thresh mutates impl state
+            set_thresh(world, tmp_Vpsi, FunctionDefaults<3>::get_thresh());
+            // in-subworld apply+truncate; framework overhead = outer timer - this
+            const bool instr = param.print_level() >= 10;
+            const double in_gb = instr ? get_size(world, tmp_Vpsi) : 0.0;
+            const double w0 = wall_time();
+            vecfuncT new_psi = apply(world, ops, tmp_Vpsi);
+            const double w1 = wall_time();
+            truncate(world, new_psi);   // in-subworld so the universe gaxpy stays small
+            const double w2 = wall_time();
+            if (instr and world.rank() == 0)
+                printf("  [ApplyTask sw nrank=%d nfunc=%zu apply=%.2fs truncate=%.2fs in=%.3fGB out=%.3fGB]\n",
+                       world.size(), tmp_Vpsi.size(), w1 - w0, w2 - w1, in_gb,
+                       get_size(world, new_psi));
             return new_psi;
         }
     };
+
+    START_TIMER(world);
+    ApplyTask apply_task;
+    // batch > 0 (from the auto dispatch) overrides the explicit params; 0 = default
+    const long maxb = batch > 0 ? batch : param.bsh_apply_max_batch();
+    const long minb = batch > 0 ? batch : param.bsh_apply_min_batch();
+    if (maxb > 0) apply_task.partitioner->set_max_batch_size(maxb);
+    if (minb > 0) apply_task.partitioner->set_min_batch_size(minb);
+    auto factory = MacroTaskQFactory(world);
+    // small_memory = StoreFunctionViaPointer: pointers in the cloud, coeffs streamed
+    factory.set_policy(MacroTaskInfo::preset(param.bsh_apply_policy()));
+    const long nw = param.bsh_apply_nworld();
+    if (nw > 0) factory.set_nworld(nw);
+    // printlevel 5 (not 3) so printtimings_detail fires -> the BSH taskq prints its own
+    // "finalize gaxpy (sw->universe)" line; still <10 so no per-task debug flood.
+    if (param.print_level() >= 10) factory.set_printlevel(5);
+    MacroTask macrotask(world, apply_task, factory);
+    const bool instr = param.print_level() >= 10;
+    const double vpsi_gb = instr ? get_size(world, Vpsi) : 0.0;
+    vecfuncT new_psi = macrotask(Vpsi, eps, param);
+    Vpsi.clear();
+    world.gop.fence();
+    if (instr) {
+        const double newpsi_gb = get_size(world, new_psi);
+        // fence-free getrusage high-water; rss_max = worst rank, rss_tot = sum
+        double rss_max = madness::get_rss_usage_in_GB();
+        double rss_tot = rss_max;
+        world.gop.max(rss_max); world.gop.sum(rss_tot);
+        if (world.rank() == 0) {
+            auto cs = macrotask.get_taskq()->get_cloud_statistics();
+            printf("  [BSH macrotask: held Vpsi=%.2fGB (%.3f/rank) result=%.2fGB | "
+                   "comm deep-copy max=%.2fs av=%.2fs | cloud-read max=%.2fs | write=%.2fs | tgt-repl=%.2fs"
+                   " | peakRSS max=%.2fGB/rank tot=%.2fGB]\n",
+                   vpsi_gb, vpsi_gb/std::max<int>(1,world.size()), newpsi_gb,
+                   cs.value("copy_time_max_s",-1.0), cs.value("copy_time_av_s",-1.0),
+                   cs.value("reading_time_max_s",-1.0), cs.value("writing_time_s",-1.0),
+                   cs.value("target_replication_time_s",-1.0),
+                   rss_max, rss_tot);
+        }
+    }
+    END_TIMER(world, "Apply BSH (macrotask)");
+    return new_psi;
+}
+
+/// Tiled apply: bounds the nonstandard working set to ~10 orbitals/rank (bsh_tile_size);
+/// the untiled apply converts every orbital at once and OOMs large systems. Consumes Vpsi.
+vecfuncT SCF::apply_bsh_tiled(World& world, vecfuncT& Vpsi, const tensorT& eps,
+                              const CalculationParameters& param) {
+    START_TIMER(world);
+    const size_t nfunc = Vpsi.size();
+    const size_t ntile = bsh_tile_size(nfunc, world.size(), param.bsh_apply_max_tile());
+    vecfuncT new_psi(nfunc);
+    for (size_t ilo=0; ilo<nfunc; ilo+=ntile) {
+        size_t iend = std::min(ilo+ntile,nfunc);
+        vecfuncT tmp_Vpsi(Vpsi.begin()+ilo,Vpsi.begin()+iend);
+        // eps(i) == min(-0.05, fock(i,i)) for the whole vector; slice it for this tile.
+        tensorT tmp_eps = eps(Slice(long(ilo), long(iend)-1));
+        std::vector<poperatorT> ops = make_bsh_operators(world, tmp_eps, param);
+        set_thresh(world, tmp_Vpsi, FunctionDefaults<3>::get_thresh());
+        vecfuncT tmp_new_psi = apply(world, ops, tmp_Vpsi);
+        truncate(world, tmp_new_psi);
+        // results home, inputs freed as the loop advances
+        for (size_t i = ilo; i<iend; ++i){
+            new_psi[i] = std::move(tmp_new_psi[i-ilo]);
+            Vpsi[i].clear(false);
+        }
+        ops.clear();
+    }
+    Vpsi.clear();
+    world.gop.fence();
+    if (param.print_level() >= 10) {   // peak RSS, comparable to the macrotask print
+        double rss_max = madness::get_rss_usage_in_GB(), rss_tot = rss_max;
+        world.gop.max(rss_max); world.gop.sum(rss_tot);
+        if (world.rank() == 0)
+            printf("  [BSH tile: peakRSS max=%.2fGB/rank tot=%.2fGB]\n", rss_max, rss_tot);
+    }
+    END_TIMER(world, "Apply BSH");
+    return new_psi;
+}
+
+/// Single un-tiled apply (small systems / debugging). Consumes Vpsi.
+vecfuncT SCF::apply_bsh_plain(World& world, vecfuncT& Vpsi, const tensorT& eps,
+                              const CalculationParameters& param) {
+    START_TIMER(world);
+    std::vector<poperatorT> ops = make_bsh_operators(world, eps, param);
+    set_thresh(world, Vpsi, FunctionDefaults<3>::get_thresh());
+    vecfuncT new_psi = apply(world, ops, Vpsi);
+    ops.clear();
+    Vpsi.clear();
+    world.gop.fence();
+    if (param.print_level() >= 10) {
+        double rss_max = madness::get_rss_usage_in_GB(), rss_tot = rss_max;
+        world.gop.max(rss_max); world.gop.sum(rss_tot);
+        if (world.rank() == 0)
+            printf("  [BSH plain: peakRSS max=%.2fGB/rank tot=%.2fGB]\n", rss_max, rss_tot);
+    }
+    END_TIMER(world, "Apply BSH");
+    START_TIMER(world);
+    truncate(world, new_psi);
+    END_TIMER(world, "Truncate new psi");
+    return new_psi;
+}
+
+vecfuncT SCF::compute_residual(World& world, tensorT& occ, tensorT& fock,
+                               const vecfuncT& psi, vecfuncT& Vpsi, double& err) {
 
     START_TIMER(world);
     PROFILE_MEMBER_FUNC(SCF);
@@ -1637,60 +1768,33 @@ vecfuncT SCF::compute_residual(World& world, tensorT& occ, tensorT& fock,
     scale(world, Vpsi, fac);
     END_TIMER(world, "Compute residual stuff");
 
-    const bool tile_applyBSH = true;
+    // bsh_apply selects the backend (executors above; eps fed identically to all).
+    // auto: macrotask when multinode (rank-local apply, no inter-node convolution comm)
+    // or at tight protocol (one orbital per task bounds the working set where memory
+    // binds); tile on a single node at loose/medium (no gather, no subworld copy).
+    std::string bsh_apply_mode = param.bsh_apply();
+    long batch = 0;   // 0 = bsh_apply_{min,max}_batch or partitioner default
+    if (bsh_apply_mode == "auto") {
+        const long n_nodes = long(ranks_per_host(world).size());   // collective
+        const bool tight = FunctionDefaults<3>::get_thresh() <= BSH_TIGHT_THRESH;
+        bsh_apply_mode = (n_nodes >= 2 or tight) ? "macrotask" : "tile";
+        // tight: one orbital per task (memory-conservative); loose/medium: a modest
+        // batch amortizes per-task overhead
+        if (bsh_apply_mode == "macrotask") batch = tight ? 1 : 4;
+        if (param.print_level() >= 2 and world.rank() == 0)
+            print("BSH apply [auto]:", bsh_apply_mode, "(nodes:", n_nodes,
+                  tight ? ", tight protocol)" : ")");
+    }
     vecfuncT new_psi;
+    if (bsh_apply_mode == "macrotask")  new_psi = apply_bsh_macrotask(world, Vpsi, eps, param, batch);
+    else if (bsh_apply_mode == "plain") new_psi = apply_bsh_plain(world, Vpsi, eps, param);
+    else                                new_psi = apply_bsh_tiled(world, Vpsi, eps, param);
 
-    if (tile_applyBSH) {
-        START_TIMER(world);
-        size_t min_tile = 10;
-        size_t ntile = std::min(amo.size(), min_tile);
-        new_psi = zero_functions<double,3>(world, Vpsi.size());
-
-        for (size_t ilo=0; ilo<Vpsi.size(); ilo+=ntile) {
-            size_t iend = std::min(ilo+ntile,Vpsi.size());
-            vecfuncT tmp_Vpsi(Vpsi.begin()+ilo,Vpsi.begin()+iend);
-
-            int tmp_nmo = tmp_Vpsi.size();
-            tensorT tmp_eps(tmp_nmo);
-            for (int i = 0; i < tmp_nmo; ++i) {
-                tmp_eps(i) = std::min(-0.05, fock(i+ilo, i+ilo));
-            }
-
-            std::vector<poperatorT> ops = make_bsh_operators(world, tmp_eps, param);
-            set_thresh(world, tmp_Vpsi, FunctionDefaults<3>::get_thresh());
-
-            vecfuncT tmp_new_psi = apply(world, ops, tmp_Vpsi);
-
-            //truncate tmp_new_psi
-            truncate(world, tmp_new_psi);
-
-            //put the results into their final home
-            for (size_t i = ilo; i<iend; ++i){
-                new_psi[i] += tmp_new_psi[i-ilo];
-            }
-            ops.clear();
-        }
-
-        Vpsi.clear();
-        world.gop.fence();
-        END_TIMER(world, "Apply BSH");
-    } else {
-        START_TIMER(world);
-
-        std::vector<poperatorT> ops = make_bsh_operators(world, eps, param);
-        set_thresh(world, Vpsi, FunctionDefaults<3>::get_thresh());
-
-        new_psi = apply(world, ops, Vpsi);
-        
-        ops.clear();
-        Vpsi.clear();
-        world.gop.fence();
-
-        END_TIMER(world, "Apply BSH");
-        
-        START_TIMER(world);
-        truncate(world, new_psi);
-        END_TIMER(world, "Truncate new psi");
+    // memory snapshot at a consistent point (inputs freed, new_psi built); the RSS
+    // still shows the in-apply high water. Adds fences -- memory runs only.
+    if (param.bsh_apply_memcheck()) {
+        if (world.rank() == 0) print("=== BSH apply memcheck, mode:", param.bsh_apply(), "===");
+        MemoryMeasurer::measure_and_print(world);
     }
 
     // Thought it was a bad idea to truncate *before* computing the residual

--- a/src/madness/chem/SCF.cc
+++ b/src/madness/chem/SCF.cc
@@ -1593,7 +1593,8 @@ static size_t bsh_tile_size(size_t nmo, size_t nranks, long max_tile) {
 static constexpr double BSH_TIGHT_THRESH = 1.0e-7;
 
 vecfuncT SCF::apply_bsh_macrotask(World& world, vecfuncT& Vpsi, const tensorT& eps,
-                                  const CalculationParameters& param, long batch) {
+                                  const CalculationParameters& param, long batch,
+                                  bool redistribute) {
     class ApplyTask : public MacroTaskOperationBase {
     public:
         ApplyTask() {
@@ -1602,6 +1603,20 @@ vecfuncT SCF::apply_bsh_macrotask(World& world, vecfuncT& Vpsi, const tensorT& e
         typedef std::tuple<const std::vector<real_function_3d> &, const Tensor<double>&,
         const CalculationParameters&> argtupleT;
         using resultT = std::vector<real_function_3d>;
+
+        // Owner-pinned placement (iff the operand was redistributed): owner_[j] is where
+        // redistribute_to_batches put Vpsi[j]; running j's task there makes the auto_copy
+        // a local fetch. owner_ MUST equal the redistribute assignment and each task must
+        // span one function (batch=1). Replicated, so all ranks compute the same slot;
+        // nsubworld==nranks under the redistribute. Empty => -1 (dynamic).
+        std::vector<ProcessID> owner_;
+        long owner_hint(const madness::Batch& batch, const long nsubworld) const override {
+            if (owner_.empty() || nsubworld <= 0) return -1;
+            const long b = batch.input[0].begin;
+            if (b >= 0 && b < static_cast<long>(owner_.size()))
+                return static_cast<long>(owner_[b]) % nsubworld;
+            return b % nsubworld;   // fallback (not reached once owner_ is populated)
+        }
 
         // called in the universe (full argtuple -> full-size result) and in each subworld
         // (batched argtuple -> batch-size result); sizing from the input vector fits both.
@@ -1643,6 +1658,21 @@ vecfuncT SCF::apply_bsh_macrotask(World& world, vecfuncT& Vpsi, const tensorT& e
 
     START_TIMER(world);
     ApplyTask apply_task;
+    const long nw = param.bsh_apply_nworld();
+    // Owner-pinning needs nworld==nranks (slot == physical rank) and batch=1 (one owner
+    // per task); an explicit conflicting request wins and the redistribute is skipped.
+    if (redistribute && ((nw > 0 && nw != world.size()) || batch != 1)) {
+        if (param.print_level() >= 2 && world.rank() == 0)
+            print("BSH apply: skipping the operand redistribute (needs nworld=nranks and batch=1)");
+        redistribute = false;
+    }
+    // cost-balanced assignment, computed UP FRONT from Vpsi's original distribution;
+    // it drives BOTH the redistribute and owner_hint -- they MUST share one assignment
+    std::vector<ProcessID> bsh_owner;
+    if (redistribute) {
+        bsh_owner = assign_cost_aware(function_costs(world, Vpsi), world.size());
+        apply_task.owner_ = bsh_owner;
+    }
     // batch > 0 (from the auto dispatch) overrides the explicit params; 0 = default
     const long maxb = batch > 0 ? batch : param.bsh_apply_max_batch();
     const long minb = batch > 0 ? batch : param.bsh_apply_min_batch();
@@ -1651,14 +1681,27 @@ vecfuncT SCF::apply_bsh_macrotask(World& world, vecfuncT& Vpsi, const tensorT& e
     auto factory = MacroTaskQFactory(world);
     // small_memory = StoreFunctionViaPointer: pointers in the cloud, coeffs streamed
     factory.set_policy(MacroTaskInfo::preset(param.bsh_apply_policy()));
-    const long nw = param.bsh_apply_nworld();
-    if (nw > 0) factory.set_nworld(nw);
+    if (redistribute) factory.set_nworld(world.size());
+    else if (nw > 0) factory.set_nworld(nw);
     // printlevel 5 (not 3) so printtimings_detail fires -> the BSH taskq prints its own
     // "finalize gaxpy (sw->universe)" line; still <10 so no per-task debug flood.
     if (param.print_level() >= 10) factory.set_printlevel(5);
     MacroTask macrotask(world, apply_task, factory);
     const bool instr = param.print_level() >= 10;
     const double vpsi_gb = instr ? get_size(world, Vpsi) : 0.0;
+    // localize Vpsi up front -- no convolution running, so the move runs at transport
+    // speed; the auto_copy then fetches locally. Streams, no 2x transient.
+    if (redistribute) {
+        const double t0 = wall_time();
+        redistribute_to_batches(world, Vpsi, bsh_owner);
+        if (instr) {
+            double rss = madness::get_rss_usage_in_GB();
+            world.gop.max(rss);
+            if (world.rank() == 0)
+                printf("  [BSH redistribute: Vpsi -> single-owner (%zu funcs) in %.2fs | peakRSS max=%.2fGB/rank]\n",
+                       Vpsi.size(), wall_time() - t0, rss);
+        }
+    }
     vecfuncT new_psi = macrotask(Vpsi, eps, param);
     Vpsi.clear();
     world.gop.fence();
@@ -1788,20 +1831,29 @@ vecfuncT SCF::compute_residual(World& world, tensorT& occ, tensorT& fock,
     // or at tight protocol (one orbital per task bounds the working set where memory
     // binds); tile on a single node at loose/medium (no gather, no subworld copy).
     std::string bsh_apply_mode = param.bsh_apply();
+    const bool tight = FunctionDefaults<3>::get_thresh() <= BSH_TIGHT_THRESH;
     long batch = 0;   // 0 = bsh_apply_{min,max}_batch or partitioner default
     if (bsh_apply_mode == "auto") {
         const long n_nodes = long(ranks_per_host(world).size());   // collective
-        const bool tight = FunctionDefaults<3>::get_thresh() <= BSH_TIGHT_THRESH;
         bsh_apply_mode = (n_nodes >= 2 or tight) ? "macrotask" : "tile";
-        // tight: one orbital per task (memory-conservative); loose/medium: a modest
-        // batch amortizes per-task overhead
+        // tight: one orbital per task (memory, and required by the redistribute
+        // below); loose/medium: a modest batch amortizes per-task overhead
         if (bsh_apply_mode == "macrotask") batch = tight ? 1 : 4;
         if (param.print_level() >= 2 and world.rank() == 0)
             print("BSH apply [auto]:", bsh_apply_mode, "(nodes:", n_nodes,
                   tight ? ", tight protocol)" : ")");
     }
+    // pre-localize ONLY at tight protocol: the per-task gather serve-starves there and
+    // the redistribute + local fetch collapse it; at loose/medium the move is a net
+    // loss. Applies to auto and to explicit bsh_apply=macrotask.
+    bool redistribute = (bsh_apply_mode == "macrotask") and tight;
+    if (redistribute and batch == 0
+        and param.bsh_apply_max_batch() == 0 and param.bsh_apply_min_batch() == 0)
+        batch = 1;   // explicit macrotask mode at tight: default to owner-coherent tasks
+    if (redistribute and param.print_level() >= 2 and world.rank() == 0)
+        print("BSH apply: redistribute operand to single-owner batches (tight protocol)");
     vecfuncT new_psi;
-    if (bsh_apply_mode == "macrotask")  new_psi = apply_bsh_macrotask(world, Vpsi, eps, param, batch);
+    if (bsh_apply_mode == "macrotask")  new_psi = apply_bsh_macrotask(world, Vpsi, eps, param, batch, redistribute);
     else if (bsh_apply_mode == "plain") new_psi = apply_bsh_plain(world, Vpsi, eps, param);
     else                                new_psi = apply_bsh_tiled(world, Vpsi, eps, param);
 

--- a/src/madness/chem/SCF.h
+++ b/src/madness/chem/SCF.h
@@ -421,6 +421,15 @@ public:
     vecfuncT compute_residual(World& world, tensorT& occ, tensorT& fock,
                               const vecfuncT& psi, vecfuncT& Vpsi, double& err);
 
+    /// BSH-apply executors for compute_residual, selected by the bsh_apply parameter.
+    /// All three consume Vpsi and return the new orbitals (not yet orthonormalized).
+    vecfuncT apply_bsh_macrotask(World& world, vecfuncT& Vpsi, const tensorT& eps,
+                                 const CalculationParameters& param, long batch);
+    vecfuncT apply_bsh_tiled(World& world, vecfuncT& Vpsi, const tensorT& eps,
+                             const CalculationParameters& param);
+    vecfuncT apply_bsh_plain(World& world, vecfuncT& Vpsi, const tensorT& eps,
+                             const CalculationParameters& param);
+
     tensorT make_fock_matrix(World& world, const vecfuncT& psi,
                              const vecfuncT& Vpsi, const tensorT& occ,
                              double& ekinetic) const;

--- a/src/madness/chem/SCF.h
+++ b/src/madness/chem/SCF.h
@@ -424,7 +424,8 @@ public:
     /// BSH-apply executors for compute_residual, selected by the bsh_apply parameter.
     /// All three consume Vpsi and return the new orbitals (not yet orthonormalized).
     vecfuncT apply_bsh_macrotask(World& world, vecfuncT& Vpsi, const tensorT& eps,
-                                 const CalculationParameters& param, long batch);
+                                 const CalculationParameters& param, long batch,
+                                 bool redistribute);
     vecfuncT apply_bsh_tiled(World& world, vecfuncT& Vpsi, const tensorT& eps,
                              const CalculationParameters& param);
     vecfuncT apply_bsh_plain(World& world, vecfuncT& Vpsi, const tensorT& eps,

--- a/src/madness/mra/funcimpl.h
+++ b/src/madness/mra/funcimpl.h
@@ -1237,8 +1237,14 @@ template<size_t NDIM>
 
             // copy coeffs from (a subset of) other's world
 
+            // single-owner pmap: fetch from that rank only -- the all-ranks poll costs
+            // N-1 empty round-trips queued behind the owner's compute
+            const ProcessID single_owner = other.get_pmap()->single_owner();
+            if (single_owner >= 0) {
+                copy_remote_coeffs_from_pid<Q>(single_owner, other);
+
             // if other's data is distributed, we need to fetch from all ranks
-            if (other.get_coeffs().is_distributed()) {
+            } else if (other.get_coeffs().is_distributed()) {
                 for (ProcessID pid=0; pid<other.world.size(); ++pid) {
                     copy_remote_coeffs_from_pid<Q>(pid, other);
                 }
@@ -1255,9 +1261,13 @@ template<size_t NDIM>
         template <typename Q>
         void copy_remote_coeffs_from_pid(const ProcessID pid, const FunctionImpl<Q,NDIM>& other) {
             typedef FunctionImpl<Q,NDIM> implQ; ///< Type of this class (implementation)
-            // std::vector<unsigned char> v=other.task(pid, &implQ::serialize_remote_coeffs).get();
-            auto v=other.task(pid, &implQ::serialize_remote_coeffs);
-            world.taskq.add(*this, &implT::insert_serialized_coeffs,v);
+            if (pid == other.world.rank()) {
+                // the shard is local: copy nodes directly, no serialize round-trip
+                copy_coeffs_same_world(other, false);
+            } else {
+                auto v=other.task(pid, &implQ::serialize_remote_coeffs);
+                world.taskq.add(*this, &implT::insert_serialized_coeffs,v);
+            }
         }
 
         /// invoked by copy_remote_coeffs_from_pid to serialize *local* coeffs

--- a/src/madness/mra/testvmra.cc
+++ b/src/madness/mra/testvmra.cc
@@ -141,6 +141,100 @@ void test_add(World& world) {
 
 
 
+/// Assignment factories: owners in range, deterministic, LPT balances a skewed load.
+void test_assignment_factories(World& world) {
+    if (world.rank()==0) print("\nentering test_assignment_factories");
+    const int nranks=5;
+    const std::size_t nfunc=17;
+
+    auto rr = assign_round_robin(nfunc, nranks);
+    for (std::size_t j=0; j<nfunc; ++j) MADNESS_CHECK(rr[j] == ProcessID(j % nranks));
+
+    // skewed costs: one heavy function per light three
+    std::vector<double> cost(nfunc);
+    for (std::size_t j=0; j<nfunc; ++j) cost[j] = (j%4==0) ? 90.0 : 10.0;
+    auto ca  = assign_cost_aware(cost, nranks);
+    auto ca2 = assign_cost_aware(cost, nranks);
+    MADNESS_CHECK(ca == ca2);                       // deterministic
+    std::vector<double> load(nranks, 0.0);
+    for (std::size_t j=0; j<nfunc; ++j) {
+        MADNESS_CHECK(ca[j] >= 0 && ca[j] < nranks);
+        load[ca[j]] += cost[j];
+    }
+    const double lmax=*std::max_element(load.begin(), load.end());
+    const double lmin=*std::min_element(load.begin(), load.end());
+    // total 570 over 5 ranks; LPT lands every rank within one light function of the mean,
+    // where a naive round-robin of this pattern would stack two heavies on one rank
+    MADNESS_CHECK(lmax - lmin <= 20.0);
+    if (world.rank()==0) print("test_assignment_factories OK, max/min load", lmax, lmin);
+}
+
+/// redistribute_to_batches: (1) single-owner pmap installed, (2) every box of v[j] on
+/// owner[j] and nowhere else, (3) global box count conserved, (4) coefficients and tree
+/// state unchanged. Reconstructed with round-robin, compressed with cost-aware (the move
+/// must be state-agnostic).
+template <typename T, std::size_t NDIM>
+void test_redistribute_to_batches(World& world) {
+    if (world.rank()==0) print("\nentering test_redistribute_to_batches, NDIM =", NDIM);
+    const double thresh=1.e-6;
+    Tensor<double> cell(NDIM,2);
+    for (std::size_t i=0; i<NDIM; ++i) { cell(i,0)=-10.0; cell(i,1)=10.0; }
+    FunctionDefaults<NDIM>::set_cell(cell);
+    FunctionDefaults<NDIM>::set_k(8);
+    FunctionDefaults<NDIM>::set_thresh(thresh);
+    FunctionDefaults<NDIM>::set_refine(true);
+    FunctionDefaults<NDIM>::set_initial_level(3);
+    FunctionDefaults<NDIM>::set_truncate_mode(1);
+
+    const std::size_t nvec=7;
+    std::vector<Function<T,NDIM> > v(nvec);
+    for (std::size_t i=0; i<nvec; ++i) {
+        const double s = 0.3*double(i+1);   // distinct functions -> real, differing trees
+        v[i]=FunctionFactory<T,NDIM>(world).functor([s](const Vector<double,NDIM>& r) {
+            return std::exp(-inner(r,r))*std::cos(s*r[0]); });
+    }
+
+    for (const TreeState state : {reconstructed, compressed}) {
+        change_tree_state(v, state);
+        world.gop.fence();
+
+        // invariants BEFORE
+        std::vector<double> norm_before(nvec);
+        std::vector<long> count_before(nvec);
+        for (std::size_t j=0; j<nvec; ++j) {
+            norm_before[j]=v[j].norm2();
+            long global=long(v[j].get_impl()->get_coeffs().size());
+            world.gop.sum(global);
+            count_before[j]=global;
+        }
+        world.gop.fence();
+
+        const auto owner = (state==reconstructed)
+            ? assign_round_robin(nvec, world.size())
+            : assign_cost_aware(function_costs(world, v), world.size());
+        redistribute_to_batches(world, v, owner);
+
+        // invariants AFTER
+        for (std::size_t j=0; j<nvec; ++j) {
+            // (1) single-owner pmap installed and reporting owner[j]
+            MADNESS_CHECK(v[j].get_impl()->get_pmap()->single_owner()==owner[j]);
+            // (2) all boxes on owner[j], none elsewhere
+            long local=long(v[j].get_impl()->get_coeffs().size());
+            long global=local; world.gop.sum(global);
+            if (world.rank()==owner[j]) MADNESS_CHECK(local==global);
+            else                        MADNESS_CHECK(local==0);
+            // (3) box count conserved
+            MADNESS_CHECK(global==count_before[j]);
+            // (4) tree state preserved, coefficients unchanged
+            MADNESS_CHECK(v[j].get_impl()->get_tree_state()==state);
+            double nrm=v[j].norm2();
+            MADNESS_CHECK(std::abs(nrm-norm_before[j]) < 1.e-10*(1.0+norm_before[j]));
+        }
+        world.gop.fence();
+        if (world.rank()==0) print("test_redistribute_to_batches OK,", state);
+    }
+}
+
 template <typename T, typename R, int NDIM, bool sym>
 void test_inner(World& world) {
     typedef std::shared_ptr< FunctionFunctorInterface<T,NDIM> > ffunctorT;
@@ -664,6 +758,9 @@ int main(int argc, char**argv) {
 
         test_add<double,3>(world);
         test_add<std::complex<double>,3 >(world);
+
+        test_assignment_factories(world);
+        test_redistribute_to_batches<double,3>(world);
 
         test_inner<double,double,1,false>(world);
         test_inner<double,double,1,true>(world);

--- a/src/madness/mra/vmra.h
+++ b/src/madness/mra/vmra.h
@@ -123,6 +123,7 @@
 #include <madness/mra/derivative.h>
 #include <madness/tensor/distributed_matrix.h>
 #include <cstdio>
+#include <algorithm>
 
 namespace madness {
 
@@ -1459,6 +1460,104 @@ namespace madness {
       }
       if (fence) world.gop.fence();
       return r;
+    }
+
+    /// owner[j] = j % nranks. For redistribute_to_batches.
+    inline std::vector<ProcessID> assign_round_robin(std::size_t nfunc, int nranks) {
+        MADNESS_CHECK(nranks > 0);
+        std::vector<ProcessID> owner(nfunc);
+        for (std::size_t j = 0; j < nfunc; ++j) owner[j] = ProcessID(j % std::size_t(nranks));
+        return owner;
+    }
+
+    /// Cost-balanced assignment: descending cost, each function to the least-loaded
+    /// rank (LPT greedy). Deterministic for a replicated cost[] (stable sort, index
+    /// tie-break), so owner[] agrees across ranks. For redistribute_to_batches.
+    /// @param[in] cost   per-function cost proxy (>= 0), identical on every rank
+    inline std::vector<ProcessID> assign_cost_aware(const std::vector<double>& cost, int nranks) {
+        MADNESS_CHECK(nranks > 0);
+        const std::size_t nfunc = cost.size();
+        std::vector<ProcessID> owner(nfunc);
+        std::vector<std::size_t> order(nfunc);
+        for (std::size_t j = 0; j < nfunc; ++j) order[j] = j;
+        // descending cost; ascending index breaks ties -> stable and reproducible
+        std::stable_sort(order.begin(), order.end(),
+                         [&](std::size_t a, std::size_t b) { return cost[a] > cost[b]; });
+        std::vector<double> load(std::size_t(nranks), 0.0);
+        for (std::size_t k = 0; k < nfunc; ++k) {
+            int best = 0;                                    // least-loaded rank; smallest
+            for (int r = 1; r < nranks; ++r)                 // rank index breaks ties
+                if (load[std::size_t(r)] < load[std::size_t(best)]) best = r;
+            const std::size_t j = order[k];
+            owner[j] = ProcessID(best);
+            load[std::size_t(best)] += std::max(1.0, cost[j]);  // floor: zero-cost funcs still rotate
+        }
+        return owner;
+    }
+
+    /// Global coefficient count per function -- one reduction, identical on every rank,
+    /// so safe for a deterministic assignment. A proxy for convolution cost; does not
+    /// predict result-tree refinement.
+    template <typename T, std::size_t NDIM>
+    std::vector<double> function_costs(World& world, const std::vector<Function<T, NDIM>>& v) {
+        std::vector<double> cost(v.size(), 0.0);
+        for (std::size_t j = 0; j < v.size(); ++j) cost[j] = double(v[j].size_local());
+        if (!v.empty()) world.gop.sum(cost.data(), cost.size());
+        return cost;
+    }
+
+    /// Move each v[j] so its whole tree lives on rank owner[j], via the coalesced
+    /// WorldContainer transport (bulk AMs, erase-after-copy: streams, no 2x transient).
+    /// State-preserving. Each function gets its OWN single-owner pmap (Key<NDIM> is
+    /// function-agnostic), and the pmap outlives the call -- until redistributed again,
+    /// every operation on v[j] runs on rank owner[j] alone.
+    ///
+    /// @param[in,out] v       functions to localize (moved in place)
+    /// @param[in] owner       destination rank per function; MUST be identical on every
+    ///                        rank (checked collectively)
+    /// @param[in] cap_bytes   soft cap per message (0 => ~1 MiB, sized for the default
+    ///                        MAD_BUFFER_SIZE; lower it if that buffer was shrunk)
+    /// @param[in] rotate      stagger destinations to reduce incast
+    template <typename T, std::size_t NDIM>
+    void redistribute_to_batches(World& world,
+                                 std::vector<Function<T, NDIM>>& v,
+                                 const std::vector<ProcessID>& owner,
+                                 std::size_t cap_bytes = 0,
+                                 bool rotate = true) {
+        MADNESS_CHECK(owner.size() == v.size());
+        if (v.empty()) return;
+
+        // owner[] must agree across ranks -- divergence silently corrupts ownership
+        {
+            long h = 0;
+            for (std::size_t j = 0; j < owner.size(); ++j) h += long(owner[j]) * long(j + 1);
+            long hmax = h, hmin = h;
+            world.gop.max(hmax);
+            world.gop.min(hmin);
+            MADNESS_CHECK(hmax == hmin);
+        }
+
+        // chunk cap in #boxes; box size bounded by the functions' own k, not
+        // FunctionDefaults (v may carry its own k)
+        if (cap_bytes == 0) cap_bytes = 1024 * 1024; // ~1 MiB, under the default RMI buffer
+        long kmax = 1;
+        for (const auto& f : v) kmax = std::max(kmax, long(f.k()));
+        std::size_t box_bytes = sizeof(T);
+        for (std::size_t d = 0; d < NDIM; ++d) box_bytes *= std::size_t(2 * kmax);
+        const std::size_t cap_boxes = std::max<std::size_t>(1, cap_bytes / box_bytes);
+
+        // fence, phase1, fence, phase2, fence: the middle fence is REQUIRED -- phase1
+        // iterates the ConcurrentHashMap and needs a quiescent window (see worlddc.h)
+        world.gop.fence();
+        for (std::size_t j = 0; j < v.size(); ++j) {
+            auto pmap = std::shared_ptr<WorldDCPmapInterface<Key<NDIM>>>(
+                new WorldDCSingleOwnerPmap<Key<NDIM>>(owner[j]));
+            v[j].get_impl()->get_coeffs().redistribute_coalesced_phase1(pmap);
+        }
+        world.gop.fence();
+        for (std::size_t j = 0; j < v.size(); ++j)
+            v[j].get_impl()->get_coeffs().redistribute_coalesced_phase2(cap_boxes, rotate);
+        world.gop.fence();
     }
 
     /// Returns new vector of functions --- q[i] = a[i] + b[i]

--- a/src/madness/world/test_dc.cc
+++ b/src/madness/world/test_dc.cc
@@ -315,6 +315,68 @@ void test_florian(World& world) {
     if (world.rank() == 0) print("test_florian passed");
 }
 
+/// Coalesced redistribute + WorldDCSingleOwnerPmap: everything onto one rank, onto
+/// another with cap_boxes=1 (chunk boundaries), back to the default pmap. Ownership,
+/// content and count checked after every move. Run at np >= 2 -- one rank makes every
+/// move a no-op.
+void test_coalesced_redistribute(World& world) {
+    const int nkeys = 1000;
+    auto checksum = [&world](WorldContainer<int,double>& c) {
+        double s = 0.0;
+        for (const auto& [k, v] : c) s += v;    // local entries only
+        world.gop.sum(s);
+        return s;
+    };
+    auto global_count = [&world](WorldContainer<int,double>& c) {
+        long n = long(c.size());
+        world.gop.sum(n);
+        return n;
+    };
+
+    WorldContainer<int,double> c(world);
+    if (world.rank() == 0)
+        for (int i=0; i<nkeys; ++i) c.replace(i, 2.0*i);
+    world.gop.fence();
+    const double sum0 = checksum(c);
+    MADNESS_CHECK(global_count(c) == nkeys);
+
+    // the two-barrier protocol: fence, phase1 (build move-list; quiescent), fence,
+    // phase2 (send bulk AMs), fence
+    auto move_to = [&](const std::shared_ptr<WorldDCPmapInterface<int>>& pmap, std::size_t cap_boxes) {
+        world.gop.fence();
+        c.redistribute_coalesced_phase1(pmap);
+        world.gop.fence();
+        c.redistribute_coalesced_phase2(cap_boxes);
+        world.gop.fence();
+    };
+
+    // 1) everything onto the last rank, chunked
+    const ProcessID last = world.size()-1;
+    move_to(std::make_shared<WorldDCSingleOwnerPmap<int>>(last), 7);
+    MADNESS_CHECK(c.get_pmap()->single_owner() == last);
+    MADNESS_CHECK(long(c.size()) == (world.rank()==last ? nkeys : 0));
+    if (world.rank() == last)
+        for (int i=0; i<nkeys; i+=97) MADNESS_CHECK(c.find(i).get()->second == 2.0*i);
+    MADNESS_CHECK(global_count(c) == nkeys);
+    MADNESS_CHECK(checksum(c) == sum0);
+
+    // 2) onto rank 0 with cap_boxes=1 (one AM per box; chunk-boundary edge case)
+    move_to(std::make_shared<WorldDCSingleOwnerPmap<int>>(0), 1);
+    MADNESS_CHECK(long(c.size()) == (world.rank()==0 ? nkeys : 0));
+    MADNESS_CHECK(checksum(c) == sum0);
+
+    // 3) back to a distributed default pmap; every key must be findable at its owner
+    move_to(std::make_shared<WorldDCDefaultPmap<int>>(world), 7);
+    MADNESS_CHECK(c.get_pmap()->single_owner() == -1);
+    MADNESS_CHECK(global_count(c) == nkeys);
+    MADNESS_CHECK(checksum(c) == sum0);
+    for (int i=world.rank(); i<nkeys; i+=13*world.size())
+        MADNESS_CHECK(c.find(i).get()->second == 2.0*i);
+
+    world.gop.fence();
+    if (world.rank() == 0) print("test_coalesced_redistribute passed");
+}
+
 int main(int argc, char** argv) {
 
     try {
@@ -325,6 +387,7 @@ int main(int argc, char** argv) {
         // test1(world);
         // test_local(world);
         test_florian(world);
+        test_coalesced_redistribute(world);
     }
     catch (const SafeMPI::Exception& e) {
         error("caught an MPI exception");

--- a/src/madness/world/worlddc.h
+++ b/src/madness/world/worlddc.h
@@ -144,6 +144,14 @@ namespace madness
             return Distributed;
         }
 
+        /// The one rank every key maps to on every process, or -1. Lets a cross-world
+        /// copy fetch from one owner instead of polling all ranks. Stronger than
+        /// WorldDCLocalPmap, whose owner is the calling rank.
+        virtual ProcessID single_owner() const
+        {
+            return -1;
+        }
+
         /// Registers object for receipt of redistribute callbacks
 
         /// @param[in] ptr Pointer to class derived from WorldDCRedistributedInterface
@@ -286,6 +294,23 @@ namespace madness
         {
             return RankReplicated;
         }
+    };
+
+    /// Places every key on one fixed rank (all ranks agree on the owner).
+    ///
+    /// Moves a container's whole content onto one rank, so a cross-world copy is
+    /// a single fetch. Distribution type stays Distributed; see single_owner().
+    /// \ingroup worlddc
+    template <typename keyT>
+    class WorldDCSingleOwnerPmap : public WorldDCPmapInterface<keyT>
+    {
+    private:
+        const ProcessID owner_;
+
+    public:
+        WorldDCSingleOwnerPmap(ProcessID owner) : owner_(owner) {}
+        ProcessID owner(const keyT & /*key*/) const override { return owner_; }
+        ProcessID single_owner() const override { return owner_; }
     };
 
     /// node-replicated map will return the lowest rank on the node as owner

--- a/src/madness/world/worlddc.h
+++ b/src/madness/world/worlddc.h
@@ -42,6 +42,9 @@
 
 #include <functional>
 #include <set>
+#include <map>
+#include <vector>
+#include <algorithm>
 #include <unordered_set>
 
 
@@ -595,6 +598,7 @@ namespace madness
         const ProcessID me;                               ///< My MPI rank
         internal_containerT local;                        ///< Locally owned data
         std::vector<keyT> *move_list;                     ///< Tempoary used to record data that needs redistributing
+        std::map<ProcessID, std::vector<keyT>> coalesced_move_; ///< Temporary: keys to move, bucketed by destination (coalesced redistribute)
 
         /// Handles find request
         void find_handler(ProcessID requestor, const keyT &key, const RemoteReference<FutureImpl<iterator>> &ref)
@@ -881,6 +885,20 @@ namespace madness
             return local.insert(acc, key);
         }
 
+        /// AM target of the coalesced redistribute: bulk-insert boxes this rank owns
+        /// under the already-adopted new pmap. Keys are disjoint from those this rank
+        /// is concurrently erasing (their new owner != me), so per-bucket locking
+        /// suffices. See redistribute_coalesced_phase2.
+        void insert_batch(const std::vector<pairT> &boxes)
+        {
+            for (const pairT &kv : boxes)
+            {
+                accessor acc;
+                [[maybe_unused]] auto inserted = local.insert(acc, kv.first);
+                acc->second = kv.second;
+            }
+        }
+
         void clear()
         {
             local.clear();
@@ -1120,6 +1138,67 @@ namespace madness
         {
             delete move_list;
         }
+
+        // --- Coalesced redistribute: like redistribute_phase1/2, but phase2 sends ONE
+        // bulk AM per (destination, chunk) instead of one AM per box. The caller owns
+        // the fences: fence, phase1 on all containers, fence, phase2, fence. The middle
+        // fence is REQUIRED -- phase1 iterates the ConcurrentHashMap and needs a
+        // quiescent window; phase2 tolerates concurrent insert_batch (disjoint keys).
+
+        /// phase1: adopt newpmap (callback swap as in replicate()) and bucket the keys
+        /// to move by destination. Quiescent window required.
+        void redistribute_coalesced_phase1(const std::shared_ptr<WorldDCPmapInterface<keyT>> &newpmap)
+        {
+            pmap->deregister_callback(this);
+            pmap = newpmap;
+            pmap->register_callback(this);
+            coalesced_move_.clear();
+            for (typename internal_containerT::iterator iter = local.begin(); iter != local.end(); ++iter)
+            {
+                ProcessID d = owner(iter->first); // uses the new pmap
+                if (d != me)
+                    coalesced_move_[d].push_back(iter->first);
+            }
+        }
+
+        /// phase2: per destination, chunk the key list (at most cap_boxes per chunk),
+        /// erase each box after copying it into the batch, send one insert_batch AM
+        /// per chunk.
+        void redistribute_coalesced_phase2(std::size_t cap_boxes, bool rotate)
+        {
+            if (cap_boxes == 0) cap_boxes = 1;
+            std::vector<ProcessID> dsts;
+            dsts.reserve(coalesced_move_.size());
+            for (const auto &kv : coalesced_move_) dsts.push_back(kv.first);
+            // rotate: destinations > me first, so ranks don't all hammer dst 0 at once
+            if (rotate)
+                std::stable_partition(dsts.begin(), dsts.end(),
+                                      [this](ProcessID d) { return d > me; });
+            for (ProcessID d : dsts)
+            {
+                const std::vector<keyT> &keys = coalesced_move_[d];
+                std::vector<pairT> batch;
+                batch.reserve(std::min(cap_boxes, keys.size()));
+                for (std::size_t i = 0; i < keys.size(); ++i)
+                {
+                    typename internal_containerT::iterator iter = local.find(keys[i]);
+                    if (iter != local.end())
+                    {
+                        batch.push_back(pairT(keys[i], iter->second));
+                        local.erase(iter); // delete local copy of the data
+                    }
+                    if (batch.size() >= cap_boxes || i + 1 == keys.size())
+                    {
+                        if (!batch.empty())
+                        {
+                            this->task(d, &implT::insert_batch, batch); // one bulk AM per chunk
+                            batch.clear();
+                        }
+                    }
+                }
+            }
+            coalesced_move_.clear();
+        }
     };
 
     /// Makes a distributed container with specified attributes
@@ -1280,6 +1359,23 @@ namespace madness
         void replicate_on_hosts(bool fence = true)
         {
             p->replicate_on_hosts(fence);
+        }
+
+        /// Coalesced redistribute, phase 1: adopt newpmap, bucket the move list.
+        /// Caller fences before (quiescent window).
+        void redistribute_coalesced_phase1(const std::shared_ptr<WorldDCPmapInterface<keyT>> &newpmap)
+        {
+            check_initialized();
+            p->redistribute_coalesced_phase1(newpmap);
+        }
+
+        /// Coalesced redistribute, phase 2: one bulk AM per (destination, chunk of at
+        /// most cap_boxes), erase-after-copy. Caller fences after; rotate staggers
+        /// destinations to reduce incast.
+        void redistribute_coalesced_phase2(std::size_t cap_boxes, bool rotate = true)
+        {
+            check_initialized();
+            p->redistribute_coalesced_phase2(cap_boxes, rotate);
         }
 
         /// Inserts/replaces key+value pair (non-blocking communication if key not local)


### PR DESCRIPTION
# PR title: BSH apply backends with a single-owner operand redistribute

## What this does

Makes the `compute_residual` BSH (Helmholtz) apply parameter-selected, with a macrotask backend
that localizes each operand function onto one rank and applies rank-locally. Default `auto`:
macrotask when multinode or at tight threshold, tile on a single node at loose/medium. The
previous hardwired tile loop (tile size independent of the rank count) and a dead inline
`ApplyTask` are replaced.

**1. `world/worlddc.h` — single-owner pmap + coalesced redistribute.**

- `WorldDCSingleOwnerPmap`: every key on one fixed rank; `single_owner()` on the pmap
  interface returns that rank, −1 for any other pmap
- `redistribute_coalesced_phase1/2`: one bulk `insert_batch` AM per (destination, chunk)
  instead of one AM per box; erase-after-copy, so the move streams instead of doubling
- the caller owns the fences; the one between the phases is required (phase1 iterates the
  ConcurrentHashMap)

**2. `mra/funcimpl.h` — cross-world copy fast paths.**

- single-owner pmap: fetch from that rank only, not an all-ranks poll
- own-rank shard: copy nodes directly, no serialize round-trip; the existing all-ranks poll
  takes the same shortcut for its own-rank turn

**3. `mra/vmra.h` — function-level redistribute.**

- `redistribute_to_batches(world, v, owner)`: v[j]'s whole tree moves to rank owner[j];
  state-preserving; owner[] agreement checked collectively
- `assign_round_robin`, `assign_cost_aware` (deterministic LPT), `function_costs`
  (replicated per-function cost proxy, one reduction)

**4. `chem/SCF.*` — the executors and the dispatch.**

- `apply_bsh_macrotask` (rank-local apply in subworlds, in-subworld truncate),
  `apply_bsh_tiled` (rank-aware tile size), `apply_bsh_plain`
- at tight threshold (≤ 1e-7) the operand is pre-localized cost-aware and each task pinned to
  its operand's rank, so the framework's input copy is a local fetch; an explicit conflicting
  `bsh_apply_nworld`/batch setting wins and skips the redistribute with a notice
- the residual `transform` is tiled over output columns: untiled it materializes all nmo fpsi
  next to psi and Vpsi (~3x orbital memory at tight thresh), the OOM site for large systems

## Commits

| commit | what |
|---|---|
| `556e2991a` | add WorldDCSingleOwnerPmap and a pmap single_owner query |
| `225230dea` | add single-owner and same-rank fast paths to the cross-world coeff copy |
| `1ace40f06` | coalesce the container redistribute into bulk per-destination messages |
| `e2e9785b6` | redistribute whole functions onto single owner ranks |
| `635654010` | select the compute_residual BSH apply by parameter, tile or macrotask |
| `4ed6ba434` | tile the residual transform over output columns |
| `aabb775c3` | pre-localize the macrotask BSH operand at tight protocol |

7 commits, +662/−77 over 8 files.

## Interface changes

- new parameters: `bsh_apply` (`auto`|`tile`|`macrotask`|`plain`, default `auto`),
  `bsh_apply_nworld`, `bsh_apply_{min,max}_batch`, `bsh_apply_max_tile`, `bsh_apply_policy`,
  `bsh_apply_memcheck`. Defaults reproduce the previous energies to the cross-run noise floor
- `print_level >= 2` logs the auto decision and the redistribute; `>= 10` adds per-task
  apply/truncate, cloud copy/read times and peak RSS
- no checkpoint-format change

## PR checklist

| item | answer |
|---|---|
| raw MPI calls | none added |
| blocking MPI collectives | none added; the redistribute uses AMs + `World::gop` fences |
| implicit default World | none added |
| non-collective container construction | none. phase1/phase2 are called on every rank between collective fences; the owner assignment is replicated and checked collectively |
| threaded-BLAS assumptions | none |
| `Function` mutation from user threads | no. The redistribute runs between fences from the caller; kernels run in tasks |
| tree-state preconditions | unchanged; `redistribute_to_batches` is state-agnostic (tested reconstructed and compressed) |
| checkpoint-format break | none |
| GENTENSOR coverage | test_dc, testvmra, test_cloud, test_vectormacrotask pass at np=1/2 in a Debug build with assertions and `-DENABLE_GENTENSOR=ON` (Pthreads backend); testsuite passes at np=1/2 |