### PR TITLE
Silence more nvcc warnings

### DIFF
--- a/src/madness/chem/GuessFactory.h
+++ b/src/madness/chem/GuessFactory.h
@@ -62,12 +62,14 @@ public:
 
 	typedef double resultT;
 
+	using FunctionFunctorInterface<double,3>::operator();
+
     /// for explicit construction of this plane-wave function
-	double operator ()(const coord_3d& r) const;
+	double operator ()(const coord_3d& r) const override;
     /// operator for the 1D plane waves
 	double operator ()(const double& x, const int& dim) const;
     /// in case this is needed at some point
-    double operator()(const coord_1d & x, const int& dim)const{
+    double operator()(const coord_1d & x, const int& dim) const {
     	return (*this)(x[0],dim);
     }
 
@@ -98,8 +100,10 @@ public:
 	const double width_;
 	const coord_3d center=coord_3d();
 
+	using FunctionFunctorInterface<double,3>::operator();
+
 	/// explicit construction
-	double operator ()(const coord_3d& rr) const;
+	double operator ()(const coord_3d& rr) const override;
 
 
 };
@@ -113,8 +117,9 @@ public :
 	PolynomialFunctor(const std::string input, const double& damp_width=0.0, const coord_3d& c=coord_3d()) : input_string_(input), data_(read_string(input)), dampf(damp_width), center(c) {}
 	PolynomialFunctor(const std::string input,const double& damp_width, const Tensor<double>& c) : input_string_(input), data_(read_string(input)), dampf(damp_width), center(tensor_to_coord<double,3>(c)) {}
 
+	using FunctionFunctorInterface<double,3>::operator();
 	/// construction by coordinates
-	double operator ()(const coord_3d& rr) const;
+	double operator ()(const coord_3d& rr) const override;
 
 	/// create the value of the polynomial according to the data in the data_ structure
 	double compute_value(const coord_3d& r) const;

--- a/src/madness/chem/PNOGuessFunctions.h
+++ b/src/madness/chem/PNOGuessFunctions.h
@@ -250,6 +250,8 @@ public:
 		double exponent;  ///< exponent
 		int i, j, k;      ///< cartesian exponents
 
+		using FunctionFunctorInterface<double, 3>::operator();
+
 		double operator()(const coord_3d& xyz) const {
 			double xx = xyz[0] - x;
 			double yy = xyz[1] - y;
@@ -295,7 +297,9 @@ public:
 			return (T(0) < val) - (val < T(0));
 		}
 
-		double operator ()(const coord_3d& xyz) const;
+		using FunctionFunctorInterface<double, 3>::operator();
+
+		double operator ()(const coord_3d& xyz) const override;
 
 		std::vector<coord_3d> special_points() const final {
 			coord_3d coord;

--- a/src/madness/chem/correlationfactor.h
+++ b/src/madness/chem/correlationfactor.h
@@ -446,7 +446,10 @@ public:
 	public:
 		R_functor(const NuclearCorrelationFactor* ncf, const int e=1)
 			: ncf(ncf), exponent(e) {}
-		double operator()(const coord_3d& xyz) const {
+
+        using FunctionFunctorInterface<double,3>::operator();
+
+		double operator()(const coord_3d& xyz) const override {
 			double result=1.0;
 			for (size_t i=0; i<ncf->molecule.natom(); ++i) {
 				const Atom& atom=ncf->molecule.get_atom(i);
@@ -479,7 +482,10 @@ public:
 		U1_functor(const NuclearCorrelationFactor* ncf, const int axis)
 			: ncf(ncf), axis(axis) {}
 
-		double operator()(const coord_3d& xyz) const {
+
+        using FunctionFunctorInterface<double,3>::operator();
+
+		double operator()(const coord_3d& xyz) const override {
 			double result=0.0;
 			for (size_t i=0; i<ncf->molecule.natom(); ++i) {
 				const Atom& atom=ncf->molecule.get_atom(i);
@@ -512,8 +518,8 @@ public:
     public:
         U1_atomic_functor(const NuclearCorrelationFactor* ncf, const size_t atom,
                 const int axis) : ncf(ncf), iatom(atom), axis(axis) {}
-
-        double operator()(const coord_3d& xyz) const {
+        using FunctionFunctorInterface<double,3>::operator();
+        double operator()(const coord_3d& xyz) const override {
             const Atom& atom=ncf->molecule.get_atom(iatom);
             const coord_3d vr1A=xyz-atom.get_coords();
             const double r=vr1A.normf();
@@ -545,7 +551,8 @@ public:
     public:
         U1_dot_U1_functor(const NuclearCorrelationFactor* ncf) : ncf(ncf) {}
 
-        double operator()(const coord_3d& xyz) const {
+        using FunctionFunctorInterface<double,3>::operator();
+        double operator()(const coord_3d& xyz) const override {
 			std::vector<double> Sr_div_S(ncf->molecule.natom());
 			std::vector<coord_3d> unitvec(ncf->molecule.natom());
 			for (size_t i=0; i<ncf->molecule.natom(); ++i) {
@@ -578,7 +585,9 @@ public:
 		const NuclearCorrelationFactor* ncf;
 	public:
 		U2_functor(const NuclearCorrelationFactor* ncf) : ncf(ncf) {}
-		double operator()(const coord_3d& xyz) const {
+
+        using FunctionFunctorInterface<double,3>::operator();
+		double operator()(const coord_3d& xyz) const override {
 			double result=0.0;
 			for (size_t i=0; i<ncf->molecule.natom(); ++i) {
 				const Atom& atom=ncf->molecule.get_atom(i);
@@ -597,7 +606,9 @@ public:
 		const NuclearCorrelationFactor* ncf;
 	public:
 		U3_functor(const NuclearCorrelationFactor* ncf) : ncf(ncf) {}
-		double operator()(const coord_3d& xyz) const {
+
+		using FunctionFunctorInterface<double,3>::operator();
+		double operator()(const coord_3d& xyz) const override {
 			std::vector<coord_3d> all_terms(ncf->molecule.natom());
 			for (size_t i=0; i<ncf->molecule.natom(); ++i) {
 				const Atom& atom=ncf->molecule.get_atom(i);
@@ -633,7 +644,8 @@ public:
         U2_atomic_functor(const NuclearCorrelationFactor* ncf, const size_t atom)
             : ncf(ncf), iatom(atom) {}
 
-        double operator()(const coord_3d& xyz) const {
+        using FunctionFunctorInterface<double,3>::operator();
+        double operator()(const coord_3d& xyz) const override {
             const Atom& atom=ncf->molecule.get_atom(iatom);
             const coord_3d vr1A=xyz-atom.get_coords();
             const double r=vr1A.normf();
@@ -660,7 +672,8 @@ public:
         U3_atomic_functor(const NuclearCorrelationFactor* ncf, const int atom)
             : ncf(ncf), iatom(atom) {}
 
-        double operator()(const coord_3d& xyz) const {
+        using FunctionFunctorInterface<double,3>::operator();
+        double operator()(const coord_3d& xyz) const override {
             const Atom& atomA=ncf->molecule.get_atom(iatom);
             const coord_3d vr1A=xyz-atomA.get_coords();
             const double rA=vr1A.normf();
@@ -702,7 +715,9 @@ public:
         square_times_V_functor(const NuclearCorrelationFactor* ncf,
                 const Molecule& mol, const size_t iatom1)
             : ncf(ncf), molecule(mol), iatom(iatom1) {}
-        double operator()(const coord_3d& xyz) const {
+
+        using FunctionFunctorInterface<double,3>::operator();
+        double operator()(const coord_3d& xyz) const override {
             double result=1.0;
             for (size_t i=0; i<ncf->molecule.natom(); ++i) {
                 const Atom& atom=ncf->molecule.get_atom(i);
@@ -730,7 +745,9 @@ public:
         square_times_V_derivative_functor(const NuclearCorrelationFactor* ncf,
                 const Molecule& molecule1, const size_t atom1, const int axis1)
             : ncf(ncf), molecule(molecule1), iatom(atom1), axis(axis1) {}
-        double operator()(const coord_3d& xyz) const {
+
+        using FunctionFunctorInterface<double,3>::operator();
+        double operator()(const coord_3d& xyz) const override {
             double result=1.0;
             for (size_t i=0; i<ncf->molecule.natom(); ++i) {
                 const Atom& atom=ncf->molecule.get_atom(i);
@@ -769,7 +786,8 @@ public:
             MADNESS_ASSERT((exponent==1) or (exponent==2) or (exponent==-1));
         }
 
-        double operator()(const coord_3d& xyz) const {
+        using FunctionFunctorInterface<double,3>::operator();
+        double operator()(const coord_3d& xyz) const override {
 
             // compute the R term
             double result=1.0;
@@ -824,7 +842,9 @@ public:
             set_length_scale(lo);
         }
 
-        double operator()(const coord_3d& xyz) const {
+        using FunctionFunctorInterface<double,3>::operator();
+
+        double operator()(const coord_3d& xyz) const override {
             const coord_3d vr1A=xyz-thisatom.get_coords();
             const double r=vr1A.normf();
             const double& Z=thisatom.q;
@@ -862,7 +882,8 @@ public:
             set_length_scale(lo);
         }
 
-        double operator()(const coord_3d& xyz) const {
+        using FunctionFunctorInterface<double,3>::operator();
+        double operator()(const coord_3d& xyz) const override {
             const Atom& atom=ncf->molecule.get_atom(iatom);
             const coord_3d vr1A=xyz-atom.get_coords();
             const double r=vr1A.normf();
@@ -906,7 +927,8 @@ public:
         U3X_functor(const NuclearCorrelationFactor* ncf, const size_t iatom,
                 const int axis) : ncf(ncf), iatom(iatom), axis(axis) {}
 
-        double operator()(const coord_3d& xyz) const {
+        using FunctionFunctorInterface<double,3>::operator();
+        double operator()(const coord_3d& xyz) const override {
             const Atom& atomA=ncf->molecule.get_atom(iatom);
             const coord_3d vr1A=xyz-atomA.get_coords();
             const double r1A=vr1A.normf();

--- a/src/madness/chem/correlationfactor.h
+++ b/src/madness/chem/correlationfactor.h
@@ -465,7 +465,7 @@ public:
 			}
 
 		}
-		std::vector<coord_3d> special_points() const {
+		std::vector<coord_3d> special_points() const override {
 			return ncf->molecule.get_all_coords_vec();
 		}
 	};
@@ -497,7 +497,7 @@ public:
 			}
 			return result;
 		}
-		std::vector<coord_3d> special_points() const {
+		std::vector<coord_3d> special_points() const override {
 			return ncf->molecule.get_all_coords_vec();
 		}
 	};
@@ -527,7 +527,7 @@ public:
             return ncf->Sr_div_S(r,Z)*ncf->smoothed_unitvec(vr1A)[axis];
         }
 
-        std::vector<coord_3d> special_points() const {
+        std::vector<coord_3d> special_points() const override {
             std::vector< madness::Vector<double,3> > c(1);
             const Atom& atom=ncf->molecule.get_atom(iatom);
             c[0][0]=atom.x;
@@ -575,7 +575,7 @@ public:
 
             return result;
         }
-        std::vector<coord_3d> special_points() const {
+        std::vector<coord_3d> special_points() const override {
             return ncf->molecule.get_all_coords_vec();
         }
     };
@@ -597,7 +597,7 @@ public:
 			}
 			return result;
 		}
-		std::vector<coord_3d> special_points() const {
+		std::vector<coord_3d> special_points() const override {
 			return ncf->molecule.get_all_coords_vec();
 		}
 	};
@@ -629,7 +629,7 @@ public:
 
 			return -1.0*result;
 		}
-		std::vector<coord_3d> special_points() const {
+		std::vector<coord_3d> special_points() const override {
 			return ncf->molecule.get_all_coords_vec();
 		}
 	};
@@ -652,7 +652,7 @@ public:
             return ncf->Spp_div_S(r,atom.q);
         }
 
-        std::vector<coord_3d> special_points() const {
+        std::vector<coord_3d> special_points() const override {
             std::vector< madness::Vector<double,3> > c(1);
             const Atom& atom=ncf->molecule.get_atom(iatom);
             c[0][0]=atom.x;
@@ -697,7 +697,7 @@ public:
             return -0.5*result;
         }
 
-        std::vector<coord_3d> special_points() const {
+        std::vector<coord_3d> special_points() const override {
             std::vector< madness::Vector<double,3> > c(1);
             const Atom& atom=ncf->molecule.get_atom(iatom);
             c[0][0]=atom.x;
@@ -730,7 +730,7 @@ public:
             return result*result*V;
 
         }
-        std::vector<coord_3d> special_points() const {
+        std::vector<coord_3d> special_points() const override {
             return ncf->molecule.get_all_coords_vec();
         }
     };
@@ -760,7 +760,7 @@ public:
             return result*result*Vprime;
 
         }
-        std::vector<coord_3d> special_points() const {
+        std::vector<coord_3d> special_points() const override {
             return ncf->molecule.get_all_coords_vec();
         }
     };
@@ -813,7 +813,7 @@ public:
             return result;
         }
 
-        std::vector<coord_3d> special_points() const {
+        std::vector<coord_3d> special_points() const override {
             return ncf->molecule.get_all_coords_vec();
         }
 
@@ -858,7 +858,7 @@ public:
                       -S1*(ncf->dsmoothed_unitvec(vr1A,derivativeaxis)[U1axis]);
         }
 
-        std::vector<coord_3d> special_points() const {
+        std::vector<coord_3d> special_points() const override {
             std::vector< madness::Vector<double,3> > c(1);
             c[0][0]=thisatom.x;
             c[0][1]=thisatom.y;
@@ -896,7 +896,7 @@ public:
             return drhodx*ncf->U2X_spherical(r,Z,rcut);
         }
 
-        std::vector<coord_3d> special_points() const {
+        std::vector<coord_3d> special_points() const override {
             std::vector< madness::Vector<double,3> > c(1);
             const Atom& atom=ncf->molecule.get_atom(iatom);
             c[0][0]=atom.x;
@@ -970,7 +970,7 @@ public:
             return term;
         }
 
-        std::vector<coord_3d> special_points() const {
+        std::vector<coord_3d> special_points() const override {
             return ncf->molecule.get_all_coords_vec();
         }
     };

--- a/src/madness/chem/electronic_correlation_factor.h
+++ b/src/madness/chem/electronic_correlation_factor.h
@@ -192,7 +192,10 @@ private:
         fg_(double gamma, double dcut) : gamma(gamma), dcut(dcut) {
             MADNESS_ASSERT(gamma>0.0);
         }
-        double operator()(const coord_6d& r) const {
+
+        using FunctionFunctorInterface<double,6>::operator();
+
+        double operator()(const coord_6d& r) const override {
             const double rr=r12(r);
             const double e=exp(-gamma*rr);
             if (rr<5.e-2) {
@@ -215,7 +218,10 @@ private:
         f_over_r_(double gamma, double dcut) : gamma(gamma), dcut(dcut) {
             MADNESS_ASSERT(gamma>0.0);
         }
-        double operator()(const coord_6d& r) const {
+
+        using FunctionFunctorInterface<double,6>::operator();
+
+        double operator()(const coord_6d& r) const override {
             const double rr=r12(r);
             const double e=exp(-gamma*rr);
             return (1.0-e)*u(rr,dcut)/(2.0*gamma);
@@ -231,7 +237,8 @@ private:
             dcut(dcut) {
             MADNESS_ASSERT(axis>=0 and axis<3);
         }
-        double operator()(const coord_6d& r) const {
+        using FunctionFunctorInterface<double,6>::operator();
+        double operator()(const coord_6d& r) const override {
             const double rr=r12(r);
             const coord_3d vr12{r[0]-r[3],r[1]-r[4],r[2]-r[5]};
             const coord_3d N=unitvec(vr12);
@@ -249,7 +256,8 @@ private:
     struct f2_ : FunctionFunctorInterface<double,6>  {
         double gamma;
         f2_(double gamma) : gamma(gamma) {MADNESS_ASSERT(gamma>0.0);}
-        double operator()(const coord_6d& r) const {
+        using FunctionFunctorInterface<double,6>::operator();
+        double operator()(const coord_6d& r) const override {
             const double rr=r12(r);
             const double e=exp(-gamma*rr);
             const double f=(1.0-e)/(2.0*gamma);
@@ -264,7 +272,8 @@ private:
             MADNESS_ASSERT(gamma>0.0);
             MADNESS_ASSERT(gamma==1.0);
         }
-        double operator()(const coord_6d& r) const {
+        using FunctionFunctorInterface<double,6>::operator();
+        double operator()(const coord_6d& r) const override {
             const double rr=r12(r);
             const double f=exp(-2.0*gamma*rr)/(4.0*gamma*gamma);
             return f;
@@ -429,8 +438,10 @@ private:
             MADNESS_ASSERT(gamma==0.5);
         }
 
+        using FunctionFunctorInterface<double,6>::operator();
+
         // only valid for gamma=1
-        double operator()(const coord_6d& r) const {
+        double operator()(const coord_6d& r) const override {
             const double rr=r12(r);
             double val=(1.0-0.5*exp(-gamma*rr));
             if (exponent==1) return val;
@@ -451,8 +462,10 @@ private:
             MADNESS_ASSERT(gamma==0.5);
         }
 
+        using FunctionFunctorInterface<double,6>::operator();
+
         // only valid for gamma=1
-        double operator()(const coord_6d& r) const {
+        double operator()(const coord_6d& r) const override {
             const double rr=r12(r);
             // Taylor expansion for small r
             if (rr<1.e-4) { // valid for gamma==0.5, otherwise singular
@@ -479,7 +492,9 @@ private:
             MADNESS_ASSERT(axis<3);
         }
 
-        double operator()(const coord_6d& r) const {
+        using FunctionFunctorInterface<double,6>::operator();
+
+        double operator()(const coord_6d& r) const override {
             const double rr=r12(r);
             const coord_3d vr12{r[0]-r[3],r[1]-r[4],r[2]-r[5]};
             const coord_3d N=unitvec(vr12);

--- a/src/madness/chem/gaussian.h
+++ b/src/madness/chem/gaussian.h
@@ -380,6 +380,8 @@ private:
 public:
     Gaussian_Functor(GaussianFunction func, std::vector<madness::coord_3d> centers) : func(func), centers(centers) {}
 
+    using madness::FunctionFunctorInterface<double, 3>::operator();
+
     double operator()(const madness::coord_3d& r) const final {
         return func(r);
     }

--- a/src/madness/chem/znemo.h
+++ b/src/madness/chem/znemo.h
@@ -481,7 +481,9 @@ protected:
 			MADNESS_ASSERT(exponent>0.0);
 		}
 
-		double_complex operator()(const coord_3d& xyz1) const {
+		using FunctionFunctorInterface<double_complex,3>::operator();
+
+		double_complex operator()(const coord_3d& xyz1) const override {
 			coord_3d xyz=xyz1-origin;
 			double r=xyz.normf();
 			return exp(-exponent*r);
@@ -500,7 +502,9 @@ protected:
 			MADNESS_ASSERT(exponent>0.0);
 		}
 
-		double_complex operator()(const coord_3d& xyz1) const {
+		using FunctionFunctorInterface<double_complex,3>::operator();
+
+		double_complex operator()(const coord_3d& xyz1) const override {
 			coord_3d xyz=xyz1-origin;
 			double r=xyz.normf();
 

--- a/src/madness/mra/key.h
+++ b/src/madness/mra/key.h
@@ -486,8 +486,8 @@ namespace madness {
         template<std::size_t LDIM>
         Key<NDIM+LDIM> merge_with(const Key<LDIM>& rhs) const {
             Vector<Translation,NDIM+LDIM> t;
-            for (size_t i=0; i<NDIM; ++i) t[i]     =this->l[i];
-            for (size_t i=0; i<LDIM; ++i) t[NDIM+i]=rhs.translation()[i];
+            if constexpr (NDIM > 0) for (size_t i=0; i<NDIM; ++i) t[i]     =this->l[i];
+            if constexpr (LDIM > 0) for (size_t i=0; i<LDIM; ++i) t[NDIM+i]=rhs.translation()[i];
             return Key<NDIM+LDIM>(rhs.level(),t);
         }
 

--- a/src/madness/world/worlddc.h
+++ b/src/madness/world/worlddc.h
@@ -2213,7 +2213,10 @@ namespace madness
                 public:
                     op_inspector(const_iterator start, const_iterator end, size_t &size)
                         : start(start), end(end), size(size) {}
-                    void run(World &world)
+
+                    using TaskInterface::run;
+
+                    void run(World &world) override
                     {
                         BufferOutputArchive bo;
                         for (const_iterator it = start; it != end; ++it)
@@ -2231,7 +2234,10 @@ namespace madness
                 public:
                     op_executor(const_iterator start, const_iterator end, unsigned char *buf, size_t size)
                         : start(start), end(end), buf(buf), size(size) {}
-                    void run(World &world)
+
+                    using TaskInterface::run;
+
+                    void run(World &world) override
                     {
                         BufferOutputArchive bo(buf, size);
                         for (const_iterator it = start; it != end; ++it)


### PR DESCRIPTION
Fixes more occurences of partially overridden virtual functions. Also fixes an instance in key.h where NVCC complains about pointless comparisons of unsigned <0.