### PR TITLE
Pr virtuals

### DIFF
--- a/doc/Latex/apps/moldft/manual.tex
+++ b/doc/Latex/apps/moldft/manual.tex
@@ -379,9 +379,15 @@ experience with this yet.
 
 {\tt charge value} --- E.g., {\tt charge -1.0} --- Total charge (default {\tt 0}) on the molecule. Atomic units.
 
-{\tt nvalpha value} --- E.g., {\tt nvalpha 2} --- The number of alpha spin virtual orbitals to solve for (default {\tt 0}) --- is this working now?
+{\tt nvalpha value} --- E.g., {\tt nvalpha 2} --- The number of alpha spin virtual orbitals to solve for (default {\tt 0}). Virtuals are canonical (eigenfunctions of the converged Fock operator, ordered by energy) whatever localization the occupied orbitals use; the tier-end eigenvalue list shows them after the occupied orbitals. A restart from an archive holding fewer orbitals than requested fills the missing virtuals from the atomic guess.
 
-{\tt nvbeta value} --- E.g., {\tt nvbeta 2} --- The number of beta spin virtual orbitals to solve for (default {\tt 0}) --- is this working now?
+{\tt nvbeta value} --- E.g., {\tt nvbeta 2} --- The number of beta spin virtual orbitals to solve for (default {\tt 0}).
+
+{\tt nv\_extra value}, {\tt nv\_step value}, {\tt nv\_its value} --- E.g., {\tt nv\_extra 2}, {\tt nv\_step 1} --- Converge {\tt nvalpha + nv\_extra} virtuals first, then drop {\tt nv\_step} of the highest per stage down to {\tt nvalpha}; intermediate stages run at most {\tt nv\_its} iterations (defaults {\tt 0}, {\tt 0} = all extras at once, {\tt 5}). Applies when the virtuals start from the atomic guess.
+
+{\tt freeze\_occupied} --- E.g., {\tt freeze\_occupied true} --- On a restart from converged orbitals, iterate only the virtuals in their fixed mean field (default {\tt false}). Exact for the virtuals and much cheaper per iteration than the coupled SCF.
+
+{\tt aocc [list]}, {\tt bocc [list]} --- E.g., {\tt aocc [0,1,1,1,1]} --- Explicit 0/1 occupations by orbital index within the occupied span (comma separated); a 0 is a hole, for $\Delta$SCF core-hole calculations. Requires canonical orbitals ({\tt localize canon}, derived automatically). {\tt bocc} needs {\tt spin\_restricted false}.
 
 {\tt no\_orient} --- Do not reorient/translate the molecule to orientation/center.
 

--- a/src/apps/moldft/tests/h2o_hf_nvstep.in
+++ b/src/apps/moldft/tests/h2o_hf_nvstep.in
@@ -1,0 +1,24 @@
+# Two virtuals via the step-down schedule: converge 4 (nvalpha + nv_extra) for
+# up to nv_its iterations, drop to 3, then to 2 with the full maxiter.
+#
+# Final energy -76.0674442, the same as a plain nvalpha 2 run. Water's
+# virtuals are unbound (positive eigenvalues, box continuum), so their
+# residual plateaus near 5e-3 with or without the schedule.
+
+dft
+  xc hf
+  protocol [1e-4,1e-6]
+  maxiter 40
+  nvalpha 2
+  nv_extra 2
+  nv_step 1
+  nv_its 5
+end
+
+geometry
+  eprec 1e-7
+  units angstrom
+  O  0.000000  0.000000  0.117300
+  H  0.000000  0.757200 -0.469200
+  H  0.000000 -0.757200 -0.469200
+end

--- a/src/apps/moldft/tests/ne_hf_corehole.in
+++ b/src/apps/moldft/tests/ne_hf_corehole.in
@@ -1,0 +1,23 @@
+# Ne 1s core hole by fixed-index occupation (Delta-SCF). aocc empties orbital 0;
+# the orbital count stays that of the neutral atom, so this is the 1s-ionized
+# cation. Canonical orbitals are required: they are re-sorted by eigenvalue
+# every iteration, which keeps the hole on the 1s.
+#
+# E(hole) = -96.63581 (energy converged to 2e-7; the residual cycles at ~3e-6
+# in the degenerate 2p shell). Against the neutral E = -128.54710 this gives a
+# 1s binding energy of 868.35 eV (Koopmans -eps(1s) = 891.78 eV, experiment
+# 870.2 eV; HF Delta-SCF is expected below experiment).
+
+dft
+  xc hf
+  spin_restricted false
+  localize canon
+  aocc [0,1,1,1,1]
+  protocol [1e-4,1e-6]
+  maxiter 40
+end
+
+geometry
+  eprec 1e-7
+  ne 0 0 0
+end

--- a/src/madness/chem/CalculationParameters.h
+++ b/src/madness/chem/CalculationParameters.h
@@ -85,6 +85,8 @@ struct CalculationParameters : public QCCalculationParametersBase {
 		initialize<double>("maxrotn",0.25,"step restriction used in autoshift algorithm");
 		initialize<int>   ("nvalpha",0,"number of alpha virtuals to compute");
 		initialize<int>   ("nvbeta",0,"number of beta virtuals to compute");
+		initialize<std::vector<double> >("aocc",std::vector<double>(),"explicit alpha occupations (0 or 1) by orbital index within the occupied span; a 0 is a hole");
+		initialize<std::vector<double> >("bocc",std::vector<double>(),"explicit beta occupations (0 or 1) by orbital index within the occupied span; a 0 is a hole");
 		initialize<int>   ("nopen",0,"number of unpaired electrons = nalpha-nbeta");
 		initialize<int>   ("maxiter",25,"maximum number of iterations");
 		initialize<int>   ("nio",1,"no. of io servers to use");
@@ -197,6 +199,8 @@ struct CalculationParameters : public QCCalculationParametersBase {
 
 	int nvalpha() const {return get<int>("nvalpha");}
 	int nvbeta() const {return get<int>("nvbeta");}
+	std::vector<double> aocc() const {return get<std::vector<double> >("aocc");}
+	std::vector<double> bocc() const {return get<std::vector<double> >("bocc");}
 	int nv_extra() const {return get<int>("nv_extra");}
 	int nv_step() const {return get<int>("nv_step");}
 	int nv_its() const {return get<int>("nv_its");}
@@ -323,6 +327,24 @@ struct CalculationParameters : public QCCalculationParametersBase {
 
         if (nv_extra() < 0 or nv_step() < 0 or nv_its() < 1) error("nv_extra, nv_step >= 0 and nv_its >= 1 required");
         if (nv_extra() > 0 and nvalpha() == 0) error("nv_extra requires nvalpha > 0");
+
+        // Explicit occupations address the occupied span. A hole there is only
+        // index-stable with canonical orbitals: every iteration re-sorts them by
+        // eigenvalue, so the empty index stays on the same orbital.
+        bool hole = false;
+        for (const auto& [name, n] : std::vector<std::pair<std::string, int>>{{"aocc", nalpha()}, {"bocc", nbeta()}}) {
+            const auto occ = get<std::vector<double> >(name);
+            if (int(occ.size()) > n) error((name + " has more entries than occupied orbitals").c_str(), occ.size());
+            for (const double o : occ) {
+                if (o != 0.0 and o != 1.0) error((name + " entries must be 0 or 1").c_str(), o);
+                if (o == 0.0) hole = true;
+            }
+        }
+        if (not bocc().empty() and spin_restricted()) error("bocc requires spin_restricted false");
+        if (hole) {
+            set_derived_value("localize", std::string("canon"));
+            if (do_localize()) error("a hole in the explicit occupations requires localize canon");
+        }
 
         // Unless overridden by the user use a cell big enough to
         // have exp(-sqrt(2*I)*r) decay to 1e-6 with I=1ev=0.037Eh

--- a/src/madness/chem/CalculationParameters.h
+++ b/src/madness/chem/CalculationParameters.h
@@ -396,11 +396,13 @@ struct CalculationParameters : public QCCalculationParametersBase {
     	}
 
 
-        //NWChem only supports Boys localization (or canonical)
+        // The nwchem guess replaces the internal minimal aobasis with the NWChem basis,
+        // so localizers that need the atomic-eigenfunction machinery (pm, new, new_sys)
+        // cannot run; boys, cholesky and canon work from the MOs alone.
         if (nwfile() != "none") {
              set_derived_value("localize",std::string("boys"));
-             //Error if user requested something other than Boys
-             if(localize_method() != "boys" and localize_method() != "canon") error("NWchem initialization only supports Boys localization");
+             if (localize_method() != "boys" and localize_method() != "cholesky" and localize_method() != "canon")
+                 error("NWchem initialization supports only localize boys, cholesky or canon");
         }
 	}
 };

--- a/src/madness/chem/CalculationParameters.h
+++ b/src/madness/chem/CalculationParameters.h
@@ -151,7 +151,9 @@ struct CalculationParameters : public QCCalculationParametersBase {
 		initialize<int> ("gmaxiter",20,"RETIRED -- use optimization group `maxiter`");
 		initialize<bool> ("ginitial_hessian",false,"RETIRED -- use optimization group `initial_hessian`");
 		initialize<std::string> ("algopt","bfgs","RETIRED -- use optimization group `algopt`",{"bfgs","cg"});
-		initialize<int> ("nv_factor",1,"factor to multiply number of virtual orbitals with when automatically decreasing nvirt");
+		initialize<int> ("nv_extra",0,"extra virtuals converged first and dropped stepwise down to nvalpha");
+		initialize<int> ("nv_step",0,"virtuals dropped per step-down stage (0: all extras at once)");
+		initialize<int> ("nv_its",5,"maximum iterations per intermediate step-down stage");
 		initialize<int> ("vnucextra",2,"load balance parameter for nuclear pot");
 		initialize<int> ("loadbalparts",2,"??");
 
@@ -195,7 +197,9 @@ struct CalculationParameters : public QCCalculationParametersBase {
 
 	int nvalpha() const {return get<int>("nvalpha");}
 	int nvbeta() const {return get<int>("nvbeta");}
-	int nv_factor() const {return get<int>("nv_factor");}
+	int nv_extra() const {return get<int>("nv_extra");}
+	int nv_step() const {return get<int>("nv_step");}
+	int nv_its() const {return get<int>("nv_its");}
 
 	int nmo_alpha() const {return get<int>("nmo_alpha");}
 	int nmo_beta() const {return get<int>("nmo_beta");}
@@ -316,6 +320,9 @@ struct CalculationParameters : public QCCalculationParametersBase {
 
         set_derived_value("nmo_alpha",nalpha() + nvalpha());
         set_derived_value("nmo_beta",nbeta() + nvbeta());
+
+        if (nv_extra() < 0 or nv_step() < 0 or nv_its() < 1) error("nv_extra, nv_step >= 0 and nv_its >= 1 required");
+        if (nv_extra() > 0 and nvalpha() == 0) error("nv_extra requires nvalpha > 0");
 
         // Unless overridden by the user use a cell big enough to
         // have exp(-sqrt(2*I)*r) decay to 1e-6 with I=1ev=0.037Eh

--- a/src/madness/chem/CalculationParameters.h
+++ b/src/madness/chem/CalculationParameters.h
@@ -156,6 +156,7 @@ struct CalculationParameters : public QCCalculationParametersBase {
 		initialize<int> ("nv_extra",0,"extra virtuals converged first and dropped stepwise down to nvalpha");
 		initialize<int> ("nv_step",0,"virtuals dropped per step-down stage (0: all extras at once)");
 		initialize<int> ("nv_its",5,"maximum iterations per intermediate step-down stage");
+		initialize<bool> ("freeze_occupied",false,"iterate only the virtuals in the mean field of restarted occupied orbitals, which stay fixed");
 		initialize<int> ("vnucextra",2,"load balance parameter for nuclear pot");
 		initialize<int> ("loadbalparts",2,"??");
 
@@ -204,6 +205,7 @@ struct CalculationParameters : public QCCalculationParametersBase {
 	int nv_extra() const {return get<int>("nv_extra");}
 	int nv_step() const {return get<int>("nv_step");}
 	int nv_its() const {return get<int>("nv_its");}
+	bool freeze_occupied() const {return get<bool>("freeze_occupied");}
 
 	int nmo_alpha() const {return get<int>("nmo_alpha");}
 	int nmo_beta() const {return get<int>("nmo_beta");}
@@ -327,6 +329,7 @@ struct CalculationParameters : public QCCalculationParametersBase {
 
         if (nv_extra() < 0 or nv_step() < 0 or nv_its() < 1) error("nv_extra, nv_step >= 0 and nv_its >= 1 required");
         if (nv_extra() > 0 and nvalpha() == 0) error("nv_extra requires nvalpha > 0");
+        if (freeze_occupied() and nvalpha() == 0 and nvbeta() == 0) error("freeze_occupied requires nvalpha or nvbeta > 0");
 
         // Explicit occupations address the occupied span. A hole there is only
         // index-stable with canonical orbitals: every iteration re-sorts them by

--- a/src/madness/chem/CalculationParameters.h
+++ b/src/madness/chem/CalculationParameters.h
@@ -396,14 +396,6 @@ struct CalculationParameters : public QCCalculationParametersBase {
     	}
 
 
-        // The nwchem guess replaces the internal minimal aobasis with the NWChem basis,
-        // so localizers that need the atomic-eigenfunction machinery (pm, new, new_sys)
-        // cannot run; boys, cholesky and canon work from the MOs alone.
-        if (nwfile() != "none") {
-             set_derived_value("localize",std::string("boys"));
-             if (localize_method() != "boys" and localize_method() != "cholesky" and localize_method() != "canon")
-                 error("NWchem initialization supports only localize boys, cholesky or canon");
-        }
 	}
 };
 

--- a/src/madness/chem/MolecularOrbitals.h
+++ b/src/madness/chem/MolecularOrbitals.h
@@ -298,14 +298,17 @@ public:
 	}
 
 	/// legacy code
-    void load_mos(archive::ParallelInputArchive<>& ar, const Molecule& molecule, const std::size_t nmo_from_input) {
+	/// @param[in]	allow_fewer	return the archive's orbitals when it holds fewer than requested
+	///							(the caller pads); otherwise that is an error
+    void load_mos(archive::ParallelInputArchive<>& ar, const Molecule& molecule, const std::size_t nmo_from_input,
+                  const bool allow_fewer = false) {
 
 		unsigned int nmo = 0;
 
 		ar & nmo;
 		// must hold in release builds too: too few orbitals in the archive
 		// otherwise silently yields a short mo vector further down
-		MADNESS_CHECK_THROW(nmo >= nmo_from_input,
+		MADNESS_CHECK_THROW(allow_fewer or nmo >= nmo_from_input,
 				"restart archive holds fewer orbitals than requested");
 		ar & eps & occ & localize_sets;
 		mo.resize(nmo);

--- a/src/madness/chem/RestartPlan.h
+++ b/src/madness/chem/RestartPlan.h
@@ -121,6 +121,9 @@ struct RestartSources {
     /// out loud rather than quietly recomputing.
     std::optional<RestartMetadata> meta;
 
+    /// alpha orbitals in the archive, 0 when unknown
+    std::size_t nmo_alpha = 0;
+
     /// <prefix>.restartaodata exists
     bool restartao_present = false;
 
@@ -197,6 +200,10 @@ struct RestartPlan {
     /// one line, for the log and for the results json
     std::string why;
 
+    /// alpha orbitals the archive holds when source is restartdata, 0 when unknown.
+    /// Fewer than requested means the missing virtuals start from the atomic guess.
+    std::size_t archive_nmo_alpha = 0;
+
     /// true if orbitals have to be read from disk before anything else happens
     bool needs_load() const { return source != RestartSource::initial_guess; }
 
@@ -213,7 +220,7 @@ struct RestartPlan {
     void serialize(Archive& ar) {
         int m = static_cast<int>(mode);
         int s = static_cast<int>(source);
-        ar & m & s & iterate & protocol_start & stale_energy & warn & why;
+        ar & m & s & iterate & protocol_start & stale_energy & warn & why & archive_nmo_alpha;
         mode = static_cast<RestartMode>(m);
         source = static_cast<RestartSource>(s);
     }
@@ -264,7 +271,8 @@ inline RestartPlan plan_restart(const RestartMode mode, const RestartSources& di
                                  const Representation wanted,
                                  const double eprec = 0.0,
                                  const std::string& xc = "",
-                                 const std::string& ncf = "") {
+                                 const std::string& ncf = "",
+                                 const std::size_t nmo_alpha = 0) {
 
     MADNESS_CHECK_THROW(not protocol.empty(), "empty protocol in plan_restart");
     const std::size_t last = protocol.size() - 1;
@@ -279,6 +287,11 @@ inline RestartPlan plan_restart(const RestartMode mode, const RestartSources& di
 
     RestartPlan plan;
     plan.mode = mode;
+    plan.archive_nmo_alpha = disk.nmo_alpha;
+
+    // an archive with fewer orbitals than requested (virtuals added on restart)
+    // is a guess for the missing ones, whatever its convergence claim says
+    const bool pads_virtuals = nmo_alpha > 0 and disk.nmo_alpha > 0 and disk.nmo_alpha < nmo_alpha;
 
     // does the archive solve the same Hamiltonian this run is asking about?
     //
@@ -385,6 +398,8 @@ inline RestartPlan plan_restart(const RestartMode mode, const RestartSources& di
             MADNESS_CHECK_THROW(
                     compare_geometry(meta.molecule, requested) == GeometryMatch::same,
                     "restart read_only: archive geometry does not match the requested geometry");
+            MADNESS_CHECK_THROW(not pads_virtuals,
+                    "restart read_only: the archive holds fewer orbitals than requested");
             // The user asserted these orbitals are the answer. Respect that even
             // when they are not converged to the requested precision -- warn and
             // hand back the stale energy rather than second-guessing.
@@ -499,6 +514,11 @@ inline RestartPlan plan_restart(const RestartMode mode, const RestartSources& di
         return continue_from_archive(meta, "restart auto: " + other +
                                            " -- a different Hamiltonian, so re-converging");
 
+    if (pads_virtuals)
+        return continue_from_archive(meta, "restart auto: archive holds " + std::to_string(disk.nmo_alpha) +
+                                           " alpha orbitals, " + std::to_string(nmo_alpha) +
+                                           " requested; the missing virtuals start from the atomic guess");
+
     if (meta.is_converged_to(target_thresh, target_dconv)) {
         plan.source = RestartSource::restartdata;
         plan.iterate = false;
@@ -536,7 +556,11 @@ inline RestartSources survey_restart_sources(World& world, const std::string& pr
     disk.restartdata_present = (flags[0] == 1);
     disk.restartao_present = (flags[1] == 1);
 
-    if (disk.restartdata_present) disk.meta = peek_restartdata(world, prefix + ".restartdata");
+    if (disk.restartdata_present) {
+        disk.meta = peek_restartdata(world, prefix + ".restartdata");
+        if (const auto summary = peek_restartdata_summary(world, prefix + ".restartdata"))
+            disk.nmo_alpha = summary->nmo_alpha;
+    }
     return disk;
 }
 
@@ -570,7 +594,7 @@ inline RestartPlan make_restart_plan(World& world, const RestartMode mode,
 
     RestartPlan plan = plan_restart(mode, disk, can, param.protocol(), param.dconv(),
                                     requested, wanted, requested.parameters.eprec(),
-                                    param.xc(), ncf);
+                                    param.xc(), ncf, std::size_t(param.nmo_alpha()));
     world.gop.broadcast_serializable(plan, 0);
 
     if (world.rank() == 0 and param.print_level() > 1) {

--- a/src/madness/chem/SCF.cc
+++ b/src/madness/chem/SCF.cc
@@ -2192,27 +2192,33 @@ void SCF::update_subspace(World& world, vecfuncT& Vpsia, vecfuncT& Vpsib,
                           double& bsh_residual, double& update_residual) {
     PROFILE_MEMBER_FUNC(SCF);
     double aerr = 0.0, berr = 0.0;
+
     vecfuncT vm = amo;
 
-    // Orbitals with occ!=1.0 exactly must be solved for as eigenfunctions
-    // so zero out off diagonal lagrange multipliers
+    // Decouple the occupied and non-occupied blocks: zero the Fock coupling
+    // between orbitals of different occupation, but KEEP the off-diagonal
+    // Lagrange terms inside each block. Occupieds converge in a localized
+    // (non-eigen) gauge precisely because those terms stay in the residual;
+    // a virtual needs the same treatment, or once it drifts into a mixture of
+    // eigenstates with different eigenvalues it has no BSH fixed point and
+    // its residual floors at the mixing scale.
     for (int i = 0; i < param.nmo_alpha(); i++) {
-        if (aocc[i] != 1.0) {
-            double tmp = focka(i, i);
-            focka(i, _) = 0.0;
-            focka(_, i) = 0.0;
-            focka(i, i) = tmp;
+        for (int j = 0; j < i; j++) {
+            if ((aocc[i] == 1.0) != (aocc[j] == 1.0)) {
+                focka(i, j) = 0.0;
+                focka(j, i) = 0.0;
+            }
         }
     }
 
     vecfuncT rm = compute_residual(world, aocc, focka, amo, Vpsia, aerr);
     if (param.nbeta() != 0 && !param.spin_restricted()) {
         for (int i = 0; i < param.nmo_beta(); i++) {
-            if (bocc[i] != 1.0) {
-                double tmp = fockb(i, i);
-                fockb(i, _) = 0.0;
-                fockb(_, i) = 0.0;
-                fockb(i, i) = tmp;
+            for (int j = 0; j < i; j++) {
+                if ((bocc[i] == 1.0) != (bocc[j] == 1.0)) {
+                    fockb(i, j) = 0.0;
+                    fockb(j, i) = 0.0;
+                }
             }
         }
 

--- a/src/madness/chem/SCF.cc
+++ b/src/madness/chem/SCF.cc
@@ -1451,7 +1451,13 @@ vecfuncT SCF::apply_potential(World& world, const tensorT& occ,
         Exchange<double, 3> K(world, this, ispin);
 
         K.set_algorithm(Exchange<double,3>::string2algorithm(param.hfexalg()));
-        K.set_symmetric(true).set_printlevel(param.print_level());
+        // symmetric requires bra == ket == argument; with virtuals present
+        // (nvalpha/nvbeta > 0) the argument vector is longer than K's occupied
+        // bra/ket and the symmetric pair batching must not be used.
+        long nocc_in_k = 0;
+        for (long i = 0; i < occ.size(); ++i)
+            if (occ(i) > 0.0) ++nocc_in_k;
+        K.set_symmetric(size_t(nocc_in_k) == amo.size()).set_printlevel(param.print_level());
         K.set_macro_task_info(MacroTaskInfo::preset("default"));
         K.set_macro_task_info(param.memory());
         K.set_batch_granularity(param.hfex_granularity());

--- a/src/madness/chem/SCF.cc
+++ b/src/madness/chem/SCF.cc
@@ -1287,6 +1287,10 @@ void SCF::initial_guess(World& world) {
         ncore = molecule.n_core_orb_all();
     }
 
+    // The constructor checked the basis size against the input nmo; the virtual
+    // step-down may have raised nmo since.
+    MADNESS_CHECK_THROW(size_t(ncore + std::max(param.nmo_alpha(), param.nmo_beta())) <= ao.size(),
+                        "too few AO basis functions for the requested number of orbitals");
     amo = transform(world, ao, c(_, Slice(ncore, ncore + param.nmo_alpha() - 1)), vtol, true);
     truncate(world, amo);
     normalize(world, amo);

--- a/src/madness/chem/SCF.cc
+++ b/src/madness/chem/SCF.cc
@@ -1350,6 +1350,22 @@ std::vector<int> SCF::group_orbital_sets(World& world, const tensorT& eps,
 }
 
 
+void SCF::apply_explicit_occupations(World& world) {
+    auto apply = [&](tensorT& occ, const std::vector<double>& input, const char* label) {
+        if (input.empty()) return;
+        MADNESS_CHECK_THROW(long(input.size()) <= occ.size(), "explicit occupations exceed the number of orbitals");
+        for (size_t i = 0; i < input.size(); ++i) occ[i] = input[i];
+        if (world.rank() == 0 && param.print_level() > 1) {
+            printf("  explicit %s occupations:", label);
+            for (long i = 0; i < occ.size(); ++i) printf(" %.0f", occ[i]);
+            printf("\n");
+        }
+    };
+    apply(aocc, param.aocc(), "alpha");
+    if (param.have_beta()) apply(bocc, param.bocc(), "beta");
+}
+
+
 void SCF::initial_load_bal(World& world) {
     PROFILE_MEMBER_FUNC(SCF);
     LoadBalanceDeux<3> lb(world);
@@ -2525,6 +2541,10 @@ void SCF::solve(World& world) {
     tensorT Q;
     bool do_this_iter = true;
     bool converged = false;
+
+    // Every orbital source (guess, restart, NWChem, the virtual step-down) rebuilds
+    // aocc/bocc as 1 below nalpha/nbeta and 0 above; the input list overrides that here.
+    apply_explicit_occupations(world);
 
     // Shrink subspace until stop localizing/canonicalizing--- probably not a good idea
     // int maxsub_save = param.maxsub;

--- a/src/madness/chem/SCF.cc
+++ b/src/madness/chem/SCF.cc
@@ -2504,7 +2504,15 @@ void SCF::solve(World& world) {
             localizer.set_method(param.localize_method());
             double t_matrix = 0.0, t_transform = 0.0;
             {
-                MolecularOrbitals<double, 3> mo(amo, aeps, {}, aocc, aset);
+                // Localize the occupied orbitals only. Virtuals (nvalpha > 0) must not
+                // enter: a set spanning the occupation boundary licenses
+                // determinant-changing rotations, and even fenced virtuals are wanted
+                // canonical for eigenvalue analysis, not gauge-churned every iteration.
+                const size_t nocc = param.nalpha();
+                vecfuncT amo_occ(amo.begin(), amo.begin() + nocc);
+                MolecularOrbitals<double, 3> mo(amo_occ, copy(aeps(Slice(0, long(nocc) - 1))), {},
+                                                copy(aocc(Slice(0, long(nocc) - 1))),
+                                                std::vector<int>(aset.begin(), aset.begin() + nocc));
                 localizer.set_pivot_state(&localize_pivot_state_a);
                 const double t_loc0 = wall_time();
                 tensorT UT = localizer.compute_localization_matrix(world, mo, iter == 0);
@@ -2512,7 +2520,8 @@ void SCF::solve(World& world) {
                 const double offdiag = max_offdiag(UT);
                 if (offdiag > localize_skip_tol) {
                     UT.screen(trantol);
-                    rotate_orbitals(amo, UT);
+                    rotate_orbitals(amo_occ, UT);
+                    for (size_t i = 0; i < nocc; ++i) amo[i] = amo_occ[i];
                 } else if (world.rank() == 0 && param.print_level() >= 3) {
                     printf("  localize: rotation skipped (max offdiag %.1e)\n", offdiag);
                 }
@@ -2520,14 +2529,19 @@ void SCF::solve(World& world) {
                 t_transform += wall_time() - t_loc1;
             }
             if (!param.spin_restricted() && param.nbeta() != 0) {
-                MolecularOrbitals<double, 3> mo(bmo, beps, {}, bocc, bset);
+                const size_t noccb = param.nbeta();
+                vecfuncT bmo_occ(bmo.begin(), bmo.begin() + noccb);
+                MolecularOrbitals<double, 3> mo(bmo_occ, copy(beps(Slice(0, long(noccb) - 1))), {},
+                                                copy(bocc(Slice(0, long(noccb) - 1))),
+                                                std::vector<int>(bset.begin(), bset.begin() + noccb));
                 localizer.set_pivot_state(&localize_pivot_state_b);
                 const double t_loc0 = wall_time();
                 tensorT UT = localizer.compute_localization_matrix(world, mo, iter == 0);
                 const double t_loc1 = wall_time();
                 if (max_offdiag(UT) > localize_skip_tol) {
                     UT.screen(trantol);
-                    rotate_orbitals(bmo, UT);
+                    rotate_orbitals(bmo_occ, UT);
+                    for (size_t i = 0; i < noccb; ++i) bmo[i] = bmo_occ[i];
                 }
                 t_matrix += t_loc1 - t_loc0;
                 t_transform += wall_time() - t_loc1;

--- a/src/madness/chem/SCF.cc
+++ b/src/madness/chem/SCF.cc
@@ -968,31 +968,37 @@ void SCF::initial_guess_from_nwchem(World& world) {
     make_nuclear_potential(world);
     real_function_3d vnuc = potentialmanager->vnuclear();
 
-    // Pull out occupation numbers
-    // NWChem orders occupied orbitals to be first
-    aocc = tensorT(param.nalpha());
-    for (int i = 0; i < param.nalpha(); i++) {
-        // NWChem stores closed shell calculations
-        // as the alpha orbital set with occupation 2.
-        // Verifying no fractional occupations.
-        MADNESS_ASSERT(nwchem.occupancies[i] == 2.0 or nwchem.occupancies[i] == 1.0);
-
-        // Madness instead stores 2 identical sets
-        // (alpha and beta) with occupation 1
-        aocc[i] = 1.0;
+    // Pull out occupation numbers. NWChem orders occupied orbitals first, so
+    // the first nmo_alpha MOs are the occupieds followed by the lowest virtuals.
+    MADNESS_CHECK_THROW(nwchem.occupancies.size() >= size_t(param.nmo_alpha()) and
+                        nwchem.energies.size() >= size_t(param.nmo_alpha()),
+                        "NWChem file holds fewer alpha MOs than requested (nalpha + nvalpha)");
+    aocc = tensorT(param.nmo_alpha());
+    for (int i = 0; i < param.nmo_alpha(); i++) {
+        // NWChem stores closed shell calculations as the alpha orbital set with
+        // occupation 2; MADNESS stores two identical sets with occupation 1.
+        // No fractional occupations, and nothing occupied beyond nalpha.
+        if (i < param.nalpha()) {
+            MADNESS_CHECK_THROW(nwchem.occupancies[i] == 2.0 or nwchem.occupancies[i] == 1.0,
+                                "NWChem alpha occupation is neither 1 nor 2 within nalpha");
+            aocc[i] = 1.0;
+        } else {
+            MADNESS_CHECK_THROW(nwchem.occupancies[i] == 0.0,
+                                "NWChem alpha orbital beyond nalpha is occupied");
+        }
     }
 
     // Pull out energies
-    aeps = tensorT(param.nalpha());
-    for (int i = 0; i < param.nalpha(); i++) {
+    aeps = tensorT(param.nmo_alpha());
+    for (int i = 0; i < param.nmo_alpha(); i++) {
         aeps[i] = nwchem.energies[i];
     }
 
     // Create the orbitals as madness functions
     // Just create the vector of atomic orbitals
     // and use the vector of MO coefficients and
-    // the transform function, then take only
-    // the occupied orbitals.
+    // the transform function, then take the first
+    // nmo_alpha orbitals.
     if (world.rank() == 0 && param.print_level() > 3)
         print("\nCreating MADNESS functions from the NWChem orbitals.");
 
@@ -1020,13 +1026,14 @@ void SCF::initial_guess_from_nwchem(World& world) {
     // Transform ao's now
     vector_real_function_3d temp = transform(world, temp1, nwchem.MOs, vtol, true);
 
-    // Now save all aos and only the occupied amo
+    // Now save all aos and the first nmo_alpha amo
+    MADNESS_CHECK_THROW(temp.size() >= size_t(param.nmo_alpha()),
+                        "NWChem file holds fewer alpha MOs than requested (nalpha + nvalpha)");
     for (unsigned int i = 0; i < temp1.size(); i++) {
         // Save all AOs
         ao.push_back(copy(temp1[i]));
 
-        // Only save occupied AMOs
-        if (nwchem.occupancies[i] > 0) {
+        if (i < unsigned(param.nmo_alpha())) {
             amo.push_back(copy(temp[i]));
         }
     }
@@ -1041,28 +1048,36 @@ void SCF::initial_guess_from_nwchem(World& world) {
     // Now for betas
     if (param.nbeta() && !param.spin_restricted()) {
 
-        // Pull out occupation numbers
-        // NWChem orders occupied orbitals to be first
-        bocc = tensorT(param.nbeta());
-        for (int i = 0; i < param.nbeta(); i++) {
-            MADNESS_ASSERT(nwchem.beta_occupancies[i] == 1.0);
-            bocc[i] = 1.0;
+        // Pull out occupation numbers, as for alpha
+        MADNESS_CHECK_THROW(nwchem.beta_occupancies.size() >= size_t(param.nmo_beta()) and
+                            nwchem.beta_energies.size() >= size_t(param.nmo_beta()),
+                            "NWChem file holds fewer beta MOs than requested (nbeta + nvbeta)");
+        bocc = tensorT(param.nmo_beta());
+        for (int i = 0; i < param.nmo_beta(); i++) {
+            if (i < param.nbeta()) {
+                MADNESS_CHECK_THROW(nwchem.beta_occupancies[i] == 1.0,
+                                    "NWChem beta occupation is not 1 within nbeta");
+                bocc[i] = 1.0;
+            } else {
+                MADNESS_CHECK_THROW(nwchem.beta_occupancies[i] == 0.0,
+                                    "NWChem beta orbital beyond nbeta is occupied");
+            }
         }
 
         // Pull out energies
-        beps = tensorT(param.nbeta());
-        for (int i = 0; i < param.nbeta(); i++) {
+        beps = tensorT(param.nmo_beta());
+        for (int i = 0; i < param.nmo_beta(); i++) {
             beps[i] = nwchem.beta_energies[i];
         }
 
         // Transform ao's now
         temp = transform(world, temp1, nwchem.beta_MOs, vtol, true);
 
-        // Now only take the occupied bmo
-        for (unsigned int i = 0; i < temp1.size(); i++) {
-            if (nwchem.beta_occupancies[i] > 0) {
-                bmo.push_back(copy(temp[i]));
-            }
+        // Now take the first nmo_beta bmo
+        MADNESS_CHECK_THROW(temp.size() >= size_t(param.nmo_beta()),
+                            "NWChem file holds fewer beta MOs than requested (nbeta + nvbeta)");
+        for (unsigned int i = 0; i < std::min(temp1.size(), size_t(param.nmo_beta())); i++) {
+            bmo.push_back(copy(temp[i]));
         }
 
         // Clean up

--- a/src/madness/chem/SCF.cc
+++ b/src/madness/chem/SCF.cc
@@ -2118,6 +2118,73 @@ tensorT SCF::diag_fock_matrix(World& world, tensorT& fock, vecfuncT& psi,
     return U;
 }
 
+bool SCF::canonicalize_virtuals(World& world, tensorT& fock, vecfuncT& psi,
+                                vecfuncT& Vpsi, const int nocc) const {
+    PROFILE_MEMBER_FUNC(SCF);
+    const int nmo = psi.size();
+    const int nv = nmo - nocc;
+    if (nv <= 0) return false;
+
+    const Slice v(nocc, nmo - 1);
+    vecfuncT vmo(psi.begin() + nocc, psi.end());
+    tensorT F_vv = copy(fock(v, v));
+    tensorT S_vv = matrix_inner(world, vmo, vmo, true);
+
+    tensorT U, evals;
+    sygvp(world, F_vv, S_vv, 1, U, evals);
+    world.gop.broadcast(U.ptr(), U.size(), 0);
+    world.gop.broadcast(evals.ptr(), evals.size(), 0);
+
+    // Fix each column's sign (largest element positive): sygvp's signs are
+    // arbitrary, and a sign-flipped virtual is inconsistent with the KAIN history.
+    for (int k = 0; k < nv; ++k) {
+        int imax = 0;
+        for (int i = 1; i < nv; ++i)
+            if (std::abs(U(i, k)) > std::abs(U(imax, k))) imax = i;
+        if (U(imax, k) < 0.0)
+            for (int i = 0; i < nv; ++i) U(i, k) = -U(i, k);
+    }
+
+    // A near-identity rotation would only churn the KAIN history; the residual
+    // off-diagonal F_vv is carried as Lagrange coupling in the residual, as for
+    // the localized occupieds.
+    double offdiag = 0.0;
+    for (int i = 0; i < nv; ++i)
+        for (int j = 0; j < nv; ++j)
+            if (i != j) offdiag = std::max(offdiag, std::abs(U(i, j)));
+    if (offdiag <= 0.01) {
+        if (world.rank() == 0 && param.print_level() >= 3)
+            printf("  canonicalize virtuals: skipped (max offdiag %.1e)\n", offdiag);
+        return false;
+    }
+    if (world.rank() == 0 && param.print_level() >= 3)
+        printf("  canonicalize virtuals: rotated (max offdiag %.1e)\n", offdiag);
+
+    // Rotating Vpsi with the same U is exact only because the exchange operator
+    // sums over occupied orbitals: a rotation within the virtual space leaves it
+    // unchanged.
+    vecfuncT vVpsi(Vpsi.begin() + nocc, Vpsi.end());
+    const double scale = std::min(30.0, double(nmo));
+    vVpsi = transform(world, vVpsi, U, vtol / scale, false);
+    vmo = transform(world, vmo, U, FunctionDefaults<3>::get_thresh() / scale, true);
+    truncate(world, vVpsi, vtol, false);
+    truncate(world, vmo);
+    normalize(world, vmo);
+    for (int k = 0; k < nv; ++k) {
+        psi[nocc + k] = vmo[k];
+        Vpsi[nocc + k] = vVpsi[k];
+    }
+
+    // Only the block diagonal is written: the occupied-virtual coupling is
+    // zeroed by the caller's occupation-block decoupling, and the whole matrix
+    // is rebuilt next iteration.
+    for (int i = 0; i < nv; ++i)
+        for (int j = 0; j < nv; ++j)
+            fock(nocc + i, nocc + j) = (i == j) ? evals(i) : 0.0;
+
+    return true;
+}
+
 void SCF::loadbal(World& world, functionT& arho, functionT& brho,
                   functionT& arho_old, functionT& brho_old, subspaceT& subspace) {
     if (world.size() == 1)
@@ -2192,6 +2259,14 @@ void SCF::update_subspace(World& world, vecfuncT& Vpsia, vecfuncT& Vpsib,
                           double& bsh_residual, double& update_residual) {
     PROFILE_MEMBER_FUNC(SCF);
     double aerr = 0.0, berr = 0.0;
+
+    // Canonicalize the virtuals before the KAIN snapshot below, so the stored
+    // orbitals and their residual share one gauge.
+    if (param.do_localize()) {
+        canonicalize_virtuals(world, focka, amo, Vpsia, param.nalpha());
+        if (param.nbeta() != 0 && !param.spin_restricted())
+            canonicalize_virtuals(world, fockb, bmo, Vpsib, param.nbeta());
+    }
 
     vecfuncT vm = amo;
 

--- a/src/madness/chem/SCF.cc
+++ b/src/madness/chem/SCF.cc
@@ -445,8 +445,9 @@ void SCF::load_mos(World& world) {
     }
 
     // virtuals the archive lacks start from the atomic guess, so the stored
-    // convergence claim no longer describes what we hold
-    if (pad_virtuals_from_guess(world)) needs_redo = true;
+    // convergence claim no longer describes what we hold; the energy still does,
+    // it belongs to the occupied orbitals alone
+    const bool padded = pad_virtuals_from_guess(world);
 
     // if everything worked out, set convergence parameters
     if (needs_redo) {
@@ -456,8 +457,8 @@ void SCF::load_mos(World& world) {
         converged_for_dconv=1.e10;
         current_energy=1.e10;
     } else {
-        converged_for_thresh= meta.converged_for_thresh;
-        converged_for_dconv= meta.converged_for_dconv;
+        converged_for_thresh= padded ? 1.e10 : meta.converged_for_thresh;
+        converged_for_dconv= padded ? 1.e10 : meta.converged_for_dconv;
         current_energy=meta.current_energy;
     }
     // NB: the requested geometry wins. Restarting must never silently move the
@@ -2343,6 +2344,192 @@ void SCF::rotate_subspace(World& world, const distmatT& dUT, subspaceT& subspace
     world.gop.fence();
 }
 
+void SCF::solve_virtuals(World& world) {
+    PROFILE_MEMBER_FUNC(SCF);
+    const double dconv = std::max(FunctionDefaults<3>::get_thresh(), param.dconv());
+    const int nocca = param.nalpha(), noccb = param.nbeta();
+    const int nva = int(amo.size()) - nocca;
+    const int nvb = param.have_beta() ? int(bmo.size()) - noccb : 0;
+    MADNESS_CHECK_THROW(nva >= 0 and nvb >= 0, "freeze_occupied: fewer orbitals than occupied");
+    MADNESS_CHECK_THROW(nva > 0 or nvb > 0, "freeze_occupied: no virtuals to iterate");
+    if (world.rank() == 0 and param.print_level() > 1)
+        printf("\nfreeze_occupied: iterating %d alpha and %d beta virtuals in the fixed mean field\n", nva, nvb);
+
+    // Nuclear and Coulomb potentials of the occupied density, once. XC and
+    // exchange are added per call by apply_potential, which takes the occupied
+    // orbitals from this object rather than from its argument.
+    START_TIMER(world);
+    functionT arho = make_density(world, aocc, amo), brho;
+    if (param.nbeta()) brho = param.spin_restricted() ? arho : make_density(world, bocc, bmo);
+    else brho = functionT(world);
+    functionT rho = arho + brho;
+    rho.truncate();
+    real_function_3d vnuc;
+    if (molecule.parameters.psp_calc()) {
+        vnuc = gthpseudopotential->vlocalpot();
+    } else if (molecule.parameters.pure_ae()) {
+        vnuc = potentialmanager->vnuclear();
+    } else {
+        vnuc = potentialmanager->vnuclear() + gthpseudopotential->vlocalpot();
+    }
+    functionT vcoul = apply(*coulop, rho);
+    functionT vlocal = vcoul + vnuc;
+    if (param.pcm_data() != "none") vlocal += pcm.compute_pcm_potential(vcoul);
+    vcoul.clear(false);
+    rho.clear(false);
+    vlocal.truncate();
+    END_TIMER(world, "frozen potential");
+
+    bool converged_all = true;
+    auto iterate_block = [&](vecfuncT& mo, tensorT& eps, const int nocc, const int nv,
+                             const int ispin, const char* spin) {
+        if (nv <= 0) return;
+        subspaceT subspace;
+        tensorT Q;
+        tensorT occ_v(nv);   // spectators: zero occupation
+        bool converged = false;
+        for (int iter = 0; iter < param.maxiter(); ++iter) {
+            vecfuncT vmo(mo.begin() + nocc, mo.end());
+            double exc = 0.0, enl = 0.0, ekin = 0.0, err = 0.0;
+            vecfuncT Vv = apply_potential(world, occ_v, vmo, vlocal, exc, enl, ispin);
+            tensorT fock = make_fock_matrix(world, vmo, Vv, occ_v, ekin);
+            canonicalize_virtuals(world, fock, vmo, Vv, 0);
+            for (int i = 0; i < nv; ++i) {
+                mo[nocc + i] = vmo[i];
+                eps[nocc + i] = fock(i, i);
+            }
+            vecfuncT rv = compute_residual(world, occ_v, fock, vmo, Vv, err);
+            world.gop.broadcast(err, 0);
+            if (world.rank() == 0 and param.print_level() > 1)
+                printf("  %s virtuals iteration %d: max residual %.2e\n", spin, iter, err);
+            if (err < 5.0 * dconv) {
+                converged = true;
+                break;
+            }
+            compress(world, vmo, false);
+            compress(world, rv, false);
+            world.gop.fence();
+            const tensorT c = kain_solve(world, vmo, rv, subspace, Q);
+            vecfuncT vnew = kain_combine(world, subspace, c, 0, nv);
+            kain_trim(subspace, Q);
+            do_step_restriction(world, vmo, vnew, spin);
+            // orthogonal to the fixed occupieds, which orthonormalize(nocc) leaves untouched
+            vecfuncT all(mo.begin(), mo.begin() + nocc);
+            all.insert(all.end(), vnew.begin(), vnew.end());
+            orthonormalize(world, all, nocc);
+            for (int i = 0; i < nv; ++i) mo[nocc + i] = all[nocc + i];
+        }
+        converged_all = converged_all and converged;
+    };
+    iterate_block(amo, aeps, nocca, nva, 0, "alpha");
+    if (param.have_beta()) iterate_block(bmo, beps, noccb, nvb, 1, "beta");
+    else if (param.nbeta() > 0) bmo = amo;
+
+    if (converged_all) {
+        converged_for_thresh = FunctionDefaults<3>::get_thresh();
+        converged_for_dconv = dconv;
+    }
+    if (world.rank() == 0 and param.print_level() > 1) {
+        if (converged_all) print("\nConverged!\n");
+        // the occupied entries of aeps/beps are the archive's, in its gauge
+        if (nva > 0) {
+            print("alpha virtual eigenvalues");
+            print(aeps(Slice(nocca, -1)));
+        }
+        if (nvb > 0) {
+            print("beta virtual eigenvalues");
+            print(beps(Slice(noccb, -1)));
+        }
+        if (current_energy < 1.e9) printf("\ntotal energy of the occupied orbitals (from the archive) %20.12f\n", current_energy);
+    }
+}
+
+
+tensorT SCF::kain_solve(World& world, const vecfuncT& vm, const vecfuncT& rm,
+                        subspaceT& subspace, tensorT& Q) const {
+    PROFILE_MEMBER_FUNC(SCF);
+    START_TIMER(world);
+    tensorT c;
+    while (true) {
+        subspace.push_back(pairvecfuncT(vm, rm));
+        const int m = subspace.size();
+        tensorT ms(m);
+        tensorT sm(m);
+        for (int s = 0; s < m; ++s) {
+            const vecfuncT& vs = subspace[s].first;
+            const vecfuncT& rs = subspace[s].second;
+            for (unsigned int i = 0; i < vm.size(); ++i) {
+                ms[s] += vm[i].inner_local(rs[i]);
+                sm[s] += vs[i].inner_local(rm[i]);
+            }
+        }
+        world.gop.sum(ms.ptr(), m);
+        world.gop.sum(sm.ptr(), m);
+        tensorT newQ(m, m);
+        if (m > 1)
+            newQ(Slice(0, -2), Slice(0, -2)) = Q;
+        newQ(m - 1, _) = ms;
+        newQ(_, m - 1) = sm;
+        Q = newQ;
+
+        double rcond = 1e-12;
+        bool restart = false;
+        while (true) {
+            c = KAIN(Q, rcond);
+            if (world.rank() == 0 and (param.print_level() > 3)) print("kain c:", c);
+            if (c.absmax() < 3.0) {
+                break;
+            } else if (rcond < 0.01) {
+                if (world.rank() == 0 and (param.print_level() > 3))
+                    print("Increasing subspace singular value threshold ", c[m - 1], rcond);
+                rcond *= 100;
+            } else {
+                if (world.rank() == 0 and (param.print_level() > 3)) print("Restarting KAIN due to subspace malfunction");
+                Q = tensorT();
+                subspace.clear();
+                restart = true;
+                break;
+            }
+        }
+        if (not restart) break;
+    }
+    END_TIMER(world, "Update subspace stuff");
+    world.gop.broadcast_serializable(c, 0); // make sure everyone has same data
+    if (world.rank() == 0 and (param.print_level() > 3)) {
+        print("Subspace solution", c);
+    }
+    return c;
+}
+
+
+vecfuncT SCF::kain_combine(World& world, const subspaceT& subspace, const tensorT& c,
+                           const size_t lo, const size_t n) const {
+    PROFILE_MEMBER_FUNC(SCF);
+    vecfuncT mo_new = zero_functions_compressed<double, 3>(world, n, false);
+    world.gop.fence();
+    for (size_t m = 0; m < subspace.size(); ++m) {
+        const vecfuncT& vm = subspace[m].first;
+        const vecfuncT& rm = subspace[m].second;
+        const vecfuncT vms(vm.begin() + lo, vm.begin() + lo + n);
+        const vecfuncT rms(rm.begin() + lo, rm.begin() + lo + n);
+        gaxpy(world, 1.0, mo_new, c(m), vms, false);
+        gaxpy(world, 1.0, mo_new, -c(m), rms, false);
+    }
+    world.gop.fence();
+    return mo_new;
+}
+
+
+void SCF::kain_trim(subspaceT& subspace, tensorT& Q) const {
+    if (param.maxsub() <= 1) {
+        subspace.clear();
+    } else if (subspace.size() == size_t(param.maxsub())) {
+        subspace.erase(subspace.begin());
+        Q = Q(Slice(1, -1), Slice(1, -1));
+    }
+}
+
+
 void SCF::update_subspace(World& world, vecfuncT& Vpsia, vecfuncT& Vpsib,
                           tensorT& focka, tensorT& fockb, subspaceT& subspace, tensorT& Q,
                           double& bsh_residual, double& update_residual) {
@@ -2397,86 +2584,16 @@ void SCF::update_subspace(World& world, vecfuncT& Vpsia, vecfuncT& Vpsib,
     compress(world, vm, false);
     compress(world, rm, false);
     world.gop.fence();
+    END_TIMER(world, "Update subspace compress");
 
-    restart:
-    subspace.push_back(pairvecfuncT(vm, rm));
-    int m = subspace.size();
-    tensorT ms(m);
-    tensorT sm(m);
-    for (int s = 0; s < m; ++s) {
-        const vecfuncT& vs = subspace[s].first;
-        const vecfuncT& rs = subspace[s].second;
-        for (unsigned int i = 0; i < vm.size(); ++i) {
-            ms[s] += vm[i].inner_local(rs[i]);
-            sm[s] += vs[i].inner_local(rm[i]);
-        }
-    }
+    const tensorT c = kain_solve(world, vm, rm, subspace, Q);
 
-    world.gop.sum(ms.ptr(), m);
-    world.gop.sum(sm.ptr(), m);
-    tensorT newQ(m, m);
-    if (m > 1)
-        newQ(Slice(0, -2), Slice(0, -2)) = Q;
-
-    newQ(m - 1, _) = ms;
-    newQ(_, m - 1) = sm;
-    Q = newQ;
-    //if (world.rank() == 0) { print("kain Q"); print(Q); }
-    tensorT c;
-    //if (world.rank() == 0) {
-    double rcond = 1e-12;
-    while (1) {
-        c = KAIN(Q, rcond);
-        if (world.rank() == 0 and (param.print_level() > 3)) print("kain c:", c);
-        //if (std::abs(c[m - 1]) < 5.0) { // was 3
-        if (c.absmax() < 3.0) { // was 3
-            break;
-        } else if (rcond < 0.01) {
-            if (world.rank() == 0 and (param.print_level() > 3))
-                print("Increasing subspace singular value threshold ", c[m - 1], rcond);
-            rcond *= 100;
-        } else {
-            //print("Forcing full step due to subspace malfunction");
-            // c = 0.0;
-            // c[m - 1] = 1.0;
-            // break;
-            if (world.rank() == 0 and (param.print_level() > 3)) print("Restarting KAIN due to subspace malfunction");
-            Q = tensorT();
-            subspace.clear();
-            goto restart; // fortran hat on ...
-        }
-    }
-    //}
-    END_TIMER(world, "Update subspace stuff");
-
-    world.gop.broadcast_serializable(c, 0); // make sure everyone has same data
-    if (world.rank() == 0 and (param.print_level() > 3)) {
-        print("Subspace solution", c);
-    }
     START_TIMER(world);
-    vecfuncT amo_new = zero_functions_compressed<double, 3>(world, amo.size(), false);
-    vecfuncT bmo_new = zero_functions_compressed<double, 3>(world, bmo.size(), false);
-    world.gop.fence();
-    for (unsigned int m = 0; m < subspace.size(); ++m) {
-        const vecfuncT& vm = subspace[m].first;
-        const vecfuncT& rm = subspace[m].second;
-        const vecfuncT vma(vm.begin(), vm.begin() + amo.size());
-        const vecfuncT rma(rm.begin(), rm.begin() + amo.size());
-        const vecfuncT vmb(vm.end() - bmo.size(), vm.end());
-        const vecfuncT rmb(rm.end() - bmo.size(), rm.end());
-        gaxpy(world, 1.0, amo_new, c(m), vma, false);
-        gaxpy(world, 1.0, amo_new, -c(m), rma, false);
-        gaxpy(world, 1.0, bmo_new, c(m), vmb, false);
-        gaxpy(world, 1.0, bmo_new, -c(m), rmb, false);
-    }
-    world.gop.fence();
+    vecfuncT amo_new = kain_combine(world, subspace, c, 0, amo.size());
+    vecfuncT bmo_new;   // in a spin-restricted run bmo mirrors amo and is not in the subspace
+    if (param.have_beta()) bmo_new = kain_combine(world, subspace, c, amo.size(), bmo.size());
     END_TIMER(world, "Subspace transform");
-    if (param.maxsub() <= 1) {
-        subspace.clear();
-    } else if (subspace.size() == size_t(param.maxsub())) {
-        subspace.erase(subspace.begin());
-        Q = Q(Slice(1, -1), Slice(1, -1));
-    }
+    kain_trim(subspace, Q);
 
     do_step_restriction(world, amo, amo_new, "alpha");
     orthonormalize(world, amo_new, param.nalpha());

--- a/src/madness/chem/SCF.cc
+++ b/src/madness/chem/SCF.cc
@@ -422,7 +422,7 @@ void SCF::load_mos(World& world) {
 
     // load orbitals
     MolecularOrbitals<double,3> amos, bmos;
-    amos.load_mos(ar, molecule, param.nmo_alpha());
+    amos.load_mos(ar, molecule, param.nmo_alpha(), true);
     amo= amos.get_mos();
     aocc=amos.get_occ();
     aeps=amos.get_eps();
@@ -435,7 +435,7 @@ void SCF::load_mos(World& world) {
     check_and_set_thresh(amo);
 
     if (param.have_beta()) {
-        bmos.load_mos(ar, molecule, param.nmo_beta());
+        bmos.load_mos(ar, molecule, param.nmo_beta(), true);
         bmo= bmos.get_mos();
         bocc=bmos.get_occ();
         beps=bmos.get_eps();
@@ -443,6 +443,10 @@ void SCF::load_mos(World& world) {
         check_and_project_k(bmo);
         check_and_set_thresh(bmo);
     }
+
+    // virtuals the archive lacks start from the atomic guess, so the stored
+    // convergence claim no longer describes what we hold
+    if (pad_virtuals_from_guess(world)) needs_redo = true;
 
     // if everything worked out, set convergence parameters
     if (needs_redo) {
@@ -1075,7 +1079,7 @@ void SCF::initial_guess_from_nwchem(World& world) {
 }
 
 
-void SCF::initial_guess(World& world) {
+void SCF::initial_guess_ao_eigenvectors(World& world, tensorT& c, tensorT& e) {
     PROFILE_MEMBER_FUNC(SCF);
     START_TIMER(world);
     // No guard on `restart` any more: reaching the atomic guess is a legitimate
@@ -1248,7 +1252,6 @@ void SCF::initial_guess(World& world) {
     vpsi.clear();
     tensorT fock = kinetic + potential;
     fock = 0.5 * (fock + transpose(fock));
-    tensorT c, e;
 
     //debug printing
     /*double ep = 0.0;
@@ -1278,6 +1281,14 @@ void SCF::initial_guess(World& world) {
     //   print("\n\nWSTHORNTON: initial eigenvectors");
     //   print(c);
     // }
+
+}
+
+
+void SCF::initial_guess(World& world) {
+    PROFILE_MEMBER_FUNC(SCF);
+    tensorT c, e;
+    initial_guess_ao_eigenvectors(world, c, e);
 
     START_TIMER(world);
     compress(world, ao);
@@ -1318,6 +1329,49 @@ void SCF::initial_guess(World& world) {
     }
     END_TIMER(world, "guess orbital grouping");
 }
+
+bool SCF::pad_virtuals_from_guess(World& world) {
+    PROFILE_MEMBER_FUNC(SCF);
+    const size_t na = amo.size(), nb = bmo.size();
+    const bool pad_a = na < size_t(param.nmo_alpha());
+    const bool pad_b = param.have_beta() && nb < size_t(param.nmo_beta());
+    if (!pad_a && !pad_b) return false;
+    MADNESS_CHECK_THROW(na >= size_t(param.nalpha()) && (!param.have_beta() || nb >= size_t(param.nbeta())),
+                        "restart archive holds fewer orbitals than are occupied");
+    if (world.rank() == 0 && param.print_level() > 1)
+        printf("padding %ld alpha and %ld beta virtuals from the atomic guess\n",
+               pad_a ? long(param.nmo_alpha() - na) : 0L, pad_b ? long(param.nmo_beta() - nb) : 0L);
+
+    reset_aobasis(param.aobasis());
+    ao = project_ao_basis(world, aobasis);
+    make_nuclear_potential(world);
+    tensorT c, e;
+    initial_guess_ao_eigenvectors(world, c, e);
+    const size_t ncore = (molecule.parameters.core_type() != "none") ? molecule.n_core_orb_all() : 0;
+
+    // Append the guess eigenvectors above the loaded block and orthogonalize them
+    // against the loaded orbitals, which orthonormalize(nocc) leaves untouched.
+    auto pad = [&](vecfuncT& mo, tensorT& eps, tensorT& occ, std::vector<int>& set, const size_t nmo) {
+        const size_t nload = mo.size();
+        if (nload >= nmo) return;
+        MADNESS_CHECK_THROW(ncore + nmo <= ao.size(), "too few AO basis functions for the requested number of orbitals");
+        MADNESS_CHECK_THROW(size_t(eps.size()) >= nload && size_t(occ.size()) >= nload, "restart archive eps/occ shorter than its orbitals");
+        vecfuncT guess = transform(world, ao, c(_, Slice(ncore + nload, ncore + nmo - 1)), vtol, true);
+        mo.insert(mo.end(), guess.begin(), guess.end());
+        orthonormalize(world, mo, int(nload));
+        const long n = long(nmo);
+        tensorT eps_new(n), occ_new(n);
+        for (size_t j = 0; j < nload; ++j) { eps_new[j] = eps[j]; occ_new[j] = occ[j]; }
+        for (size_t j = nload; j < nmo; ++j) eps_new[j] = e[ncore + j];
+        eps = eps_new;
+        occ = occ_new;
+        set = group_orbital_sets(world, eps, occ, int(nmo));
+    };
+    pad(amo, aeps, aocc, aset, param.nmo_alpha());
+    if (pad_b) pad(bmo, beps, bocc, bset, param.nmo_beta());
+    return true;
+}
+
 
 /// group orbitals into sets of similar orbital energies for localization
 

--- a/src/madness/chem/SCF.h
+++ b/src/madness/chem/SCF.h
@@ -828,7 +828,10 @@ public:
 
 
         to_json(j, int_vals);
-        double_vals.push_back({"return_energy", value(calc.molecule.get_all_coords().flat())});
+        // current_energy, not value(): a re-solve here would run on rank 0 only
+        // (non-collective), and the nwfile guess translates the molecule, which
+        // stales value()'s coords cache.
+        double_vals.push_back({"return_energy", calc.current_energy});
         to_json(j, double_vals);
         double_tensor_vals.push_back({"scf_eigenvalues_a", calc.aeps});
         if (param.nbeta() != 0 && !param.spin_restricted()) {

--- a/src/madness/chem/SCF.h
+++ b/src/madness/chem/SCF.h
@@ -508,6 +508,15 @@ public:
                              vecfuncT& psi, vecfuncT& Vpsi, tensorT& evals,
                              const tensorT& occ, const double thresh) const;
 
+    /// canonicalize the virtual orbitals: diagonalize the virtual-virtual Fock
+    /// block and rotate psi and Vpsi in phase. Occupied orbitals are untouched;
+    /// the occupied-virtual coupling is left for the caller to decouple. No-op
+    /// when there are no virtuals or the rotation is near-identity.
+    /// @param[in]	nocc	number of occupied orbitals; the block [nocc, nmo) is canonicalized
+    /// @return		true if a rotation was applied
+    bool canonicalize_virtuals(World& world, tensorT& fock, vecfuncT& psi,
+                               vecfuncT& Vpsi, const int nocc) const;
+
 
     void loadbal(World& world, functionT& arho, functionT& brho, functionT& arho_old,
                  functionT& brho_old, subspaceT& subspace);

--- a/src/madness/chem/SCF.h
+++ b/src/madness/chem/SCF.h
@@ -419,6 +419,28 @@ public:
     /// @param[out]	e	eigenvalues
     void initial_guess_ao_eigenvectors(World& world, tensorT& c, tensorT& e);
 
+    /// iterate the virtuals in the fixed mean field of the occupied orbitals
+    ///
+    /// The occupied orbitals are not updated: nuclear and Coulomb potentials are
+    /// built once, the exchange and XC operators take the occupied orbitals from
+    /// this object at every call. Each spin's virtual block is canonicalized,
+    /// BSH-updated with KAIN, and re-orthogonalized against its occupieds.
+    void solve_virtuals(World& world);
+
+    /// KAIN: append (vm, rm) to the subspace and return the mixing coefficients
+    ///
+    /// Rebuilds the subspace matrix Q incrementally; on a singular subspace the
+    /// history is dropped and the step is a plain update.
+    tensorT kain_solve(World& world, const vecfuncT& vm, const vecfuncT& rm,
+                       subspaceT& subspace, tensorT& Q) const;
+
+    /// KAIN: the updated orbitals lo..lo+n of the subspace's vectors for coefficients c
+    vecfuncT kain_combine(World& world, const subspaceT& subspace, const tensorT& c,
+                          const size_t lo, const size_t n) const;
+
+    /// KAIN: drop the oldest history entry once the subspace holds maxsub of them
+    void kain_trim(subspaceT& subspace, tensorT& Q) const;
+
     /// fill in the virtuals a restart archive lacks, up to nmo_alpha/nmo_beta, with
     /// atomic-guess orbitals orthogonalized against the loaded ones
     /// @return		true if anything was added
@@ -640,6 +662,8 @@ public:
         }
 
         calc.get_initial_orbitals(world, plan);
+        MADNESS_CHECK_THROW(not calc.param.freeze_occupied() or plan.source == RestartSource::restartdata,
+                            "freeze_occupied needs converged occupied orbitals from a restartdata archive");
 
         // Reading can invalidate the plan's premise. load_mos resets
         // converged_for_thresh when it has to reproject, and it may have fallen
@@ -708,12 +732,14 @@ public:
                     // the vector drops the highest ones.
                     calc.amo.resize(calc.param.nmo_alpha());
                     calc.aset.resize(calc.param.nmo_alpha());
+                    calc.aeps = copy(calc.aeps(Slice(0, calc.param.nmo_alpha() - 1)));
                     calc.aocc = tensorT(calc.param.nmo_alpha());
                     for (int i = 0; i < calc.param.nalpha(); ++i)
                         calc.aocc[i] = 1.0;
                     if (calc.param.have_beta()) {
                         calc.bmo.resize(calc.param.nmo_beta());
                         calc.bset.resize(calc.param.nmo_beta());
+                        calc.beps = copy(calc.beps(Slice(0, calc.param.nmo_beta() - 1)));
                         calc.bocc = tensorT(calc.param.nmo_beta());
                         for (int i = 0; i < calc.param.nbeta(); ++i)
                             calc.bocc[i] = 1.0;
@@ -738,7 +764,8 @@ public:
                 }
                 calc.ao.clear(); world.gop.fence();
                 calc.ao = calc.project_ao_basis(world, calc.aobasis);
-                calc.solve(world);
+                if (calc.param.freeze_occupied()) calc.solve_virtuals(world);
+                else calc.solve(world);
 
                 if (calc.param.save())
                     calc.save_mos(world);

--- a/src/madness/chem/SCF.h
+++ b/src/madness/chem/SCF.h
@@ -395,6 +395,9 @@ public:
     std::vector<int> group_orbital_sets(World& world, const tensorT& eps,
                                         const tensorT& occ, const int nmo) const;
 
+    /// overwrite the leading occupation numbers with the explicit aocc/bocc input, if given
+    void apply_explicit_occupations(World& world);
+
     static void analyze_vectors(World& world, const vecfuncT& mo,
             const vecfuncT& ao, double vtol,
             const Molecule& molecule, const int print_level,

--- a/src/madness/chem/SCF.h
+++ b/src/madness/chem/SCF.h
@@ -609,6 +609,19 @@ public:
             calc.pcm = PCM(world, calc.molecule, calc.param.pcm_data(), true);
         }
 
+        // The virtual step-down converges nv_extra extra virtuals first. Only the
+        // atomic guess can be sized for them, so a restart skips the schedule.
+        const int nvalpha = calc.param.nmo_alpha() - calc.param.nalpha();
+        const int nvbeta = calc.param.nmo_beta() - calc.param.nbeta();
+        const int nv_extra = (plan.source == RestartSource::initial_guess) ? calc.param.nv_extra() : 0;
+        if (calc.param.nv_extra() > 0 && nv_extra == 0 && world.rank() == 0)
+            print("virtual step-down skipped: not starting from the atomic guess");
+        if (nv_extra > 0) {
+            calc.param.set_user_defined_value("nmo_alpha", calc.param.nalpha() + nvalpha + nv_extra);
+            if (calc.param.have_beta())
+                calc.param.set_user_defined_value("nmo_beta", calc.param.nbeta() + nvbeta + nv_extra);
+        }
+
         calc.get_initial_orbitals(world, plan);
 
         // Reading can invalidate the plan's premise. load_mos resets
@@ -651,51 +664,45 @@ public:
         // Make the nuclear potential, initial orbitals, etc.
         for (unsigned int proto = plan.protocol_start; proto < calc.param.protocol().size(); proto++) {
 
-            int nvalpha = calc.param.nmo_alpha() - calc.param.nalpha();
-            int nvbeta = calc.param.nmo_beta() - calc.param.nbeta();
-            int nvalpha_start, nv_old;
+            // Drop the extra virtuals stepwise down to nvalpha on the first rung we
+            // run. Intermediate stages are capped at nv_its iterations; the last
+            // stage runs with the input maxiter.
+            const int extra = (proto == plan.protocol_start) ? nv_extra : 0;
+            const int nv_step = calc.param.nv_step() > 0 ? calc.param.nv_step() : std::max(extra, 1);
+            const int maxiter_input = calc.param.maxiter();
+            int nv_old = nvalpha + extra;
 
-            //repeat with gradually decreasing nvirt, only for the first protocol
-            // rung we actually run -- which is not rung 0 after a restart
-            if (proto == plan.protocol_start && nvalpha > 0) {
-                nvalpha_start = nvalpha * calc.param.nv_factor();
-            } else {
-                nvalpha_start = nvalpha;
-            }
+            for (int nv = nvalpha + extra; ; nv = std::max(nv - nv_step, nvalpha)) {
 
-            nv_old = nvalpha_start;
-
-            for (int nv = nvalpha_start; nv >= nvalpha; nv -= nvalpha) {
-
-                if (nv > 0 && world.rank() == 0) std::cout << "Running with " << nv << " virtual states" << std::endl;
+                if (extra > 0)
+                    calc.param.set_user_defined_value("maxiter", nv > nvalpha ? calc.param.nv_its() : maxiter_input);
+                if (nv > 0 && world.rank() == 0)
+                    std::cout << "Running with " << nv << " virtual states, maxiter " << calc.param.maxiter() << std::endl;
 
                 calc.param.set_user_defined_value("nmo_alpha", calc.param.nalpha() + nv);
-                // check whether this is sensible for spin restricted case
-                if (calc.param.nbeta() && !calc.param.spin_restricted()) {
-                    if (nvbeta == nvalpha) {
-                        calc.param.set_user_defined_value("nmo_beta", calc.param.nbeta() + nv);
-                    } else {
-                        calc.param.set_user_defined_value("nmo_beta", calc.param.nbeta() + nv + nvbeta - nvalpha);
-                    }
-                }
+                if (calc.param.have_beta())
+                    calc.param.set_user_defined_value("nmo_beta", calc.param.nbeta() + nv + nvbeta - nvalpha);
 
                 calc.set_protocol<3>(world, calc.param.protocol()[proto]);
                 calc.make_nuclear_potential(world);
 
                 if (nv != nv_old) {
+                    // The virtuals are canonical (ascending eigenvalue), so shrinking
+                    // the vector drops the highest ones.
                     calc.amo.resize(calc.param.nmo_alpha());
-                    calc.bmo.resize(calc.param.nmo_beta());
-
+                    calc.aset.resize(calc.param.nmo_alpha());
                     calc.aocc = tensorT(calc.param.nmo_alpha());
                     for (int i = 0; i < calc.param.nalpha(); ++i)
                         calc.aocc[i] = 1.0;
-
-                    calc.bocc = tensorT(calc.param.nmo_beta());
-                    for (int i = 0; i < calc.param.nbeta(); ++i)
-                        calc.bocc[i] = 1.0;
-
-                    // might need to resize aset, bset, but for the moment this doesn't seem to be necessary
-
+                    if (calc.param.have_beta()) {
+                        calc.bmo.resize(calc.param.nmo_beta());
+                        calc.bset.resize(calc.param.nmo_beta());
+                        calc.bocc = tensorT(calc.param.nmo_beta());
+                        for (int i = 0; i < calc.param.nbeta(); ++i)
+                            calc.bocc[i] = 1.0;
+                    } else if (calc.param.nbeta() > 0) {
+                        calc.bmo = calc.amo;    // spin-restricted: bmo mirrors amo (see update_subspace)
+                    }
                 }
 
                 // project orbitals into higher k. Not needed on the first rung we
@@ -720,9 +727,7 @@ public:
                     calc.save_mos(world);
 
                 nv_old = nv;
-                // exit loop over decreasing nvirt if nvirt=0
-                if (nv == 0) break;
-
+                if (nv == nvalpha) break;
             }
 
         }

--- a/src/madness/chem/SCF.h
+++ b/src/madness/chem/SCF.h
@@ -414,6 +414,16 @@ public:
 
     void initial_guess(World& world);
 
+    /// diagonalize the atomic-guess Fock matrix in the AO basis
+    /// @param[out]	c	eigenvectors, one column per orbital
+    /// @param[out]	e	eigenvalues
+    void initial_guess_ao_eigenvectors(World& world, tensorT& c, tensorT& e);
+
+    /// fill in the virtuals a restart archive lacks, up to nmo_alpha/nmo_beta, with
+    /// atomic-guess orbitals orthogonalized against the loaded ones
+    /// @return		true if anything was added
+    bool pad_virtuals_from_guess(World& world);
+
     void initial_guess_from_nwchem(World& world);
 
     void initial_load_bal(World& world);
@@ -612,13 +622,17 @@ public:
             calc.pcm = PCM(world, calc.molecule, calc.param.pcm_data(), true);
         }
 
-        // The virtual step-down converges nv_extra extra virtuals first. Only the
-        // atomic guess can be sized for them, so a restart skips the schedule.
+        // The virtual step-down converges nv_extra extra virtuals first. Only
+        // virtuals that start from the atomic guess can be sized for them: a fresh
+        // guess, or a restart whose archive lacks them. A complete restart skips it.
         const int nvalpha = calc.param.nmo_alpha() - calc.param.nalpha();
         const int nvbeta = calc.param.nmo_beta() - calc.param.nbeta();
-        const int nv_extra = (plan.source == RestartSource::initial_guess) ? calc.param.nv_extra() : 0;
+        const bool pads_virtuals = plan.source == RestartSource::restartdata &&
+                                   plan.archive_nmo_alpha > 0 &&
+                                   plan.archive_nmo_alpha < std::size_t(calc.param.nmo_alpha());
+        const int nv_extra = (plan.source == RestartSource::initial_guess || pads_virtuals) ? calc.param.nv_extra() : 0;
         if (calc.param.nv_extra() > 0 && nv_extra == 0 && world.rank() == 0)
-            print("virtual step-down skipped: not starting from the atomic guess");
+            print("virtual step-down skipped: the virtuals do not start from the atomic guess");
         if (nv_extra > 0) {
             calc.param.set_user_defined_value("nmo_alpha", calc.param.nalpha() + nvalpha + nv_extra);
             if (calc.param.have_beta())

--- a/src/madness/chem/SCF.h
+++ b/src/madness/chem/SCF.h
@@ -764,7 +764,13 @@ public:
                 }
                 calc.ao.clear(); world.gop.fence();
                 calc.ao = calc.project_ao_basis(world, calc.aobasis);
-                if (calc.param.freeze_occupied()) calc.solve_virtuals(world);
+                if (calc.param.freeze_occupied()) {
+                    // The frozen solver reports the archive's energy. load_mos clears
+                    // current_energy when it reprojects (a plan starting below the
+                    // archive's rung), so take the header value the plan kept.
+                    calc.current_energy = plan.stale_energy;
+                    calc.solve_virtuals(world);
+                }
                 else calc.solve(world);
 
                 if (calc.param.save())

--- a/src/madness/chem/exchangeoperator.cc
+++ b/src/madness/chem/exchangeoperator.cc
@@ -13,19 +13,25 @@ template<typename T, std::size_t NDIM>
 Exchange<T, NDIM>::ExchangeImpl::ExchangeImpl(World& world, const SCF *calc, const int ispin)
         : world(world), symmetric_(false), lo(calc->param.lo()) {
 
+    // The exchange sum runs over occupied orbitals only: drop zero-occupation
+    // orbitals (the virtuals when nvalpha/nvbeta > 0). Fractional occupations
+    // would need an occ-scaled bra, which the symmetric algorithms cannot
+    // represent -- refuse them rather than sum them unweighted.
+    const Tensor<double>& occ = (ispin == 0) ? calc->aocc : calc->bocc;
+    const std::vector<Function<double, 3>>& mo = (ispin == 0) ? calc->amo : calc->bmo;
+    std::vector<Function<double, 3>> occupied_mo;
+    for (size_t i = 0; i < mo.size(); ++i) {
+        if (long(i) < occ.size() and occ(long(i)) == 0.0) continue;
+        MADNESS_CHECK_THROW(long(i) >= occ.size() or occ(long(i)) == 1.0,
+                            "Exchange requires occupation numbers of 0 or 1");
+        occupied_mo.push_back(mo[i]);
+    }
+
     if constexpr (std::is_same_v<T,double_complex>) {
-        if (ispin == 0) { // alpha spin
-            mo_ket = convert<double, T, NDIM>(world, calc->amo);        // deep copy necessary if T==double_complex
-        } else if (ispin == 1) {  // beta spin
-            mo_ket = convert<double, T, NDIM>(world, calc->bmo);
-        }
+        mo_ket = convert<double, T, NDIM>(world, occupied_mo);        // deep copy necessary if T==double_complex
         mo_bra = conj(world, mo_ket);
     } else {
-        if (ispin == 0) { // alpha spin
-            mo_ket = calc->amo;        // deep copy necessary if T==double_complex
-        } else if (ispin == 1) {  // beta spin
-            mo_ket = calc->bmo;
-        }
+        mo_ket = occupied_mo;
         mo_bra = mo_ket;
     }
 


### PR DESCRIPTION
# Virtual orbitals: fix the SCF dynamics, add the step-down, explicit occupations, and restart/frozen-occupied solvers (resurrects PR #307)

With `nvalpha`/`nvbeta > 0` the virtuals entered the exchange operator, were
localized together with the occupieds and lost their mutual Fock coupling;
they converged poorly and carried spurious eigenvalues. This PR fixes that,
resurrects and supersedes #307 (@lratcliff: explicit occupations and the
virtual step-down, on the current parameter class), and adds restart paths
that give the virtuals of a converged ground state cheaply. Follow-up to the
virtuals discussion on #784.

- Exchange sums over occupied orbitals only. Fractional occupations are refused.
- Localization acts on the occupied orbitals only.
- The virtual–virtual Fock coupling stays in the residual; only the
  occupied–virtual coupling is zeroed.
- The virtual block is canonicalized every iteration: virtual eigenvalues are
  eigenvalues of the converged Fock operator, ordered by energy.
- `nv_extra`, `nv_step`, `nv_its`: converge `nvalpha + nv_extra` virtuals,
  then drop `nv_step` of the highest per stage down to `nvalpha`, with
  `nv_its` iterations per intermediate stage. Replaces `nv_factor`.
- `aocc [0,1,1,1,1]`, `bocc [...]`: 0/1 occupations by orbital index in the
  occupied span; a 0 is a hole (Delta-SCF). Holes require `localize canon`,
  derived automatically.
- A restart from an archive with fewer orbitals than requested pads the
  missing virtuals from the atomic guess, orthogonal to the loaded orbitals,
  and iterates at the archive's rung. `read_only` refuses a short archive.
- `freeze_occupied true`: only the virtuals are iterated, in the fixed mean
  field of the restarted occupied orbitals.
- NWChem guess: virtuals kept up to `nmo_alpha`/`nmo_beta`, every localizer
  accepted, results json reports `current_energy` instead of re-solving on
  rank 0.
- KAIN subspace solve factored into `kain_solve`/`kain_combine`/`kain_trim`;
  `initial_guess` split into AO Fock diagonalization and orbital assembly;
  `MolecularOrbitals::load_mos` gains `allow_fewer`.
- Decks `tests/h2o_hf_nvstep.in` and `tests/ne_hf_corehole.in`; manual
  entries for the new keywords.

Vector parameters are comma separated: `aocc [0,1,1,1,1]`. No serialization
or checkpoint-format change.

## Commits

| commit | what |
|---|---|
| `7315e0aa5` | exchange operator: sum over occupied orbitals only |
| `f017585c1` | localize only the occupied orbitals |
| `2ca18fad5` | keep the virtual-virtual Lagrange coupling in update_subspace |
| `d37b51e4e` | canonicalize the virtual block before the BSH update |
| `ea00f1f13` | virtual step-down schedule nv_extra/nv_step/nv_its replaces nv_factor (#307-B) |
| `af603e302` | explicit occupations aocc/bocc for core-hole (Delta-SCF) calculations (#307-A) |
| `35c21fbe8` | restart may add virtuals, padding the archive from the atomic guess |
| `a89c72f22` | NWChem initial guess keeps virtuals up to nmo_alpha/nmo_beta |
| `62b3fe31d` | freeze_occupied iterates only the virtuals in the fixed occupied mean field |
| `432368fe4` | nwfile guess: allow cholesky localization; calc_info reports current_energy |
| `5c3e67fd0` | nwfile guess: allow every localizer |
| `03ab9ff79` | moldft manual: describe the virtual-orbital keywords |

12 commits, +678/−194 over 9 files.

## Semantics

- Virtual eigenvalues are independent of the occupied localizer: every
  `localize` value matches `canon` to 1e-8 Ha for bound virtuals (H2O+).
  Unbound virtuals are box-continuum states and do not converge to `dconv`;
  unchanged.
- `freeze_occupied` gives the same virtuals as the coupled SCF. The reported
  energy is the archive's. Off by default.
- Runs without virtuals are unchanged digit-for-digit (water, H2O+; HF and
  LDA; restricted and unrestricted).
- `nv_extra 0` is a single pass, as `nv_factor 1` was.

## Tests

`test_restart` 142/142, extended by the archive orbital count. Application
checks on water, H2O+ and Ne; HF and LDA; protocol 1e-4/1e-6; 8 ranks:

- H2O+ nvalpha 2 nvbeta 2 with `new_sys`: virtual eigenvalues equal `canon`
  to 1e-8. Step-down 4→3→2 and 4→2 give the same values.
- HOMO hole `aocc [1,1,1,1,0]` at charge 0 equals the cation (charge 1,
  nopen 1) to 0.2 uHa: from scratch, via restart, with virtuals. Ne 1s
  Delta-SCF 868.35 eV (Koopmans 891.78, expt 870.2); water O1s 538.87 eV
  (expt 539.8).
- Padded restart, 5-orbital archive + nvalpha 2 nvbeta 2: virtuals equal the
  from-scratch run to 1e-8; 29 iterations coupled, 28 virtual-only iterations
  with `freeze_occupied`. LDA LUMO to 1.4e-7.
- NWChem starts, RHF and UHF movecs, HF/6-31G, rotated geometry: every
  localizer reaches the same virtuals (<= 3e-7). Too few MOs refused.
- Refused before any orbital work: fractional occupation, list longer than
  nalpha, hole with a non-canonical localizer, `freeze_occupied` without a
  restart, `read_only` on a short archive.

## PR checklist

| item | answer |
|---|---|
| raw MPI calls | none |
| blocking MPI collectives | none; `world.gop` broadcasts and sums only |
| implicit default World | none |
| non-collective container construction | none; the new solver reuses the collective SCF machinery |
| threaded-BLAS assumptions | none |
| Function mutation / tree-state preconditions | rotations and updates via the existing `transform`/BSH machinery |
| checkpoint-format break | none; archive layout unchanged, the plan reads the existing orbital count |
| GENTENSOR coverage | no tensor-layer change |

## Verification

- CI pending at `03ab9ff79`.
- Full local tree builds with no warnings in the changed files (gcc 13, MKL/TBB).
- `freeze_occupied` is validated at water/H2O+ scale; the benchmark comparison
  behind a default change is not part of this PR.