### PR TITLE
AGENTS.md: warn against ctest -j

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,14 @@ ctest -L short -R "madness/test/mra"         # all mra tests in the short set
 ctest -R "madness/test/mra/test_cloud/run"   # a single test by name
 ```
 
+**Do not pass `-j` to ctest.** Each test sizes its own thread pool from
+`MAD_NUM_THREADS`, which defaults to every core, so ctest's `-j` multiplies
+that instead of dividing the machine between tests: `-j 2` on a 12-core host
+is ~24 workers on 12 cores, and `-j 4` is ~48. Nothing fails outright — the
+suite just crawls, and the slower tests then blow their timeouts and are
+reported as failures that vanish on a serial re-run. If you need parallelism,
+pin `MAD_NUM_THREADS` so that `-j` times that value still fits the machine.
+
 Each test is also a normal binary under
 `<build-dir>/<path-of-source-dir>/<name>` (mirroring the source tree, so
 `src/madness/mra` tests land at `<build-dir>/src/madness/mra/<name>`, and


### PR DESCRIPTION
Each MADNESS test sizes its own thread pool from `MAD_NUM_THREADS`, which defaults to every core, so ctest's `-j` multiplies rather than divides the machine between tests: `-j 2` on a 12-core host is ~24 workers on 12 cores, `-j 4` is ~48.

The failure mode is what makes this worth documenting. Nothing errors out — the suite just crawls, and the slower tests then blow their timeouts and are reported as ordinary failures. You then go debug a test that was never broken.

Observed while reviewing #782 on a 12-core host: `ctest -L short -j 2` drove the load average past 200, and `nemo_he_hf` reported a timeout at 121 s. Run serially it completes in **9.5 s**. `test_eval_mpi2` likewise reported a timeout and takes 590 s serially, comfortably inside its limit.

The note goes right after the existing subset-running examples in the Tests section, and suggests pinning `MAD_NUM_THREADS` if parallelism is actually wanted.

A stronger fix, if anyone wants it later, would be setting the ctest `PROCESSORS` property per test so ctest's own scheduler accounts for the pool size instead of relying on people reading this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hct2iMfVZn9XtM3urtFaEg