### PR TITLE
cmake: budget the per-rank thread pool for the MPI tests

### DIFF
--- a/cmake/modules/AddMPITests.cmake
+++ b/cmake/modules/AddMPITests.cmake
@@ -14,6 +14,8 @@
 #                              Example: MADNESS_MPI_NODE_OPTIONS="--hostfile /path/to/hostfile --map-by node" ctest -R mpi
 #   MAD_CHECK_BINDING        - Defaulted to OFF for these tests, see below.  Set it
 #                              explicitly to keep MADNESS' start-up binding check enabled.
+#   MAD_NUM_THREADS          - Defaulted to a per-rank budget for these tests, see below.
+#                              Set it explicitly to pick the pool size yourself.
 #
 # Default launch options
 #   mpiexec pins each rank to a single core when a machine has more cores than ranks,
@@ -24,10 +26,26 @@
 #   MADNESS_MPI_NODE_OPTIONS we launch them unbound.  The flag spelling is
 #   vendor-specific, hence the version-string sniffing; unknown vendors get no flag.
 #
-#   MAD_CHECK_BINDING is defaulted to OFF on top of that: unbinding fixes the
-#   per-rank oversubscription, but the check also compares the *aggregate* thread
-#   demand of all ranks on the host against the cores available, and that still
-#   trips whenever MAD_NUM_THREADS is left at its default of (ncores - 1).
+#   Unbinding alone still leaves the ranks fighting each other, because each one
+#   sizes its pool independently: MADNESS defaults MAD_NUM_THREADS to
+#   (logical cores - 1), so an N-rank test asks for N*(cores-1) threads on one
+#   host.  On a 12-core arm64 Mac the 2-rank tests ran ~2.5x oversubscribed, and
+#   it cost more than an order of magnitude in wall time: test_eval_mpi2 301 s
+#   and test_halo_mpi2 15.6 s at the old pool size, versus 11.7 s and 2.2 s once
+#   the pool was budgeted.  So the wrapper also defaults MAD_NUM_THREADS to
+#   (cores / nprocs - 2), the two spare cores per rank being the MADNESS
+#   communication thread and the MPI implementation's own progress thread.
+#
+#   The matching CTest PROCESSORS property tells 'ctest -j' what one run of the
+#   test actually costs, so it does not schedule several of them side by side and
+#   put the oversubscription straight back.
+#
+#   MAD_CHECK_BINDING is defaulted to OFF on top of all that.  The budget above is
+#   what its aggregate-demand test asks for, so it would now mostly pass -- but
+#   cmake_host_system_information reports the host's cores, not the cpuset a
+#   container or batch allocation has confined the job to.  Where those differ the
+#   budget overshoots, and with the check on that turns a slow test into a hard
+#   abort.  'MAD_CHECK_BINDING=ON ctest -L mpi' still exercises it.
 
 # Add MPI tests for a single test
 # Usage: add_mpi_tests(component test_name "2;4;8" "libs" "labels")
@@ -53,6 +71,14 @@ macro(add_mpi_tests _component _test_name _nprocs _libs _labels)
   # Ensure the test executable exists or will be created
   if(NOT TARGET ${_test_name})
     message(WARNING "Test target ${_test_name} does not exist. Make sure it is created before calling add_mpi_tests.")
+  endif()
+
+  # Host size, probed once per configure.  Used only for the PROCESSORS property,
+  # which CTest reads at configure time; the wrapper re-probes at run time for the
+  # thread budget, where the machine running the test is the one that matters.
+  if(NOT DEFINED MADNESS_TEST_HOST_CORES)
+    cmake_host_system_information(RESULT MADNESS_TEST_HOST_CORES
+                                  QUERY NUMBER_OF_LOGICAL_CORES)
   endif()
 
   # Default launch options: run unbound, so the ranks' threads get the whole node.
@@ -121,6 +147,19 @@ macro(add_mpi_tests _component _test_name _nprocs _libs _labels)
     file(APPEND ${_wrapper_script_template} "if(NOT DEFINED ENV{MAD_CHECK_BINDING})\n")
     file(APPEND ${_wrapper_script_template} "  set(ENV{MAD_CHECK_BINDING} \"OFF\")\n")
     file(APPEND ${_wrapper_script_template} "endif()\n")
+    file(APPEND ${_wrapper_script_template} "# Budget the per-rank thread pool.  Left alone every rank sizes its own pool at\n")
+    file(APPEND ${_wrapper_script_template} "# (cores - 1), and the ranks then time-share the host several times over.  Leave\n")
+    file(APPEND ${_wrapper_script_template} "# two cores per rank for the MADNESS communication thread and the MPI progress\n")
+    file(APPEND ${_wrapper_script_template} "# thread.  An explicit MAD_NUM_THREADS in the environment wins.\n")
+    file(APPEND ${_wrapper_script_template} "if(NOT DEFINED ENV{MAD_NUM_THREADS})\n")
+    file(APPEND ${_wrapper_script_template} "  cmake_host_system_information(RESULT _ncores QUERY NUMBER_OF_LOGICAL_CORES)\n")
+    file(APPEND ${_wrapper_script_template} "  math(EXPR _nthreads \"\${_ncores} / ${NPROC} - 2\")\n")
+    file(APPEND ${_wrapper_script_template} "  if(_nthreads LESS 1)\n")
+    file(APPEND ${_wrapper_script_template} "    set(_nthreads 1)\n")
+    file(APPEND ${_wrapper_script_template} "  endif()\n")
+    file(APPEND ${_wrapper_script_template} "  set(ENV{MAD_NUM_THREADS} \"\${_nthreads}\")\n")
+    file(APPEND ${_wrapper_script_template} "  message(STATUS \"MAD_NUM_THREADS=\${_nthreads} (${NPROC} rank(s) on \${_ncores} logical cores)\")\n")
+    file(APPEND ${_wrapper_script_template} "endif()\n")
     file(APPEND ${_wrapper_script_template} "# Execute MPI command\n")
     file(APPEND ${_wrapper_script_template} "message(STATUS \"Running: ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${NPROC} \${MPI_OPTIONS_LIST} ${MPIEXEC_PREFLAGS_STR} \\\"\$<TARGET_FILE:${_test_name}>\\\" ${MPIEXEC_POSTFLAGS_STR}\")\n")
     file(APPEND ${_wrapper_script_template} "execute_process(\n")
@@ -138,10 +177,20 @@ macro(add_mpi_tests _component _test_name _nprocs _libs _labels)
     add_test(NAME madness/test/${_component}/${_mpi_test_name}/run
              COMMAND ${CMAKE_COMMAND} -P ${_wrapper_script})
     
+    # What one run costs the host, so 'ctest -j' does not start several of these
+    # side by side and undo the budget.  Mirrors the wrapper's arithmetic, with the
+    # two spare cores per rank added back in.
+    math(EXPR _mad_rank_threads "${MADNESS_TEST_HOST_CORES} / ${NPROC} - 2")
+    if(_mad_rank_threads LESS 1)
+      set(_mad_rank_threads 1)
+    endif()
+    math(EXPR _mad_test_procs "${NPROC} * (${_mad_rank_threads} + 2)")
+
     # Set test properties
     set_tests_properties(madness/test/${_component}/${_mpi_test_name}/run
                          PROPERTIES DEPENDS madness/test/${_component}/build 
-                         LABELS "${_labels};mpi")
+                         LABELS "${_labels};mpi"
+                         PROCESSORS ${_mad_test_procs})
     
     # Add dependency to component unittests
     if(TARGET ${_component}_unittests-madness)

--- a/cmake/modules/AddMPITests.cmake
+++ b/cmake/modules/AddMPITests.cmake
@@ -36,9 +36,23 @@
 #   (cores / nprocs - 2), the two spare cores per rank being the MADNESS
 #   communication thread and the MPI implementation's own progress thread.
 #
+#   That budget is only applied to the default, single-host launch.  The wrapper
+#   runs on the host ctest runs on, so the core count it probes is that host's --
+#   fine when the ranks stay there, wrong the moment they do not.  Setting
+#   MADNESS_MPI_NODE_OPTIONS is how this module spells "I am choosing the layout"
+#   (a hostfile, --map-by node, a batch allocation), so when it is set the budget
+#   is skipped and MADNESS' own per-rank default applies instead.  That default is
+#   (cores - 1) measured on the host the rank actually lands on, which for one
+#   rank per node is already right; a global number derived here would not be.
+#   Set MAD_NUM_THREADS explicitly to budget such a run.
+#
 #   The matching CTest PROCESSORS property tells 'ctest -j' what one run of the
 #   test actually costs, so it does not schedule several of them side by side and
-#   put the oversubscription straight back.
+#   put the oversubscription straight back.  CTest fixes that reservation at
+#   configure time, so it describes the default budget and nothing else: override
+#   MAD_NUM_THREADS at run time and the reservation no longer matches what the
+#   test asks for -- larger overrides under-reserve, smaller ones over-reserve.
+#   Run overridden tests without 'ctest -j', or reserve by hand.
 #
 #   MAD_CHECK_BINDING is defaulted to OFF on top of all that.  The budget above is
 #   what its aggregate-demand test asks for, so it would now mostly pass -- but
@@ -151,7 +165,12 @@ macro(add_mpi_tests _component _test_name _nprocs _libs _labels)
     file(APPEND ${_wrapper_script_template} "# (cores - 1), and the ranks then time-share the host several times over.  Leave\n")
     file(APPEND ${_wrapper_script_template} "# two cores per rank for the MADNESS communication thread and the MPI progress\n")
     file(APPEND ${_wrapper_script_template} "# thread.  An explicit MAD_NUM_THREADS in the environment wins.\n")
-    file(APPEND ${_wrapper_script_template} "if(NOT DEFINED ENV{MAD_NUM_THREADS})\n")
+    file(APPEND ${_wrapper_script_template} "# Only for the default layout: this script runs on the host ctest runs on, so\n")
+    file(APPEND ${_wrapper_script_template} "# the core count below is that host's.  Once MADNESS_MPI_NODE_OPTIONS puts the\n")
+    file(APPEND ${_wrapper_script_template} "# ranks somewhere else -- a hostfile, --map-by node, a batch allocation -- a\n")
+    file(APPEND ${_wrapper_script_template} "# number derived here describes the wrong machine.  MADNESS' own default,\n")
+    file(APPEND ${_wrapper_script_template} "# (cores - 1) measured wherever the rank lands, is the better answer there.\n")
+    file(APPEND ${_wrapper_script_template} "if(NOT DEFINED ENV{MAD_NUM_THREADS} AND NOT DEFINED ENV{MADNESS_MPI_NODE_OPTIONS})\n")
     file(APPEND ${_wrapper_script_template} "  cmake_host_system_information(RESULT _ncores QUERY NUMBER_OF_LOGICAL_CORES)\n")
     file(APPEND ${_wrapper_script_template} "  math(EXPR _nthreads \"\${_ncores} / ${NPROC} - 2\")\n")
     file(APPEND ${_wrapper_script_template} "  if(_nthreads LESS 1)\n")
@@ -159,6 +178,9 @@ macro(add_mpi_tests _component _test_name _nprocs _libs _labels)
     file(APPEND ${_wrapper_script_template} "  endif()\n")
     file(APPEND ${_wrapper_script_template} "  set(ENV{MAD_NUM_THREADS} \"\${_nthreads}\")\n")
     file(APPEND ${_wrapper_script_template} "  message(STATUS \"MAD_NUM_THREADS=\${_nthreads} (${NPROC} rank(s) on \${_ncores} logical cores)\")\n")
+    file(APPEND ${_wrapper_script_template} "elseif(NOT DEFINED ENV{MAD_NUM_THREADS})\n")
+    file(APPEND ${_wrapper_script_template} "  message(STATUS \"MADNESS_MPI_NODE_OPTIONS is set: leaving the thread count to MADNESS' \"\n")
+    file(APPEND ${_wrapper_script_template} "                 \"per-host default.  Set MAD_NUM_THREADS to budget this run.\")\n")
     file(APPEND ${_wrapper_script_template} "endif()\n")
     file(APPEND ${_wrapper_script_template} "# Execute MPI command\n")
     file(APPEND ${_wrapper_script_template} "message(STATUS \"Running: ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${NPROC} \${MPI_OPTIONS_LIST} ${MPIEXEC_PREFLAGS_STR} \\\"\$<TARGET_FILE:${_test_name}>\\\" ${MPIEXEC_POSTFLAGS_STR}\")\n")
@@ -179,7 +201,9 @@ macro(add_mpi_tests _component _test_name _nprocs _libs _labels)
     
     # What one run costs the host, so 'ctest -j' does not start several of these
     # side by side and undo the budget.  Mirrors the wrapper's arithmetic, with the
-    # two spare cores per rank added back in.
+    # two spare cores per rank added back in.  CTest fixes this at configure time,
+    # so it describes the default budget only: a run-time MAD_NUM_THREADS override
+    # or a MADNESS_MPI_NODE_OPTIONS layout will not match it (see the header).
     math(EXPR _mad_rank_threads "${MADNESS_TEST_HOST_CORES} / ${NPROC} - 2")
     if(_mad_rank_threads LESS 1)
       set(_mad_rank_threads 1)


### PR DESCRIPTION
The `*_mpi<N>` ctest entries oversubscribe the host, badly enough that they read
as hangs rather than as contention.

`add_mpi_tests` generates a wrapper that runs
`mpiexec -n N --bind-to none <test>` and never sets `MAD_NUM_THREADS`. Each rank
then sizes its own pool at `logical cores - 1`, so an N-rank test asks for
`N*(cores-1)` threads on one host. The module already knew about this — it is
the stated reason `MAD_CHECK_BINDING` is defaulted to OFF:

> *unbinding fixes the per-rank oversubscription, but the check also compares the
> aggregate thread demand of all ranks on the host against the cores available,
> and that still trips whenever `MAD_NUM_THREADS` is left at its default of
> (ncores - 1).*

Silencing the detector left the ranks fighting each other for the whole run.

## What it costs

12-core arm64 Mac, Release, PaRSEC, same build directory, tests run serially.
The "before" column forces `MAD_NUM_THREADS=11`, i.e. the pool size the old
wrapper produced on this host:

| test | `MAD_NUM_THREADS=11` | budgeted |
|---|---|---|
| `test_eval_mpi2` | 301.4 s | 11.7 s |
| `test_halo_mpi2` | 15.6 s | 2.2 s |

All six `-L mpi` tests together, `ctest -j 4`: **37.6 s**, 6/6 pass.

These carry the `short` label, so this is on every CI run.

## The change

One file, `cmake/modules/AddMPITests.cmake`.

**Default `MAD_NUM_THREADS` to `max(1, cores/nprocs - 2)`** in the generated
wrapper, the two spare cores per rank being the MADNESS communication thread and
the MPI implementation's own progress thread — the rule in `CLAUDE.md`. The core
count is probed in the wrapper rather than at configure time, so it reflects the
machine actually running the test. An explicit `MAD_NUM_THREADS` still wins, so
`MAD_NUM_THREADS=8 ctest -L mpi` behaves as before.

**Set the CTest `PROCESSORS` property to match.** Without it `ctest -j`
schedules several of these side by side and puts the oversubscription straight
back — that is what turned `test_eval_mpi2` into a 1200 s timeout under
`ctest -j 2` rather than a slow pass. On this host it comes out as `PROCESSORS =
12`, the whole machine, which is correct for 2 ranks × a 4-thread pool plus two
comm threads each.

**`MAD_CHECK_BINDING` stays OFF by default.** Tempting to re-enable now that the
budget is what its aggregate-demand test asks for, but
`cmake_host_system_information` reports the host's cores, not the cpuset a
container or batch allocation has confined the job to. Where those differ the
budget overshoots and the check would turn a slow test into a hard abort. The
header comment now says so rather than leaving it implicit.

Found while reviewing #753 — `test_eval_mpi2` looked like a regression from the
code under review before it turned out to be this. Independent of that PR; the
only interaction is that #753 adds a sixth test to the same set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UczrEoFsN4hwR5w3YifF5h
