### PR TITLE
Pr localizer

### DIFF
--- a/src/madness/chem/CalculationParameters.h
+++ b/src/madness/chem/CalculationParameters.h
@@ -94,7 +94,7 @@ struct CalculationParameters : public QCCalculationParametersBase {
 		initialize<bool>  ("plotdens",false,"If true print the density at convergence");
 		initialize<bool>  ("plotcoul",false,"If true plot the total coulomb potential at convergence");
 		initialize<bool>  ("plotcube",false,"If true also write Gaussian .cube files (for Avogadro/VMD) alongside .dx");
-		initialize<std::string> ("localize","new","localization method",{"pm","boys","new","new_sys","canon"});
+		initialize<std::string> ("localize","new","localization method",{"pm","boys","new","new_sys","cholesky","canon"});
 		initialize<std::string> ("pointgroup","c1","use point (sub) group symmetry if not localized",{"c1","c2","ci","cs","c2v","c2h","d2","d2h"});
 		initialize<std::string>("restart","auto","where the initial orbitals come from: auto picks "
 				"between none/iterate/read_only by what is on disk",

--- a/src/madness/chem/CalculationParameters.h
+++ b/src/madness/chem/CalculationParameters.h
@@ -94,7 +94,7 @@ struct CalculationParameters : public QCCalculationParametersBase {
 		initialize<bool>  ("plotdens",false,"If true print the density at convergence");
 		initialize<bool>  ("plotcoul",false,"If true plot the total coulomb potential at convergence");
 		initialize<bool>  ("plotcube",false,"If true also write Gaussian .cube files (for Avogadro/VMD) alongside .dx");
-		initialize<std::string> ("localize","new","localization method",{"pm","boys","new","canon"});
+		initialize<std::string> ("localize","new","localization method",{"pm","boys","new","new_sys","canon"});
 		initialize<std::string> ("pointgroup","c1","use point (sub) group symmetry if not localized",{"c1","c2","ci","cs","c2v","c2h","d2","d2h"});
 		initialize<std::string>("restart","auto","where the initial orbitals come from: auto picks "
 				"between none/iterate/read_only by what is on disk",

--- a/src/madness/chem/SCF.cc
+++ b/src/madness/chem/SCF.cc
@@ -2494,9 +2494,16 @@ void SCF::solve(World& world) {
             localizer.set_tolloc_scale(localize_tolloc_scale);
             {
                 MolecularOrbitals<double, 3> mo(amo, aeps, {}, aocc, aset);
+                const double t_loc0 = wall_time();
                 tensorT UT = localizer.compute_localization_matrix(world, mo, iter == 0);
+                const double t_loc1 = wall_time();
                 UT.screen(trantol);
                 rotate_orbitals(amo, UT);
+                // split the localize timer: matrix = the localizer optimization (incl. U
+                // replication); transform = screen + the nmo^2 orbital rotation
+                if (world.rank() == 0 && param.print_level() >= 3)
+                    printf("  localize phases: matrix %.2fs transform %.2fs\n",
+                           t_loc1 - t_loc0, wall_time() - t_loc1);
             }
             if (!param.spin_restricted() && param.nbeta() != 0) {
                 MolecularOrbitals<double, 3> mo(bmo, beps, {}, bocc, bset);

--- a/src/madness/chem/SCF.cc
+++ b/src/madness/chem/SCF.cc
@@ -2479,17 +2479,36 @@ void SCF::solve(World& world) {
             normalize(world, v);
         };
 
+        // Applying a near-identity localization rotation churns the trees and de-syncs
+        // the KAIN history (the stored subspace is never rotated), so skip the transform
+        // when the localizer barely moved anything: accumulated drift re-engages it by
+        // growing past the threshold on a later iteration.
+        auto max_offdiag = [](const tensorT& U) {
+            double m = 0.0;
+            for (long i = 0; i < U.dim(0); ++i)
+                for (long j = 0; j < U.dim(1); ++j)
+                    if (i != j) m = std::max(m, std::abs(U(i, j)));
+            return m;
+        };
+        const double localize_skip_tol = 0.01;
+
         if (param.do_localize() && do_this_iter) {
             START_TIMER(world);
             Localizer localizer(world, aobasis, molecule, ao);
             localizer.set_method(param.localize_method());
             {
                 MolecularOrbitals<double, 3> mo(amo, aeps, {}, aocc, aset);
+                localizer.set_pivot_state(&localize_pivot_state_a);
                 const double t_loc0 = wall_time();
                 tensorT UT = localizer.compute_localization_matrix(world, mo, iter == 0);
                 const double t_loc1 = wall_time();
-                UT.screen(trantol);
-                rotate_orbitals(amo, UT);
+                const double offdiag = max_offdiag(UT);
+                if (offdiag > localize_skip_tol) {
+                    UT.screen(trantol);
+                    rotate_orbitals(amo, UT);
+                } else if (world.rank() == 0 && param.print_level() >= 3) {
+                    printf("  localize: rotation skipped (max offdiag %.1e)\n", offdiag);
+                }
                 // split the localize timer: matrix = the localizer optimization (incl. U
                 // replication); transform = screen + the nmo^2 orbital rotation
                 if (world.rank() == 0 && param.print_level() >= 3)
@@ -2498,9 +2517,12 @@ void SCF::solve(World& world) {
             }
             if (!param.spin_restricted() && param.nbeta() != 0) {
                 MolecularOrbitals<double, 3> mo(bmo, beps, {}, bocc, bset);
+                localizer.set_pivot_state(&localize_pivot_state_b);
                 tensorT UT = localizer.compute_localization_matrix(world, mo, iter == 0);
-                UT.screen(trantol);
-                rotate_orbitals(bmo, UT);
+                if (max_offdiag(UT) > localize_skip_tol) {
+                    UT.screen(trantol);
+                    rotate_orbitals(bmo, UT);
+                }
             }
             END_TIMER(world, "localize");
         }

--- a/src/madness/chem/SCF.cc
+++ b/src/madness/chem/SCF.cc
@@ -2452,14 +2452,6 @@ void SCF::solve(World& world) {
         //     //do_this_iter = false;
         //     param.maxsub = maxsub_save;
         // }
-        // The first localization starts from the atomic guess, where CG can spend hundreds of
-        // iterations chasing 1e-6 while still bouncing above it. Later iterations re-localize
-        // anyway, so loosen that one call.
-        double localize_tolloc_scale = 1.0;
-        if (param.do_localize() && do_this_iter && !initial_localization_done) {
-            localize_tolloc_scale = 100.0;
-            initial_localization_done = true;
-        }
         // Tiling the transform bounds the transient memory of the rotated orbitals, which only
         // threatens at high precision. Below that it only buys an extra truncation per tile.
         // Take the untiled path except at the tight protocols.
@@ -2491,7 +2483,6 @@ void SCF::solve(World& world) {
             START_TIMER(world);
             Localizer localizer(world, aobasis, molecule, ao);
             localizer.set_method(param.localize_method());
-            localizer.set_tolloc_scale(localize_tolloc_scale);
             {
                 MolecularOrbitals<double, 3> mo(amo, aeps, {}, aocc, aset);
                 const double t_loc0 = wall_time();

--- a/src/madness/chem/SCF.cc
+++ b/src/madness/chem/SCF.cc
@@ -2496,6 +2496,7 @@ void SCF::solve(World& world) {
             START_TIMER(world);
             Localizer localizer(world, aobasis, molecule, ao);
             localizer.set_method(param.localize_method());
+            double t_matrix = 0.0, t_transform = 0.0;
             {
                 MolecularOrbitals<double, 3> mo(amo, aeps, {}, aocc, aset);
                 localizer.set_pivot_state(&localize_pivot_state_a);
@@ -2509,21 +2510,26 @@ void SCF::solve(World& world) {
                 } else if (world.rank() == 0 && param.print_level() >= 3) {
                     printf("  localize: rotation skipped (max offdiag %.1e)\n", offdiag);
                 }
-                // split the localize timer: matrix = the localizer optimization (incl. U
-                // replication); transform = screen + the nmo^2 orbital rotation
-                if (world.rank() == 0 && param.print_level() >= 3)
-                    printf("  localize phases: matrix %.2fs transform %.2fs\n",
-                           t_loc1 - t_loc0, wall_time() - t_loc1);
+                t_matrix += t_loc1 - t_loc0;
+                t_transform += wall_time() - t_loc1;
             }
             if (!param.spin_restricted() && param.nbeta() != 0) {
                 MolecularOrbitals<double, 3> mo(bmo, beps, {}, bocc, bset);
                 localizer.set_pivot_state(&localize_pivot_state_b);
+                const double t_loc0 = wall_time();
                 tensorT UT = localizer.compute_localization_matrix(world, mo, iter == 0);
+                const double t_loc1 = wall_time();
                 if (max_offdiag(UT) > localize_skip_tol) {
                     UT.screen(trantol);
                     rotate_orbitals(bmo, UT);
                 }
+                t_matrix += t_loc1 - t_loc0;
+                t_transform += wall_time() - t_loc1;
             }
+            // split the localize timer: matrix = the localizer optimization (incl. U
+            // replication); transform = screen + the nmo^2 orbital rotation
+            if (world.rank() == 0 && param.print_level() >= 3)
+                printf("  localize phases: matrix %.2fs transform %.2fs\n", t_matrix, t_transform);
             END_TIMER(world, "localize");
         }
 

--- a/src/madness/chem/SCF.h
+++ b/src/madness/chem/SCF.h
@@ -239,7 +239,6 @@ public:
     double converged_for_thresh=1.e10;   ///< mos are converged for this threshold
     double converged_for_dconv=1.e10;    ///< mos are converged for this density
     double converged_for_tconv=1.e10;    ///< derivatives of mos are converged for this threshold
-    bool initial_localization_done=false; ///< the first localization of this calculation is loosened
 
     /// what amo/bmo actually hold, recorded in the restartdata header
     ///

--- a/src/madness/chem/SCF.h
+++ b/src/madness/chem/SCF.h
@@ -221,6 +221,8 @@ public:
     /// sets of orbitals grouped by their orbital energies (for localization?)
     /// only orbitals within the same set will be mixed to localize
     std::vector<int> aset, bset;
+    /// cholesky localization's pivot order from the previous iteration (per spin)
+    std::vector<long> localize_pivot_state_a, localize_pivot_state_b;
 
     /// MRA projection of the minimal basis set
     vecfuncT ao;

--- a/src/madness/chem/distpm.cc
+++ b/src/madness/chem/distpm.cc
@@ -72,7 +72,10 @@ void matrix_inner(DistributedMatrix<T>& A,
 static inline double PM_q(const tensorT & S, const double * MADNESS_RESTRICT Ci, const double * MADNESS_RESTRICT Cj, int lo, int nbf)
 {
     double qij = 0.0;
-    if (nbf == 1) { // H atom in STO-3G ... often lots of these!
+    if (S.size() == 0) { // empty S marks an orthonormal block (S == identity): the "new" method
+        for(int mu = 0;mu < nbf;++mu) qij += Ci[mu + lo] * Cj[mu + lo];
+    }
+    else if (nbf == 1) { // H atom in STO-3G ... often lots of these!
         qij = Ci[lo]*S(0,0)*Cj[lo];
     }
     else {
@@ -386,6 +389,42 @@ DistributedMatrix<double> distributed_localize_PM(World & world,
     // }
     // world.gop.broadcast(U.ptr(), U.size(), 0);
     //return U;
+}
+
+DistributedMatrix<double> distributed_localize_new(World& world,
+                                                   const Tensor<double>& C,
+                                                   const std::vector<int>& set,
+                                                   const std::vector<int>& at_to_bf,
+                                                   const std::vector<int>& at_nbf,
+                                                   const double thresh,
+                                                   const double thetamax)
+{
+    const long nmo = C.dim(0);
+    const long nao = C.dim(1);
+    const long natom = at_to_bf.size();
+
+    // Empty overlap blocks select PM_q's orthonormal fast path (S == identity): in the
+    // orthonormal atomic-eigenfunction basis the charge q_ij(a) is a plain dot product.
+    std::vector<tensorT> Svec(natom);
+
+    DistributedMatrix<double> dU = column_distributed_matrix<double>(world, nmo, nmo);
+    dU.fill_identity();
+
+    DistributedMatrix<double> dC = column_distributed_matrix<double>(world, nmo, nao);
+    dC.copy_from_replicated(C);
+
+    DistributedMatrix<double> dA = concatenate_rows(dC, dU);
+
+    world.taskq.add(new SystolicPMOrbitalLocalize(dA, set, at_to_bf, at_nbf, Svec, thresh,
+                                                  thetamax, natom, nao, nmo));
+    world.taskq.fence();
+
+    dA.extract_columns(nao, nmo+nao-1, dU);
+
+    world.taskq.add(new SystolicFixOrbitalOrders(dU));
+    world.taskq.fence();
+
+    return dU;
 }
 
 }

--- a/src/madness/chem/distpm.cc
+++ b/src/madness/chem/distpm.cc
@@ -72,7 +72,7 @@ void matrix_inner(DistributedMatrix<T>& A,
 static inline double PM_q(const tensorT & S, const double * MADNESS_RESTRICT Ci, const double * MADNESS_RESTRICT Cj, int lo, int nbf)
 {
     double qij = 0.0;
-    if (S.size() == 0) { // empty S marks an orthonormal block (S == identity): the "new" method
+    if (S.size() == 0) { // an empty S signals an orthonormal basis (overlap = identity): the "new" method
         for(int mu = 0;mu < nbf;++mu) qij += Ci[mu + lo] * Cj[mu + lo];
     }
     else if (nbf == 1) { // H atom in STO-3G ... often lots of these!

--- a/src/madness/chem/distpm.h
+++ b/src/madness/chem/distpm.h
@@ -19,6 +19,21 @@ extern DistributedMatrix<double> distributed_localize_PM(World& world,
                                                          const double thetamax = 0.5,
                                                          const bool randomize = true,
                                                          const bool doprint = false);
+
+/// Distributed optimization for the "new" localization method.
+
+/// The "new" objective is Pipek-Mezey in an orthonormal basis, so it is optimized with
+/// the same systolic Jacobi sweeps as distributed_localize_PM. C is the replicated
+/// (nmo x nao) coefficient matrix already transformed to the orthonormal
+/// atomic-eigenfunction basis; at_to_bf/at_nbf hold the per-atom 1s / 2s2p / rest
+/// blocks built by Localizer::prepare_new_basis.
+extern DistributedMatrix<double> distributed_localize_new(World& world,
+                                                          const Tensor<double>& C,
+                                                          const std::vector<int>& set,
+                                                          const std::vector<int>& at_to_bf,
+                                                          const std::vector<int>& at_nbf,
+                                                          const double thresh = 1e-9,
+                                                          const double thetamax = 0.5);
 }
 
 #endif // MADNESS_DISTPM_H

--- a/src/madness/chem/localizer.cc
+++ b/src/madness/chem/localizer.cc
@@ -80,6 +80,8 @@ Tensor<T> Localizer::compute_localization_matrix(World& world, const MolecularOr
         dUT = localize_boys(world, psi, mo_in.get_localize_sets(), tolloc, randomize);
     } else if (method == "new") {
         dUT = localize_new(world, psi, mo_in.get_localize_sets(), tolloc * tolloc_scale, randomize, false);
+    } else if (method == "new_sys") {
+        dUT = localize_new_systolic(world, psi, mo_in.get_localize_sets(), tolloc * tolloc_scale, randomize, false);
     } else {
         print("unknown localization method", method);
         MADNESS_EXCEPTION("unknown localization method", 1);
@@ -313,18 +315,17 @@ DistributedMatrix<T> Localizer::localize_PM(World& world, const std::vector<Func
 }
 
 
+/// Build the "new" method's working basis: transform the AO-projection matrix C into the
+/// orthonormal atomic-eigenfunction basis and construct the per-atom localization blocks
+/// (1s / 2s2p / rest). Shared by localize_new (rank-0 CG) and localize_new_systolic.
 template<typename T, std::size_t NDIM>
-DistributedMatrix<T> Localizer::localize_new(World& world, const std::vector<Function<T, NDIM>>& mo,
-                                             const std::vector<int>& set, double thresh,
-                                             const bool randomize, const bool doprint) const {
-    // PROFILE_MEMBER_FUNC(SCF);
+void Localizer::prepare_new_basis(World& world, const std::vector<Function<T, NDIM>>& mo,
+                                  Tensor<T>& C, std::vector<int>& at_to_bf,
+                                  std::vector<int>& at_nbf) const {
     typedef Tensor<T> tensorT;
-
-    int nmo = mo.size();
     int nao = ao.size();
 
-    tensorT C = matrix_inner(world, mo, ao);
-    std::vector<int> at_to_bf, at_nbf; // OVERRIDE DATA IN CLASS OBJ TO USE ATOMS OR SHELLS FOR TESTING
+    C = matrix_inner(world, mo, ao);
 
     bool use_atomic_evecs = true;
     if (use_atomic_evecs) {
@@ -393,6 +394,22 @@ DistributedMatrix<T> Localizer::localize_new(World& world, const std::vector<Fun
         aobasis.shells_to_bfn(molecule, at_to_bf, at_nbf);
         //aobasis.atoms_to_bfn(molecule, at_to_bf, at_nbf);
     }
+
+}
+
+template<typename T, std::size_t NDIM>
+DistributedMatrix<T> Localizer::localize_new(World& world, const std::vector<Function<T, NDIM>>& mo,
+                                             const std::vector<int>& set, double thresh,
+                                             const bool randomize, const bool doprint) const {
+    // PROFILE_MEMBER_FUNC(SCF);
+    typedef Tensor<T> tensorT;
+
+    int nmo = mo.size();
+    int nao = ao.size();
+
+    tensorT C;
+    std::vector<int> at_to_bf, at_nbf;
+    prepare_new_basis(world, mo, C, at_to_bf, at_nbf);
 
     // Below here atoms may be shells or atoms --- by default shells
 
@@ -571,6 +588,26 @@ DistributedMatrix<T> Localizer::localize_new(World& world, const std::vector<Fun
     //print(UT);
     return dUT;
 }
+
+/// The "new" objective optimized with distributed systolic Jacobi sweeps
+
+/// In the orthonormal atomic-eigenfunction basis the "new" objective is Pipek-Mezey
+/// (q_ij(a) with identity overlap), so it can reuse localize_PM's systolic machinery:
+/// every rank works every call, where localize_new's rank-0 optimizer leaves all other
+/// ranks idle -- beyond ~1500 orbitals a single call then exceeds the runtime idle
+/// watchdog (MAD_WAIT_TIMEOUT). A different optimizer on the same objective: it reaches
+/// a different, equally valid local maximum.
+template<typename T, std::size_t NDIM>
+DistributedMatrix<T> Localizer::localize_new_systolic(World& world, const std::vector<Function<T, NDIM>>& mo,
+                                                      const std::vector<int>& set, double thresh,
+                                                      const bool randomize, const bool doprint) const {
+    Tensor<T> C;
+    std::vector<int> at_to_bf, at_nbf;
+    prepare_new_basis(world, mo, C, at_to_bf, at_nbf);
+    // randomize is ignored, as in the PM path
+    return distributed_localize_new(world, C, set, at_to_bf, at_nbf, thresh, thetamax);
+}
+
 
 template<typename T>
 std::size_t Localizer::determine_frozen_orbitals(const Tensor<T> fmat) {

--- a/src/madness/chem/localizer.cc
+++ b/src/madness/chem/localizer.cc
@@ -79,9 +79,9 @@ Tensor<T> Localizer::compute_localization_matrix(World& world, const MolecularOr
     } else if (method == "boys") {
         dUT = localize_boys(world, psi, mo_in.get_localize_sets(), tolloc, randomize);
     } else if (method == "new") {
-        dUT = localize_new(world, psi, mo_in.get_localize_sets(), tolloc * tolloc_scale, randomize, false);
+        dUT = localize_new(world, psi, mo_in.get_localize_sets(), tolloc, randomize, false);
     } else if (method == "new_sys") {
-        dUT = localize_new_systolic(world, psi, mo_in.get_localize_sets(), tolloc * tolloc_scale, randomize, false);
+        dUT = localize_new_systolic(world, psi, mo_in.get_localize_sets(), tolloc, randomize, false);
     } else if (method == "cholesky") {
         dUT = localize_cholesky(world, psi, mo_in.get_localize_sets());
     } else {

--- a/src/madness/chem/localizer.cc
+++ b/src/madness/chem/localizer.cc
@@ -639,6 +639,18 @@ DistributedMatrix<T> Localizer::localize_cholesky(World& world, const std::vecto
 
     tensorT U(nmo, nmo);
 
+    // Pivot memory: reuse last iteration's pivot order unless a candidate decisively
+    // beats it. Near-ties in the diagonal density otherwise flip the greedy order under
+    // tiny density changes, and a flip cascades a discontinuous rotation through every
+    // later factorization step -- a constant residual-noise floor. With the order held,
+    // the factorization is a smooth function of the density and the noise shrinks with
+    // the residual. Slot indexing is call-order-stable (sets iterate identically), and
+    // the hysteresis decision uses replicated values only, so determinism and
+    // rank-independence are preserved.
+    const bool have_memory = pivot_state && !pivot_state->empty();
+    std::vector<long> used_pivots;
+    used_pivots.reserve(nmo);
+
     // factor each localize-set separately: rotations never mix core and valence
     std::vector<int> setids;
     for (long i = 0; i < nmo; ++i)
@@ -666,6 +678,12 @@ DistributedMatrix<T> Localizer::localize_cholesky(World& world, const std::vecto
             if (dglob < 1e-10) break; // density exhausted; U is completed below
             long cand = (piv >= 0 && dmax == dglob) ? piv : nao; // lowest index wins ties
             world.gop.min(cand);
+            if (have_memory && used_pivots.size() < pivot_state->size()) {
+                const long prev = (*pivot_state)[used_pivots.size()];
+                double dprev = (prev >= mulo && prev < muhi) ? d(prev) : -1.0;
+                world.gop.max(dprev);
+                if (dprev > 1e-10 && 2.0 * dprev >= dglob) cand = prev;
+            }
 
             // the pivot's coefficient column, orthonormalized against u_0..u_{k-1}
             tensorT w(ns);
@@ -693,6 +711,7 @@ DistributedMatrix<T> Localizer::localize_cholesky(World& world, const std::vecto
                 d(mu) -= z * z;
                 if (d(mu) < 0.0) d(mu) = 0.0;
             }
+            used_pivots.push_back(cand);
             ++k;
         }
 
@@ -713,6 +732,7 @@ DistributedMatrix<T> Localizer::localize_cholesky(World& world, const std::vecto
             if (nrm2 < 1e-6) continue;
             const double scale = 1.0 / std::sqrt(nrm2);
             for (long ii = 0; ii < ns; ++ii) u(ii, k) = w(ii) * scale;
+            used_pivots.push_back(-1); // completion slot: no pivot to remember
             ++k;
         }
         MADNESS_CHECK_THROW(k == ns, "cholesky localization failed to complete the rotation");
@@ -720,6 +740,8 @@ DistributedMatrix<T> Localizer::localize_cholesky(World& world, const std::vecto
         for (long kk = 0; kk < ns; ++kk)
             for (long ii = 0; ii < ns; ++ii) U(idx[ii], idx[kk]) = u(ii, kk);
     }
+
+    if (pivot_state) *pivot_state = used_pivots;
 
     // least-rotation ordering and phases, as in the other methods
     bool switched = true;

--- a/src/madness/chem/localizer.cc
+++ b/src/madness/chem/localizer.cc
@@ -82,6 +82,8 @@ Tensor<T> Localizer::compute_localization_matrix(World& world, const MolecularOr
         dUT = localize_new(world, psi, mo_in.get_localize_sets(), tolloc * tolloc_scale, randomize, false);
     } else if (method == "new_sys") {
         dUT = localize_new_systolic(world, psi, mo_in.get_localize_sets(), tolloc * tolloc_scale, randomize, false);
+    } else if (method == "cholesky") {
+        dUT = localize_cholesky(world, psi, mo_in.get_localize_sets());
     } else {
         print("unknown localization method", method);
         MADNESS_EXCEPTION("unknown localization method", 1);
@@ -606,6 +608,145 @@ DistributedMatrix<T> Localizer::localize_new_systolic(World& world, const std::v
     prepare_new_basis(world, mo, C, at_to_bf, at_nbf);
     // randomize is ignored, as in the PM path
     return distributed_localize_new(world, C, set, at_to_bf, at_nbf, thresh, thetamax);
+}
+
+
+/// Cholesky localization: deterministic and non-iterative
+
+/// A pivoted Cholesky factorization of the density in the orthonormal
+/// atomic-eigenfunction basis: repeatedly pick the basis function carrying the largest
+/// remaining diagonal density, take its coefficient column as the next orbital, and
+/// orthonormalize (Aquilante, Pedersen, Koch, J. Chem. Phys. 125, 174101 (2006)).
+/// No objective is optimized, so successive SCF iterations cannot hop between the
+/// near-degenerate maxima an iterative localizer wanders over. The pivot diagonal is
+/// divided over ranks; slices evolve by identical per-function arithmetic on
+/// replicated data, so the pivot sequence -- and U -- are independent of the rank
+/// count. Each pivot step costs two scalar allreduces.
+template<typename T, std::size_t NDIM>
+DistributedMatrix<T> Localizer::localize_cholesky(World& world, const std::vector<Function<T, NDIM>>& mo,
+                                                  const std::vector<int>& set) const {
+    typedef Tensor<T> tensorT;
+    const long nmo = mo.size();
+
+    tensorT C;
+    std::vector<int> at_to_bf, at_nbf;
+    prepare_new_basis(world, mo, C, at_to_bf, at_nbf);
+    const long nao = C.dim(1);
+
+    // this rank owns the pivot-diagonal slice [mulo, muhi)
+    const long nproc = world.size(), me = world.rank();
+    const long mulo = (nao * me) / nproc, muhi = (nao * (me + 1)) / nproc;
+
+    tensorT U(nmo, nmo);
+
+    // factor each localize-set separately: rotations never mix core and valence
+    std::vector<int> setids;
+    for (long i = 0; i < nmo; ++i)
+        if (std::find(setids.begin(), setids.end(), set[i]) == setids.end()) setids.push_back(set[i]);
+
+    for (int s : setids) {
+        std::vector<long> idx;
+        for (long i = 0; i < nmo; ++i) if (set[i] == s) idx.push_back(i);
+        const long ns = long(idx.size());
+
+        // remaining diagonal density of the owned basis functions
+        tensorT d(nao);
+        for (long ii = 0; ii < ns; ++ii)
+            for (long mu = mulo; mu < muhi; ++mu) d(mu) += C(idx[ii], mu) * C(idx[ii], mu);
+
+        tensorT u(ns, ns); // columns = the new orbitals in terms of the set's orbitals
+        long k = 0;
+        while (k < ns) {
+            long piv = -1;
+            double dmax = -1.0;
+            for (long mu = mulo; mu < muhi; ++mu)
+                if (d(mu) > dmax) { dmax = d(mu); piv = mu; }
+            double dglob = dmax;
+            world.gop.max(dglob);
+            if (dglob < 1e-10) break; // density exhausted; U is completed below
+            long cand = (piv >= 0 && dmax == dglob) ? piv : nao; // lowest index wins ties
+            world.gop.min(cand);
+
+            // the pivot's coefficient column, orthonormalized against u_0..u_{k-1}
+            tensorT w(ns);
+            for (long ii = 0; ii < ns; ++ii) w(ii) = C(idx[ii], cand);
+            for (int pass = 0; pass < 2; ++pass) {
+                for (long l = 0; l < k; ++l) {
+                    T ov = 0.0;
+                    for (long ii = 0; ii < ns; ++ii) ov += u(ii, l) * w(ii);
+                    for (long ii = 0; ii < ns; ++ii) w(ii) -= ov * u(ii, l);
+                }
+            }
+            double nrm2 = 0.0;
+            for (long ii = 0; ii < ns; ++ii) nrm2 += w(ii) * w(ii);
+            if (nrm2 < 1e-12) { // pivot already spanned: discard it and pick again
+                if (cand >= mulo && cand < muhi) d(cand) = 0.0;
+                continue;
+            }
+            const double scale = 1.0 / std::sqrt(nrm2);
+            for (long ii = 0; ii < ns; ++ii) u(ii, k) = w(ii) * scale;
+
+            // downdate the owned slice: d_mu -= (u_k . C(:,mu))^2
+            for (long mu = mulo; mu < muhi; ++mu) {
+                T z = 0.0;
+                for (long ii = 0; ii < ns; ++ii) z += u(ii, k) * C(idx[ii], mu);
+                d(mu) -= z * z;
+                if (d(mu) < 0.0) d(mu) = 0.0;
+            }
+            ++k;
+        }
+
+        // the projected basis can span fewer than ns dimensions; complete with
+        // coordinate vectors so the transform stays exactly unitary
+        for (long j = 0; k < ns && j < ns; ++j) {
+            tensorT w(ns);
+            w(j) = 1.0;
+            for (int pass = 0; pass < 2; ++pass) {
+                for (long l = 0; l < k; ++l) {
+                    T ov = 0.0;
+                    for (long ii = 0; ii < ns; ++ii) ov += u(ii, l) * w(ii);
+                    for (long ii = 0; ii < ns; ++ii) w(ii) -= ov * u(ii, l);
+                }
+            }
+            double nrm2 = 0.0;
+            for (long ii = 0; ii < ns; ++ii) nrm2 += w(ii) * w(ii);
+            if (nrm2 < 1e-6) continue;
+            const double scale = 1.0 / std::sqrt(nrm2);
+            for (long ii = 0; ii < ns; ++ii) u(ii, k) = w(ii) * scale;
+            ++k;
+        }
+        MADNESS_CHECK_THROW(k == ns, "cholesky localization failed to complete the rotation");
+
+        for (long kk = 0; kk < ns; ++kk)
+            for (long ii = 0; ii < ns; ++ii) U(idx[ii], idx[kk]) = u(ii, kk);
+    }
+
+    // least-rotation ordering and phases, as in the other methods
+    bool switched = true;
+    while (switched) {
+        switched = false;
+        for (long i = 0; i < nmo; i++) {
+            for (long j = i + 1; j < nmo; j++) {
+                if (set[i] == set[j]) {
+                    double sold = U(i, i) * U(i, i) + U(j, j) * U(j, j);
+                    double snew = U(i, j) * U(i, j) + U(j, i) * U(j, i);
+                    if (snew > sold) {
+                        tensorT tmp = copy(U(_, i));
+                        U(_, i) = U(_, j);
+                        U(_, j) = tmp;
+                        switched = true;
+                    }
+                }
+            }
+        }
+    }
+    for (long i = 0; i < nmo; ++i) {
+        if (U(i, i) < 0.0) U(_, i).scale(-1.0);
+    }
+
+    DistributedMatrix<double> dUT = column_distributed_matrix<double>(world, nmo, nmo);
+    dUT.copy_from_replicated(transpose(U));
+    return dUT;
 }
 
 

--- a/src/madness/chem/localizer.h
+++ b/src/madness/chem/localizer.h
@@ -149,6 +149,21 @@ private:
                                       const bool randomize = true,
                                       const bool doprint = false) const;
 
+    /// the "new" objective optimized with distributed systolic Jacobi sweeps (localize=new_sys)
+    template<typename T, std::size_t NDIM>
+    DistributedMatrix<T> localize_new_systolic(World& world,
+                                               const std::vector<Function<T, NDIM>>& mo,
+                                               const std::vector<int>& set,
+                                               const double thresh = 1e-9,
+                                               const bool randomize = true,
+                                               const bool doprint = false) const;
+
+    /// build the "new" method's orthonormal atomic-eigenfunction basis and localization blocks
+    template<typename T, std::size_t NDIM>
+    void prepare_new_basis(World& world, const std::vector<Function<T, NDIM>>& mo,
+                           Tensor<T>& C, std::vector<int>& at_to_bf,
+                           std::vector<int>& at_nbf) const;
+
     template<typename T>
     inline double DIP(const Tensor<T>& dip, int i, int j, int k, int l) const {
         return dip(i, j, 0) * dip(k, l, 0) + dip(i, j, 1) * dip(k, l, 1) + dip(i, j, 2) * dip(k, l, 2);

--- a/src/madness/chem/localizer.h
+++ b/src/madness/chem/localizer.h
@@ -45,12 +45,6 @@ public:
         return *this;
     }
 
-    /// Multiply the "new" method's convergence threshold by this factor (default 1.0).
-    Localizer& set_tolloc_scale(const double scale) {
-        tolloc_scale=scale;
-        return *this;
-    }
-
     AtomicBasisSet get_aobasis() const {
         return aobasis;
     }
@@ -185,7 +179,6 @@ private:
     Function<double,3> metric;       /// =R for computing matrix elements of operators
     double thetamax=0.1;                /// maximum rotation(?)
     const double tolloc = 1e-6; // was std::min(1e-6,0.01*dconv) but now trying to avoid unnecessary change
-    double tolloc_scale = 1.0;  // multiplies tolloc, "new" method only
     double thresh_degenerate;           /// when are orbitals degenerate
     bool enforce_core_valence_separation=false;  /// no rotations between core and valence orbitals (distinguished by 'set')
     std::string method="new";           /// localization method

--- a/src/madness/chem/localizer.h
+++ b/src/madness/chem/localizer.h
@@ -49,6 +49,13 @@ public:
         return aobasis;
     }
 
+    /// hand the cholesky method last iteration's pivot order; it reads the order and
+    /// overwrites it with the one it used (see localize_cholesky)
+    Localizer& set_pivot_state(std::vector<long>* state) {
+        pivot_state = state;
+        return *this;
+    }
+
     void print_info() const {
         print("Localizer info");
         print("method  ",method);
@@ -182,6 +189,7 @@ private:
     double thresh_degenerate;           /// when are orbitals degenerate
     bool enforce_core_valence_separation=false;  /// no rotations between core and valence orbitals (distinguished by 'set')
     std::string method="new";           /// localization method
+    std::vector<long>* pivot_state = nullptr;  /// cholesky pivot memory across SCF iterations
 
 };
 

--- a/src/madness/chem/localizer.h
+++ b/src/madness/chem/localizer.h
@@ -142,6 +142,11 @@ private:
                                        const bool doprint = false) const;
 
     template<typename T, std::size_t NDIM>
+    DistributedMatrix<T> localize_cholesky(World& world,
+                                           const std::vector<Function<T, NDIM>>& mo,
+                                           const std::vector<int>& set) const;
+
+    template<typename T, std::size_t NDIM>
     DistributedMatrix<T> localize_new(World& world,
                                       const std::vector<Function<T, NDIM>>& mo,
                                       const std::vector<int>& set,


### PR DESCRIPTION
# Distributed orbital localization: localize=new_sys, localize=cholesky

`localize new` runs its optimizer on rank 0 only; beyond ~1500 orbitals a
single call exceeds the idle-rank watchdog (`MAD_WAIT_TIMEOUT`) and aborts
the job. This PR adds two distributed localizers that are fast and
watchdog-safe at that scale, plus small SCF-side localization changes. The
existing optimizers (`new`, `boys`, `pm`) are untouched.

- `localize new_sys`: the "new" objective (Pipek–Mezey in the orthonormal
  atomic-eigenfunction basis) optimized with the distributed systolic
  Jacobi-sweep engine of `distributed_localize_PM`. Localize-set boundaries
  are respected during the sweeps (in moldft, multiple sets are populated
  only for `pm`; the nemo stack enforces core–valence separation through
  the same interface).
- `localize cholesky`: non-iterative, deterministic localization by pivoted
  Cholesky of the density in the orthonormal atomic-eigenfunction basis
  (Aquilante, Pedersen, Koch 2006). The pivot search is divided over ranks.
  Each SCF iteration reuses the previous iteration's pivot order; a slot
  re-pivots only when a candidate beats the remembered pivot by 2x.
- The orbital transform is skipped when the computed rotation is
  near-identity (max off-diagonal <= 0.01), keeping the KAIN history in one
  orbital basis across skipped iterations.
- The loosened (100x) localization tolerance on the initial-guess iteration
  is removed.
- The SCF localize timer is split into matrix and transform phases
  (`print_level >= 3`).

All localizers give results independent of rank count. No new input
parameters beyond the two `localize` values. No serialization or
checkpoint-format change.

## Commits

| commit | what |
|---|---|
| `d07e403c8` | `localize=new_sys`: the new localizer's objective via distributed systolic sweeps |
| `a6128adba` | split the localize timer into matrix and transform phases |
| `47eda78a1` | `localize=cholesky`: non-iterative localization by pivoted Cholesky |
| `5d6ca7638` | remove the loosened localization tolerance on the initial-guess iteration |
| `cc9d2439d` | cholesky pivot memory + skip near-identity localization rotations |
| `76640a95b` | clarify the PM_q comment: an empty S signals an orthonormal basis (review) |
| `26f2c9bb2` | localize phase timing: sum matrix/transform over both spin blocks (review) |

7 commits, +334/−32 over 7 files.

## Semantics

- `new` and `new_sys` are different optimizers of the same objective.
  Converged SCF energies agree (valinomycin, full protocol to k10:
  0.07 uHa; identical iteration counts).
- `new` and `boys` are unchanged. The only edit near them factors the
  "new" basis preparation into a shared helper (`prepare_new_basis`, used
  by `new_sys` and `cholesky`); `new` reproduces the pre-PR result
  digit-for-digit (water5).

## Tests

No new unit tests; `test_localizer` is unchanged. Application-level checks:

- water5: `new` matches the pre-PR binary digit-for-digit; `new_sys`
  bitwise identical at 1 vs 8 ranks; multi-set (core/valence) clean.
- valinomycin k10: `new_sys` / `cholesky` converge to the `new` energy
  within 0.07 / 0.05 uHa.
- Pivot memory, input-identical A/B (1546-MO protein): KAIN
  subspace warnings 16 -> 0, monotone energy descent.
- Timing, warm localize call at 1535 MOs / 24 ranks: 2172 s (`new`, rank 0)
  -> 88 s (`new_sys`).

## PR checklist

| item | answer |
|---|---|
| raw MPI calls | none |
| blocking MPI collectives | none; reductions via `world.gop` |
| implicit default World | none |
| non-collective container construction | the added localizers run collectively on every rank; `new`/`boys` keep their rank-0 + broadcast structure |
| threaded-BLAS assumptions | none |
| Function mutation / tree-state preconditions | rotations via the unchanged `transform` machinery |
| checkpoint-format break | none |
| GENTENSOR coverage | no tensor-layer change |

## Verification

- CI green (12/12) at `d4cc00554`; rerunning at `26f2c9bb2` (review edits
  and scope reduction only).
- In production since 2026-08: the `new_sys` and `cholesky` paths ran the
  full Rudberg polypeptide benchmark set (150-790 orbitals) and a 1065-MO
  localized-SCF campaign.