### PR TITLE
BoxSurfaceDisplacementRange: choose the probe offset in real space

### DIFF
--- a/src/examples/periodic/testpercoul.cc
+++ b/src/examples/periodic/testpercoul.cc
@@ -314,8 +314,8 @@ int main(int argc, char**argv) {
         {
           BoxSurfaceDisplacementRange<ND> range_boundary_face_displacements(
               key, box_radius, surface_thickness, madness::no_lattice_sum<3>(),
-              [](const auto level, const auto &dest,
-                 const auto &displacement) -> bool { return true; });
+              // keep everything: infinite domain, no lattice sum, no standard displacements to deduplicate against
+              BoxSurfaceDisplacementValidator<ND>(array_of_bools<ND>{true}, madness::no_lattice_sum<3>()));
           // check that all displacements are unique:
           {
             std::vector disps(range_boundary_face_displacements.begin(),

--- a/src/madness/mra/displacements.h
+++ b/src/madness/mra/displacements.h
@@ -39,9 +39,9 @@
 
 #include <algorithm>
 #include <array>
+#include <cmath>
 #include <functional>
 #include <iterator>
-#include <limits>
 #include <optional>
 #include <tuple>
 #include <utility>
@@ -340,6 +340,13 @@ namespace madness {
       /// the validator should normally be a BoxSurfaceDisplacementFilter object. anything else is probably a hack.
       using Validator = std::function<bool(Level, const PointPattern&, std::optional<Displacement>&)>;
 
+      /// Real-space extent of the standard (short-range) displacements that BoxSurfaceDisplacementValidator
+      /// filters out of the surface; used to place the probing displacement just outside of it.
+      struct StandardDisplacementsReach {
+        double max_distsq;                    ///< max real distance squared reached by the standard displacements (see Key::real_distsq_bc)
+        std::array<double, NDIM> cell_width;  ///< real-space width of the simulation cell along each axis, as used to compute `max_distsq`
+      };
+
     private:
       using BoxRadius = std::array<std::optional<Translation>, NDIM>;  // null radius = unlimited size
       using SurfaceThickness = std::array<std::optional<Translation>, NDIM>;  // null thickness for dimensions with null radius
@@ -355,8 +362,7 @@ namespace madness {
       Hollowness hollowness_;    ///< does box contain non-surface points along each dimension?
       Periodicity is_lattice_summed_;  ///< which dimensions are lattice summed?
       Validator validator_;      ///< optional validator function
-      std::optional<Translation> probe_offset_radius_; ///< least N such that being N boxes away from origin guarantees
-                                                       ///   the point was not a short-range point already considered
+      std::optional<StandardDisplacementsReach> standard_reach_;  ///< what the validator filters out; null if nothing is known to be filtered
       Displacement probing_displacement_;  ///< displacement to a nearby point on the surface; it may not be able to pass the filter, but is sufficiently representative of the surface displacements to allow screening with isotropic kernels
 
       /**
@@ -686,19 +692,21 @@ namespace madness {
        * @param surface_thickness Surface thickness in each dimension, measured in number of addl. boxes *on each half* of the surface box proper. Omit for dim `i` if and only if omitted in `box_radius`
        * @param is_lattice_summed whether each dimension is lattice summed; along lattice summed dimensions only one side of the box is iterated over.
        * @param validator Optional filter function (if returns false, displacement is dropped; default: no filter); it may update the displacement to make it valid as needed (e.g. map displacement to the simulation cell)
+       * @param standard_reach the real-space extent of the standard/short-range displacements that `validator` discards
+       *        from the surface (see BoxSurfaceDisplacementValidator); it is used to place the probing displacement
+       *        just outside of that region. Omit if nothing is known to be filtered out: the surface then reaches all
+       *        the way in to `center`, and the probe falls back to the on-site displacement, which screens nothing.
        * @pre `surface_radius[d]>0 && surface_thickness[d]<=surface_radius[d]`
-       * @param probe_offset_radius the smallest displacement magnitude, in boxes, that `validator` does *not* discard as a duplicate of the standard/short-range displacement list, Pass 0 to signal that nothing is filtered out (the surface then reaches all the way in to `center` and no probe can screen it). Omit if unknown, in which case the half-simulation-cell offset is used.
-       *
        */
       explicit BoxSurfaceDisplacementRange(const Key<NDIM>& center,
                                            const std::array<std::optional<std::int64_t>, NDIM>& box_radius,
                                            const std::array<std::optional<std::int64_t>, NDIM>& surface_thickness,
                                            const array_of_bools<NDIM>& is_lattice_summed,
                                            Validator validator = {},
-                                           std::optional<Translation> probe_offset_radius = {})
+                                           std::optional<StandardDisplacementsReach> standard_reach = {})
           : center_(center), box_radius_(box_radius),
             surface_thickness_(surface_thickness), is_lattice_summed_(is_lattice_summed), validator_(std::move(validator)),
-            probe_offset_radius_(probe_offset_radius) {
+            standard_reach_(std::move(standard_reach)) {
         // initialize bounds
         bool has_finite_dimensions = false;
         const auto n = center_.level();
@@ -774,7 +782,7 @@ namespace madness {
       }
 
     private:
-      const Displacement compute_probing_displacement() {
+      Displacement compute_probing_displacement() const {
         // Large boxes we must consider are both those near the center (because 1/r is large
         // for small r), and near the box radius (because going from 1/r to 0 is a sharp change).
         // The probe displacement is a way to screen out cases where the box radius is negligible.
@@ -806,8 +814,8 @@ namespace madness {
         //    even though they're actually 0, to account for the offset we'll need to add.
         // 2. Is an offset needed? Avoiding it is preferred.
         // 3. Choose the smallest N possible.
-        // Requirement (3) would be better formulated in real-space, but the expected
-        // bound improvement doesn't justify expanding the argument signature.
+        // Requirement (3) would be better formulated in real-space (cell widths are available via
+        // standard_reach_, when given), as is done for the offset below.
         const auto sort_key = [&](size_t d) {
           const auto N = *box_radius_[d];
           return std::make_tuple(is_lattice_summed_[d] ? Translation(1) : N, face_origin_is_center(d), N);
@@ -835,43 +843,56 @@ namespace madness {
         if (!face_origin_is_center(face_dimension) || n == 0 || NDIM == 1)
           return Displacement(n, probing_displacement_vec);
 
-        // No (or negative) radius means none of the surface points have been processed
-        // 
-        if (probe_offset_radius_ && *probe_offset_radius_ <= 0)
+        // If nothing is known to be filtered out, none of the surface points have been processed,
+        // so the surface reaches all the way in to center_ and the on-site probe is the only safe choice.
+        if (!standard_reach_)
           return Displacement(n, probing_displacement_vec);
 
         // Else, we still need to satisfy requirement (2) while trying to obey (3). We need to displace along
         // a different dimension.
 
-        // choose the dimension to displace along. The offset magnitude is dimension-independent;
-        // prefer the narrowest finite dimension, else the first unrestricted one.
-        size_t offset_dimension = NDIM;
-        size_t unrestricted_dimension = NDIM;
-        for (size_t d=0; d != NDIM; ++d) {
-          if (d == face_dimension) continue;
-          if (box_radius_[d]) {
-            if (offset_dimension == NDIM || *box_radius_[d] < *box_radius_[offset_dimension])
-              offset_dimension = d;
-          } else if (unrestricted_dimension == NDIM) {
-              unrestricted_dimension = d;
-            }
-        }
-
+        // The offset along axis d is the least number of boxes that takes us out of the region covered by
+        // the standard displacements (see BoxSurfaceDisplacementValidator): either beyond bmax boxes
+        // (see Displacements::make_disp), or, within bmax, beyond sqrt(max_distsq) in real space.
+        // Key::real_distsq_bc measures cell_width*(|l|-1) along an axis, so invert that.
         // Cap the offset at half a cell. If our dimension is lattice-summed, it's even, and half a cell
         // is where it's furthest from the origin. Else, half a cell is the furthest away we can
         // guarantee we can displace to, in the case of an open dimension and the center_ is the origin.
         const Translation half_cell = Translation(1) << (n-1);
-        const Translation offset = probe_offset_radius_
-                                       ? std::clamp(*probe_offset_radius_, Translation(1), half_cell)
-                                       : half_cell;
-        if (offset_dimension != NDIM) {
+        const Translation bmax = Displacements<NDIM>::bmax_default();
+        const auto offset_along = [&](size_t d) -> Translation {
+          const double width = standard_reach_->cell_width[d];
+          MADNESS_ASSERT(width > 0);
+          const Translation reach = 1 + static_cast<Translation>(std::sqrt(standard_reach_->max_distsq) / width);
+          return std::min(std::min(reach, bmax) + 1, half_cell);
+        };
+        // real-space distance of the offset; since the face axis folds to zero this is the probe's real distance
+        const auto offset_distance = [&](size_t d) -> double {
+          return standard_reach_->cell_width[d] * (offset_along(d) - 1);
+        };
+
+        // choose the dimension to displace along: the one with the least real-space offset (requirement (3)),
+        // which for anisotropic cells need not be the narrowest one in boxes. Break ties in favor of
+        // finite dimensions (offset is guaranteed to stay on the face) with the smallest radius, then by index.
+        const auto offset_sort_key = [&](size_t d) {
+          return std::make_tuple(offset_distance(d), !box_radius_[d].has_value(), box_radius_[d].value_or(0));
+        };
+        size_t offset_dimension = NDIM;
+        for (size_t d=0; d != NDIM; ++d) {
+          if (d == face_dimension) continue;
+          if (offset_dimension == NDIM || offset_sort_key(d) < offset_sort_key(offset_dimension))
+            offset_dimension = d;
+        }
+        MADNESS_ASSERT(offset_dimension != NDIM);  // NDIM > 1, so some dimension was found
+
+        const auto d = offset_dimension;
+        const Translation offset = offset_along(d);
+        if (box_radius_[d]) {
           // the offset stays on the face: box_radius_ >= 1 means the box spans at least a half
           // simulation cell along this dimension, and offset <= half_cell
-          probing_displacement_vec[offset_dimension] = offset;
+          probing_displacement_vec[d] = offset;
         } else {
           // we're bounded by the simulation cell; displace toward whichever side of center_ has more room
-          MADNESS_ASSERT(unrestricted_dimension != NDIM);  // NDIM > 1, so some dimension was found
-          const auto d = unrestricted_dimension;
           const auto left_distance = center_[d] - box_[d].first;
           const auto right_distance = box_[d].second - center_[d];
           const auto sign = right_distance >= left_distance ? +1 : -1;

--- a/src/madness/mra/displacements.h
+++ b/src/madness/mra/displacements.h
@@ -363,7 +363,8 @@ namespace madness {
       Periodicity is_lattice_summed_;  ///< which dimensions are lattice summed?
       Validator validator_;      ///< optional validator function
       std::optional<StandardDisplacementsReach> standard_reach_;  ///< what the validator filters out; null if nothing is known to be filtered
-      Displacement probing_displacement_;  ///< displacement to a nearby point on the surface; it may not be able to pass the filter, but is sufficiently representative of the surface displacements to allow screening with isotropic kernels
+      std::array<std::optional<Displacement>, NDIM> probing_displacements_;  ///< for each finite-radius dimension, a displacement to a nearby point on the face normal to it; it may not be able to pass the filter, but is sufficiently representative of that face's displacements to allow screening with decaying kernels
+      std::array<bool, NDIM> skip_face_{};  ///< faces excluded from iteration (see skip_face())
 
       /**
      * @brief Iterator class for lazy generation of surface points
@@ -388,6 +389,7 @@ namespace madness {
                                                     ///  the edge points shared with the processed hyperfaces. So, we need to evaluate effective hyperfaces
                                                     ///  [-3, 3] x [-6, -4] and [-3, 3] x [4, 6]. The unprocessed_bounds are reset to [-3, 3] x [-6, 6].
         bool done;                                  ///< Flag indicating iteration completion
+        bool positioned = false;                    ///< whether the iterator is positioned on a point that has been (or is about to be) yielded; false until the first advance_till_valid() completes
 
         // return true if we have another surface layer for the fixed_dim
         // if we do, translate point onto that next surface layer
@@ -467,29 +469,13 @@ namespace madness {
           }
 
           // we finished this fixed dimension, so update unprocessed bounds to exclude the layers of the current fixed dimension
-          // if box along this dimension is not hollow, the new interval would be [0, 0] - we are done!
-          if (parent->hollowness_[fixed_dim]) {
-            unprocessed_bounds[fixed_dim] = {
-                parent->box_[fixed_dim].first +
-                    parent->surface_thickness_[fixed_dim].value_or(0) + 1,
-                parent->box_[fixed_dim].second -
-                    parent->surface_thickness_[fixed_dim].value_or(0) - 1};
-          }
-          else {
+          if (!exclude_face(fixed_dim)) {
             done = true;
             return;
           }
           // (3) switch to next fixed dimension with finite radius
-          ++fixed_dim;
-          while (!parent->box_radius_[fixed_dim] && fixed_dim < NDIM) {
-            ++fixed_dim;
-          }
-
-          // Exit if we've displaced along all dimensions of finite radius
-          if (fixed_dim >= NDIM) {
-            done = true;
-            return;
-          }
+          select_face(fixed_dim + 1);
+          if (done) return;
 
           // reset our search along all non-fixed dimensions
           // the reset along the fixed_dim returns silently
@@ -498,23 +484,53 @@ namespace madness {
           }
         }
 
-        /// Perform advance, repeating if you are at a filtered point
+        /// Excludes the layers of the face normal to `dim` from the faces that remain to be processed,
+        /// so that the edge boxes shared with it are not visited twice.
+        /// @return false if nothing remains, i.e. the box along `dim` is not hollow and every remaining box lies on this face
+        bool exclude_face(size_t dim) {
+          if (!parent->hollowness_[dim]) return false;
+          const auto t = parent->surface_thickness_[dim].value_or(0);
+          if (parent->is_lattice_summed_[dim]) {
+            // the box is at least as wide as the simulation cell, so the Z interval between the two faces wraps
+            // around and covers the layers just processed; what remains is the complement of the layer classes
+            // [box.second-t, box.second+t] within one period, expressed as a contiguous interval
+            const auto period = Translation(1) << parent->center_.level();
+            unprocessed_bounds[dim] = {parent->box_[dim].second + t + 1,
+                                       parent->box_[dim].second + period - t - 1};
+          } else {
+            unprocessed_bounds[dim] = {parent->box_[dim].first + t + 1,
+                                       parent->box_[dim].second - t - 1};
+          }
+          return true;
+        }
+
+        /// Sets `fixed_dim` to the first finite-radius dimension at or after `from` whose face is not skipped.
+        /// Sets `done` if no face remains.
+        /// N.B. a skipped face is not excluded from the remaining faces (unlike a processed one), so the
+        /// edge boxes it shares with them are still visited through them; hence a box is visited iff it
+        /// lies on at least one face that is not skipped, regardless of the order in which faces are visited.
+        void select_face(size_t from) {
+          for (fixed_dim = from; fixed_dim < NDIM; ++fixed_dim) {
+            if (parent->box_radius_[fixed_dim] && !parent->skip_face_[fixed_dim]) return;
+          }
+          done = true;
+        }
+
+        /// Leave the current point (if positioned on one) and advance to the next point that passes the filter
         void advance_till_valid() {
+          if (positioned && !done) this->advance();
+          positioned = true;
+
           if (parent->validator_) {
             const auto filtered_out = [&]() -> bool {
               this->displacement(); // ensure disp is up to date
               return !parent->validator_(point.level(), point.translation(), disp);
             };
 
-            // if displacement has value, filter has already been applied to it, just advance it
-            if (!done && disp) this->advance();
-
             while (!done && filtered_out()) {
               this->advance();
             }
           }
-          else
-            this->advance();
         }
 
         // Recall that the surface is a union of hyperfaces, i.e., direct products of intervals.
@@ -609,17 +625,19 @@ namespace madness {
         Iterator(const BoxSurfaceDisplacementRange* p, Type type)
             : parent(p), point(parent->center_.level()), fixed_dim(type == End ? NDIM : 0), done(type == End) {
           if (type != End) {
-            // skip to first dimensions with limited range
-            while (!parent->box_radius_[fixed_dim] && fixed_dim < NDIM) {
-              ++fixed_dim;
-            }
-
             for (size_t d = 0; d != NDIM; ++d) {
               // min/max displacements along this axis ... N.B. take into account surface thickness!
               unprocessed_bounds[d] = parent->box_radius_[d] ? std::pair{parent->box_[d].first -
                                 parent->surface_thickness_[d].value_or(0),
                          parent->box_[d].second +
                              parent->surface_thickness_[d].value_or(0)} : parent->box_[d];
+            }
+
+            // skip to first dimension with limited range whose face is not skipped
+            select_face(0);
+            if (done) return;
+
+            for (size_t d = 0; d != NDIM; ++d) {
               reset_along_dim(d);
             }
             advance_till_valid();
@@ -723,12 +741,20 @@ namespace madness {
           }
         }
         MADNESS_ASSERT(has_finite_dimensions);
-        probing_displacement_ = compute_probing_displacement();
+        for (size_t d=0; d!= NDIM; ++d) {
+          if (box_radius_[d]) probing_displacements_[d] = compute_probing_displacement(d);
+        }
         for (size_t d=0; d!= NDIM; ++d) {
           // surface thickness should be only given for finite-radius dimensions
           MADNESS_ASSERT(!(box_radius_[d].has_value() ^ surface_thickness_[d].has_value()));
           MADNESS_ASSERT(surface_thickness_[d].value_or(0) >= 0);
-          hollowness_[d] = surface_thickness_[d] ? (box_[d].first + surface_thickness_[d].value() < box_[d].second - surface_thickness_[d].value()) : false;
+          // hollow = there are boxes between the two faces (with their thickness) ... for lattice-summed dimensions
+          // the box is at least as wide as the simulation cell, so the question is whether the layers of the single
+          // face cover every equivalence class of the cell
+          hollowness_[d] = surface_thickness_[d]
+                               ? (is_lattice_summed_[d] ? (Translation(1) << n) > 2 * surface_thickness_[d].value() + 1
+                                                        : box_[d].first + surface_thickness_[d].value() < box_[d].second - surface_thickness_[d].value())
+                               : false;
         }
       }
 
@@ -775,20 +801,51 @@ namespace madness {
       const array_of_bools<NDIM>& is_lattice_summed() const { return is_lattice_summed_; }
 
       /**
-       * @return 'probing" displacement to a nearby point *on* the surface; it may not necessarily be in the range of iteration (e.g., it may not be able to pass the filter) but is representative of the surface displacements for the purposes of screening
+       * @param face_dimension a dimension with finite radius; the face is the pair of hyperplanes normal to it (one, if lattice summed)
+       * @return "probing" displacement to a nearby point *on* the face normal to `face_dimension`; it may not necessarily be in the range of iteration (e.g., it may not be able to pass the filter) but is representative of that face's displacements for the purposes of screening
        */
-      const Displacement& probing_displacement() const {
-        return probing_displacement_;
+      const Displacement& probing_displacement(size_t face_dimension) const {
+        MADNESS_ASSERT(face_dimension < NDIM && probing_displacements_[face_dimension].has_value());
+        return *probing_displacements_[face_dimension];
+      }
+
+      /**
+       * @return probing displacements for every face; null for dimensions of unlimited size, which have no face
+       * @sa probing_displacement()
+       */
+      const std::array<std::optional<Displacement>, NDIM>& probing_displacements() const {
+        return probing_displacements_;
+      }
+
+      /**
+       * Excludes the face normal to `face_dimension` from iteration, e.g. because its probing displacement
+       * showed its contributions to be negligible. The edge boxes it shares with faces that are not skipped
+       * are still visited through those faces, i.e. a box is visited iff it lies on at least one face that is not skipped.
+       * @param face_dimension a dimension with finite radius
+       * @pre no iterator has been obtained from this object yet
+       */
+      void skip_face(size_t face_dimension) {
+        MADNESS_ASSERT(face_dimension < NDIM && box_radius_[face_dimension].has_value());
+        skip_face_[face_dimension] = true;
+      }
+
+      /**
+       * @return whether the face normal to `face_dimension` is excluded from iteration
+       */
+      bool face_skipped(size_t face_dimension) const {
+        return skip_face_[face_dimension];
       }
 
     private:
-      Displacement compute_probing_displacement() const {
+      Displacement compute_probing_displacement(const size_t face_dimension) const {
         // Large boxes we must consider are both those near the center (because 1/r is large
         // for small r), and near the box radius (because going from 1/r to 0 is a sharp change).
         // The probe displacement is a way to screen out cases where the box radius is negligible.
-        // Our probe displacement must satisfy:
-        // (1) It must actually be on the box, e.g., on a boundary face, perpendicular to a
-        //     dimension with finite box_radius_. We call those the target face and dimensions.
+        // Each face (the pair of hyperplanes normal to a dimension with finite box_radius_, or one hyperplane
+        // if that dimension is lattice summed) gets its own probe, so that faces at different real-space
+        // distances (anisotropic cells, lattice summation along some dimensions only, mixed-parity radii)
+        // can be screened independently. Our probe displacement for the face normal to face_dimension must satisfy:
+        // (1) It must actually be on that face.
         // To ensure we're probing the box radius effect and not the near-center effect, we require:
         // (2) If at all possible, it must be distinct from the zero displacement and
         //     from the displacements "near" the center, both of which should have already been considered.
@@ -805,29 +862,10 @@ namespace madness {
         //     affect whether we're within epsilon, but it's still good practice.
         //     For the same reason, the sigma should matter as well.
 
+        MADNESS_ASSERT(face_dimension < NDIM && box_radius_[face_dimension].has_value());
         const auto face_origin_is_center = [this](size_t d) {
           return is_lattice_summed_[d] && (*box_radius_[d] % 2 == 0);
         };
-
-        // Create a sort key on candidates for the target dimension.
-        // 1. The "effective number of half cells away" the face is. Even cells are treated as 1,
-        //    even though they're actually 0, to account for the offset we'll need to add.
-        // 2. Is an offset needed? Avoiding it is preferred.
-        // 3. Choose the smallest N possible.
-        // Requirement (3) would be better formulated in real-space (cell widths are available via
-        // standard_reach_, when given), as is done for the offset below.
-        const auto sort_key = [&](size_t d) {
-          const auto N = *box_radius_[d];
-          return std::make_tuple(is_lattice_summed_[d] ? Translation(1) : N, face_origin_is_center(d), N);
-        };
-
-        // The initial value registers "not set yet".
-        size_t face_dimension = NDIM;
-        for (size_t d=0; d != NDIM; ++d) {
-          if (!box_radius_[d]) continue;
-          if (face_dimension == NDIM || sort_key(d) < sort_key(face_dimension)) face_dimension = d;
-        }
-        MADNESS_ASSERT(face_dimension != NDIM);  // guaranteed by has_finite_dimensions in the ctor
 
         // Enforce requirement (1)
         Vector<Translation, NDIM> probing_displacement_vec(0);
@@ -862,7 +900,7 @@ namespace madness {
         const Translation bmax = Displacements<NDIM>::bmax_default();
         const auto offset_along = [&](size_t d) -> Translation {
           const double width = standard_reach_->cell_width[d];
-          MADNESS_ASSERT(width > 0);
+          MADNESS_CHECK_THROW(width > 0, "BoxSurfaceDisplacementRange: cell widths in StandardDisplacementsReach must be positive");
           const Translation reach = 1 + static_cast<Translation>(std::sqrt(standard_reach_->max_distsq) / width);
           return std::min(std::min(reach, bmax) + 1, half_cell);
         };

--- a/src/madness/mra/displacements.h
+++ b/src/madness/mra/displacements.h
@@ -1033,6 +1033,15 @@ namespace madness {
         r = (n == 0) ? (r+1)/2 : (r * Translation(1) << (n-1));
         MADNESS_ASSERT(r > 0);
         probing_displacement_vec[face_dimension] = r - surface_thickness_[face_dimension].value_or(0);
+        // Along a lattice-summed dimension fold the probe into the cell, to the representative nearest to the
+        // source, as the validator does for the displacements it yields (the operator's norm only sums over a
+        // few lattice images of a displacement, so a representative several cells away would be underestimated).
+        if (is_lattice_summed_[face_dimension]) {
+          const auto period = Translation(1) << n;
+          auto& l = probing_displacement_vec[face_dimension];
+          l = ((l % period) + period) % period;
+          if (l > period / 2) l -= period;
+        }
 
         // In these cases, requirement (2) is already satisfied or unsatisfiable.
         // Choosing 0 for all other dimensions satisfies requirement (3).

--- a/src/madness/mra/displacements.h
+++ b/src/madness/mra/displacements.h
@@ -329,29 +329,184 @@ namespace madness {
      * For dimensions with unlimited size the point coordinates are limited to [0,2^n], with n being the level of the box.
      * N.B. "points" are really boxes in the standard MADNESS sense, which we'll call "primitive boxes" to disambiguate from box as the product of intervals mentioned above,
      */
+    /// Real-space extent of the standard (short-range) displacements, i.e. of what FunctionImpl::do_apply processes
+    /// before turning to the surface of the kernel range boundary (see Displacements). BoxSurfaceDisplacementValidator
+    /// uses it to skip the surface displacements already processed, and BoxSurfaceDisplacementRange to place its
+    /// probing displacements just outside of them; both must therefore see the same reach.
+    template <std::size_t NDIM>
+    struct StandardDisplacementsReach {
+      double max_distsq;                    ///< max real distance squared reached by the standard displacements (see Key::real_distsq_bc)
+      std::array<double, NDIM> cell_width;  ///< real-space width of the simulation cell along each axis, as used to compute `max_distsq`
+    };
+
+    /// Filters the surface displacements produced by BoxSurfaceDisplacementRange: drops the destinations outside of
+    /// the domain, maps the destinations along lattice-summed axes into the simulation cell, and drops the displacements
+    /// already processed as standard (short-range) displacements, as described by StandardDisplacementsReach.
+    template <size_t NDIM>
+    class BoxSurfaceDisplacementValidator {
+    public:
+      using Point = Key<NDIM>;
+      using PointPattern = Vector<std::optional<Translation>, NDIM>;
+      using Displacement = Key<NDIM>;
+      using Periodicity = array_of_bools<NDIM>;
+      using Reach = StandardDisplacementsReach<NDIM>;
+
+      /// \param is_infinite_domain whether the domain along each axis is finite (simulation cell) or infinite (the entire axis); if true for a given axis then any destination coordinate is valid, else only values in [0,2^n) are valid
+      /// \param is_lattice_summed if true for a given axis, displacement to x and x+2^n are equivalent, hence will be canonicalized to end up in the simulation cell. Periodic axes imply infinite domain, whatever was passed to `is_infinite_domain`.
+      /// \param reach the real-space extent of the standard displacements that have been processed; surface displacements
+      ///        within it are filtered out as duplicates. Omit if no standard displacements have been processed (nothing is filtered on that account).
+      BoxSurfaceDisplacementValidator(
+          const array_of_bools<NDIM>& is_infinite_domain,
+          const array_of_bools<NDIM>& is_lattice_summed,
+          std::optional<Reach> reach = {}
+          ) :
+              is_lattice_summed_(is_lattice_summed),
+              reach_(std::move(reach)),
+              cell_width_(NDIM) {
+        for (size_t i = 0; i < NDIM; i++) {
+          if (is_lattice_summed[i]) {
+            domain_policies_[i] = ExtraDomainPolicy::Translate;
+          } else if (is_infinite_domain[i]) {
+            domain_policies_[i] = ExtraDomainPolicy::Keep;
+          } else {
+            domain_policies_[i] = ExtraDomainPolicy::Discard;
+          }
+          if (reach_) {
+            MADNESS_CHECK_THROW(reach_->cell_width[i] > 0, "BoxSurfaceDisplacementValidator: cell widths in StandardDisplacementsReach must be positive");
+            cell_width_(i) = reach_->cell_width[i];
+          }
+        }
+      }
+
+      /// @return which axes are lattice summed
+      const array_of_bools<NDIM>& is_lattice_summed() const { return is_lattice_summed_; }
+
+      /// @return the real-space extent of the standard displacements this filters out as duplicates; null if none
+      const std::optional<Reach>& reach() const { return reach_; }
+
+      /// Apply filter to a displacement ending up at a point or a group of points (point pattern)
+
+      /// @param level the tree level
+      /// @param dest the target point (when all elements are nonnull) or point pattern (when only some are).
+      ///        The latter is useful to skip the entire surface layer. The
+      ///        point coordinates are only used to determine whether we end up
+      ///        in or out of the domain.
+      /// @param displacement the optional displacement; if given then will check if it's among
+      ///        the standard displacement and whether it was used as part of
+      ///        the standard displacement set; if it has not been used and the
+      ///        operator is lattice summed, the displacement will be adjusted
+      ///        to end up in the simulation cell. Primary use case for omitting `displacement`
+      ///        is if `dest` is not equivalent to a point.
+      /// @return true if the displacement is to be used
+      bool operator()(
+          const Level level,
+          const PointPattern& dest,
+          std::optional<Displacement>&  displacement
+      ) const {
+        // preliminaries
+        const auto twon = (static_cast<Translation>(1) << level);  // number of boxes along an axis
+        // map_to_range_twon(x) returns for x >= 0 ? x % 2^level : map_to_range_twon(x+2^level)
+        // idiv is generally slow, so instead use bit logic that relies on 2's complement representation of integers
+        const auto map_to_range_twon = [&, mask = ((~(static_cast<std::uint64_t>(0)) << (64-level)) >> (64-level))](std::int64_t x) -> std::int64_t {
+          const std::int64_t x_mapped = x & mask;
+          MADNESS_ASSERT(x_mapped >=0 && x_mapped < twon && (std::abs(x_mapped-x)%twon==0));
+          return x_mapped;
+        };
+
+        const auto out_of_domain = [&](const Translation& t) -> bool {
+          return t < 0 || t >= twon;
+        };
+
+        // check that dest is in the domain
+        const bool dest_is_in_domain = [&]() {
+          for(size_t d=0; d!=NDIM; ++d) {
+            if (domain_policies_[d] == ExtraDomainPolicy::Discard && dest[d].has_value() && out_of_domain(*dest[d])) return false;
+          }
+          return true;
+        }();
+
+        if (dest_is_in_domain) {
+          if (displacement.has_value()) {
+
+            // N.B. avoid duplicates of standard displacements previously included:
+            // A displacement has been possibly considered if along EVERY axis the "effective" displacement size
+            // fits within the box explored by the standard displacement.
+            // If so, skip if <= max magnitude of standard displacements encountered
+            // Otherwise this is a new non-standard displacement, consider it
+            bool among_standard_displacements = true;
+            for(size_t d=0; d!=NDIM; ++d) {
+              const auto disp_d = (*displacement)[d];
+              auto bmax_standard = Displacements<NDIM>::bmax_default();
+
+              // the effective displacement length depends on whether lattice summation is performed along it
+              // compare Displacements::make_disp vs Displacements::make_disp_periodic
+              auto disp_d_eff_abs = std::abs(disp_d);
+              if (domain_policies_[d] == ExtraDomainPolicy::Translate) {
+                // for "periodic" displacements the effective disp_d is the shortest of {..., disp_d-twon, disp_d, disp_d+twon, ...} ... see make_disp_periodic
+                const std::int64_t disp_d_eff = map_to_range_twon(disp_d);
+                disp_d_eff_abs = std::min(disp_d_eff,std::abs(disp_d_eff-twon));
+
+                // IMPORTANT for lattice-summed axes, if the destination is out of the simulation cell map the displacement back to the cell
+                // same logic as for disp_d: dest[d] -> dest[d] % twon
+                if (dest[d].has_value()) {
+                  const Translation dest_d = dest[d].value();
+                  const auto dest_d_in_cell = map_to_range_twon(dest_d);
+                  MADNESS_ASSERT(!out_of_domain(
+                      dest_d_in_cell));
+                  // adjust displacement[d] so that it produces dest_d_cell, not dest_d
+                  auto t = (*displacement).translation();
+                  t[d] += (dest_d_in_cell - dest_d);
+                  displacement.emplace(displacement->level(), t);
+                }
+
+                // N.B. bmax in make_disp_periodic is clipped in the same way
+                if (Displacements<NDIM>::bmax_default() >= twon) bmax_standard = twon-1;
+              }
+
+              if (disp_d_eff_abs > bmax_standard) {
+                among_standard_displacements = false;
+                // Do not break - this loop needs not only to determine among_standard_displacements but to shift the displacement if domain_is_periodic_
+                // Therefore, looping over all dim is strictly necessary.
+              }
+            }
+            if (among_standard_displacements) {
+              if (!reach_) return true;  // no standard displacements were processed => nothing to duplicate
+              // among standard displacements => keep if longer than the longest standard displacement considered
+              // N.B. same distance as used to order the standard displacements (see FunctionImpl::do_apply)
+              const auto distsq = displacement->real_distsq_bc(is_lattice_summed_, cell_width_);
+              return distsq > reach_->max_distsq;
+            }
+            else  // not among standard displacements => keep it
+              return true;
+          }
+          else  // skip the displacement-based filter if not given
+            return true;
+        }
+        else
+          return false;
+      }
+
+    private:
+      std::array<ExtraDomainPolicy, NDIM> domain_policies_;
+      array_of_bools<NDIM> is_lattice_summed_;
+      std::optional<Reach> reach_;
+      Tensor<double> cell_width_;  ///< reach_->cell_width as a Tensor, for Key::real_distsq_bc
+    };
+
+
     template<std::size_t NDIM>
     class BoxSurfaceDisplacementRange {
     public:
       using Point = Key<NDIM>;
       using PointPattern = Vector<std::optional<Translation>, NDIM>;
       using Displacement = Key<NDIM>;
-      /// this callable returns whether a given primitive box (or hyperface if only one coordinate is provided) can be filtered out.
-      /// if screening a primitive box, the corresponding displacement should be provided both for further screening and for the displacement to be updated, if displacements are translated to connect two cells in the box.
-      /// the validator should normally be a BoxSurfaceDisplacementFilter object. anything else is probably a hack.
-      using Validator = std::function<bool(Level, const PointPattern&, std::optional<Displacement>&)>;
-
-      /// Real-space extent of the standard (short-range) displacements that BoxSurfaceDisplacementValidator
-      /// filters out of the surface; used to place the probing displacement just outside of it.
-      struct StandardDisplacementsReach {
-        double max_distsq;                    ///< max real distance squared reached by the standard displacements (see Key::real_distsq_bc)
-        std::array<double, NDIM> cell_width;  ///< real-space width of the simulation cell along each axis, as used to compute `max_distsq`
-      };
+      using Validator = BoxSurfaceDisplacementValidator<NDIM>;
 
     private:
       using BoxRadius = std::array<std::optional<Translation>, NDIM>;  // null radius = unlimited size
       using SurfaceThickness = std::array<std::optional<Translation>, NDIM>;  // null thickness for dimensions with null radius
       using Box = std::array<std::pair<Translation, Translation>, NDIM>;
-      using Hollowness = std::array<bool, NDIM>;  // this can be uninitialized, unlike array_of_bools ... hollow = gap between -radius+thickness and +radius-thickness.
+      using Hollowness = std::array<bool, NDIM>;  // this can be uninitialized, unlike array_of_bools ... hollow = there are boxes between the faces, besides those of the faces themselves
       using Periodicity = array_of_bools<NDIM>;
 
       Point center_;                          ///< Center point of the box
@@ -359,11 +514,11 @@ namespace madness {
       SurfaceThickness
           surface_thickness_;    ///< surface thickness in each dimension, measured in boxes. Real-space surface size is thus n-dependent.
       Box box_;                  ///< box bounds in each dimension.
+      Box initial_bounds_;       ///< bounds of the boxes to be iterated over, before any face is processed: the box plus its surface thickness, or, along a lattice-summed dimension, one period ending at the top layer (so that each equivalence class of boxes appears exactly once)
       Hollowness hollowness_;    ///< does box contain non-surface points along each dimension?
       Periodicity is_lattice_summed_;  ///< which dimensions are lattice summed?
-      Validator validator_;      ///< optional validator function
-      std::optional<StandardDisplacementsReach> standard_reach_;  ///< what the validator filters out; null if nothing is known to be filtered
-      std::array<std::optional<Displacement>, NDIM> probing_displacements_;  ///< for each finite-radius dimension, a displacement to a nearby point on the face normal to it; it may not be able to pass the filter, but is sufficiently representative of that face's displacements to allow screening with decaying kernels
+      std::optional<Validator> validator_;  ///< optional filter; also the source of the reach of the standard displacements, which the probing displacements are placed outside of
+      std::array<std::optional<Displacement>, NDIM> probing_displacements_;  ///< for each finite-radius dimension, a displacement to a nearby point on the faces normal to it (the pair of hyperplanes at -radius and +radius, which lattice summation folds onto each other); it may not be able to pass the filter, but among the displacements those faces contribute it errs toward the largest norm, so that a decaying kernel can be screened with it
       std::array<bool, NDIM> skip_face_{};  ///< faces excluded from iteration (see skip_face())
 
       /**
@@ -459,7 +614,7 @@ namespace madness {
                 PointPattern point_pattern;
                 point_pattern[fixed_dim] = point[fixed_dim];
                 std::optional<Displacement> nulldisp;
-                result = !validator(point.level(), point_pattern, nulldisp);
+                result = !(*validator)(point.level(), point_pattern, nulldisp);
               }
               return result;
             };
@@ -484,30 +639,22 @@ namespace madness {
           }
         }
 
-        /// Excludes the layers of the face normal to `dim` from the faces that remain to be processed,
-        /// so that the edge boxes shared with it are not visited twice.
-        /// @return false if nothing remains, i.e. the box along `dim` is not hollow and every remaining box lies on this face
+        /// Excludes the layers of the faces normal to `dim` from the faces that remain to be processed,
+        /// so that the edge boxes shared with them are not visited twice.
+        /// @return false if nothing remains, i.e. the box along `dim` is not hollow and every remaining box lies on these faces
         bool exclude_face(size_t dim) {
           if (!parent->hollowness_[dim]) return false;
-          const auto t = parent->surface_thickness_[dim].value_or(0);
-          if (parent->is_lattice_summed_[dim]) {
-            // the box is at least as wide as the simulation cell, so the Z interval between the two faces wraps
-            // around and covers the layers just processed; what remains is the complement of the layer classes
-            // [box.second-t, box.second+t] within one period, expressed as a contiguous interval
-            const auto period = Translation(1) << parent->center_.level();
-            unprocessed_bounds[dim] = {parent->box_[dim].second + t + 1,
-                                       parent->box_[dim].second + period - t - 1};
-          } else {
-            unprocessed_bounds[dim] = {parent->box_[dim].first + t + 1,
-                                       parent->box_[dim].second - t - 1};
-          }
+          // the layers are at both ends of the bounds, or only at the top end if lattice summed (see initial_bounds_)
+          const auto nlayers = 2 * parent->surface_thickness_[dim].value_or(0) + 1;
+          unprocessed_bounds[dim] = {unprocessed_bounds[dim].first + (parent->is_lattice_summed_[dim] ? 0 : nlayers),
+                                     unprocessed_bounds[dim].second - nlayers};
           return true;
         }
 
-        /// Sets `fixed_dim` to the first finite-radius dimension at or after `from` whose face is not skipped.
+        /// Sets `fixed_dim` to the first finite-radius dimension at or after `from` whose faces are not skipped.
         /// Sets `done` if no face remains.
-        /// N.B. a skipped face is not excluded from the remaining faces (unlike a processed one), so the
-        /// edge boxes it shares with them are still visited through them; hence a box is visited iff it
+        /// N.B. skipped faces are not excluded from the remaining faces (unlike processed ones), so the
+        /// edge boxes they share with them are still visited through them; hence a box is visited iff it
         /// lies on at least one face that is not skipped, regardless of the order in which faces are visited.
         void select_face(size_t from) {
           for (fixed_dim = from; fixed_dim < NDIM; ++fixed_dim) {
@@ -524,7 +671,7 @@ namespace madness {
           if (parent->validator_) {
             const auto filtered_out = [&]() -> bool {
               this->displacement(); // ensure disp is up to date
-              return !parent->validator_(point.level(), point.translation(), disp);
+              return !(*parent->validator_)(point.level(), point.translation(), disp);
             };
 
             while (!done && filtered_out()) {
@@ -553,18 +700,11 @@ namespace madness {
             // This dimension consists of two finite-thickness hyperfaces, lattice summed.
             // The two hyperfaces are the same interval shifted by parent->surface_radius_[dim]
             // periods. So by lattice summation, the - hyperface is included. Initialize
-            // to the start of the + hyperface.
-            l_dim_min = parent->box_[dim].second -
-                        parent->surface_thickness_[dim].value_or(0);
-          }
-          if (parent->is_lattice_summed_[dim]) {
-            // By lattice summation, boxes that differ by a SimulationCell are equivalent.
-            // Therefore, we need to sum over equivalence classes and not displacements.
-            const auto period = 1 << parent->center_.level();
-            const Translation last_equiv_class = is_fixed_dim ? parent->box_[dim].second +
-              parent->surface_thickness_[dim].value_or(0) : unprocessed_bounds[dim].second;
-            const Translation first_equiv_class = last_equiv_class - period + 1;
-            l_dim_min = std::max(first_equiv_class, l_dim_min);
+            // to the start of the + hyperface, clipped to one period (= the bounds) in case
+            // the layers are thicker than the simulation cell.
+            l_dim_min = std::max(parent->box_[dim].second -
+                                     parent->surface_thickness_[dim].value_or(0),
+                                 unprocessed_bounds[dim].first);
           }
           l[dim] = l_dim_min;
 
@@ -581,7 +721,7 @@ namespace madness {
                 PointPattern point_pattern;
                 point_pattern[fixed_dim] = point[fixed_dim];
                 std::optional<Displacement> nulldisp;
-                result = !validator(point.level(), point_pattern, nulldisp);
+                result = !(*validator)(point.level(), point_pattern, nulldisp);
               }
               return result;
             };
@@ -625,15 +765,9 @@ namespace madness {
         Iterator(const BoxSurfaceDisplacementRange* p, Type type)
             : parent(p), point(parent->center_.level()), fixed_dim(type == End ? NDIM : 0), done(type == End) {
           if (type != End) {
-            for (size_t d = 0; d != NDIM; ++d) {
-              // min/max displacements along this axis ... N.B. take into account surface thickness!
-              unprocessed_bounds[d] = parent->box_radius_[d] ? std::pair{parent->box_[d].first -
-                                parent->surface_thickness_[d].value_or(0),
-                         parent->box_[d].second +
-                             parent->surface_thickness_[d].value_or(0)} : parent->box_[d];
-            }
+            unprocessed_bounds = parent->initial_bounds_;
 
-            // skip to first dimension with limited range whose face is not skipped
+            // skip to first dimension with limited range whose faces are not skipped
             select_face(0);
             if (done) return;
 
@@ -709,25 +843,29 @@ namespace madness {
        * @param box_radius Box radius in each dimension, in half-SimulationCells. Omit for dim `i` to signal that the bound for dim `i` is simply the simulation cell.
        * @param surface_thickness Surface thickness in each dimension, measured in number of addl. boxes *on each half* of the surface box proper. Omit for dim `i` if and only if omitted in `box_radius`
        * @param is_lattice_summed whether each dimension is lattice summed; along lattice summed dimensions only one side of the box is iterated over.
-       * @param validator Optional filter function (if returns false, displacement is dropped; default: no filter); it may update the displacement to make it valid as needed (e.g. map displacement to the simulation cell)
-       * @param standard_reach the real-space extent of the standard/short-range displacements that `validator` discards
-       *        from the surface (see BoxSurfaceDisplacementValidator); it is used to place the probing displacement
-       *        just outside of that region. Omit if nothing is known to be filtered out: the surface then reaches all
-       *        the way in to `center`, and the probe falls back to the on-site displacement, which screens nothing.
+       * @param validator Optional filter (if returns false, displacement is dropped; default: no filter); it also maps displacements
+       *        along lattice-summed axes into the simulation cell, and carries the real-space reach of the standard displacements
+       *        it filters out as duplicates, outside of which the probing displacements are placed. Its lattice-summation flags
+       *        must match `is_lattice_summed`. If omitted (or if it carries no reach) nothing is known to be filtered out: the
+       *        surface then reaches all the way in to `center`, and the probes fall back to the on-site displacement, which screens nothing.
        * @pre `surface_radius[d]>0 && surface_thickness[d]<=surface_radius[d]`
        */
       explicit BoxSurfaceDisplacementRange(const Key<NDIM>& center,
                                            const std::array<std::optional<std::int64_t>, NDIM>& box_radius,
                                            const std::array<std::optional<std::int64_t>, NDIM>& surface_thickness,
                                            const array_of_bools<NDIM>& is_lattice_summed,
-                                           Validator validator = {},
-                                           std::optional<StandardDisplacementsReach> standard_reach = {})
+                                           std::optional<Validator> validator = {})
           : center_(center), box_radius_(box_radius),
-            surface_thickness_(surface_thickness), is_lattice_summed_(is_lattice_summed), validator_(std::move(validator)),
-            standard_reach_(std::move(standard_reach)) {
+            surface_thickness_(surface_thickness), is_lattice_summed_(is_lattice_summed), validator_(std::move(validator)) {
+        if (validator_) {
+          for (size_t d=0; d!= NDIM; ++d)
+            MADNESS_CHECK_THROW(validator_->is_lattice_summed()[d] == is_lattice_summed_[d],
+                                "BoxSurfaceDisplacementRange: validator and range disagree on which axes are lattice summed");
+        }
         // initialize bounds
         bool has_finite_dimensions = false;
         const auto n = center_.level();
+        const auto period = Translation(1) << n;
         for (size_t d=0; d!= NDIM; ++d) {
           if (box_radius_[d]) {
             auto r = *box_radius_[d];  // in units of 2^{n-1}
@@ -748,13 +886,20 @@ namespace madness {
           // surface thickness should be only given for finite-radius dimensions
           MADNESS_ASSERT(!(box_radius_[d].has_value() ^ surface_thickness_[d].has_value()));
           MADNESS_ASSERT(surface_thickness_[d].value_or(0) >= 0);
-          // hollow = there are boxes between the two faces (with their thickness) ... for lattice-summed dimensions
-          // the box is at least as wide as the simulation cell, so the question is whether the layers of the single
-          // face cover every equivalence class of the cell
-          hollowness_[d] = surface_thickness_[d]
-                               ? (is_lattice_summed_[d] ? (Translation(1) << n) > 2 * surface_thickness_[d].value() + 1
-                                                        : box_[d].first + surface_thickness_[d].value() < box_[d].second - surface_thickness_[d].value())
-                               : false;
+          const auto t = surface_thickness_[d].value_or(0);
+          if (box_radius_[d]) {
+            // the boxes to iterate over: the box plus its surface thickness. Along a lattice-summed dimension the
+            // box is at least one simulation cell wide, so instead take one period ending at the top layer: each
+            // equivalence class of boxes then appears exactly once, and only the top layers are on the surface.
+            initial_bounds_[d] = is_lattice_summed_[d] ? std::pair{box_[d].second + t - period + 1, box_[d].second + t}
+                                                       : std::pair{box_[d].first - t, box_[d].second + t};
+            // hollow = the bounds hold more boxes than the layers of the faces (both ends, or the top end if lattice summed)
+            const auto nlayers = (is_lattice_summed_[d] ? 1 : 2) * (2 * t + 1);
+            hollowness_[d] = (initial_bounds_[d].second - initial_bounds_[d].first + 1) > nlayers;
+          } else {
+            initial_bounds_[d] = box_[d];
+            hollowness_[d] = false;
+          }
         }
       }
 
@@ -801,8 +946,8 @@ namespace madness {
       const array_of_bools<NDIM>& is_lattice_summed() const { return is_lattice_summed_; }
 
       /**
-       * @param face_dimension a dimension with finite radius; the face is the pair of hyperplanes normal to it (one, if lattice summed)
-       * @return "probing" displacement to a nearby point *on* the face normal to `face_dimension`; it may not necessarily be in the range of iteration (e.g., it may not be able to pass the filter) but is representative of that face's displacements for the purposes of screening
+       * @param face_dimension a dimension with finite radius; its faces are the pair of hyperplanes normal to it at -radius and +radius (which lattice summation folds onto each other)
+       * @return "probing" displacement to a nearby point *on* the faces normal to `face_dimension`; it may not necessarily be in the range of iteration (e.g., it may not be able to pass the filter) but, among the displacements those faces contribute, it errs toward the largest norm, so that a decaying kernel can be screened with it. One probe serves both faces since the real-space distance of a displacement depends on its magnitude along each axis only.
        */
       const Displacement& probing_displacement(size_t face_dimension) const {
         MADNESS_ASSERT(face_dimension < NDIM && probing_displacements_[face_dimension].has_value());
@@ -810,7 +955,7 @@ namespace madness {
       }
 
       /**
-       * @return probing displacements for every face; null for dimensions of unlimited size, which have no face
+       * @return probing displacements for the faces normal to every dimension; null for dimensions of unlimited size, which have no faces
        * @sa probing_displacement()
        */
       const std::array<std::optional<Displacement>, NDIM>& probing_displacements() const {
@@ -818,9 +963,9 @@ namespace madness {
       }
 
       /**
-       * Excludes the face normal to `face_dimension` from iteration, e.g. because its probing displacement
-       * showed its contributions to be negligible. The edge boxes it shares with faces that are not skipped
-       * are still visited through those faces, i.e. a box is visited iff it lies on at least one face that is not skipped.
+       * Excludes the faces normal to `face_dimension` (both, if not lattice summed) from iteration, e.g. because their
+       * probing displacement showed their contributions to be negligible. The edge boxes they share with faces that are
+       * not skipped are still visited through those faces, i.e. a box is visited iff it lies on at least one face that is not skipped.
        * @param face_dimension a dimension with finite radius
        * @pre no iterator has been obtained from this object yet
        */
@@ -830,7 +975,7 @@ namespace madness {
       }
 
       /**
-       * @return whether the face normal to `face_dimension` is excluded from iteration
+       * @return whether the faces normal to `face_dimension` are excluded from iteration
        */
       bool face_skipped(size_t face_dimension) const {
         return skip_face_[face_dimension];
@@ -883,15 +1028,16 @@ namespace madness {
 
         // If nothing is known to be filtered out, none of the surface points have been processed,
         // so the surface reaches all the way in to center_ and the on-site probe is the only safe choice.
-        if (!standard_reach_)
+        if (!validator_ || !validator_->reach())
           return Displacement(n, probing_displacement_vec);
+        const auto& reach = *validator_->reach();
 
         // Else, we still need to satisfy requirement (2) while trying to obey (3). We need to displace along
         // a different dimension.
 
         // The offset along axis d is the least number of boxes that takes us out of the region covered by
-        // the standard displacements (see BoxSurfaceDisplacementValidator): either beyond bmax boxes
-        // (see Displacements::make_disp), or, within bmax, beyond sqrt(max_distsq) in real space.
+        // the standard displacements, which the validator filters out (see BoxSurfaceDisplacementValidator):
+        // either beyond bmax boxes (see Displacements::make_disp), or, within bmax, beyond sqrt(max_distsq) in real space.
         // Key::real_distsq_bc measures cell_width*(|l|-1) along an axis, so invert that.
         // Cap the offset at half a cell. If our dimension is lattice-summed, it's even, and half a cell
         // is where it's furthest from the origin. Else, half a cell is the furthest away we can
@@ -899,14 +1045,13 @@ namespace madness {
         const Translation half_cell = Translation(1) << (n-1);
         const Translation bmax = Displacements<NDIM>::bmax_default();
         const auto offset_along = [&](size_t d) -> Translation {
-          const double width = standard_reach_->cell_width[d];
-          MADNESS_CHECK_THROW(width > 0, "BoxSurfaceDisplacementRange: cell widths in StandardDisplacementsReach must be positive");
-          const Translation reach = 1 + static_cast<Translation>(std::sqrt(standard_reach_->max_distsq) / width);
-          return std::min(std::min(reach, bmax) + 1, half_cell);
+          const double width = reach.cell_width[d];  // positive, checked by the validator
+          const Translation nboxes = 1 + static_cast<Translation>(std::sqrt(reach.max_distsq) / width);
+          return std::min(std::min(nboxes, bmax) + 1, half_cell);
         };
         // real-space distance of the offset; since the face axis folds to zero this is the probe's real distance
         const auto offset_distance = [&](size_t d) -> double {
-          return standard_reach_->cell_width[d] * (offset_along(d) - 1);
+          return reach.cell_width[d] * (offset_along(d) - 1);
         };
 
         // choose the dimension to displace along: the one with the least real-space offset (requirement (3)),
@@ -947,150 +1092,5 @@ namespace madness {
     /// For dealing with the lattice-summed operators the filter
     /// can adjusts the displacement to make sure that we end up in
     /// the simulation cell.
-    template <size_t NDIM>
-    class BoxSurfaceDisplacementValidator {
-    public:
-      using Point = Key<NDIM>;
-      using PointPattern = Vector<std::optional<Translation>, NDIM>;
-      using Displacement = Key<NDIM>;
-      using Periodicity = array_of_bools<NDIM>;
-      using DistanceSquaredFunc = std::function<double(const Displacement&)>;
-
-      /// \param is_infinite_domain whether the domain along each axis is finite (simulation cell) or infinite (the entire axis); if true for a given axis then any destination coordinate is valid, else only values in [0,2^n) are valid
-      /// \param is_lattice_summed if true for a given axis, displacement to x and x+2^n are equivalent, hence will be canonicalized to end up in the simulation cell. Periodic axes imply infinite domain, whatever was passed to `is_infinite_domain`.
-      /// \param range the kernel range for each axis
-      /// \param default_distance_squared function that converts a displacement to its effective distance squared (effective may be different from the real distance squared due to periodicity)
-      /// \param max_distsq_reached max effective distance squared reached by standard displacements
-      BoxSurfaceDisplacementValidator(
-          const array_of_bools<NDIM>& is_infinite_domain,
-          const array_of_bools<NDIM>& is_lattice_summed,
-          const std::array<KernelRange, NDIM>& range,
-          DistanceSquaredFunc default_distance_squared,
-          double max_distsq_reached
-          ) :
-              range_(range),
-              default_distance_squared_(default_distance_squared),
-              max_distsq_reached_(max_distsq_reached) {
-        for (size_t i = 0; i < NDIM; i++) {
-          if (is_lattice_summed[i]) {
-            domain_policies_[i] = ExtraDomainPolicy::Translate;
-          } else if (is_infinite_domain[i]) {
-            domain_policies_[i] = ExtraDomainPolicy::Keep;
-          } else {
-            domain_policies_[i] = ExtraDomainPolicy::Discard;
-          }
-        }
-      }
-
-      /// Apply filter to a displacement ending up at a point or a group of points (point pattern)
-
-      /// @param level the tree level
-      /// @param dest the target point (when all elements are nonnull) or point pattern (when only some are).
-      ///        The latter is useful to skip the entire surface layer. The
-      ///        point coordinates are only used to determine whether we end up
-      ///        in or out of the domain.
-      /// @param displacement the optional displacement; if given then will check if it's among
-      ///        the standard displacement and whether it was used as part of
-      ///        the standard displacement set; if it has not been used and the
-      ///        operator is lattice summed, the displacement will be adjusted
-      ///        to end up in the simulation cell. Primary use case for omitting `displacement`
-      ///        is if `dest` is not equivalent to a point.
-      /// @return true if the displacement is to be used
-      bool operator()(
-          const Level level,
-          const PointPattern& dest,
-          std::optional<Displacement>&  displacement
-      ) const {
-        // preliminaries
-        const auto twon = (static_cast<Translation>(1) << level);  // number of boxes along an axis
-        // map_to_range_twon(x) returns for x >= 0 ? x % 2^level : map_to_range_twon(x+2^level)
-        // idiv is generally slow, so instead use bit logic that relies on 2's complement representation of integers
-        const auto map_to_range_twon = [&, mask = ((~(static_cast<std::uint64_t>(0)) << (64-level)) >> (64-level))](std::int64_t x) -> std::int64_t {
-          const std::int64_t x_mapped = x & mask;
-          MADNESS_ASSERT(x_mapped >=0 && x_mapped < twon && (std::abs(x_mapped-x)%twon==0));
-          return x_mapped;
-        };
-
-        const auto out_of_domain = [&](const Translation& t) -> bool {
-          return t < 0 || t >= twon;
-        };
-
-        // check that dest is in the domain
-        const bool dest_is_in_domain = [&]() {
-          for(size_t d=0; d!=NDIM; ++d) {
-            if (domain_policies_[d] == ExtraDomainPolicy::Discard && dest[d].has_value() && out_of_domain(*dest[d])) return false;
-          }
-          return true;
-        }();
-
-        if (dest_is_in_domain) {
-          if (displacement.has_value()) {
-
-            // N.B. avoid duplicates of standard displacements previously included:
-            // A displacement has been possibly considered if along EVERY axis the "effective" displacement size
-            // fits within the box explored by the standard displacement.
-            // If so, skip if <= max magnitude of standard displacements encountered
-            // Otherwise this is a new non-standard displacement, consider it
-            bool among_standard_displacements = true;
-            for(size_t d=0; d!=NDIM; ++d) {
-              const auto disp_d = (*displacement)[d];
-              auto bmax_standard = Displacements<NDIM>::bmax_default();
-
-              // the effective displacement length depends on whether lattice summation is performed along it
-              // compare Displacements::make_disp vs Displacements::make_disp_periodic
-              auto disp_d_eff_abs = std::abs(disp_d);
-              if (domain_policies_[d] == ExtraDomainPolicy::Translate) {
-                // for "periodic" displacements the effective disp_d is the shortest of {..., disp_d-twon, disp_d, disp_d+twon, ...} ... see make_disp_periodic
-                const std::int64_t disp_d_eff = map_to_range_twon(disp_d);
-                disp_d_eff_abs = std::min(disp_d_eff,std::abs(disp_d_eff-twon));
-
-                // IMPORTANT for lattice-summed axes, if the destination is out of the simulation cell map the displacement back to the cell
-                // same logic as for disp_d: dest[d] -> dest[d] % twon
-                if (dest[d].has_value()) {
-                  const Translation dest_d = dest[d].value();
-                  const auto dest_d_in_cell = map_to_range_twon(dest_d);
-                  MADNESS_ASSERT(!out_of_domain(
-                      dest_d_in_cell));
-                  // adjust displacement[d] so that it produces dest_d_cell, not dest_d
-                  auto t = (*displacement).translation();
-                  t[d] += (dest_d_in_cell - dest_d);
-                  displacement.emplace(displacement->level(), t);
-                }
-
-                // N.B. bmax in make_disp_periodic is clipped in the same way
-                if (Displacements<NDIM>::bmax_default() >= twon) bmax_standard = twon-1;
-              }
-
-              if (disp_d_eff_abs > bmax_standard) {
-                among_standard_displacements = false;
-                // Do not break - this loop needs not only to determine among_standard_displacements but to shift the displacement if domain_is_periodic_
-                // Therefore, looping over all dim is strictly necessary.
-              }
-            }
-            if (among_standard_displacements) {
-              const auto distsq = default_distance_squared_(*displacement);
-              if (distsq > max_distsq_reached_) { // among standard displacements => keep if longer than the longest standard displacement considered
-                return true;
-              } {
-                return false;
-              }
-            }
-            else  // not among standard displacements => keep it
-              return true;
-          }
-          else  // skip the displacement-based filter if not given
-            return true;
-        }
-        else
-          return false;
-      }
-
-    private:
-      std::array<ExtraDomainPolicy, NDIM> domain_policies_;
-      std::array<KernelRange, NDIM> range_;
-      DistanceSquaredFunc default_distance_squared_;
-      double max_distsq_reached_;
-    };
-
 }  // namespace madness
 #endif // MADNESS_MRA_DISPLACEMENTS_H__INCLUDED

--- a/src/madness/mra/displacements.h
+++ b/src/madness/mra/displacements.h
@@ -407,7 +407,7 @@ namespace madness {
         const auto twon = (static_cast<Translation>(1) << level);  // number of boxes along an axis
         // map_to_range_twon(x) returns for x >= 0 ? x % 2^level : map_to_range_twon(x+2^level)
         // idiv is generally slow, so instead use bit logic that relies on 2's complement representation of integers
-        const auto map_to_range_twon = [&, mask = ((~(static_cast<std::uint64_t>(0)) << (64-level)) >> (64-level))](std::int64_t x) -> std::int64_t {
+        const auto map_to_range_twon = [&, mask = level == 0 ? std::uint64_t(0) : ((~(static_cast<std::uint64_t>(0)) << (64-level)) >> (64-level))](std::int64_t x) -> std::int64_t {
           const std::int64_t x_mapped = x & mask;
           MADNESS_ASSERT(x_mapped >=0 && x_mapped < twon && (std::abs(x_mapped-x)%twon==0));
           return x_mapped;
@@ -436,7 +436,10 @@ namespace madness {
             bool among_standard_displacements = true;
             for(size_t d=0; d!=NDIM; ++d) {
               const auto disp_d = (*displacement)[d];
+              // N.B. if lattice summation is performed along any axis the standard displacements come from
+              // Displacements::make_disp_periodic, which clips bmax to 2^n-1 along *every* axis
               auto bmax_standard = Displacements<NDIM>::bmax_default();
+              if (is_lattice_summed_.any() && bmax_standard >= twon) bmax_standard = twon - 1;
 
               // the effective displacement length depends on whether lattice summation is performed along it
               // compare Displacements::make_disp vs Displacements::make_disp_periodic
@@ -458,9 +461,6 @@ namespace madness {
                   t[d] += (dest_d_in_cell - dest_d);
                   displacement.emplace(displacement->level(), t);
                 }
-
-                // N.B. bmax in make_disp_periodic is clipped in the same way
-                if (Displacements<NDIM>::bmax_default() >= twon) bmax_standard = twon-1;
               }
 
               if (disp_d_eff_abs > bmax_standard) {
@@ -623,20 +623,31 @@ namespace madness {
               return;
           }
 
-          // we finished this fixed dimension, so update unprocessed bounds to exclude the layers of the current fixed dimension
-          if (!exclude_face(fixed_dim)) {
-            done = true;
-            return;
-          }
-          // (3) switch to next fixed dimension with finite radius
-          select_face(fixed_dim + 1);
-          if (done) return;
+          // (3) we finished this fixed dimension: move on to the next face
+          next_face();
+        }
 
-          // reset our search along all non-fixed dimensions
-          // the reset along the fixed_dim returns silently
+        /// Positions the iterator on the first point of the current face (`fixed_dim`)
+        /// @return false if every layer of the face is filtered out, i.e. the face has no point to offer
+        bool start_face() {
+          bool has_layer = true;
           for (size_t i = 0; i < NDIM; ++i) {
-            reset_along_dim(i);
+            if (!reset_along_dim(i)) has_layer = false;
           }
+          return has_layer;
+        }
+
+        /// Leaves the current face (finished, or without any layer to offer) for the next one that has a point
+        /// to offer, excluding the layers of the faces left behind from the remaining ones. Sets `done` if none remains.
+        void next_face() {
+          do {
+            if (!exclude_face(fixed_dim)) {
+              done = true;
+              return;
+            }
+            select_face(fixed_dim + 1);
+            if (done) return;
+          } while (!start_face());
         }
 
         /// Excludes the layers of the faces normal to `dim` from the faces that remain to be processed,
@@ -682,7 +693,8 @@ namespace madness {
 
         // Recall that the surface is a union of hyperfaces, i.e., direct products of intervals.
         // Reset state on dimension `dim` to initialize for the start of interval `dim` in the the current direct product
-        void reset_along_dim(size_t dim) {
+        // @return false if `dim` is the fixed dimension and every layer of its faces is filtered out
+        bool reset_along_dim(size_t dim) {
           const auto is_fixed_dim = dim == fixed_dim;
           Vector<Translation, NDIM> l = point.translation();
           Translation l_dim_min;
@@ -732,10 +744,11 @@ namespace madness {
                 if (!filtered_out())
                   break;
               }
-              MADNESS_ASSERT(have_another_surface_layer);
+              return have_another_surface_layer;  // false: every layer of this face is filtered out (e.g. lies outside the domain)
             }
 
           }
+          return true;
         };
 
         /**
@@ -767,13 +780,12 @@ namespace madness {
           if (type != End) {
             unprocessed_bounds = parent->initial_bounds_;
 
-            // skip to first dimension with limited range whose faces are not skipped
+            // skip to first dimension with limited range whose faces are not skipped and have a point to offer
             select_face(0);
             if (done) return;
+            if (!start_face()) next_face();
+            if (done) return;
 
-            for (size_t d = 0; d != NDIM; ++d) {
-              reset_along_dim(d);
-            }
             advance_till_valid();
           }
         }
@@ -1012,14 +1024,15 @@ namespace madness {
           return is_lattice_summed_[d] && (*box_radius_[d] % 2 == 0);
         };
 
-        // Enforce requirement (1)
+        // Enforce requirement (1). The faces have finite thickness: their layers span [r-t, r+t], and
+        // by (3) the probe goes on the innermost one, which is the nearest to the source.
         Vector<Translation, NDIM> probing_displacement_vec(0);
         const auto n = center_.level();
         auto r = *box_radius_[face_dimension];  // in units of 2^{n-1}
         // n = 0 is special b/c << -1 is undefined
         r = (n == 0) ? (r+1)/2 : (r * Translation(1) << (n-1));
         MADNESS_ASSERT(r > 0);
-        probing_displacement_vec[face_dimension] = r;
+        probing_displacement_vec[face_dimension] = r - surface_thickness_[face_dimension].value_or(0);
 
         // In these cases, requirement (2) is already satisfied or unsatisfiable.
         // Choosing 0 for all other dimensions satisfies requirement (3).

--- a/src/madness/mra/funcimpl.h
+++ b/src/madness/mra/funcimpl.h
@@ -5199,29 +5199,26 @@ template<size_t NDIM>
             if (max_distsq_reached)
               validator = BoxSurfaceDisplacementValidator<opdim>(/* is_infinite_domain= */ op->func_domain_is_periodic(), /* is_lattice_summed= */ op->lattice_summed(), range, default_real_distance_squared, *max_distsq_reached);
 
-            // Least N such that being N boxes away from origin_ guarantees you're outside of the short-range region.
-            std::optional<Translation> probe_offset_radius;
+            // real-space extent of what the validator filters out, so that the range can place its probing
+            // displacement just outside of it. If there is no validator, nothing is filtered and the surface
+            // reaches all the way in to the center; leave this empty so that the probe screens nothing.
+            using SurfaceRange = BoxSurfaceDisplacementRange<opdim>;
+            std::optional<typename SurfaceRange::StandardDisplacementsReach> standard_reach;
             if (max_distsq_reached) {
-              // default_real_distance_squared measures cell_width*(|l|-1) per axis (see Key::real_distsq_bc);
-              // invert it. The offset axis is not known here, so use the widest one, which yields the
-              // smallest radius and hence the most conservative probe.
+              // N.B. must use the same widths as default_real_distance_squared, i.e. the first opdim axes
               const auto &cell_width = FunctionDefaults<NDIM>::get_cell_width();
-              const std::size_t d0 = (op->particle() == 1) ? 0 : NDIM - opdim;
-              double widest = 0.;
-              for (std::size_t d = d0; d != d0 + opdim; ++d) widest = std::max(widest, cell_width(d));
-              const Translation reach = 1 + static_cast<Translation>(std::sqrt(*max_distsq_reached) / widest);
-              probe_offset_radius = std::min<Translation>(reach, Displacements<opdim>::bmax_default()) + 1;
-            } else  // no validator => no treatment of short-range point. let surface handle everything
-              probe_offset_radius = 0;
+              std::array<double, opdim> widths;
+              for (std::size_t d = 0; d != opdim; ++d) widths[d] = cell_width(d);
+              standard_reach = typename SurfaceRange::StandardDisplacementsReach{*max_distsq_reached, widths};
+            }
 
             // this range iterates over the entire surface layer(s), and provides a probing displacement that can be used to screen out the entire box
             auto opkey = op->particle() == 1 ? key.template extract_front<opdim>() : key.template extract_back<opdim>();
-            BoxSurfaceDisplacementRange<opdim>
-                range_boundary_face_displacements(opkey, box_radius,
-                                                  surface_thickness,
-                                                  op->lattice_summed(),
-                                                  validator,
-                                                  probe_offset_radius);
+            SurfaceRange range_boundary_face_displacements(opkey, box_radius,
+                                                           surface_thickness,
+                                                           op->lattice_summed(),
+                                                           validator,
+                                                           standard_reach);
             for_each(
                 range_boundary_face_displacements,
                 // surface displacements are not screened, all are included

--- a/src/madness/mra/funcimpl.h
+++ b/src/madness/mra/funcimpl.h
@@ -5080,7 +5080,7 @@ template<size_t NDIM>
               -> bool {
             return false;
           };
-          const auto for_each = [&](const auto &displacements,
+          const auto for_each = [&](auto &displacements,
                                     const auto &real_distance_squared,
                                     const auto &lattice_distance_squared,
                                     const auto &skip_predicate) -> std::optional<double> {
@@ -5102,14 +5102,23 @@ template<size_t NDIM>
             std::optional<double> real_last_distsq;
             std::optional<std::uint64_t> lattice_last_distsq;
 
-            // displacements to the kernel range boundary are typically same magnitude (modulo variation)
-            // estimate the norm of the resulting contributions and skip all if one is too small
+            // displacements to a face of the kernel range boundary are typically same magnitude (modulo variation),
+            // but faces can be at quite different distances (anisotropic cells, lattice summation along some axes only,
+            // mixed-parity ranges). Estimate the norm of the contributions from each face using its probing
+            // displacement, skip the faces whose contributions are negligible, and skip everything if all are.
             if constexpr (std::is_same_v<std::decay_t<decltype(displacements)>,BoxSurfaceDisplacementRange<opdim>>) {
-              const auto &probing_displacement =
-                  displacements.probing_displacement();
-              const double opnorm =
-                  op->norm(key.level(), probing_displacement, source);
-              if (cnorm * opnorm <= tol / fac) {
+              bool any_face_survives = false;
+              const auto &probing_displacements = displacements.probing_displacements();
+              for (std::size_t d = 0; d != opdim; ++d) {
+                if (!probing_displacements[d]) continue;  // no face normal to an unlimited dimension
+                const double opnorm =
+                    op->norm(key.level(), *probing_displacements[d], source);
+                if (cnorm * opnorm <= tol / fac)
+                  displacements.skip_face(d);
+                else
+                  any_face_survives = true;
+              }
+              if (!any_face_survives) {
                 return {};
               }
             }

--- a/src/madness/mra/funcimpl.h
+++ b/src/madness/mra/funcimpl.h
@@ -5202,32 +5202,28 @@ template<size_t NDIM>
               }
             }
 
-            typename BoxSurfaceDisplacementRange<opdim>::Validator validator;
             // skip surface displacements that take us outside of the domain and/or were included in regular displacements
-            // N.B. for lattice-summed axes the "filter" also maps the displacement back into the simulation cell
-            if (max_distsq_reached)
-              validator = BoxSurfaceDisplacementValidator<opdim>(/* is_infinite_domain= */ op->func_domain_is_periodic(), /* is_lattice_summed= */ op->lattice_summed(), range, default_real_distance_squared, *max_distsq_reached);
-
-            // real-space extent of what the validator filters out, so that the range can place its probing
-            // displacement just outside of it. If there is no validator, nothing is filtered and the surface
-            // reaches all the way in to the center; leave this empty so that the probe screens nothing.
+            // N.B. for lattice-summed axes the "filter" also maps the displacement back into the simulation cell.
+            // The filter also carries the real-space reach of the standard displacements it discards, outside of which
+            // the range places its probing displacements. If no standard displacements were processed there is nothing
+            // to filter and nothing is known about the reach; the probes then screen nothing.
             using SurfaceRange = BoxSurfaceDisplacementRange<opdim>;
-            std::optional<typename SurfaceRange::StandardDisplacementsReach> standard_reach;
+            std::optional<typename SurfaceRange::Validator> validator;
             if (max_distsq_reached) {
               // N.B. must use the same widths as default_real_distance_squared, i.e. the first opdim axes
               const auto &cell_width = FunctionDefaults<NDIM>::get_cell_width();
               std::array<double, opdim> widths;
               for (std::size_t d = 0; d != opdim; ++d) widths[d] = cell_width(d);
-              standard_reach = typename SurfaceRange::StandardDisplacementsReach{*max_distsq_reached, widths};
+              validator.emplace(/* is_infinite_domain= */ op->func_domain_is_periodic(), /* is_lattice_summed= */ op->lattice_summed(),
+                                StandardDisplacementsReach<opdim>{*max_distsq_reached, widths});
             }
 
-            // this range iterates over the entire surface layer(s), and provides a probing displacement that can be used to screen out the entire box
+            // this range iterates over the entire surface layer(s), and provides a probing displacement per face that can be used to screen out the face
             auto opkey = op->particle() == 1 ? key.template extract_front<opdim>() : key.template extract_back<opdim>();
             SurfaceRange range_boundary_face_displacements(opkey, box_radius,
                                                            surface_thickness,
                                                            op->lattice_summed(),
-                                                           validator,
-                                                           standard_reach);
+                                                           validator);
             for_each(
                 range_boundary_face_displacements,
                 // surface displacements are not screened, all are included

--- a/src/madness/mra/test_displacements.cc
+++ b/src/madness/mra/test_displacements.cc
@@ -55,6 +55,61 @@ typename BoxSurfaceDisplacementRange<NDIM>::Validator in_domain_only() {
   };
 }
 
+template <std::size_t NDIM>
+BoxSurfaceDisplacementRange<NDIM> make_range(Level n, const Radii<NDIM>& box_radius,
+                                             const array_of_bools<NDIM>& is_lattice_summed,
+                                             std::optional<Reach<NDIM>> reach = {},
+                                             typename BoxSurfaceDisplacementRange<NDIM>::Validator validator = {}) {
+  Radii<NDIM> surface_thickness;
+  for (std::size_t d = 0; d != NDIM; ++d) {
+    if (box_radius[d]) surface_thickness[d] = 1;
+  }
+  return BoxSurfaceDisplacementRange<NDIM>(centered_key<NDIM>(n), box_radius, surface_thickness, is_lattice_summed,
+                                           std::move(validator), std::move(reach));
+}
+
+/// the probing displacement of every face, as a translation; null for dimensions of unlimited size (no face)
+template <std::size_t NDIM>
+using Probes = std::array<std::optional<std::array<std::int64_t, NDIM>>, NDIM>;
+
+template <std::size_t NDIM>
+Probes<NDIM> probes_of(const BoxSurfaceDisplacementRange<NDIM>& range) {
+  Probes<NDIM> result;
+  for (std::size_t d = 0; d != NDIM; ++d) {
+    if (!range.probing_displacements()[d]) continue;
+    std::array<std::int64_t, NDIM> v;
+    for (std::size_t e = 0; e != NDIM; ++e) v[e] = range.probing_displacement(d).translation()[e];
+    result[d] = v;
+  }
+  return result;
+}
+
+template <std::size_t NDIM>
+Probes<NDIM> probes_of(Level n, const Radii<NDIM>& box_radius, const array_of_bools<NDIM>& is_lattice_summed,
+                       std::optional<Reach<NDIM>> reach = {}) {
+  return probes_of(make_range<NDIM>(n, box_radius, is_lattice_summed, std::move(reach)));
+}
+
+template <std::size_t NDIM>
+void check_probes(test_output& t, const Probes<NDIM>& actual, const Probes<NDIM>& expected, const std::string& what) {
+  for (std::size_t d = 0; d != NDIM; ++d) {
+    const auto face = what + " face " + std::to_string(d);
+    t.checkpoint(actual[d].has_value() == expected[d].has_value(), face + " exists iff radius is finite");
+    if (actual[d] && expected[d]) {
+      for (std::size_t e = 0; e != NDIM; ++e)
+        t.checkpoint((*actual[d])[e] == (*expected[d])[e], face + " component " + std::to_string(e));
+    }
+  }
+}
+
+/// shorthand for all-finite radii
+template <std::size_t NDIM>
+Radii<NDIM> finite(std::array<std::int64_t, NDIM> N) {
+  Radii<NDIM> result;
+  for (std::size_t d = 0; d != NDIM; ++d) result[d] = N[d];
+  return result;
+}
+
 /// No displacement may be enumerated twice.
 /// We test any and cases where the logic splits, including lattice summed or not,
 /// and odd vs even N
@@ -64,15 +119,10 @@ int test_no_duplicates(World& world) {
   const auto check_unique = [&](auto ndim_tag, Level n, std::array<std::int64_t, decltype(ndim_tag)::value> N,
                                 bool lattice_summed, bool filter_to_domain, const std::string& what) {
     constexpr std::size_t NDIM = decltype(ndim_tag)::value;
-    Radii<NDIM> box_radius, surface_thickness;
-    for (std::size_t d = 0; d != NDIM; ++d) {
-      box_radius[d] = N[d];
-      surface_thickness[d] = 1;
-    }
     // N.B. the domain filter is only meaningful when the range boundary can land
     // inside the cell at all.
-    BoxSurfaceDisplacementRange<NDIM> range(
-        centered_key<NDIM>(n), box_radius, surface_thickness, array_of_bools<NDIM>{lattice_summed},
+    const auto range = make_range<NDIM>(
+        n, finite<NDIM>(N), array_of_bools<NDIM>{lattice_summed}, {},
         filter_to_domain ? in_domain_only<NDIM>() : typename BoxSurfaceDisplacementRange<NDIM>::Validator{});
     std::vector<Key<NDIM>> disps;
     for (auto&& disp : range) disps.push_back(disp);
@@ -120,13 +170,7 @@ int test_validator_agnostic(World& world) {
 
   constexpr std::size_t NDIM = 2;
   const auto disps_of = [](typename BoxSurfaceDisplacementRange<NDIM>::Validator validator) {
-    Radii<NDIM> box_radius, surface_thickness;
-    for (std::size_t d = 0; d != NDIM; ++d) {
-      box_radius[d] = 1;
-      surface_thickness[d] = 1;
-    }
-    BoxSurfaceDisplacementRange<NDIM> range(centered_key<NDIM>(4), box_radius, surface_thickness,
-                                            array_of_bools<NDIM>{false}, std::move(validator));
+    const auto range = make_range<NDIM>(4, finite<NDIM>({1, 1}), array_of_bools<NDIM>{false}, {}, std::move(validator));
     std::vector<Key<NDIM>> disps;
     for (auto&& disp : range) disps.push_back(disp);
     std::sort(disps.begin(), disps.end());
@@ -143,32 +187,23 @@ int test_validator_agnostic(World& world) {
   return t.end();
 }
 
-/// Test the cases where there is an odd box radius.
+/// Every face gets its own probe: odd (lattice-summed) faces sit a half cell out and need no offset,
+/// even ones fold onto the source and need an offset along another axis.
 int test_odds(World& world) {
-  test_output t("BoxSurfaceDisplacementRange: odd dimensions", world.rank() == 0);
+  test_output t("BoxSurfaceDisplacementRange: mixed-parity radii", world.rank() == 0);
 
-  Level level = 4;
-
-  const auto check_probe = [&](Level n, std::array<std::int64_t, 3> N, std::array<std::int64_t, 3> expected,
-                               const std::string& what) {
-    constexpr std::size_t NDIM = 3;
-    Radii<NDIM> box_radius, surface_thickness;
-    for (std::size_t d = 0; d != NDIM; ++d) {
-      box_radius[d] = N[d];
-      surface_thickness[d] = 1;
-    }
-    BoxSurfaceDisplacementRange<NDIM> range(centered_key<NDIM>(n), box_radius, surface_thickness,
-                                            array_of_bools<NDIM>{true} /* lattice_summed */);
-    const auto probe = range.probing_displacement().translation();
-    for (size_t d = 0; d < NDIM; d++) {
-      t.checkpoint(probe[d] == expected[d], "3D n=" + std::to_string(n) + " N=" + what + " component " + std::to_string(d));
-    }
+  const Level level = 4;
+  const auto r = [&](std::int64_t N) { return radius_in_boxes(N, level); };
+  const auto off = far_offset<3>(level);
+  const auto probes = [&](std::array<std::int64_t, 3> N) {
+    return probes_of<3>(level, finite<3>(N), array_of_bools<3>{true}, far_reach<3>());
   };
 
-  check_probe(level, {3, 2, 1}, {0, 0, radius_in_boxes(1, level)}, "{3,2,1}");
-  check_probe(level, {1, 2, 3}, {radius_in_boxes(1, level), 0, 0}, "{1,2,3}");
-  check_probe(level, {1, 2, 1}, {radius_in_boxes(1, level), 0, 0}, "{1,2,1}");
-  check_probe(level, {3, 2, 3}, {radius_in_boxes(3, level), 0, 0}, "{3,2,3}");
+  // the offset of an even face goes along the finite axis with the smallest radius
+  check_probes<3>(t, probes({3, 2, 1}), {{{{r(3), 0, 0}}, {{0, r(2), off}}, {{0, 0, r(1)}}}}, "3D n=4 N={3,2,1}");
+  check_probes<3>(t, probes({1, 2, 3}), {{{{r(1), 0, 0}}, {{off, r(2), 0}}, {{0, 0, r(3)}}}}, "3D n=4 N={1,2,3}");
+  // ... ties are broken by index
+  check_probes<3>(t, probes({1, 2, 1}), {{{{r(1), 0, 0}}, {{off, r(2), 0}}, {{0, 0, r(1)}}}}, "3D n=4 N={1,2,1}");
   return t.end();
 }
 
@@ -176,24 +211,12 @@ int test_odds(World& world) {
 int test_singular(World& world) {
   test_output t("BoxSurfaceDisplacementRange: singular cases", world.rank() == 0);
 
-  const auto check_probe = [&]<std::size_t NDIM>(Level n, std::array<std::int64_t, NDIM> N, std::array<std::int64_t, NDIM> expected,
-                               const std::string& what) {
-    Radii<NDIM> box_radius, surface_thickness;
-    for (std::size_t d = 0; d != NDIM; ++d) {
-      box_radius[d] = N[d];
-      surface_thickness[d] = 1;
-    }
-    BoxSurfaceDisplacementRange<NDIM> range(centered_key<NDIM>(n), box_radius, surface_thickness,
-                                            array_of_bools<NDIM>{true} /* lattice_summed */);
-    const auto probe = range.probing_displacement().translation();
-    for (size_t d = 0; d < NDIM; d++) {
-      t.checkpoint(probe[d] == expected[d], std::to_string(NDIM) + "D n=" + std::to_string(n) + " N=" + what + " component " + std::to_string(d));
-    }
-  };
-
-  Level level = 4;
-  check_probe(level, std::array<std::int64_t, 1>{4}, {radius_in_boxes(4, level)}, "{4}");
-  check_probe(0, std::array<std::int64_t, 3>{3, 2, 1}, {0, 0, 1}, "{3,2,1}");
+  const Level level = 4;
+  check_probes<1>(t, probes_of<1>(level, finite<1>({4}), array_of_bools<1>{true}, far_reach<1>()),
+                  {{{{radius_in_boxes(4, level)}}}}, "1D n=4 N={4}");
+  // at level 0 a half cell is 1 box: N=3 -> 2 boxes, N=2 -> 1 box, N=1 -> 1 box; no offsets
+  check_probes<3>(t, probes_of<3>(0, finite<3>({3, 2, 1}), array_of_bools<3>{true}, far_reach<3>()),
+                  {{{{2, 0, 0}}, {{0, 1, 0}}, {{0, 0, 1}}}}, "3D n=0 N={3,2,1}");
   return t.end();
 }
 
@@ -201,64 +224,41 @@ int test_singular(World& world) {
 int test_mixed(World& world) {
   test_output t("BoxSurfaceDisplacementRange: mixed cases", world.rank() == 0);
 
-  Level level = 4;
-
-  const auto check_probe = [&]<std::size_t NDIM>(Level n, Radii<NDIM> box_radius, std::array<std::int64_t, NDIM> expected,
-                               const std::string& what) {
-    Radii<NDIM> surface_thickness;
-    for (std::size_t d = 0; d != NDIM; ++d) {
-      if (box_radius[d]) surface_thickness[d] = 1;
-    }
-    BoxSurfaceDisplacementRange<NDIM> range(centered_key<NDIM>(n), box_radius, surface_thickness,
-                                            array_of_bools<NDIM>{true} /* lattice_summed */, {}, far_reach<NDIM>());
-    const auto probe = range.probing_displacement().translation();
-    for (size_t d = 0; d < NDIM; d++) {
-      t.checkpoint(probe[d] == expected[d], what + " component " + std::to_string(d));
-    }
-  };
-
+  const Level level = 4;
+  const auto r = [&](std::int64_t N) { return radius_in_boxes(N, level); };
 
   Radii<2> radii2d;
   radii2d[1] = 2;
-  check_probe(level, radii2d, {-far_offset<2>(level), radius_in_boxes(2, level)}, "2D n=4 N={*,2}");
+  // no face normal to the unrestricted dimension; the even face's offset goes along it, toward the side with more room
+  check_probes<2>(t, probes_of<2>(level, radii2d, array_of_bools<2>{true}, far_reach<2>()),
+                  {{std::nullopt, {{-far_offset<2>(level), r(2)}}}}, "2D n=4 N={*,2}");
   radii2d[1] = 3;
-  check_probe(level, radii2d, {0, radius_in_boxes(3, level)}, "2D n=4 N={*,3}");
+  check_probes<2>(t, probes_of<2>(level, radii2d, array_of_bools<2>{true}, far_reach<2>()),
+                  {{std::nullopt, {{0, r(3)}}}}, "2D n=4 N={*,3}");
   Radii<3> radii3d;
   radii3d[1] = 2;
   radii3d[2] = 3;
-  check_probe(level, radii3d, {0, 0, radius_in_boxes(3, level)}, "3D n=4 N={*,2,3}");
+  // a finite axis is preferred over an unrestricted one for the offset (the probe is guaranteed to stay on the face)
+  check_probes<3>(t, probes_of<3>(level, radii3d, array_of_bools<3>{true}, far_reach<3>()),
+                  {{std::nullopt, {{0, r(2), far_offset<3>(level)}}, {{0, 0, r(3)}}}}, "3D n=4 N={*,2,3}");
   return t.end();
 }
 
-/// Test the case in which every box radius is even, so that the face dimension alone cannot satisfy
-/// criterion 2 and an offset along a second dimension is needed.
+/// Test the case in which every box radius is even, so that every face folds onto the source
+/// and needs an offset along a second dimension.
 int test_all_evens(World& world) {
   test_output t("BoxSurfaceDisplacementRange: pure evens", world.rank() == 0);
 
-  Level level = 4;
-
-  const auto check_probe = [&](Level n, std::array<std::int64_t, 3> N, std::array<std::int64_t, 3> expected,
-                               const std::string& what) {
-    constexpr std::size_t NDIM = 3;
-    Radii<NDIM> box_radius, surface_thickness;
-    for (std::size_t d = 0; d != NDIM; ++d) {
-      box_radius[d] = N[d];
-      surface_thickness[d] = 1;
-    }
-    BoxSurfaceDisplacementRange<NDIM> range(centered_key<NDIM>(n), box_radius, surface_thickness,
-                                            array_of_bools<NDIM>{true} /* lattice_summed */, {}, far_reach<NDIM>());
-    const auto probe = range.probing_displacement().translation();
-    for (size_t d = 0; d < NDIM; d++) {
-      t.checkpoint(probe[d] == expected[d], std::to_string(NDIM) + "D n=" + std::to_string(n) + " N=" + what + " component " + std::to_string(d));
-    }
+  const Level level = 4;
+  const auto r = [&](std::int64_t N) { return radius_in_boxes(N, level); };
+  const auto off = far_offset<3>(level);
+  const auto probes = [&](std::array<std::int64_t, 3> N) {
+    return probes_of<3>(level, finite<3>(N), array_of_bools<3>{true}, far_reach<3>());
   };
 
-  const auto off = far_offset<3>(level);
-  check_probe(level, {4, 6, 2}, {off, 0, radius_in_boxes(2, level)}, "{4,6,2}");
-  check_probe(level, {6, 2, 2}, {0, radius_in_boxes(2, level), off}, "{6,2,2}");
-  check_probe(level, {8, 2, 2}, {0, radius_in_boxes(2, level), off}, "{8,2,2}");
-  check_probe(level, {6, 4, 2}, {0, off, radius_in_boxes(2, level)}, "{6,4,2}");
-  check_probe(level, {4, 6, 4}, {radius_in_boxes(4, level), 0, off}, "{4,6,4}");
+  check_probes<3>(t, probes({2, 2, 2}), {{{{r(2), off, 0}}, {{off, r(2), 0}}, {{off, 0, r(2)}}}}, "3D n=4 N={2,2,2}");
+  check_probes<3>(t, probes({4, 6, 2}), {{{{r(4), 0, off}}, {{0, r(6), off}}, {{off, 0, r(2)}}}}, "3D n=4 N={4,6,2}");
+  check_probes<3>(t, probes({6, 2, 2}), {{{{r(6), off, 0}}, {{0, r(2), off}}, {{0, off, r(2)}}}}, "3D n=4 N={6,2,2}");
 
   return t.end();
 }
@@ -268,66 +268,52 @@ int test_all_evens(World& world) {
 int test_lattice_summation_awareness(World& world) {
   test_output t("BoxSurfaceDisplacementRange: offset only where lattice summed", world.rank() == 0);
 
-  const auto check_probe = [&]<std::size_t NDIM>(Level n, Radii<NDIM> box_radius,
-                                                 array_of_bools<NDIM> is_lattice_summed,
-                                                 std::array<std::int64_t, NDIM> expected,
-                                                 const std::string& what) {
-    Radii<NDIM> surface_thickness;
-    for (std::size_t d = 0; d != NDIM; ++d) {
-      if (box_radius[d]) surface_thickness[d] = 1;
-    }
-    BoxSurfaceDisplacementRange<NDIM> range(centered_key<NDIM>(n), box_radius, surface_thickness,
-                                            is_lattice_summed, {}, far_reach<NDIM>());
-    const auto probe = range.probing_displacement().translation();
-    for (size_t d = 0; d < NDIM; d++) {
-      t.checkpoint(probe[d] == expected[d], what + " component " + std::to_string(d));
-    }
-  };
-
-  Level level = 4;
+  const Level level = 4;
   const auto r = [&](std::int64_t N) { return radius_in_boxes(N, level); };
   const auto off3 = far_offset<3>(level);
+  const auto probes = [&](std::array<std::int64_t, 3> N, array_of_bools<3> summed) {
+    return probes_of<3>(level, finite<3>(N), summed, far_reach<3>());
+  };
 
-  // all even, nothing lattice summed => no offset, and the probe is the nearest surface point
-  check_probe(level, Radii<3>{2, 2, 2}, array_of_bools<3>{false}, {r(2), 0, 0}, "3D N={2,2,2} not summed");
-  check_probe(level, Radii<3>{4, 2, 6}, array_of_bools<3>{false}, {0, r(2), 0}, "3D N={4,2,6} not summed");
-  // ... the same radii with lattice summation on do need the offset
-  check_probe(level, Radii<3>{2, 2, 2}, array_of_bools<3>{true}, {r(2), off3, 0}, "3D N={2,2,2} summed");
-
-  // with only the first dimension lattice summed, that dimension is the best face even though it has to
-  // pay for an offset: it folds to the origin plus a few boxes, whereas y or z would leave the probe a full
-  // 2 half-cells out with nothing to fold it back
-  check_probe(level, Radii<3>{2, 2, 2}, array_of_bools<3>{true, false, false}, {r(2), off3, 0},
-                 "3D N={2,2,2} summed along x only");
-  // ... and all the more so when the unsummed dimensions are wider
-  check_probe(level, Radii<3>{2, 4, 4}, array_of_bools<3>{true, false, false}, {r(2), off3, 0},
-                 "3D N={2,4,4} summed along x only");
+  // all even, nothing lattice summed => no offsets, each probe is the nearest point of its face
+  check_probes<3>(t, probes({2, 2, 2}, array_of_bools<3>{false}), {{{{r(2), 0, 0}}, {{0, r(2), 0}}, {{0, 0, r(2)}}}},
+                  "3D N={2,2,2} not summed");
+  check_probes<3>(t, probes({4, 2, 6}, array_of_bools<3>{false}), {{{{r(4), 0, 0}}, {{0, r(2), 0}}, {{0, 0, r(6)}}}},
+                  "3D N={4,2,6} not summed");
+  // ... the same radii with lattice summation on do need the offsets
+  check_probes<3>(t, probes({2, 2, 2}, array_of_bools<3>{true}), {{{{r(2), off3, 0}}, {{off3, r(2), 0}}, {{off3, 0, r(2)}}}},
+                  "3D N={2,2,2} summed");
+  // ... with only the first dimension lattice summed, only its face needs the offset
+  check_probes<3>(t, probes({2, 2, 2}, array_of_bools<3>{true, false, false}),
+                  {{{{r(2), off3, 0}}, {{0, r(2), 0}}, {{0, 0, r(2)}}}}, "3D N={2,2,2} summed along x only");
 
   // an unrestricted dimension absorbs the offset, but again only when one is needed
   Radii<2> radii2d;
   radii2d[1] = 2;
-  check_probe(level, radii2d, array_of_bools<2>{false, true}, {-far_offset<2>(level), r(2)}, "2D N={*,2} summed along y");
-  check_probe(level, radii2d, array_of_bools<2>{false, false}, {0, r(2)}, "2D N={*,2} not summed");
+  check_probes<2>(t, probes_of<2>(level, radii2d, array_of_bools<2>{false, true}, far_reach<2>()),
+                  {{std::nullopt, {{-far_offset<2>(level), r(2)}}}}, "2D N={*,2} summed along y");
+  check_probes<2>(t, probes_of<2>(level, radii2d, array_of_bools<2>{false, false}, far_reach<2>()),
+                  {{std::nullopt, {{0, r(2)}}}}, "2D N={*,2} not summed");
 
   return t.end();
 }
 
-/// The offset for all-even radii is derived from the real-space reach of the standard displacements,
+/// The offset for an even face is derived from the real-space reach of the standard displacements,
 /// as supplied by the caller: it is the least number of boxes that the validator does not filter out.
 int test_standard_reach(World& world) {
   test_output t("BoxSurfaceDisplacementRange: offset follows the reach of the standard displacements", world.rank() == 0);
 
   constexpr std::size_t NDIM = 3;
   const Translation bmax = Displacements<NDIM>::bmax_default();  // 4
-  const auto check = [&](Level n, std::optional<Reach<NDIM>> reach, std::array<std::int64_t, NDIM> expected,
+  // all radii even and lattice summed; check the probe of face `face`
+  const auto check = [&](Level n, std::optional<Reach<NDIM>> reach, std::size_t face, std::array<std::int64_t, NDIM> expected,
                          const std::string& what) {
-    Radii<NDIM> box_radius, surface_thickness;
-    for (std::size_t d = 0; d != NDIM; ++d) { box_radius[d] = 2; surface_thickness[d] = 1; }  // all even
-    BoxSurfaceDisplacementRange<NDIM> range(centered_key<NDIM>(n), box_radius, surface_thickness,
-                                            array_of_bools<NDIM>{true} /* lattice_summed */, {}, reach);
-    const auto probe = range.probing_displacement().translation();
-    for (size_t d = 0; d < NDIM; d++)
-      t.checkpoint(probe[d] == expected[d], what + " component " + std::to_string(d));
+    const auto probe = probes_of<NDIM>(n, finite<NDIM>({2, 2, 2}), array_of_bools<NDIM>{true}, std::move(reach))[face];
+    t.checkpoint(probe.has_value(), what + " face " + std::to_string(face) + " exists");
+    if (probe) {
+      for (size_t d = 0; d < NDIM; d++)
+        t.checkpoint((*probe)[d] == expected[d], what + " face " + std::to_string(face) + " component " + std::to_string(d));
+    }
   };
   const auto anisotropic_reach = [](double max_distsq, std::array<double, NDIM> cell_width) {
     return Reach<NDIM>{max_distsq, cell_width};
@@ -339,42 +325,141 @@ int test_standard_reach(World& world) {
 
     // nothing is known to be filtered => the surface reaches the source and no offset helps;
     // fall back to the bare face probe, whose norm is the on-site norm and screens nothing
-    check(n, std::nullopt, {face, 0, 0}, "nothing filtered");
+    check(n, std::nullopt, 0, {face, 0, 0}, "nothing filtered");
 
     // unit cell widths: the real distance of a displacement l along an axis is |l|-1 (see Key::real_distsq_bc),
     // so the least offset beyond real distance sqrt(max_distsq) is floor(sqrt(max_distsq))+2 boxes ...
-    check(n, unit_reach<NDIM>(0.), {face, 2, 0}, "unit widths, only the nearest neighbors reached");
-    check(n, unit_reach<NDIM>(6.25), {face, 4, 0}, "unit widths, sqrt(max_distsq)=2.5");
-    check(n, unit_reach<NDIM>(9.), {face, 5, 0}, "unit widths, sqrt(max_distsq)=3");
+    check(n, unit_reach<NDIM>(0.), 0, {face, 2, 0}, "unit widths, only the nearest neighbors reached");
+    check(n, unit_reach<NDIM>(6.25), 0, {face, 4, 0}, "unit widths, sqrt(max_distsq)=2.5");
+    check(n, unit_reach<NDIM>(9.), 0, {face, 5, 0}, "unit widths, sqrt(max_distsq)=3");
     // ... but never more than bmax+1, beyond which nothing is a standard displacement
-    check(n, unit_reach<NDIM>(1e6), {face, bmax + 1, 0}, "unit widths, reached beyond bmax");
+    check(n, unit_reach<NDIM>(1e6), 0, {face, bmax + 1, 0}, "unit widths, reached beyond bmax");
 
     // anisotropic cell: the offset goes along the axis with the least *real-space* offset.
     // With sqrt(max_distsq)=5 and width 1 the offset is capped at bmax+1=5 boxes, i.e. 4 real units ...
-    check(n, anisotropic_reach(25., {10., 1., 10.}), {face, 5, 0}, "widths {10,1,10}");
-    check(n, anisotropic_reach(25., {10., 10., 1.}), {face, 0, 5}, "widths {10,10,1}");
+    check(n, anisotropic_reach(25., {10., 1., 10.}), 0, {face, 5, 0}, "widths {10,1,10}");
+    check(n, anisotropic_reach(25., {10., 1., 10.}), 2, {0, 5, face}, "widths {10,1,10}");
+    check(n, anisotropic_reach(25., {10., 10., 1.}), 0, {face, 0, 5}, "widths {10,10,1}");
     // ... whereas a wider axis can need fewer boxes yet be farther in real space (width 2: 4 boxes = 6 units) ...
-    check(n, anisotropic_reach(25., {1., 2., 100.}), {face, 4, 0}, "widths {1,2,100}");
+    check(n, anisotropic_reach(25., {1., 2., 100.}), 0, {face, 4, 0}, "widths {1,2,100}");
     // ... or fewer boxes *and* nearer in real space (width 2.6: 3 boxes = 5.2 units vs. width 2: 4 boxes = 6 units)
-    check(n, anisotropic_reach(25., {1., 2., 2.6}), {face, 0, 3}, "widths {1,2,2.6}");
+    check(n, anisotropic_reach(25., {1., 2., 2.6}), 0, {face, 0, 3}, "widths {1,2,2.6}");
   }
 
   // the offset is capped at a half cell: a step of 2^{n-1}+k folds back down to 2^{n-1}-k
   {
     const Level n = 2;  // half cell = 2 boxes < bmax+1
-    check(n, unit_reach<NDIM>(1e6), {radius_in_boxes(2, n), 2, 0}, "n=2, reached beyond bmax");
+    check(n, unit_reach<NDIM>(1e6), 0, {radius_in_boxes(2, n), 2, 0}, "n=2, reached beyond bmax");
   }
 
   // the same cap applies when the offset lands on an unrestricted dimension
   {
     const Level n = 6;
-    Radii<2> box_radius, surface_thickness;
-    box_radius[1] = 2; surface_thickness[1] = 1;
-    BoxSurfaceDisplacementRange<2> range(centered_key<2>(n), box_radius, surface_thickness,
-                                         array_of_bools<2>{true}, {}, unit_reach<2>(4.));
-    const auto probe = range.probing_displacement().translation();
-    t.checkpoint(probe[0] == -4, "2D N={*,2} sqrt(max_distsq)=2 component 0");
-    t.checkpoint(probe[1] == radius_in_boxes(2, n), "2D N={*,2} sqrt(max_distsq)=2 component 1");
+    Radii<2> box_radius;
+    box_radius[1] = 2;
+    check_probes<2>(t, probes_of<2>(n, box_radius, array_of_bools<2>{true}, unit_reach<2>(4.)),
+                    {{std::nullopt, {{-4, radius_in_boxes(2, n)}}}}, "2D N={*,2} sqrt(max_distsq)=2");
+  }
+
+  return t.end();
+}
+
+/// Skipping a face drops exactly the boxes that lie on no other face; the edge boxes it shares
+/// with the remaining faces are still visited through them.
+int test_skip_face(World& world) {
+  test_output t("BoxSurfaceDisplacementRange: skipping faces", world.rank() == 0);
+
+  // displacements that differ by a period along a lattice-summed axis are equivalent, and which representative
+  // is produced depends on the order in which faces are visited; so compare them mapped to [0, 2^n)
+  const auto sorted = [](const auto& range, bool lattice_summed) {
+    using key_type = std::decay_t<decltype(*range.begin())>;
+    constexpr std::size_t NDIM = key_type::static_size;
+    std::vector<key_type> disps;
+    for (auto&& disp : range) {
+      auto l = disp.translation();
+      if (lattice_summed) {
+        const auto period = Translation(1) << disp.level();
+        for (std::size_t d = 0; d != NDIM; ++d) l[d] = ((l[d] % period) + period) % period;
+      }
+      disps.emplace_back(disp.level(), l);
+    }
+    std::sort(disps.begin(), disps.end());
+    return disps;
+  };
+
+  const auto check = [&](auto ndim_tag, Level n, std::array<std::int64_t, decltype(ndim_tag)::value> N,
+                         bool lattice_summed, std::size_t skipped, const std::string& what) {
+    constexpr std::size_t NDIM = decltype(ndim_tag)::value;
+    const auto radii = finite<NDIM>(N);
+    const auto summed = array_of_bools<NDIM>{lattice_summed};
+
+    const auto all = sorted(make_range<NDIM>(n, radii, summed), lattice_summed);
+
+    auto range = make_range<NDIM>(n, radii, summed);
+    range.skip_face(skipped);
+    t.checkpoint(range.face_skipped(skipped), what + ": face " + std::to_string(skipped) + " marked skipped");
+    const auto rest = sorted(range, lattice_summed);
+
+    // is `disp` on the layers of the face normal to `d`? surface thickness is 1 box on each side of the boundary;
+    // along a lattice-summed dimension only the + side is iterated over
+    const auto on_face = [&](const Key<NDIM>& disp, std::size_t d) {
+      const auto r = radius_in_boxes(N[d], n);
+      auto l = disp.translation()[d];
+      if (lattice_summed) {  // `disp` is canonical, so map the face position into [0, 2^n) as well
+        const auto period = Translation(1) << n;
+        for (Translation layer = r - 1; layer <= r + 1; ++layer)
+          if (((layer % period) + period) % period == l) return true;
+        return false;
+      }
+      return (l >= r - 1 && l <= r + 1) || (l >= -r - 1 && l <= -r + 1);
+    };
+    const auto on_another_face = [&](const Key<NDIM>& disp) {
+      for (std::size_t d = 0; d != NDIM; ++d)
+        if (d != skipped && on_face(disp, d)) return true;
+      return false;
+    };
+    std::vector<Key<NDIM>> expected;
+    std::copy_if(all.begin(), all.end(), std::back_inserter(expected), on_another_face);
+
+    t.checkpoint(!rest.empty(), what + ": other faces remain");
+    t.checkpoint(rest.size() < all.size(), what + ": fewer displacements than the full surface");
+    t.checkpoint(rest == expected, what + ": exactly the boxes on the other faces remain");
+  };
+
+  constexpr auto d2 = std::integral_constant<std::size_t, 2>{};
+  constexpr auto d3 = std::integral_constant<std::size_t, 3>{};
+  // skipping the first face (whose edges would otherwise be excluded from the later faces) and a later one
+  check(d2, 4, {2, 2}, false, 0, "2D n=4 N={2,2} plain, skip x");
+  check(d2, 4, {2, 2}, false, 1, "2D n=4 N={2,2} plain, skip y");
+  check(d2, 4, {1, 2}, true, 0, "2D n=4 N={1,2} lattice-summed, skip x");
+  check(d3, 3, {1, 2, 1}, true, 0, "3D n=3 N={1,2,1} lattice-summed, skip x");
+  check(d3, 3, {1, 2, 1}, true, 1, "3D n=3 N={1,2,1} lattice-summed, skip y");
+  check(d3, 3, {1, 2, 1}, true, 2, "3D n=3 N={1,2,1} lattice-summed, skip z");
+
+  // skipping every face leaves nothing
+  {
+    auto range = make_range<3>(3, finite<3>({1, 2, 1}), array_of_bools<3>{true});
+    for (std::size_t d = 0; d != 3; ++d) range.skip_face(d);
+    t.checkpoint(range.begin() == range.end(), "3D n=3 N={1,2,1}: skipping all faces leaves nothing");
+  }
+  // a box that is not hollow along some dimension has every box on that face; skipping it changes nothing
+  // since every box is on the other face as well
+  {
+    const auto radii = finite<2>({1, 1});  // at n=1 the radius is 1 box = the thickness
+    const auto all = sorted(make_range<2>(1, radii, array_of_bools<2>{false}), false);
+    auto range = make_range<2>(1, radii, array_of_bools<2>{false});
+    range.skip_face(0);
+    t.checkpoint(!all.empty() && sorted(range, false) == all, "2D n=1 N={1,1}: skipping the face of a non-hollow dimension changes nothing");
+  }
+  // an unrestricted dimension has no face and the others are unaffected
+  {
+    Radii<2> radii;
+    radii[1] = 2;
+    const auto all = sorted(make_range<2>(4, radii, array_of_bools<2>{false}), false);
+    auto range = make_range<2>(4, radii, array_of_bools<2>{false});
+    range.skip_face(1);
+    t.checkpoint(range.begin() == range.end(), "2D n=4 N={*,2}: skipping the only face leaves nothing");
+    t.checkpoint(!all.empty(), "2D n=4 N={*,2}: the only face is non-empty");
   }
 
   return t.end();
@@ -395,6 +480,7 @@ int main(int argc, char** argv) {
   errors += test_all_evens(world);
   errors += test_lattice_summation_awareness(world);
   errors += test_standard_reach(world);
+  errors += test_skip_face(world);
 
   world.gop.fence();
   madness::finalize();

--- a/src/madness/mra/test_displacements.cc
+++ b/src/madness/mra/test_displacements.cc
@@ -21,6 +21,28 @@ Key<NDIM> centered_key(Level n) {
   return Key<NDIM>(n, Vector<Translation, NDIM>(n == 0 ? 0 : (Translation(1) << (n - 1))));
 }
 
+template <std::size_t NDIM>
+using Reach = typename BoxSurfaceDisplacementRange<NDIM>::StandardDisplacementsReach;
+
+/// standard displacements of unit-width cells reached out to real distance squared \p max_distsq
+template <std::size_t NDIM>
+Reach<NDIM> unit_reach(double max_distsq) {
+  Reach<NDIM> reach{max_distsq, {}};
+  reach.cell_width.fill(1.);
+  return reach;
+}
+
+/// standard displacements that reached (far) beyond bmax boxes, so that the least unfiltered
+/// offset is bmax+1 boxes, capped at a half cell
+template <std::size_t NDIM>
+Reach<NDIM> far_reach() {
+  return unit_reach<NDIM>(1e6);
+}
+template <std::size_t NDIM>
+Translation far_offset(Level n) {
+  return std::min<Translation>(Displacements<NDIM>::bmax_default() + 1, Translation(1) << (n - 1));
+}
+
 /// keeps only destinations inside the simulation cell
 template <std::size_t NDIM>
 typename BoxSurfaceDisplacementRange<NDIM>::Validator in_domain_only() {
@@ -188,7 +210,7 @@ int test_mixed(World& world) {
       if (box_radius[d]) surface_thickness[d] = 1;
     }
     BoxSurfaceDisplacementRange<NDIM> range(centered_key<NDIM>(n), box_radius, surface_thickness,
-                                            array_of_bools<NDIM>{true} /* lattice_summed */);
+                                            array_of_bools<NDIM>{true} /* lattice_summed */, {}, far_reach<NDIM>());
     const auto probe = range.probing_displacement().translation();
     for (size_t d = 0; d < NDIM; d++) {
       t.checkpoint(probe[d] == expected[d], what + " component " + std::to_string(d));
@@ -198,7 +220,7 @@ int test_mixed(World& world) {
 
   Radii<2> radii2d;
   radii2d[1] = 2;
-  check_probe(level, radii2d, {-radius_in_boxes(1, level), radius_in_boxes(2, level)}, "2D n=4 N={*,2}");
+  check_probe(level, radii2d, {-far_offset<2>(level), radius_in_boxes(2, level)}, "2D n=4 N={*,2}");
   radii2d[1] = 3;
   check_probe(level, radii2d, {0, radius_in_boxes(3, level)}, "2D n=4 N={*,3}");
   Radii<3> radii3d;
@@ -209,7 +231,7 @@ int test_mixed(World& world) {
 }
 
 /// Test the case in which every box radius is even, so that the face dimension alone cannot satisfy
-/// criterion 2 and a half-simulation-cell offset along a second dimension is needed.
+/// criterion 2 and an offset along a second dimension is needed.
 int test_all_evens(World& world) {
   test_output t("BoxSurfaceDisplacementRange: pure evens", world.rank() == 0);
 
@@ -224,18 +246,19 @@ int test_all_evens(World& world) {
       surface_thickness[d] = 1;
     }
     BoxSurfaceDisplacementRange<NDIM> range(centered_key<NDIM>(n), box_radius, surface_thickness,
-                                            array_of_bools<NDIM>{true} /* lattice_summed */);
+                                            array_of_bools<NDIM>{true} /* lattice_summed */, {}, far_reach<NDIM>());
     const auto probe = range.probing_displacement().translation();
     for (size_t d = 0; d < NDIM; d++) {
       t.checkpoint(probe[d] == expected[d], std::to_string(NDIM) + "D n=" + std::to_string(n) + " N=" + what + " component " + std::to_string(d));
     }
   };
 
-  check_probe(level, {4, 6, 2}, {radius_in_boxes(1, level), 0, radius_in_boxes(2, level)}, "{4,6,2}");
-  check_probe(level, {6, 2, 2}, {0, radius_in_boxes(2, level), radius_in_boxes(1, level)}, "{6,2,2}");
-  check_probe(level, {8, 2, 2}, {0, radius_in_boxes(2, level), radius_in_boxes(1, level)}, "{8,2,2}");
-  check_probe(level, {6, 4, 2}, {0, radius_in_boxes(1, level), radius_in_boxes(2, level)}, "{6,4,2}");
-  check_probe(level, {4, 6, 4}, {radius_in_boxes(4, level), 0, radius_in_boxes(1, level)}, "{4,6,4}");
+  const auto off = far_offset<3>(level);
+  check_probe(level, {4, 6, 2}, {off, 0, radius_in_boxes(2, level)}, "{4,6,2}");
+  check_probe(level, {6, 2, 2}, {0, radius_in_boxes(2, level), off}, "{6,2,2}");
+  check_probe(level, {8, 2, 2}, {0, radius_in_boxes(2, level), off}, "{8,2,2}");
+  check_probe(level, {6, 4, 2}, {0, off, radius_in_boxes(2, level)}, "{6,4,2}");
+  check_probe(level, {4, 6, 4}, {radius_in_boxes(4, level), 0, off}, "{4,6,4}");
 
   return t.end();
 }
@@ -254,7 +277,7 @@ int test_lattice_summation_awareness(World& world) {
       if (box_radius[d]) surface_thickness[d] = 1;
     }
     BoxSurfaceDisplacementRange<NDIM> range(centered_key<NDIM>(n), box_radius, surface_thickness,
-                                            is_lattice_summed);
+                                            is_lattice_summed, {}, far_reach<NDIM>());
     const auto probe = range.probing_displacement().translation();
     for (size_t d = 0; d < NDIM; d++) {
       t.checkpoint(probe[d] == expected[d], what + " component " + std::to_string(d));
@@ -263,74 +286,95 @@ int test_lattice_summation_awareness(World& world) {
 
   Level level = 4;
   const auto r = [&](std::int64_t N) { return radius_in_boxes(N, level); };
+  const auto off3 = far_offset<3>(level);
 
   // all even, nothing lattice summed => no offset, and the probe is the nearest surface point
   check_probe(level, Radii<3>{2, 2, 2}, array_of_bools<3>{false}, {r(2), 0, 0}, "3D N={2,2,2} not summed");
   check_probe(level, Radii<3>{4, 2, 6}, array_of_bools<3>{false}, {0, r(2), 0}, "3D N={4,2,6} not summed");
   // ... the same radii with lattice summation on do need the offset
-  check_probe(level, Radii<3>{2, 2, 2}, array_of_bools<3>{true}, {r(2), r(1), 0}, "3D N={2,2,2} summed");
+  check_probe(level, Radii<3>{2, 2, 2}, array_of_bools<3>{true}, {r(2), off3, 0}, "3D N={2,2,2} summed");
 
   // with only the first dimension lattice summed, that dimension is the best face even though it has to
-  // pay for an offset: it folds to a half cell (8 boxes), whereas y or z would leave the probe a full
+  // pay for an offset: it folds to the origin plus a few boxes, whereas y or z would leave the probe a full
   // 2 half-cells out with nothing to fold it back
-  check_probe(level, Radii<3>{2, 2, 2}, array_of_bools<3>{true, false, false}, {r(2), r(1), 0},
+  check_probe(level, Radii<3>{2, 2, 2}, array_of_bools<3>{true, false, false}, {r(2), off3, 0},
                  "3D N={2,2,2} summed along x only");
   // ... and all the more so when the unsummed dimensions are wider
-  check_probe(level, Radii<3>{2, 4, 4}, array_of_bools<3>{true, false, false}, {r(2), r(1), 0},
+  check_probe(level, Radii<3>{2, 4, 4}, array_of_bools<3>{true, false, false}, {r(2), off3, 0},
                  "3D N={2,4,4} summed along x only");
 
   // an unrestricted dimension absorbs the offset, but again only when one is needed
   Radii<2> radii2d;
   radii2d[1] = 2;
-  check_probe(level, radii2d, array_of_bools<2>{false, true}, {-r(1), r(2)}, "2D N={*,2} summed along y");
+  check_probe(level, radii2d, array_of_bools<2>{false, true}, {-far_offset<2>(level), r(2)}, "2D N={*,2} summed along y");
   check_probe(level, radii2d, array_of_bools<2>{false, false}, {0, r(2)}, "2D N={*,2} not summed");
 
   return t.end();
 }
 
-/// The offset for all-even radii is set by the caller.
-int test_probe_offset_radius(World& world) {
-  test_output t("BoxSurfaceDisplacementRange: offset magnitude follows the filter shortrange", world.rank() == 0);
+/// The offset for all-even radii is derived from the real-space reach of the standard displacements,
+/// as supplied by the caller: it is the least number of boxes that the validator does not filter out.
+int test_standard_reach(World& world) {
+  test_output t("BoxSurfaceDisplacementRange: offset follows the reach of the standard displacements", world.rank() == 0);
 
   constexpr std::size_t NDIM = 3;
-  const Level n = 6;                       // half-cell = 32 boxes, so the clamp is far away
-  const auto check = [&](std::optional<Translation> cutoff, std::array<std::int64_t, NDIM> expected,
+  const Translation bmax = Displacements<NDIM>::bmax_default();  // 4
+  const auto check = [&](Level n, std::optional<Reach<NDIM>> reach, std::array<std::int64_t, NDIM> expected,
                          const std::string& what) {
     Radii<NDIM> box_radius, surface_thickness;
     for (std::size_t d = 0; d != NDIM; ++d) { box_radius[d] = 2; surface_thickness[d] = 1; }  // all even
     BoxSurfaceDisplacementRange<NDIM> range(centered_key<NDIM>(n), box_radius, surface_thickness,
-                                            array_of_bools<NDIM>{true} /* lattice_summed */,
-                                            typename BoxSurfaceDisplacementRange<NDIM>::Validator{}, cutoff);
+                                            array_of_bools<NDIM>{true} /* lattice_summed */, {}, reach);
     const auto probe = range.probing_displacement().translation();
     for (size_t d = 0; d < NDIM; d++)
       t.checkpoint(probe[d] == expected[d], what + " component " + std::to_string(d));
   };
+  const auto anisotropic_reach = [](double max_distsq, std::array<double, NDIM> cell_width) {
+    return Reach<NDIM>{max_distsq, cell_width};
+  };
 
-  const auto face = radius_in_boxes(2, n);         // 64
-  const auto half_cell = radius_in_boxes(1, n);    // 32
-
-  // unknown shortrange cutoff => the maximal (half-cell) offset, i.e. the behavior when nothing better is known
-  check(std::nullopt, {face, half_cell, 0}, "cutoff unknown");
-  // a cutoff inside the half cell is used verbatim -- this is the case that matters in practice, since
-  // the cutoff is capped by bmax_default() (4 in 3D) while the half cell grows as 2^{n-1}
-  check(Translation(5), {face, 5, 0}, "cutoff=5");
-  check(Translation(2), {face, 2, 0}, "cutoff=2");
-  // a cutoff beyond the half cell is clamped: a step of 2^{n-1}+k folds back down to 2^{n-1}-k
-  check(Translation(1000), {face, half_cell, 0}, "cutoff beyond half cell");
-  // a cutoff of zero says nothing is filtered, so the surface reaches the source and no offset helps;
-  // fall back to the bare face probe, whose norm is the on-site norm and screens nothing
-  check(Translation(0), {face, 0, 0}, "cutoff=0 (nothing filtered)");
-
-  // the same clamping applies when the offset lands on an unrestricted dimension
   {
+    const Level n = 6;                     // half-cell = 32 boxes, so the cap is far away
+    const auto face = radius_in_boxes(2, n);  // 64
+
+    // nothing is known to be filtered => the surface reaches the source and no offset helps;
+    // fall back to the bare face probe, whose norm is the on-site norm and screens nothing
+    check(n, std::nullopt, {face, 0, 0}, "nothing filtered");
+
+    // unit cell widths: the real distance of a displacement l along an axis is |l|-1 (see Key::real_distsq_bc),
+    // so the least offset beyond real distance sqrt(max_distsq) is floor(sqrt(max_distsq))+2 boxes ...
+    check(n, unit_reach<NDIM>(0.), {face, 2, 0}, "unit widths, only the nearest neighbors reached");
+    check(n, unit_reach<NDIM>(6.25), {face, 4, 0}, "unit widths, sqrt(max_distsq)=2.5");
+    check(n, unit_reach<NDIM>(9.), {face, 5, 0}, "unit widths, sqrt(max_distsq)=3");
+    // ... but never more than bmax+1, beyond which nothing is a standard displacement
+    check(n, unit_reach<NDIM>(1e6), {face, bmax + 1, 0}, "unit widths, reached beyond bmax");
+
+    // anisotropic cell: the offset goes along the axis with the least *real-space* offset.
+    // With sqrt(max_distsq)=5 and width 1 the offset is capped at bmax+1=5 boxes, i.e. 4 real units ...
+    check(n, anisotropic_reach(25., {10., 1., 10.}), {face, 5, 0}, "widths {10,1,10}");
+    check(n, anisotropic_reach(25., {10., 10., 1.}), {face, 0, 5}, "widths {10,10,1}");
+    // ... whereas a wider axis can need fewer boxes yet be farther in real space (width 2: 4 boxes = 6 units) ...
+    check(n, anisotropic_reach(25., {1., 2., 100.}), {face, 4, 0}, "widths {1,2,100}");
+    // ... or fewer boxes *and* nearer in real space (width 2.6: 3 boxes = 5.2 units vs. width 2: 4 boxes = 6 units)
+    check(n, anisotropic_reach(25., {1., 2., 2.6}), {face, 0, 3}, "widths {1,2,2.6}");
+  }
+
+  // the offset is capped at a half cell: a step of 2^{n-1}+k folds back down to 2^{n-1}-k
+  {
+    const Level n = 2;  // half cell = 2 boxes < bmax+1
+    check(n, unit_reach<NDIM>(1e6), {radius_in_boxes(2, n), 2, 0}, "n=2, reached beyond bmax");
+  }
+
+  // the same cap applies when the offset lands on an unrestricted dimension
+  {
+    const Level n = 6;
     Radii<2> box_radius, surface_thickness;
     box_radius[1] = 2; surface_thickness[1] = 1;
     BoxSurfaceDisplacementRange<2> range(centered_key<2>(n), box_radius, surface_thickness,
-                                         array_of_bools<2>{true},
-                                         typename BoxSurfaceDisplacementRange<2>::Validator{}, Translation(3));
+                                         array_of_bools<2>{true}, {}, unit_reach<2>(4.));
     const auto probe = range.probing_displacement().translation();
-    t.checkpoint(probe[0] == -3, "2D N={*,2} cutoff=3 component 0");
-    t.checkpoint(probe[1] == radius_in_boxes(2, n), "2D N={*,2} cutoff=3 component 1");
+    t.checkpoint(probe[0] == -4, "2D N={*,2} sqrt(max_distsq)=2 component 0");
+    t.checkpoint(probe[1] == radius_in_boxes(2, n), "2D N={*,2} sqrt(max_distsq)=2 component 1");
   }
 
   return t.end();
@@ -350,7 +394,7 @@ int main(int argc, char** argv) {
   errors += test_mixed(world);
   errors += test_all_evens(world);
   errors += test_lattice_summation_awareness(world);
-  errors += test_probe_offset_radius(world);
+  errors += test_standard_reach(world);
 
   world.gop.fence();
   madness::finalize();

--- a/src/madness/mra/test_displacements.cc
+++ b/src/madness/mra/test_displacements.cc
@@ -58,6 +58,18 @@ int test_no_duplicates(World& world) {
     const auto last = std::unique(disps.begin(), disps.end());
     t.checkpoint(!disps.empty(), what + ": surface is non-empty");
     t.checkpoint(last == disps.end(), what + ": all displacements distinct");
+    if (lattice_summed) {  // displacements that differ by a period along a lattice-summed axis are the same displacement
+      const auto period = Translation(1) << n;
+      std::vector<Key<NDIM>> canonical;
+      for (const auto& disp : disps) {
+        auto l = disp.translation();
+        for (std::size_t d = 0; d != NDIM; ++d) l[d] = ((l[d] % period) + period) % period;
+        canonical.emplace_back(n, l);
+      }
+      std::sort(canonical.begin(), canonical.end());
+      const auto ndup = canonical.end() - std::unique(canonical.begin(), canonical.end());
+      t.checkpoint(ndup == 0, what + ": all displacements distinct modulo the lattice (" + std::to_string(ndup) + " duplicates)");
+    }
   };
 
   constexpr auto d2 = std::integral_constant<std::size_t, 2>{};
@@ -76,6 +88,36 @@ int test_no_duplicates(World& world) {
   check_unique(d3, 3, {2, 2, 2}, true, false, "3D n=3 N={2,2,2} lattice-summed");
   check_unique(d3, 3, {1, 2, 3}, true, false, "3D n=3 N={1,2,3} lattice-summed (mixed parity)");
 
+  return t.end();
+}
+
+/// The iteration must not depend on whether a validator is given: a validator that accepts
+/// everything must yield the same displacements as no validator at all.
+int test_validator_agnostic(World& world) {
+  test_output t("BoxSurfaceDisplacementRange: iteration does not depend on the presence of a validator", world.rank() == 0);
+
+  constexpr std::size_t NDIM = 2;
+  const auto disps_of = [](typename BoxSurfaceDisplacementRange<NDIM>::Validator validator) {
+    Radii<NDIM> box_radius, surface_thickness;
+    for (std::size_t d = 0; d != NDIM; ++d) {
+      box_radius[d] = 1;
+      surface_thickness[d] = 1;
+    }
+    BoxSurfaceDisplacementRange<NDIM> range(centered_key<NDIM>(4), box_radius, surface_thickness,
+                                            array_of_bools<NDIM>{false}, std::move(validator));
+    std::vector<Key<NDIM>> disps;
+    for (auto&& disp : range) disps.push_back(disp);
+    std::sort(disps.begin(), disps.end());
+    return disps;
+  };
+
+  const auto without = disps_of({});
+  const auto with = disps_of([](const Level, const typename BoxSurfaceDisplacementRange<NDIM>::PointPattern&,
+                                std::optional<Key<NDIM>>&) { return true; });
+  t.checkpoint(!with.empty(), "2D n=4 N={1,1}: surface is non-empty");
+  t.checkpoint(without.size() == with.size(), "2D n=4 N={1,1}: same number of displacements with and without a validator (" +
+                                                  std::to_string(without.size()) + " vs " + std::to_string(with.size()) + ")");
+  t.checkpoint(without == with, "2D n=4 N={1,1}: same displacements with and without a validator");
   return t.end();
 }
 
@@ -302,6 +344,7 @@ int main(int argc, char** argv) {
 
   int errors = 0;
   errors += test_no_duplicates(world);
+  errors += test_validator_agnostic(world);
   errors += test_odds(world);
   errors += test_singular(world);
   errors += test_mixed(world);

--- a/src/madness/mra/test_displacements.cc
+++ b/src/madness/mra/test_displacements.cc
@@ -15,6 +15,11 @@ Translation radius_in_boxes(std::int64_t N, Level n) {
   return (n == 0) ? (N + 1) / 2 : (N * Translation(1) << (n - 1));
 }
 
+/// where the probe of a face sits: on its innermost layer, i.e. one box (the surface thickness used throughout) inside the boundary
+Translation probe_radius(std::int64_t N, Level n) {
+  return radius_in_boxes(N, n) - 1;
+}
+
 /// the center box of the level-\p n grid
 template <std::size_t NDIM>
 Key<NDIM> centered_key(Level n) {
@@ -62,14 +67,15 @@ template <std::size_t NDIM>
 BoxSurfaceDisplacementRange<NDIM> make_range(Level n, const Radii<NDIM>& box_radius,
                                              const array_of_bools<NDIM>& is_lattice_summed,
                                              std::optional<Reach<NDIM>> reach = {},
-                                             std::optional<Validator<NDIM>> validator = {}) {
+                                             std::optional<Validator<NDIM>> validator = {},
+                                             std::optional<Key<NDIM>> center = {}) {
   Radii<NDIM> surface_thickness;
   for (std::size_t d = 0; d != NDIM; ++d) {
     if (box_radius[d]) surface_thickness[d] = 1;
   }
   if (reach && !validator) validator.emplace(array_of_bools<NDIM>{true}, is_lattice_summed, std::move(reach));
-  return BoxSurfaceDisplacementRange<NDIM>(centered_key<NDIM>(n), box_radius, surface_thickness, is_lattice_summed,
-                                           std::move(validator));
+  return BoxSurfaceDisplacementRange<NDIM>(center.value_or(centered_key<NDIM>(n)), box_radius, surface_thickness,
+                                           is_lattice_summed, std::move(validator));
 }
 
 /// the probing displacement of every face, as a translation; null for dimensions of unlimited size (no face)
@@ -121,11 +127,13 @@ int test_no_duplicates(World& world) {
   test_output t("BoxSurfaceDisplacementRange: no duplicate displacements", world.rank() == 0);
 
   const auto check_unique = [&](auto ndim_tag, Level n, std::array<std::int64_t, decltype(ndim_tag)::value> N,
-                                bool lattice_summed, bool filter_to_domain, const std::string& what) {
+                                std::array<bool, decltype(ndim_tag)::value> lattice_summed, bool filter_to_domain,
+                                const std::string& what) {
     constexpr std::size_t NDIM = decltype(ndim_tag)::value;
+    array_of_bools<NDIM> summed{false};
+    for (std::size_t d = 0; d != NDIM; ++d) summed[d] = lattice_summed[d];
     // N.B. the domain filter is only meaningful when the range boundary can land
     // inside the cell at all.
-    const auto summed = array_of_bools<NDIM>{lattice_summed};
     const auto range = make_range<NDIM>(n, finite<NDIM>(N), summed, {},
                                         filter_to_domain ? std::optional{in_domain_only<NDIM>(summed)} : std::nullopt);
     std::vector<Key<NDIM>> disps;
@@ -134,12 +142,13 @@ int test_no_duplicates(World& world) {
     const auto last = std::unique(disps.begin(), disps.end());
     t.checkpoint(!disps.empty(), what + ": surface is non-empty");
     t.checkpoint(last == disps.end(), what + ": all displacements distinct");
-    if (lattice_summed) {  // displacements that differ by a period along a lattice-summed axis are the same displacement
+    if (summed.any()) {  // displacements that differ by a period along a lattice-summed axis are the same displacement
       const auto period = Translation(1) << n;
       std::vector<Key<NDIM>> canonical;
       for (const auto& disp : disps) {
         auto l = disp.translation();
-        for (std::size_t d = 0; d != NDIM; ++d) l[d] = ((l[d] % period) + period) % period;
+        for (std::size_t d = 0; d != NDIM; ++d)
+          if (summed[d]) l[d] = ((l[d] % period) + period) % period;
         canonical.emplace_back(n, l);
       }
       std::sort(canonical.begin(), canonical.end());
@@ -152,17 +161,23 @@ int test_no_duplicates(World& world) {
   constexpr auto d3 = std::integral_constant<std::size_t, 3>{};
 
   // odd N and its even counterpart
-  check_unique(d2, 4, {1, 1}, false, true, "2D n=4 N={1,1} plain, in-domain");
-  check_unique(d2, 4, {1, 1}, false, false, "2D n=4 N={1,1} plain");
-  check_unique(d2, 4, {2, 2}, false, false, "2D n=4 N={2,2} plain");
+  check_unique(d2, 4, {1, 1}, {false, false}, true, "2D n=4 N={1,1} plain, in-domain");
+  check_unique(d2, 4, {1, 1}, {false, false}, false, "2D n=4 N={1,1} plain");
+  check_unique(d2, 4, {2, 2}, {false, false}, false, "2D n=4 N={2,2} plain");
   // ... and both parities again with lattice summation on
-  check_unique(d2, 4, {1, 1}, true, false, "2D n=4 N={1,1} lattice-summed");
-  check_unique(d2, 4, {2, 2}, true, false, "2D n=4 N={2,2} lattice-summed");
-  check_unique(d2, 4, {2, 3}, true, false, "2D n=4 N={2,3} lattice-summed (mixed parity)");
+  check_unique(d2, 4, {1, 1}, {true, true}, false, "2D n=4 N={1,1} lattice-summed");
+  check_unique(d2, 4, {2, 2}, {true, true}, false, "2D n=4 N={2,2} lattice-summed");
+  check_unique(d2, 4, {2, 3}, {true, true}, false, "2D n=4 N={2,3} lattice-summed (mixed parity)");
   // ... and in 3D, where each face has two free axes rather than one
-  check_unique(d3, 3, {1, 1, 1}, true, false, "3D n=3 N={1,1,1} lattice-summed");
-  check_unique(d3, 3, {2, 2, 2}, true, false, "3D n=3 N={2,2,2} lattice-summed");
-  check_unique(d3, 3, {1, 2, 3}, true, false, "3D n=3 N={1,2,3} lattice-summed (mixed parity)");
+  check_unique(d3, 3, {1, 1, 1}, {true, true, true}, false, "3D n=3 N={1,1,1} lattice-summed");
+  check_unique(d3, 3, {2, 2, 2}, {true, true, true}, false, "3D n=3 N={2,2,2} lattice-summed");
+  check_unique(d3, 3, {1, 2, 3}, {true, true, true}, false, "3D n=3 N={1,2,3} lattice-summed (mixed parity)");
+  // ... and with lattice summation along some axes only, so that a summed axis (one period, one face)
+  // is processed next to an unsummed one (box plus thickness, two faces) in either order
+  check_unique(d2, 4, {2, 2}, {true, false}, false, "2D n=4 N={2,2} summed along x only");
+  check_unique(d2, 4, {2, 2}, {false, true}, false, "2D n=4 N={2,2} summed along y only");
+  check_unique(d3, 3, {2, 2, 2}, {true, false, true}, false, "3D n=3 N={2,2,2} summed along x and z");
+  check_unique(d3, 3, {1, 2, 3}, {false, true, true}, false, "3D n=3 N={1,2,3} summed along y and z (mixed parity)");
 
   return t.end();
 }
@@ -196,7 +211,7 @@ int test_odds(World& world) {
   test_output t("BoxSurfaceDisplacementRange: mixed-parity radii", world.rank() == 0);
 
   const Level level = 4;
-  const auto r = [&](std::int64_t N) { return radius_in_boxes(N, level); };
+  const auto r = [&](std::int64_t N) { return probe_radius(N, level); };
   const auto off = far_offset<3>(level);
   const auto probes = [&](std::array<std::int64_t, 3> N) {
     return probes_of<3>(level, finite<3>(N), array_of_bools<3>{true}, far_reach<3>());
@@ -216,10 +231,11 @@ int test_singular(World& world) {
 
   const Level level = 4;
   check_probes<1>(t, probes_of<1>(level, finite<1>({4}), array_of_bools<1>{true}, far_reach<1>()),
-                  {{{{radius_in_boxes(4, level)}}}}, "1D n=4 N={4}");
-  // at level 0 a half cell is 1 box: N=3 -> 2 boxes, N=2 -> 1 box, N=1 -> 1 box; no offsets
+                  {{{{probe_radius(4, level)}}}}, "1D n=4 N={4}");
+  // at level 0 a half cell is 1 box: N=3 -> 2 boxes, N=2 -> 1 box, N=1 -> 1 box; no offsets, and with unit
+  // thickness the innermost layer of the N=2 and N=1 faces is the source box itself
   check_probes<3>(t, probes_of<3>(0, finite<3>({3, 2, 1}), array_of_bools<3>{true}, far_reach<3>()),
-                  {{{{2, 0, 0}}, {{0, 1, 0}}, {{0, 0, 1}}}}, "3D n=0 N={3,2,1}");
+                  {{{{1, 0, 0}}, {{0, 0, 0}}, {{0, 0, 0}}}}, "3D n=0 N={3,2,1}");
   return t.end();
 }
 
@@ -228,7 +244,7 @@ int test_mixed(World& world) {
   test_output t("BoxSurfaceDisplacementRange: mixed cases", world.rank() == 0);
 
   const Level level = 4;
-  const auto r = [&](std::int64_t N) { return radius_in_boxes(N, level); };
+  const auto r = [&](std::int64_t N) { return probe_radius(N, level); };
 
   Radii<2> radii2d;
   radii2d[1] = 2;
@@ -253,7 +269,7 @@ int test_all_evens(World& world) {
   test_output t("BoxSurfaceDisplacementRange: pure evens", world.rank() == 0);
 
   const Level level = 4;
-  const auto r = [&](std::int64_t N) { return radius_in_boxes(N, level); };
+  const auto r = [&](std::int64_t N) { return probe_radius(N, level); };
   const auto off = far_offset<3>(level);
   const auto probes = [&](std::array<std::int64_t, 3> N) {
     return probes_of<3>(level, finite<3>(N), array_of_bools<3>{true}, far_reach<3>());
@@ -272,7 +288,7 @@ int test_lattice_summation_awareness(World& world) {
   test_output t("BoxSurfaceDisplacementRange: offset only where lattice summed", world.rank() == 0);
 
   const Level level = 4;
-  const auto r = [&](std::int64_t N) { return radius_in_boxes(N, level); };
+  const auto r = [&](std::int64_t N) { return probe_radius(N, level); };
   const auto off3 = far_offset<3>(level);
   const auto probes = [&](std::array<std::int64_t, 3> N, array_of_bools<3> summed) {
     return probes_of<3>(level, finite<3>(N), summed, far_reach<3>());
@@ -324,7 +340,7 @@ int test_standard_reach(World& world) {
 
   {
     const Level n = 6;                     // half-cell = 32 boxes, so the cap is far away
-    const auto face = radius_in_boxes(2, n);  // 64
+    const auto face = probe_radius(2, n);  // 63: the innermost layer of the face at 64
 
     // nothing is known to be filtered => the surface reaches the source and no offset helps;
     // fall back to the bare face probe, whose norm is the on-site norm and screens nothing
@@ -352,7 +368,7 @@ int test_standard_reach(World& world) {
   // the offset is capped at a half cell: a step of 2^{n-1}+k folds back down to 2^{n-1}-k
   {
     const Level n = 2;  // half cell = 2 boxes < bmax+1
-    check(n, unit_reach<NDIM>(1e6), 0, {radius_in_boxes(2, n), 2, 0}, "n=2, reached beyond bmax");
+    check(n, unit_reach<NDIM>(1e6), 0, {probe_radius(2, n), 2, 0}, "n=2, reached beyond bmax");
   }
 
   // the same cap applies when the offset lands on an unrestricted dimension
@@ -361,7 +377,7 @@ int test_standard_reach(World& world) {
     Radii<2> box_radius;
     box_radius[1] = 2;
     check_probes<2>(t, probes_of<2>(n, box_radius, array_of_bools<2>{true}, unit_reach<2>(4.)),
-                    {{std::nullopt, {{-4, radius_in_boxes(2, n)}}}}, "2D N={*,2} sqrt(max_distsq)=2");
+                    {{std::nullopt, {{-4, probe_radius(2, n)}}}}, "2D N={*,2} sqrt(max_distsq)=2");
   }
 
   return t.end();
@@ -374,16 +390,15 @@ int test_skip_face(World& world) {
 
   // displacements that differ by a period along a lattice-summed axis are equivalent, and which representative
   // is produced depends on the order in which faces are visited; so compare them mapped to [0, 2^n)
-  const auto sorted = [](const auto& range, bool lattice_summed) {
+  const auto sorted = [](const auto& range, const auto& lattice_summed) {
     using key_type = std::decay_t<decltype(*range.begin())>;
     constexpr std::size_t NDIM = key_type::static_size;
     std::vector<key_type> disps;
     for (auto&& disp : range) {
       auto l = disp.translation();
-      if (lattice_summed) {
-        const auto period = Translation(1) << disp.level();
-        for (std::size_t d = 0; d != NDIM; ++d) l[d] = ((l[d] % period) + period) % period;
-      }
+      const auto period = Translation(1) << disp.level();
+      for (std::size_t d = 0; d != NDIM; ++d)
+        if (lattice_summed[d]) l[d] = ((l[d] % period) + period) % period;
       disps.emplace_back(disp.level(), l);
     }
     std::sort(disps.begin(), disps.end());
@@ -391,24 +406,26 @@ int test_skip_face(World& world) {
   };
 
   const auto check = [&](auto ndim_tag, Level n, std::array<std::int64_t, decltype(ndim_tag)::value> N,
-                         bool lattice_summed, std::size_t skipped, const std::string& what) {
+                         std::array<bool, decltype(ndim_tag)::value> lattice_summed, std::size_t skipped,
+                         const std::string& what) {
     constexpr std::size_t NDIM = decltype(ndim_tag)::value;
     const auto radii = finite<NDIM>(N);
-    const auto summed = array_of_bools<NDIM>{lattice_summed};
+    array_of_bools<NDIM> summed{false};
+    for (std::size_t d = 0; d != NDIM; ++d) summed[d] = lattice_summed[d];
 
-    const auto all = sorted(make_range<NDIM>(n, radii, summed), lattice_summed);
+    const auto all = sorted(make_range<NDIM>(n, radii, summed), summed);
 
     auto range = make_range<NDIM>(n, radii, summed);
     range.skip_face(skipped);
     t.checkpoint(range.face_skipped(skipped), what + ": face " + std::to_string(skipped) + " marked skipped");
-    const auto rest = sorted(range, lattice_summed);
+    const auto rest = sorted(range, summed);
 
-    // is `disp` on the layers of the face normal to `d`? surface thickness is 1 box on each side of the boundary;
+    // is `disp` on the layers of the faces normal to `d`? surface thickness is 1 box on each side of the boundary;
     // along a lattice-summed dimension only the + side is iterated over
     const auto on_face = [&](const Key<NDIM>& disp, std::size_t d) {
       const auto r = radius_in_boxes(N[d], n);
       auto l = disp.translation()[d];
-      if (lattice_summed) {  // `disp` is canonical, so map the face position into [0, 2^n) as well
+      if (summed[d]) {  // `disp` is canonical, so map the face position into [0, 2^n) as well
         const auto period = Translation(1) << n;
         for (Translation layer = r - 1; layer <= r + 1; ++layer)
           if (((layer % period) + period) % period == l) return true;
@@ -432,12 +449,17 @@ int test_skip_face(World& world) {
   constexpr auto d2 = std::integral_constant<std::size_t, 2>{};
   constexpr auto d3 = std::integral_constant<std::size_t, 3>{};
   // skipping the first face (whose edges would otherwise be excluded from the later faces) and a later one
-  check(d2, 4, {2, 2}, false, 0, "2D n=4 N={2,2} plain, skip x");
-  check(d2, 4, {2, 2}, false, 1, "2D n=4 N={2,2} plain, skip y");
-  check(d2, 4, {1, 2}, true, 0, "2D n=4 N={1,2} lattice-summed, skip x");
-  check(d3, 3, {1, 2, 1}, true, 0, "3D n=3 N={1,2,1} lattice-summed, skip x");
-  check(d3, 3, {1, 2, 1}, true, 1, "3D n=3 N={1,2,1} lattice-summed, skip y");
-  check(d3, 3, {1, 2, 1}, true, 2, "3D n=3 N={1,2,1} lattice-summed, skip z");
+  check(d2, 4, {2, 2}, {false, false}, 0, "2D n=4 N={2,2} plain, skip x");
+  check(d2, 4, {2, 2}, {false, false}, 1, "2D n=4 N={2,2} plain, skip y");
+  check(d2, 4, {1, 2}, {true, true}, 0, "2D n=4 N={1,2} lattice-summed, skip x");
+  check(d3, 3, {1, 2, 1}, {true, true, true}, 0, "3D n=3 N={1,2,1} lattice-summed, skip x");
+  check(d3, 3, {1, 2, 1}, {true, true, true}, 1, "3D n=3 N={1,2,1} lattice-summed, skip y");
+  check(d3, 3, {1, 2, 1}, {true, true, true}, 2, "3D n=3 N={1,2,1} lattice-summed, skip z");
+  // ... and with lattice summation along some axes only
+  check(d2, 4, {2, 2}, {true, false}, 0, "2D n=4 N={2,2} summed along x only, skip x");
+  check(d2, 4, {2, 2}, {true, false}, 1, "2D n=4 N={2,2} summed along x only, skip y");
+  check(d3, 3, {2, 1, 2}, {true, false, true}, 1, "3D n=3 N={2,1,2} summed along x and z, skip y");
+  check(d3, 3, {2, 1, 2}, {true, false, true}, 2, "3D n=3 N={2,1,2} summed along x and z, skip z");
 
   // skipping every face leaves nothing
   {
@@ -449,22 +471,98 @@ int test_skip_face(World& world) {
   // since every box is on the other face as well
   {
     const auto radii = finite<2>({1, 1});  // at n=1 the radius is 1 box = the thickness
-    const auto all = sorted(make_range<2>(1, radii, array_of_bools<2>{false}), false);
+    const auto all = sorted(make_range<2>(1, radii, array_of_bools<2>{false}), array_of_bools<2>{false});
     auto range = make_range<2>(1, radii, array_of_bools<2>{false});
     range.skip_face(0);
-    t.checkpoint(!all.empty() && sorted(range, false) == all, "2D n=1 N={1,1}: skipping the face of a non-hollow dimension changes nothing");
+    t.checkpoint(!all.empty() && sorted(range, array_of_bools<2>{false}) == all, "2D n=1 N={1,1}: skipping the face of a non-hollow dimension changes nothing");
   }
   // an unrestricted dimension has no face and the others are unaffected
   {
     Radii<2> radii;
     radii[1] = 2;
-    const auto all = sorted(make_range<2>(4, radii, array_of_bools<2>{false}), false);
+    const auto all = sorted(make_range<2>(4, radii, array_of_bools<2>{false}), array_of_bools<2>{false});
     auto range = make_range<2>(4, radii, array_of_bools<2>{false});
     range.skip_face(1);
     t.checkpoint(range.begin() == range.end(), "2D n=4 N={*,2}: skipping the only face leaves nothing");
     t.checkpoint(!all.empty(), "2D n=4 N={*,2}: the only face is non-empty");
   }
 
+  return t.end();
+}
+
+/// Faces (or whole surfaces) lying entirely outside of a finite domain: the iterator must skip them
+/// and produce exactly the in-domain part of the surface.
+int test_faces_outside_domain(World& world) {
+  test_output t("BoxSurfaceDisplacementRange: faces outside of the domain", world.rank() == 0);
+
+  constexpr std::size_t NDIM = 2;
+  const Level n = 4;
+  const auto twon = Translation(1) << n;
+  const array_of_bools<NDIM> not_summed{false};
+  const auto in_domain = [&](const Key<NDIM>& disp, const Key<NDIM>& center) {
+    for (std::size_t d = 0; d != NDIM; ++d) {
+      const auto x = center.translation()[d] + disp.translation()[d];
+      if (x < 0 || x >= twon) return false;
+    }
+    return true;
+  };
+  const auto check = [&](std::array<std::int64_t, NDIM> N, Key<NDIM> center, const std::string& what) {
+    // without a validator: the whole surface, in and out of the domain
+    std::vector<Key<NDIM>> expected;
+    for (auto&& disp : make_range<NDIM>(n, finite<NDIM>(N), not_summed, {}, {}, center))
+      if (in_domain(disp, center)) expected.push_back(disp);
+    std::sort(expected.begin(), expected.end());
+    // with the domain filter
+    std::vector<Key<NDIM>> actual;
+    for (auto&& disp : make_range<NDIM>(n, finite<NDIM>(N), not_summed, {}, in_domain_only<NDIM>(not_summed), center))
+      actual.push_back(disp);
+    std::sort(actual.begin(), actual.end());
+    t.checkpoint(actual == expected, what + ": exactly the in-domain part of the surface (" + std::to_string(actual.size()) +
+                                         " vs " + std::to_string(expected.size()) + ")");
+    return expected.size();
+  };
+
+  // both faces normal to x are out (at -8 and 24), those normal to y are partly in
+  t.checkpoint(check({2, 1}, Key<NDIM>(n, {8, 8}), "N={2,1} centered") > 0, "N={2,1} centered: something is in the domain");
+  // the + face normal to x is out (at 20), the - face is in
+  t.checkpoint(check({1, 1}, Key<NDIM>(n, {12, 8}), "N={1,1} off-center") > 0, "N={1,1} off-center: something is in the domain");
+  // everything is out
+  t.checkpoint(check({2, 2}, Key<NDIM>(n, {8, 8}), "N={2,2} centered") == 0, "N={2,2} centered: nothing is in the domain");
+
+  return t.end();
+}
+
+/// The validator's notion of "standard displacement" must match Displacements: with lattice summation along
+/// any axis the standard displacements are clipped to 2^n-1 boxes along *every* axis, summed or not.
+int test_validator_bmax(World& world) {
+  test_output t("BoxSurfaceDisplacementValidator: bmax of the standard displacements", world.rank() == 0);
+
+  constexpr std::size_t NDIM = 2;
+  const Level n = 2;  // 4 boxes per axis, fewer than bmax+1 in 2D
+  const Translation bmax = Displacements<NDIM>::bmax_default();
+  t.checkpoint(bmax > 3, "2D bmax exceeds 2^n-1 at n=2");
+  // lattice summed along x only, infinite domain, and every standard displacement was reached
+  const Validator<NDIM> v(array_of_bools<NDIM>{true}, array_of_bools<NDIM>{true, false}, unit_reach<NDIM>(1e6));
+  const auto keeps = [&](std::int64_t lx, std::int64_t ly) {
+    typename BoxSurfaceDisplacementRange<NDIM>::PointPattern dest;
+    dest[0] = 2 + lx;
+    dest[1] = 2 + ly;
+    std::optional<Key<NDIM>> disp(Key<NDIM>(n, {lx, ly}));
+    return v(n, dest, disp);
+  };
+  t.checkpoint(!keeps(0, 3), "(0,3): within 2^n-1 along the unsummed axis => standard => filtered");
+  t.checkpoint(keeps(0, 4), "(0,4): beyond 2^n-1 along the unsummed axis => not standard => kept");
+  t.checkpoint(!keeps(4, 0), "(4,0): folds onto 0 along the summed axis => standard => filtered");
+  t.checkpoint(!keeps(3, 0), "(3,0): folds onto -1 along the summed axis => standard => filtered");
+
+  // level 0 must not trip the bit tricks: everything folds onto the single box
+  {
+    typename BoxSurfaceDisplacementRange<NDIM>::PointPattern dest;
+    dest[0] = 0;
+    dest[1] = 0;
+    std::optional<Key<NDIM>> disp(Key<NDIM>(0, {0, 0}));
+    t.checkpoint(!v(0, dest, disp), "level 0: the on-site displacement is standard => filtered");
+  }
   return t.end();
 }
 
@@ -484,6 +582,8 @@ int main(int argc, char** argv) {
   errors += test_lattice_summation_awareness(world);
   errors += test_standard_reach(world);
   errors += test_skip_face(world);
+  errors += test_faces_outside_domain(world);
+  errors += test_validator_bmax(world);
 
   world.gop.fence();
   madness::finalize();

--- a/src/madness/mra/test_displacements.cc
+++ b/src/madness/mra/test_displacements.cc
@@ -20,6 +20,15 @@ Translation probe_radius(std::int64_t N, Level n) {
   return radius_in_boxes(N, n) - 1;
 }
 
+/// ... and, if the face's dimension is lattice summed, folded into the cell to the representative nearest to the source:
+/// -1 for even N (the face folds onto the source), 2^{n-1}-1 for odd N (a half cell away)
+Translation probe_radius_summed(std::int64_t N, Level n) {
+  const auto period = Translation(1) << n;
+  auto l = ((probe_radius(N, n) % period) + period) % period;
+  if (l > period / 2) l -= period;
+  return l;
+}
+
 /// the center box of the level-\p n grid
 template <std::size_t NDIM>
 Key<NDIM> centered_key(Level n) {
@@ -211,7 +220,7 @@ int test_odds(World& world) {
   test_output t("BoxSurfaceDisplacementRange: mixed-parity radii", world.rank() == 0);
 
   const Level level = 4;
-  const auto r = [&](std::int64_t N) { return probe_radius(N, level); };
+  const auto r = [&](std::int64_t N) { return probe_radius_summed(N, level); };
   const auto off = far_offset<3>(level);
   const auto probes = [&](std::array<std::int64_t, 3> N) {
     return probes_of<3>(level, finite<3>(N), array_of_bools<3>{true}, far_reach<3>());
@@ -231,11 +240,10 @@ int test_singular(World& world) {
 
   const Level level = 4;
   check_probes<1>(t, probes_of<1>(level, finite<1>({4}), array_of_bools<1>{true}, far_reach<1>()),
-                  {{{{probe_radius(4, level)}}}}, "1D n=4 N={4}");
-  // at level 0 a half cell is 1 box: N=3 -> 2 boxes, N=2 -> 1 box, N=1 -> 1 box; no offsets, and with unit
-  // thickness the innermost layer of the N=2 and N=1 faces is the source box itself
+                  {{{{probe_radius_summed(4, level)}}}}, "1D n=4 N={4}");
+  // at level 0 the cell is a single box, onto which every lattice-summed face folds; no offsets
   check_probes<3>(t, probes_of<3>(0, finite<3>({3, 2, 1}), array_of_bools<3>{true}, far_reach<3>()),
-                  {{{{1, 0, 0}}, {{0, 0, 0}}, {{0, 0, 0}}}}, "3D n=0 N={3,2,1}");
+                  {{{{0, 0, 0}}, {{0, 0, 0}}, {{0, 0, 0}}}}, "3D n=0 N={3,2,1}");
   return t.end();
 }
 
@@ -244,7 +252,7 @@ int test_mixed(World& world) {
   test_output t("BoxSurfaceDisplacementRange: mixed cases", world.rank() == 0);
 
   const Level level = 4;
-  const auto r = [&](std::int64_t N) { return probe_radius(N, level); };
+  const auto r = [&](std::int64_t N) { return probe_radius_summed(N, level); };
 
   Radii<2> radii2d;
   radii2d[1] = 2;
@@ -269,7 +277,7 @@ int test_all_evens(World& world) {
   test_output t("BoxSurfaceDisplacementRange: pure evens", world.rank() == 0);
 
   const Level level = 4;
-  const auto r = [&](std::int64_t N) { return probe_radius(N, level); };
+  const auto r = [&](std::int64_t N) { return probe_radius_summed(N, level); };
   const auto off = far_offset<3>(level);
   const auto probes = [&](std::array<std::int64_t, 3> N) {
     return probes_of<3>(level, finite<3>(N), array_of_bools<3>{true}, far_reach<3>());
@@ -289,6 +297,7 @@ int test_lattice_summation_awareness(World& world) {
 
   const Level level = 4;
   const auto r = [&](std::int64_t N) { return probe_radius(N, level); };
+  const auto rs = [&](std::int64_t N) { return probe_radius_summed(N, level); };
   const auto off3 = far_offset<3>(level);
   const auto probes = [&](std::array<std::int64_t, 3> N, array_of_bools<3> summed) {
     return probes_of<3>(level, finite<3>(N), summed, far_reach<3>());
@@ -300,17 +309,17 @@ int test_lattice_summation_awareness(World& world) {
   check_probes<3>(t, probes({4, 2, 6}, array_of_bools<3>{false}), {{{{r(4), 0, 0}}, {{0, r(2), 0}}, {{0, 0, r(6)}}}},
                   "3D N={4,2,6} not summed");
   // ... the same radii with lattice summation on do need the offsets
-  check_probes<3>(t, probes({2, 2, 2}, array_of_bools<3>{true}), {{{{r(2), off3, 0}}, {{off3, r(2), 0}}, {{off3, 0, r(2)}}}},
+  check_probes<3>(t, probes({2, 2, 2}, array_of_bools<3>{true}), {{{{rs(2), off3, 0}}, {{off3, rs(2), 0}}, {{off3, 0, rs(2)}}}},
                   "3D N={2,2,2} summed");
   // ... with only the first dimension lattice summed, only its face needs the offset
   check_probes<3>(t, probes({2, 2, 2}, array_of_bools<3>{true, false, false}),
-                  {{{{r(2), off3, 0}}, {{0, r(2), 0}}, {{0, 0, r(2)}}}}, "3D N={2,2,2} summed along x only");
+                  {{{{rs(2), off3, 0}}, {{0, r(2), 0}}, {{0, 0, r(2)}}}}, "3D N={2,2,2} summed along x only");
 
   // an unrestricted dimension absorbs the offset, but again only when one is needed
   Radii<2> radii2d;
   radii2d[1] = 2;
   check_probes<2>(t, probes_of<2>(level, radii2d, array_of_bools<2>{false, true}, far_reach<2>()),
-                  {{std::nullopt, {{-far_offset<2>(level), r(2)}}}}, "2D N={*,2} summed along y");
+                  {{std::nullopt, {{-far_offset<2>(level), rs(2)}}}}, "2D N={*,2} summed along y");
   check_probes<2>(t, probes_of<2>(level, radii2d, array_of_bools<2>{false, false}, far_reach<2>()),
                   {{std::nullopt, {{0, r(2)}}}}, "2D N={*,2} not summed");
 
@@ -340,7 +349,7 @@ int test_standard_reach(World& world) {
 
   {
     const Level n = 6;                     // half-cell = 32 boxes, so the cap is far away
-    const auto face = probe_radius(2, n);  // 63: the innermost layer of the face at 64
+    const auto face = probe_radius_summed(2, n);  // -1: the innermost layer of the face at 64, folded onto the source
 
     // nothing is known to be filtered => the surface reaches the source and no offset helps;
     // fall back to the bare face probe, whose norm is the on-site norm and screens nothing
@@ -368,7 +377,7 @@ int test_standard_reach(World& world) {
   // the offset is capped at a half cell: a step of 2^{n-1}+k folds back down to 2^{n-1}-k
   {
     const Level n = 2;  // half cell = 2 boxes < bmax+1
-    check(n, unit_reach<NDIM>(1e6), 0, {probe_radius(2, n), 2, 0}, "n=2, reached beyond bmax");
+    check(n, unit_reach<NDIM>(1e6), 0, {probe_radius_summed(2, n), 2, 0}, "n=2, reached beyond bmax");
   }
 
   // the same cap applies when the offset lands on an unrestricted dimension
@@ -377,7 +386,7 @@ int test_standard_reach(World& world) {
     Radii<2> box_radius;
     box_radius[1] = 2;
     check_probes<2>(t, probes_of<2>(n, box_radius, array_of_bools<2>{true}, unit_reach<2>(4.)),
-                    {{std::nullopt, {{-4, probe_radius(2, n)}}}}, "2D N={*,2} sqrt(max_distsq)=2");
+                    {{std::nullopt, {{-4, probe_radius_summed(2, n)}}}}, "2D N={*,2} sqrt(max_distsq)=2");
   }
 
   return t.end();

--- a/src/madness/mra/test_displacements.cc
+++ b/src/madness/mra/test_displacements.cc
@@ -22,7 +22,9 @@ Key<NDIM> centered_key(Level n) {
 }
 
 template <std::size_t NDIM>
-using Reach = typename BoxSurfaceDisplacementRange<NDIM>::StandardDisplacementsReach;
+using Reach = StandardDisplacementsReach<NDIM>;
+template <std::size_t NDIM>
+using Validator = BoxSurfaceDisplacementValidator<NDIM>;
 
 /// standard displacements of unit-width cells reached out to real distance squared \p max_distsq
 template <std::size_t NDIM>
@@ -43,29 +45,31 @@ Translation far_offset(Level n) {
   return std::min<Translation>(Displacements<NDIM>::bmax_default() + 1, Translation(1) << (n - 1));
 }
 
-/// keeps only destinations inside the simulation cell
+/// keeps only destinations inside the simulation cell (finite domain), nothing else is filtered
 template <std::size_t NDIM>
-typename BoxSurfaceDisplacementRange<NDIM>::Validator in_domain_only() {
-  return [](const Level level, const typename BoxSurfaceDisplacementRange<NDIM>::PointPattern& dest,
-            std::optional<Key<NDIM>>&) -> bool {
-    const auto twon = (Translation(1) << level);
-    for (std::size_t d = 0; d != NDIM; ++d)
-      if (dest[d].has_value() && (*dest[d] < 0 || *dest[d] >= twon)) return false;
-    return true;
-  };
+Validator<NDIM> in_domain_only(const array_of_bools<NDIM>& is_lattice_summed) {
+  return Validator<NDIM>(array_of_bools<NDIM>{false}, is_lattice_summed);
 }
 
+/// keeps everything (infinite domain, no standard displacements to deduplicate against)
+template <std::size_t NDIM>
+Validator<NDIM> keep_all(const array_of_bools<NDIM>& is_lattice_summed) {
+  return Validator<NDIM>(array_of_bools<NDIM>{true}, is_lattice_summed);
+}
+
+/// surface with unit thickness; if only `reach` is given the validator keeps everything but the standard displacements
 template <std::size_t NDIM>
 BoxSurfaceDisplacementRange<NDIM> make_range(Level n, const Radii<NDIM>& box_radius,
                                              const array_of_bools<NDIM>& is_lattice_summed,
                                              std::optional<Reach<NDIM>> reach = {},
-                                             typename BoxSurfaceDisplacementRange<NDIM>::Validator validator = {}) {
+                                             std::optional<Validator<NDIM>> validator = {}) {
   Radii<NDIM> surface_thickness;
   for (std::size_t d = 0; d != NDIM; ++d) {
     if (box_radius[d]) surface_thickness[d] = 1;
   }
+  if (reach && !validator) validator.emplace(array_of_bools<NDIM>{true}, is_lattice_summed, std::move(reach));
   return BoxSurfaceDisplacementRange<NDIM>(centered_key<NDIM>(n), box_radius, surface_thickness, is_lattice_summed,
-                                           std::move(validator), std::move(reach));
+                                           std::move(validator));
 }
 
 /// the probing displacement of every face, as a translation; null for dimensions of unlimited size (no face)
@@ -121,9 +125,9 @@ int test_no_duplicates(World& world) {
     constexpr std::size_t NDIM = decltype(ndim_tag)::value;
     // N.B. the domain filter is only meaningful when the range boundary can land
     // inside the cell at all.
-    const auto range = make_range<NDIM>(
-        n, finite<NDIM>(N), array_of_bools<NDIM>{lattice_summed}, {},
-        filter_to_domain ? in_domain_only<NDIM>() : typename BoxSurfaceDisplacementRange<NDIM>::Validator{});
+    const auto summed = array_of_bools<NDIM>{lattice_summed};
+    const auto range = make_range<NDIM>(n, finite<NDIM>(N), summed, {},
+                                        filter_to_domain ? std::optional{in_domain_only<NDIM>(summed)} : std::nullopt);
     std::vector<Key<NDIM>> disps;
     for (auto&& disp : range) disps.push_back(disp);
     std::sort(disps.begin(), disps.end());
@@ -169,7 +173,7 @@ int test_validator_agnostic(World& world) {
   test_output t("BoxSurfaceDisplacementRange: iteration does not depend on the presence of a validator", world.rank() == 0);
 
   constexpr std::size_t NDIM = 2;
-  const auto disps_of = [](typename BoxSurfaceDisplacementRange<NDIM>::Validator validator) {
+  const auto disps_of = [](std::optional<Validator<NDIM>> validator) {
     const auto range = make_range<NDIM>(4, finite<NDIM>({1, 1}), array_of_bools<NDIM>{false}, {}, std::move(validator));
     std::vector<Key<NDIM>> disps;
     for (auto&& disp : range) disps.push_back(disp);
@@ -177,9 +181,8 @@ int test_validator_agnostic(World& world) {
     return disps;
   };
 
-  const auto without = disps_of({});
-  const auto with = disps_of([](const Level, const typename BoxSurfaceDisplacementRange<NDIM>::PointPattern&,
-                                std::optional<Key<NDIM>>&) { return true; });
+  const auto without = disps_of(std::nullopt);
+  const auto with = disps_of(keep_all<NDIM>(array_of_bools<NDIM>{false}));
   t.checkpoint(!with.empty(), "2D n=4 N={1,1}: surface is non-empty");
   t.checkpoint(without.size() == with.size(), "2D n=4 N={1,1}: same number of displacements with and without a validator (" +
                                                   std::to_string(without.size()) + " vs " + std::to_string(with.size()) + ")");


### PR DESCRIPTION
Follow-up to #778, targeting its branch so only the fix shows.

**Per-face probes (third commit).** A single probing displacement gated the whole surface: `for_each` evaluated its norm once and, if negligible, skipped every face. That is sound only if the probe is at least as close as the nearest kept surface point on *any* face, which no face ranking can guarantee once faces sit at different real-space distances (mixed-parity lattice-summed radii, lattice summation along some axes only, anisotropic cells). Now every face has its own probe (`probing_displacement(d)` / `probing_displacements()`), `do_apply` probes each face, skips the negligible ones via `skip_face(d)`, and skips the surface only if every face screens. A skipped face is simply not iterated: a box is visited iff it lies on at least one non-skipped face, independent of face order. The face ranking is gone.

**Real-space offset (second commit).** The offset of an even lattice-summed face was computed in boxes from the widest cell axis while the offset axis was chosen by box radius, so in anisotropic cells the probe could sit farther than the nearest kept surface point. `probe_offset_radius` is replaced by `StandardDisplacementsReach` (max real distance squared plus the cell widths that produced it, carried by the validator since the fourth commit); the range inverts it per axis and picks the offset axis with the least real-space offset. The widths are the same ones `default_real_distance_squared` uses, so probe and validator agree. Omitting the reach means nothing is known to be filtered, so the on-site probe is used.

*No reproducer for this one.* The defect is in the contract between `funcimpl.h` and the range, not inside either: at the base the range takes a single box count, `funcimpl.h` derives it from the widest cell axis, and the range applies it along the finite axis with the smallest radius. Neither side is wrong on its own terms, and cell widths only enter the interface with this fix, so no test against the base API can fail. The anisotropic cases in `test_standard_reach` pin the corrected behavior. A failing demonstration would need an end-to-end `apply` of a range-restricted lattice-summed operator in an anisotropic periodic cell, compared against an unscreened reference (there is no switch to disable the probe), with tolerances tuned so the over-screening error stands out from truncation error; I have not attempted that.

**Reproducers first.** The first commit (063dbe60c) adds only two tests to `test_displacements.cc` and fails against the unchanged iteration code (identical to master): CI run https://github.com/m-a-d-n-e-s-s/madness/actions/runs/34061462957. The fixes follow in the next two commits and turn it green.

**Two pre-existing iteration bugs** surfaced by the new tests and fixed in the third commit:
- Without a validator the first surface point was never yielded (`advance_till_valid` advanced unconditionally in that branch).
- For lattice-summed radii of 2 or more half cells the box is wider than the cell, so the range of box indices between its two faces, [-r+t+1, r-t-1] in the integer box coordinates the iterator works in, spans more than one period; after a face was processed the later faces iterated over that whole range and thus re-enumerated boxes that are lattice-equivalent to the layers just processed (the 3×3 edge boxes of a 2D N={2,2} surface twice, 189 duplicates for 3D N={2,2,2} at level 3). Bounds of a processed lattice-summed dimension now shrink to the complement of its layer classes within one period; hollowness is defined modulo the period too.

**Review follow-ups (fourth commit).** The iteration bounds are lattice-aware from initialization (one period ending at the top layer along a lattice-summed dimension), which removes the equivalence-class clipping in `reset_along_dim` and makes the post-face shrink and the hollowness test uniform. `BoxSurfaceDisplacementValidator` now owns `StandardDisplacementsReach` (a namespace-scope struct) and computes its distances from it; the range takes an optional validator object instead of a callable plus a separate reach, reads the reach from it, and checks that the lattice-summation flags agree. The validator no longer takes the (unused) kernel range or a distance callable. Probe docs reworded: a finite-radius dimension has a pair of faces, served by one probe, which errs toward the largest norm.

**Re-review and audit fixes (fifth and sixth commits).** The probe sits on the innermost layer r-t and, for a lattice-summed face, is folded into the cell like the yielded displacements. Faces whose layers are all filtered out (entirely outside a finite domain) are skipped instead of tripping an assert. The validator clips `bmax` to 2^n-1 on every axis whenever any axis is lattice summed, matching `make_disp_periodic`. A 64-bit shift at level 0 is guarded. Tests cover mixed-axis lattice summation, faces outside the domain, and the validator's `bmax`. Two pre-existing issues found by the audit are recorded in a PR comment and left for follow-up: the standard displacement list is ordered with unit cell widths, and the `Keep` policy on an unrestricted axis uses the absolute cell as the face window.

**Review nits.** Unused `<limits>` dropped, `<cmath>` added, `compute_probing_displacement` is `const` and returns by value, Doxygen ordering and a typo fixed, cell-width check is an always-on `MADNESS_CHECK_THROW`.

**Tests.** `test_displacements`: per-face probe expectations, anisotropic-cell cases, the half-cell cap, a face-skipping test against the "on at least one remaining face" rule, and uniqueness of the surface modulo the lattice for lattice-summed cases. `test_displacements`, `testgconv`, and `testpercoul` pass locally (Release, PaRSEC, macOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RX8v3398TLeTzqAghZ5ivQ





