### PR TITLE
Displacements: keep the ordering of the standard displacements in sync with the cell

### DIFF
--- a/src/madness/mra/displacements.h
+++ b/src/madness/mra/displacements.h
@@ -34,7 +34,8 @@
 #define MADNESS_MRA_DISPLACEMENTS_H__INCLUDED
 
 #include <madness/mra/indexit.h>
-#include <madness/mra/funcdefaults.h>
+#include <madness/mra/key.h>
+#include <madness/misc/array_of_bools.h>
 #include <madness/tensor/tensor.h>
 
 #include <algorithm>
@@ -48,6 +49,8 @@
 #include <vector>
 
 namespace madness {
+
+    template <std::size_t NDIM> class FunctionDefaults;  // funcdefaults.h includes this header at its end
 
     // How should we treat destinations "extra" to the [0, 2^n) standard domain?
     enum class ExtraDomainPolicy {
@@ -287,8 +290,11 @@ namespace madness {
           MADNESS_PRAGMA_CLANG(diagnostic pop)
         }
 
+        /// Sets the cell widths used to order the displacements by real-space distance, and reorders them.
+        /// Called by FunctionDefaults::recompute_cell_info whenever the cell changes.
+        /// @warning not thread safe: must not be called while operators are being applied
         static void set_width(const Tensor<double>& width) {
-          widths = width;
+          widths = copy(width);
           if (!disp.empty()) {
             std::sort(disp.begin(), disp.end(), cmp_keys);
           }

--- a/src/madness/mra/displacements.h
+++ b/src/madness/mra/displacements.h
@@ -34,8 +34,7 @@
 #define MADNESS_MRA_DISPLACEMENTS_H__INCLUDED
 
 #include <madness/mra/indexit.h>
-#include <madness/mra/key.h>
-#include <madness/misc/array_of_bools.h>
+#include <madness/mra/funcdefaults.h>
 #include <madness/tensor/tensor.h>
 
 #include <algorithm>
@@ -49,8 +48,6 @@
 #include <vector>
 
 namespace madness {
-
-    template <std::size_t NDIM> class FunctionDefaults;  // funcdefaults.h includes this header at its end
 
     // How should we treat destinations "extra" to the [0, 2^n) standard domain?
     enum class ExtraDomainPolicy {
@@ -290,10 +287,15 @@ namespace madness {
           MADNESS_PRAGMA_CLANG(diagnostic pop)
         }
 
-        /// Sets the cell widths used to order the displacements by real-space distance, and reorders them.
-        /// Called by FunctionDefaults::recompute_cell_info whenever the cell changes.
-        /// @warning not thread safe: must not be called while operators are being applied
+        /// Sets the cell widths used to order the displacements by real-space distance, and reorders them
+        /// if the widths changed. Called by FunctionDefaults::recompute_cell_info whenever the cell is set.
+        /// @warning reorders the lists in place: must not be called while operators are being applied
+        ///          (see FunctionDefaults::set_cell)
         static void set_width(const Tensor<double>& width) {
+          MADNESS_ASSERT(width.ndim() == 1 && width.size() == NDIM);
+          bool changed = widths.ndim() != 1 || widths.size() != NDIM;
+          for (std::size_t i = 0; !changed && i != NDIM; ++i) changed = widths(i) != width(i);
+          if (!changed) return;
           widths = copy(width);
           if (!disp.empty()) {
             std::sort(disp.begin(), disp.end(), cmp_keys);

--- a/src/madness/mra/funcdefaults.h
+++ b/src/madness/mra/funcdefaults.h
@@ -48,6 +48,7 @@
 #include <optional>
 
 namespace madness {
+    template <std::size_t NDIM> class Displacements;  // defined in displacements.h, included at the end of this file
     template <typename T, std::size_t NDIM> class FunctionImpl;
 
     /// The maximum wavelet order presently supported
@@ -149,6 +150,9 @@ namespace madness {
             cell_min_width = cell_width.min();
             rcell_width = copy(cell_width);
             for (std::size_t i=0; i<NDIM; ++i) rcell_width(i) = 1.0/rcell_width(i);
+            // the standard displacements used to apply operators are ordered by real-space distance,
+            // which depends on the cell; keep them in sync (see Displacements::set_width)
+            Displacements<NDIM>::set_width(cell_width);
         }
 
     public:
@@ -477,4 +481,10 @@ namespace madness {
 
 
 }
+
+// Displacements depends on FunctionDefaults (boundary conditions) and FunctionDefaults on Displacements
+// (recompute_cell_info); both are templates, so each header forward-declares the other's class and this
+// one includes the other at the end, after FunctionDefaults is complete
+#include <madness/mra/displacements.h>
+
 #endif // MADNESS_MRA_FUNCDEFAULTS_H__INCLUDED

--- a/src/madness/mra/funcdefaults.h
+++ b/src/madness/mra/funcdefaults.h
@@ -364,7 +364,10 @@ namespace madness {
 
         /// Sets the user cell for the simulation
 
-        /// Existing functions are probably rendered useless
+        /// Existing functions are probably rendered useless.
+        /// @warning Must be called in a quiescent window: no operator application (FunctionImpl::apply, including
+        ///          unfenced ones) may be in flight, since the standard displacements used by operators are
+        ///          reordered in place when the cell changes (see Displacements::set_width).
         static void set_cell(const Tensor<double>& value) {
         	cell=copy(value);
         	recompute_cell_info();
@@ -372,7 +375,8 @@ namespace madness {
 
         /// Sets the user cell to be cubic with each dimension having range \c [lo,hi]
 
-        /// Existing functions are probably rendered useless
+        /// Existing functions are probably rendered useless.
+        /// @warning Same quiescence requirement as set_cell().
         static void set_cubic_cell(double lo, double hi) {
         	cell(_,0)=lo;
         	cell(_,1)=hi;
@@ -483,8 +487,9 @@ namespace madness {
 }
 
 // Displacements depends on FunctionDefaults (boundary conditions) and FunctionDefaults on Displacements
-// (recompute_cell_info); both are templates, so each header forward-declares the other's class and this
-// one includes the other at the end, after FunctionDefaults is complete
+// (recompute_cell_info). Displacements is forward-declared above so that FunctionDefaults can be defined first,
+// and its header is included here, after FunctionDefaults is complete; displacements.h in turn includes this
+// header at its top, so either header can be included first (the include guards break the cycle).
 #include <madness/mra/displacements.h>
 
 #endif // MADNESS_MRA_FUNCDEFAULTS_H__INCLUDED

--- a/src/madness/mra/indexit.h
+++ b/src/madness/mra/indexit.h
@@ -38,6 +38,7 @@
 
 #include <vector>
 #include <madness/world/print.h>
+#include <madness/world/vector.h>
 
 namespace madness {
 

--- a/src/madness/mra/test_displacements.cc
+++ b/src/madness/mra/test_displacements.cc
@@ -575,6 +575,48 @@ int test_validator_bmax(World& world) {
   return t.end();
 }
 
+/// The standard displacements must be ordered by the real-space distance measured with the FunctionDefaults cell,
+/// since FunctionImpl::do_apply screens them shell by shell in that metric; the order must follow the cell when it changes.
+int test_standard_displacements_order(World& world) {
+  test_output t("Displacements: ordered by real-space distance in the FunctionDefaults cell", world.rank() == 0);
+
+  constexpr std::size_t NDIM = 3;
+  const Level n = 4;
+  const auto is_sorted_by = [&](const std::vector<Key<NDIM>>& disps, auto distsq) {
+    for (std::size_t i = 1; i < disps.size(); ++i)
+      if (distsq(disps[i]) < distsq(disps[i - 1])) return false;
+    return true;
+  };
+  const auto check_order = [&](const std::string& what) {
+    const auto& width = FunctionDefaults<NDIM>::get_cell_width();
+    Displacements<NDIM> displacements;  // builds the lists if this is the first use
+    const auto& plain = displacements.get_disp(n, array_of_bools<NDIM>{false});
+    const auto& summed = displacements.get_disp(n, array_of_bools<NDIM>{true});
+    t.checkpoint(!plain.empty() && !summed.empty(), what + ": lists are populated");
+    t.checkpoint(is_sorted_by(plain, [&](const Key<NDIM>& k) { return k.real_distsq(width); }),
+                 what + ": plain displacements ordered by real distance");
+    t.checkpoint(is_sorted_by(summed, [&](const Key<NDIM>& k) { return k.real_distsq_bc(array_of_bools<NDIM>{true}, width); }),
+                 what + ": lattice-summed displacements ordered by real distance");
+  };
+
+  const Tensor<double> cell0 = copy(FunctionDefaults<NDIM>::get_cell());
+  check_order("default (cubic) cell");
+
+  // an anisotropic cell: the order in boxes and in real space differ, e.g. (0,2,0) is 1 box but 10 units out
+  // while (3,0,0) is 2 boxes but 2 units out
+  Tensor<double> cell(NDIM, 2);
+  cell(0, 0) = 0.; cell(0, 1) = 1.;
+  cell(1, 0) = 0.; cell(1, 1) = 10.;
+  cell(2, 0) = 0.; cell(2, 1) = 10.;
+  FunctionDefaults<NDIM>::set_cell(cell);
+  check_order("anisotropic cell (1,10,10) set after the lists were built");
+
+  FunctionDefaults<NDIM>::set_cell(cell0);
+  check_order("cubic cell restored");
+
+  return t.end();
+}
+
 }
 
 int main(int argc, char** argv) {
@@ -593,6 +635,7 @@ int main(int argc, char** argv) {
   errors += test_skip_face(world);
   errors += test_faces_outside_domain(world);
   errors += test_validator_bmax(world);
+  errors += test_standard_displacements_order(world);
 
   world.gop.fence();
   madness::finalize();


### PR DESCRIPTION
Closes #799.

**Problem.** `Displacements<NDIM>::widths` defaulted to 1 and `set_width` was only called from `testopdir.cc`, so the standard displacement lists were ordered with unit cell widths, while `FunctionImpl::do_apply` measures shells with the real `FunctionDefaults` cell widths. For an anisotropic cell the list is not monotone in the metric the shell loop assumes (e.g. widths (1,10,10): (0,2,0) precedes (3,0,0) in the list but is five times farther in real space). The early break can then leave nearer displacements unprocessed, and for range-restricted kernels the surface validator drops their images as duplicates. Cubic cells are unaffected.

**Reproducer first.** The first commit only adds a test that the lists are ordered by real-space distance in the current cell, for the cubic default and for an anisotropic cell set after the lists were built. It fails against master on the anisotropic checks (CI on that commit alone, eed663de6: https://github.com/m-a-d-n-e-s-s/madness/actions/runs/34609551533, expected red in the Threads cells).

**Fix.** `FunctionDefaults::recompute_cell_info` now calls `Displacements::set_width`, so the lists follow the cell whenever it is set, at setup time and off the task pool. The two headers depend on each other (`Displacements` reads the boundary conditions from `FunctionDefaults`), so both forward-declare the other's class, `displacements.h` no longer includes `funcdefaults.h`, and `funcdefaults.h` includes `displacements.h` at its end, after `FunctionDefaults` is complete. `set_width` copies the widths instead of aliasing the cell tensor, and its doc now says it must not run while operators are being applied.

**Review follow-ups (third commit).** `displacements.h` includes `funcdefaults.h` again so it stays self-contained (the include guards make the header cycle safe in either order); `indexit.h`, which it includes first, now includes `madness/world/vector.h`, which it was missing. `set_width` is a no-op when the widths are unchanged, so re-setting the same cell at startup does not reorder the lists; `set_cell` / `set_cubic_cell` document that they must be called with no operator application in flight, since the lists are reordered in place.

**Not covered.** For a 6D operator acting on one particle, `do_apply` measures with the first three widths of the 6D cell while `Displacements<3>` is ordered by the 3D cell; the two agree when the 6D cell is the replicated 3D cell, which is the only case in use.

**Verification** (Release, PaRSEC, macOS): `test_displacements` (323 checkpoints), `testgconv`, and `testopdir` pass at the tip; the test-only commit fails as intended.

Rebased onto master after #802 brought #788 in; the ordering test now sits alongside the #788 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


