### PR TITLE
Destroy a multithreaded task when its last queue entry is handled

### DIFF
--- a/src/madness/world/thread.h
+++ b/src/madness/world/thread.h
@@ -1250,8 +1250,12 @@ namespace madness {
 #ifdef MADNESS_TASK_PROFILING
                 t.first->set_event(event_list->event());
 #endif // MADNESS_TASK_PROFILING
-                if (t.first->run_multi_threaded())         // What we are here to do
-                    delete t.first;
+                // Same ownership rule as run_tasks(): the task belongs to
+                // whichever thread handles its last queue entry, not to
+                // whichever leaves the barrier last.
+                PoolTaskInterface* const task = t.first;
+                task->run_multi_threaded();                // What we are here to do
+                if (task->release_nqueued()) delete task;
             }
             return t.second;
 #endif

--- a/src/madness/world/thread.h
+++ b/src/madness/world/thread.h
@@ -955,6 +955,19 @@ namespace madness {
         Barrier* barrier; ///< Barrier, only allocated for multithreaded tasks.
         AtomicInt count; ///< Used to count threads as they start.
 
+        /// Number of queue entries still referring to this task.
+        ///
+        /// A multithreaded task is enqueued once per requested thread, so the
+        /// task outlives the barrier: it may only be destroyed once every one of
+        /// those entries has been taken off the queue and handled.  Tying
+        /// destruction to the barrier instead lets the last thread out free the
+        /// task while copies of its pointer are still queued, and the allocator
+        /// then hands the same address to the next task -- two generations live
+        /// at one address, `count` restarted by the new constructor, duplicate
+        /// participant ids, and a barrier waiting forever for an id that was
+        /// never issued.
+        AtomicInt nqueued;
+
     	/// Returns true for the one thread that should invoke the destructor.
 
         /// \return True for the one thread that should invoke the destructor.
@@ -1007,6 +1020,7 @@ namespace madness {
 #endif
         {
     	    count = 0;
+            nqueued = 1;
     	}
 
         /// Constructor setting the specified task attributes.
@@ -1020,7 +1034,20 @@ namespace madness {
 #endif
         {
             count = 0;
+            nqueued = 1;
         }
+
+        /// Set the number of queue entries that refer to this task.
+
+        /// Called by ThreadPool::add() before the task is enqueued.
+        /// \param[in] n The number of entries about to be pushed.
+        void set_nqueued(int n) { nqueued = n; }
+
+        /// Release one queue entry once it has been handled.
+
+        /// \return True if this was the last outstanding entry, i.e. the caller
+        ///         now owns the task and must destroy it.
+        bool release_nqueued() { return nqueued.dec_and_test(); }
 
         /// Destructor.
         /// \todo Should we either use a unique_ptr for barrier or check that barrier != nullptr here?
@@ -1262,9 +1289,11 @@ namespace madness {
 #ifdef MADNESS_TASK_PROFILING
                     taskbuf[i]->set_event(event_list->event());
 #endif // MADNESS_TASK_PROFILING
-                    if (taskbuf[i]->run_multi_threaded()) {
-                        delete taskbuf[i];
-                    }
+                    PoolTaskInterface* const task = taskbuf[i];
+                    task->run_multi_threaded();  // returns true for the last thread
+                                                 // out of the barrier -- informational
+                                                 // only; it does not confer ownership
+                    if (task->release_nqueued()) delete task;
                 }
             }
 #if HAVE_PARSEC
@@ -1360,6 +1389,13 @@ namespace madness {
 #else
             if (!task) MADNESS_EXCEPTION("ThreadPool: inserting a NULL task pointer", 1);
             int task_threads = task->get_nthread();
+            // One reference per queue entry, established before the task becomes
+            // visible to the pool.  The task is destroyed by whichever thread
+            // handles the last entry, not by whichever leaves the barrier last:
+            // those are the same thread in the common case, but not always, and
+            // getting it wrong frees the task while copies of its pointer are
+            // still queued.
+            task->set_nqueued(task_threads);
             // Currently multithreaded tasks must be shoved on the end of the q
             // to avoid a race condition as multithreaded task is starting up
             if (task->is_high_priority() && (task_threads == 1)) {


### PR DESCRIPTION
A use-after-free in the Pthreads task pool, found while chasing intermittent `test_systolic` hangs.

## The defect

A multithreaded task is enqueued once per requested thread — `queue.push_back(task, nthread)`, i.e. `nthread` copies of one pointer — but it was destroyed by whichever thread left the barrier last:

```cpp
if (taskbuf[i]->run_multi_threaded()) delete taskbuf[i];
```

Nothing tied those two things together. If any copy of the pointer was still on the queue when the last participant left the barrier, the queue was left holding a dangling pointer, and the allocator hands the same address straight back to the next task of the same size.

Two generations of the task are then live at one address. The new constructor resets `count`, so participant ids restart and collide: threads on the old and the new generation draw the same id while another id is never issued at all. `nworking` never reaches zero and every participant waits forever for a thread that cannot arrive.

## Evidence

Per-thread trace of the claim path at the point of deadlock (`test_systolic`, Pthreads, `nthread = 12`):

```
ids issued: 0 1 2 3 4 5 6 7 8 8 9 10        <- id 8 twice, id 11 never

slot 8:  I AM LAST, deleting 7e1290a00
         run_multi_threaded: nthread=12
         got id 9

slot 1:  I AM LAST, deleting 80b1903c0
         pop returned 1 task(s)
         run task 80b1903c0                 <- runs the pointer it just freed
```

`count` is an `AtomicInt`, so two threads cannot draw the same id from the same object — they were drawing from different objects at one address. Every thread saw `nthread=12`, so none took the single-threaded early-return path.

## The fix

Give the task one reference per queue entry, established before it becomes visible to the pool, and destroy it when the last entry has been handled. The barrier then does synchronisation only; its "last thread out" result stays informational. A stranded entry now leaks the task rather than corrupting the next one.

## Measurements

`test_systolic` at full subscription (`MAD_NUM_THREADS=12` on 12 cores), 400 runs per configuration:

| configuration | pass | hang | abort |
| --- | ---: | ---: | ---: |
| master | 373 | 17 | 10 |
| master + this change | 373 | 9 | 18 |
| + barrier acquire fence (#782) | **400** | **0** | **0** |

**This change alone does not help.** master's `Barrier` also lacks an acquire fence on the waiting side, and that corruption dominates — the middle row is the same 27 failures, just redistributed. The two defects are independent and both are needed. The fence fix is in flight as part of #782; with both, the reproducer is clean over 400 runs, against roughly 3 hangs per 100 with the fence alone.

I am raising this separately because it is a distinct bug in `thread.h` with its own cause, and it is on master today.

## Scope

Pthreads only. TBB never constructs a `Barrier` (`systolic.h` uses `tbb::parallel_for`), and PaRSEC runs multithreaded tasks via `run(TaskThreadEnv(1,0,0))`, so `nthread` is ignored there — worth a separate look, since it means these tasks get no thread parallelism under the production backend.

In production the only consumer is the distributed Pipek-Mezey localizer (`chem/distpm.cc`, via `SystolicMatrixAlgorithm`), reached with localization method `pm`.

## Verification

Build clean with 0 warnings; TBB backend also builds clean, since the change touches `#ifndef HAVE_INTEL_TBB` code. `ctest -L short` for tensor/linalg/world 35/35 serial; `mra/testsuite` passes.

Worth adding a stress entry for this: `test_systolic` at full subscription over a few hundred runs is a reliable reproducer at ~3%, and nothing in the current suite exercises it that way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hct2iMfVZn9XtM3urtFaEg